### PR TITLE
use a mutex around the canvases pvt map

### DIFF
--- a/driver/efl/canvas.go
+++ b/driver/efl/canvas.go
@@ -24,11 +24,14 @@ import "github.com/fyne-io/fyne/theme"
 import "github.com/fyne-io/fyne/layout"
 import "github.com/fyne-io/fyne/widget"
 
+var canvasMutex sync.RWMutex
 var canvases = make(map[*C.Evas]*eflCanvas)
 
 //export onObjectMouseDown
 func onObjectMouseDown(obj *C.Evas_Object, info *C.Evas_Event_Mouse_Down) {
+	canvasMutex.RLock()
 	current := canvases[C.evas_object_evas_get(obj)]
+	canvasMutex.RUnlock()
 	co := current.objects[obj]
 
 	var x, y C.int
@@ -482,7 +485,9 @@ func (c *eflCanvas) SetContent(o fyne.CanvasObject) {
 	c.offsets = make(map[fyne.CanvasObject]fyne.Position)
 	c.dirty = make(map[fyne.CanvasObject]bool)
 	c.content = o
+	canvasMutex.Lock()
 	canvases[C.ecore_evas_get(c.window.ee)] = c
+	canvasMutex.Unlock()
 
 	c.resizeContent()
 	c.setup(o, fyne.NewPos(0, 0))

--- a/driver/efl/loop.go
+++ b/driver/efl/loop.go
@@ -116,6 +116,8 @@ func (d *eFLDriver) Quit() {
 
 // renderCycle will cause all queued objects to be refreshed
 func renderCycle() {
+	canvasMutex.RLock()
+	defer canvasMutex.RUnlock()
 	for _, canvas := range canvases {
 		if len(canvas.dirty) == 0 {
 			continue

--- a/driver/gl/draw.go
+++ b/driver/gl/draw.go
@@ -145,7 +145,9 @@ func (c *glCanvas) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Siz
 }
 
 func (c *glCanvas) drawObject(o fyne.CanvasObject, offset fyne.Position, frame fyne.Size) {
+	canvasMutex.Lock()
 	canvases[o] = c
+	canvasMutex.Unlock()
 	pos := o.CurrentPosition().Add(offset)
 	switch obj := o.(type) {
 	case *canvas.Rectangle:

--- a/driver/gl/driver.go
+++ b/driver/gl/driver.go
@@ -3,13 +3,16 @@
 package gl
 
 import (
+	"log"
+	"sync"
+
 	"github.com/fyne-io/fyne"
 	"github.com/fyne-io/fyne/theme"
 	"github.com/golang/freetype/truetype"
 	"golang.org/x/image/font"
-	"log"
 )
 
+var canvasMutex sync.RWMutex
 var canvases = make(map[fyne.CanvasObject]fyne.Canvas)
 
 const textDPI = 78


### PR DESCRIPTION
canvases private map can throw concurrent access panics whilst being updated.

Implementation doesnt suite sync.Map, so wrap whats there with a mutex (in both the EFL and GL tagged builds)

Tested by loading fyne_demo in both EFL and GL mode, and bringing up dozens of windows quickly.