### PR TITLE
lock the canvases before reading from them

### DIFF
--- a/driver/gl/driver.go
+++ b/driver/gl/driver.go
@@ -23,6 +23,8 @@ type gLDriver struct {
 }
 
 func (d *gLDriver) CanvasForObject(obj fyne.CanvasObject) fyne.Canvas {
+	canvasMutex.RLock()
+	defer canvasMutex.RUnlock()
 	return canvases[obj]
 }
 


### PR DESCRIPTION
I forgot to do a readlock on the canvases object in the GL driver

This should fix that