### PR TITLE
do the deletion of windows after ranging over them

### DIFF
--- a/driver/gl/loop.go
+++ b/driver/gl/loop.go
@@ -74,6 +74,7 @@ func (d *gLDriver) runGL() {
 			walkObjects(object, fyne.NewPos(0, 0), freeWalked)
 		case <-fps.C:
 			glfw.PollEvents()
+			closers := []int{}
 			for i, win := range d.windows {
 				viewport := win.(*window).viewport
 				viewport.MakeContextCurrent()
@@ -83,7 +84,8 @@ func (d *gLDriver) runGL() {
 
 				if viewport.ShouldClose() {
 					// remove window from window list
-					d.windows = append(d.windows[:i], d.windows[i+1:]...)
+					//d.windows = append(d.windows[:i], d.windows[i+1:]...)
+					closers = append(closers, i)
 					viewport.Destroy()
 					glfw.DetachCurrentContext()
 
@@ -108,6 +110,9 @@ func (d *gLDriver) runGL() {
 
 				win.(*window).viewport.SwapBuffers()
 				glfw.DetachCurrentContext()
+			}
+			for _, i := range closers {
+				d.windows = append(d.windows[:i], d.windows[i+1:]...)
 			}
 		}
 	}


### PR DESCRIPTION
When a GL window is closed, the driver/gl/loop code ranges over all the windows, and does the GL close.  It also deletes the element from the slice that is being ranged over.

This can produce a panic 

```
panic: runtime error: slice bounds out of range

goroutine 1 [running, locked to thread]:
github.com/fyne-io/fyne/driver/gl.(*gLDriver).runGL(0xc00000c840)
        /home/steve/go/src/github.com/fyne-io/fyne/driver/gl/loop.go:86 +0x5d0
github.com/fyne-io/fyne/driver/gl.(*gLDriver).Run(0xc00000c840)
        /home/steve/go/src/github.com/fyne-io/fyne/driver/gl/driver.go:82 +0x2b
github.com/fyne-io/fyne/driver/gl.(*window).ShowAndRun(0xc0000a81e0)
        /home/steve/go/src/github.com/fyne-io/fyne/driver/gl/window.go:161 +0x57
main.welcome(0x959a00, 0xc00000c860)
        /home/steve/go/src/github.com/fyne-io/examples/main.go:33 +0x270
main.main()
        /home/steve/go/src/github.com/fyne-io/examples/main.go:60 +0x4c9
```

Simple fix is to collect a list of windows to be deleted, and then delete them outside the range statement.

To try it out - load the examples in GL without the patch, and bring up a few fractals.  Close the fractals - observe that it either crashes, or the window isnt destroyed.

Do it again with the patch, and all the windows should close cleanly.



