### PR TITLE
Fix error deleting unicode char in entry widget

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -27,10 +27,10 @@ func formApp(app fyne.App) {
 		},
 		OnSubmit: func() {
 			fmt.Println("Form submitted")
-			fmt.Println("Name:", name.Text)
-			fmt.Println("Email:", email.Text)
-			fmt.Println("Password:", password.Text)
-			fmt.Println("Message:", largeText.Text)
+			fmt.Println("Name:", name.Text())
+			fmt.Println("Email:", email.Text())
+			fmt.Println("Password:", password.Text())
+			fmt.Println("Message:", largeText.Text())
 		},
 	}
 	form.Append("Name", name)
@@ -50,7 +50,7 @@ func main() {
 
 	w := app.NewWindow("Fyne Demo")
 	entry := widget.NewEntry()
-	entry.Text = "Entry"
+	entry.SetText("Entry")
 
 	cv := canvas.NewImageFromResource(theme.FyneLogo())
 	cv.SetMinSize(fyne.NewSize(64, 64))

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -27,10 +27,10 @@ func formApp(app fyne.App) {
 		},
 		OnSubmit: func() {
 			fmt.Println("Form submitted")
-			fmt.Println("Name:", name.Text())
-			fmt.Println("Email:", email.Text())
-			fmt.Println("Password:", password.Text())
-			fmt.Println("Message:", largeText.Text())
+			fmt.Println("Name:", name.Text)
+			fmt.Println("Email:", email.Text)
+			fmt.Println("Password:", password.Text)
+			fmt.Println("Message:", largeText.Text)
 		},
 	}
 	form.Append("Name", name)

--- a/cmd/fyne_demo/widget.go
+++ b/cmd/fyne_demo/widget.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/fyne-io/fyne"
 	"github.com/fyne-io/fyne/theme"
 )
@@ -17,7 +18,7 @@ func makeButtonTab() fyne.Widget {
 
 func makeInputTab() fyne.Widget {
 	entry := widget.NewEntry()
-	entry.Text = "Entry"
+	entry.SetText("Entry")
 
 	return widget.NewVBox(
 		entry,

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -25,7 +25,7 @@ func TestEntry_OnKeyDown(t *testing.T) {
 	key.String = "i"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "Hi", entry.Text())
+	assert.Equal(t, "Hi", entry.Text)
 }
 
 func TestEntry_OnKeyDown_Insert(t *testing.T) {
@@ -36,14 +36,14 @@ func TestEntry_OnKeyDown_Insert(t *testing.T) {
 	entry.OnKeyDown(key)
 	key.String = "i"
 	entry.OnKeyDown(key)
-	assert.Equal(t, "Hi", entry.Text())
+	assert.Equal(t, "Hi", entry.Text)
 
 	left := &fyne.KeyEvent{Name: "Left"}
 	entry.OnKeyDown(left)
 
 	key.String = "o"
 	entry.OnKeyDown(key)
-	assert.Equal(t, "Hoi", entry.Text())
+	assert.Equal(t, "Hoi", entry.Text)
 }
 
 func TestEntry_OnKeyDown_Backspace(t *testing.T) {
@@ -59,7 +59,7 @@ func TestEntry_OnKeyDown_Backspace(t *testing.T) {
 	key.Name = "BackSpace"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "H", entry.Text())
+	assert.Equal(t, "H", entry.Text)
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 1, entry.CursorColumn)
 }
@@ -77,7 +77,7 @@ func TestEntry_OnKeyDown_BackspaceBeyondText(t *testing.T) {
 	entry.OnKeyDown(key)
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "", entry.Text())
+	assert.Equal(t, "", entry.Text)
 }
 
 func TestEntry_OnKeyDown_BackspaceNewline(t *testing.T) {
@@ -91,7 +91,7 @@ func TestEntry_OnKeyDown_BackspaceNewline(t *testing.T) {
 	key.Name = "BackSpace"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "Hi", entry.Text())
+	assert.Equal(t, "Hi", entry.Text)
 }
 
 func TestEntry_OnKeyDown_Backspace_Unicode(t *testing.T) {
@@ -106,7 +106,7 @@ func TestEntry_OnKeyDown_Backspace_Unicode(t *testing.T) {
 	bs := new(fyne.KeyEvent)
 	bs.Name = "BackSpace"
 	entry.OnKeyDown(bs)
-	assert.Equal(t, "", entry.Text())
+	assert.Equal(t, "", entry.Text)
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 0, entry.CursorColumn)
 }
@@ -123,7 +123,7 @@ func TestEntry_OnKeyDown_Delete(t *testing.T) {
 	key.Name = "Delete"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "H", entry.Text())
+	assert.Equal(t, "H", entry.Text)
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 1, entry.CursorColumn)
 }
@@ -138,7 +138,7 @@ func TestEntry_OnKeyDown_DeleteBeyondText(t *testing.T) {
 	entry.OnKeyDown(key)
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "", entry.Text())
+	assert.Equal(t, "", entry.Text)
 }
 
 func TestEntry_OnKeyDown_DeleteNewline(t *testing.T) {
@@ -152,7 +152,7 @@ func TestEntry_OnKeyDown_DeleteNewline(t *testing.T) {
 	key.Name = "Delete"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "Hi", entry.Text())
+	assert.Equal(t, "Hi", entry.Text)
 }
 
 func TestEntryNotify(t *testing.T) {
@@ -317,6 +317,6 @@ func TestPasswordEntry_Obfuscation(t *testing.T) {
 	key := new(fyne.KeyEvent)
 	key.String = "Hié™שרה"
 	entry.OnKeyDown(key)
-	assert.Equal(t, "Hié™שרה", entry.Text())
+	assert.Equal(t, "Hié™שרה", entry.Text)
 	assert.Equal(t, "*******", entry.label().Text)
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -25,7 +25,7 @@ func TestEntry_OnKeyDown(t *testing.T) {
 	key.String = "i"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "Hi", entry.Text)
+	assert.Equal(t, "Hi", entry.Text())
 }
 
 func TestEntry_OnKeyDown_Insert(t *testing.T) {
@@ -36,14 +36,14 @@ func TestEntry_OnKeyDown_Insert(t *testing.T) {
 	entry.OnKeyDown(key)
 	key.String = "i"
 	entry.OnKeyDown(key)
-	assert.Equal(t, "Hi", entry.Text)
+	assert.Equal(t, "Hi", entry.Text())
 
 	left := &fyne.KeyEvent{Name: "Left"}
 	entry.OnKeyDown(left)
 
 	key.String = "o"
 	entry.OnKeyDown(key)
-	assert.Equal(t, "Hoi", entry.Text)
+	assert.Equal(t, "Hoi", entry.Text())
 }
 
 func TestEntry_OnKeyDown_Backspace(t *testing.T) {
@@ -59,12 +59,12 @@ func TestEntry_OnKeyDown_Backspace(t *testing.T) {
 	key.Name = "BackSpace"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "H", entry.Text)
+	assert.Equal(t, "H", entry.Text())
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 1, entry.CursorColumn)
 }
 
-func TestEntry_OnKeyDown_BackspaceBeyondContent(t *testing.T) {
+func TestEntry_OnKeyDown_BackspaceBeyondText(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("Hi")
 	right := &fyne.KeyEvent{Name: "Right"}
@@ -77,7 +77,7 @@ func TestEntry_OnKeyDown_BackspaceBeyondContent(t *testing.T) {
 	entry.OnKeyDown(key)
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "", entry.Text)
+	assert.Equal(t, "", entry.Text())
 }
 
 func TestEntry_OnKeyDown_BackspaceNewline(t *testing.T) {
@@ -91,7 +91,24 @@ func TestEntry_OnKeyDown_BackspaceNewline(t *testing.T) {
 	key.Name = "BackSpace"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "Hi", entry.Text)
+	assert.Equal(t, "Hi", entry.Text())
+}
+
+func TestEntry_OnKeyDown_Backspace_Unicode(t *testing.T) {
+	entry := NewEntry()
+
+	key := new(fyne.KeyEvent)
+	key.String = "è"
+	entry.OnKeyDown(key)
+	assert.Equal(t, 0, entry.CursorRow)
+	assert.Equal(t, 1, entry.CursorColumn)
+
+	bs := new(fyne.KeyEvent)
+	bs.Name = "BackSpace"
+	entry.OnKeyDown(bs)
+	assert.Equal(t, "", entry.Text())
+	assert.Equal(t, 0, entry.CursorRow)
+	assert.Equal(t, 0, entry.CursorColumn)
 }
 
 func TestEntry_OnKeyDown_Delete(t *testing.T) {
@@ -106,12 +123,12 @@ func TestEntry_OnKeyDown_Delete(t *testing.T) {
 	key.Name = "Delete"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "H", entry.Text)
+	assert.Equal(t, "H", entry.Text())
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 1, entry.CursorColumn)
 }
 
-func TestEntry_OnKeyDown_DeleteBeyondContent(t *testing.T) {
+func TestEntry_OnKeyDown_DeleteBeyondText(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("Hi")
 
@@ -121,7 +138,7 @@ func TestEntry_OnKeyDown_DeleteBeyondContent(t *testing.T) {
 	entry.OnKeyDown(key)
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "", entry.Text)
+	assert.Equal(t, "", entry.Text())
 }
 
 func TestEntry_OnKeyDown_DeleteNewline(t *testing.T) {
@@ -135,7 +152,7 @@ func TestEntry_OnKeyDown_DeleteNewline(t *testing.T) {
 	key.Name = "Delete"
 	entry.OnKeyDown(key)
 
-	assert.Equal(t, "Hi", entry.Text)
+	assert.Equal(t, "Hi", entry.Text())
 }
 
 func TestEntryNotify(t *testing.T) {
@@ -300,6 +317,6 @@ func TestPasswordEntry_Obfuscation(t *testing.T) {
 	key := new(fyne.KeyEvent)
 	key.String = "Hié™שרה"
 	entry.OnKeyDown(key)
-	assert.Equal(t, "Hié™שרה", entry.Text)
+	assert.Equal(t, "Hié™שרה", entry.Text())
 	assert.Equal(t, "*******", entry.label().Text)
 }


### PR DESCRIPTION
This PR fixes a slice bounds out of range error when a unicode char is deleted using "Backspace" in the entry widget. (gl driver)

Additionally updates the entry widget to use internally runes (aiming to help with #38)
This has introduced a BC removing the entry.Text field in favour of entry.Text() method.