### PR TITLE
check error before processing pixels

### DIFF
--- a/driver/gl/gl.go
+++ b/driver/gl/gl.go
@@ -150,14 +150,14 @@ func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
 		} else {
 			file, _ := os.Open(img.File)
 			pixels, _, err := image.Decode(file)
-			// this is used by our render code, so let's set it to the file aspect
-			img.PixelAspect = float32(pixels.Bounds().Size().X) / float32(pixels.Bounds().Size().Y)
 
 			if err != nil {
 				log.Println("image err", err)
 
 				return 0
 			}
+			// this is used by our render code, so let's set it to the file aspect
+			img.PixelAspect = float32(pixels.Bounds().Size().X) / float32(pixels.Bounds().Size().Y)
 
 			raw = image.NewRGBA(pixels.Bounds())
 			draw.Draw(raw, pixels.Bounds(), pixels, image.ZP, draw.Src)

--- a/driver/gl/gl.go
+++ b/driver/gl/gl.go
@@ -134,14 +134,14 @@ func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
 	if img.File != "" {
 		if strings.ToLower(filepath.Ext(img.File)) == ".svg" {
 			icon, err := oksvg.ReadIcon(img.File)
-			icon.SetTarget(0, 0, float64(width), float64(height))
-
-			w, h := int(icon.ViewBox.W), int(icon.ViewBox.H)
 			if err != nil {
 				log.Println("SVG Load error:", err, img.File)
 
 				return 0
 			}
+			icon.SetTarget(0, 0, float64(width), float64(height))
+
+			w, h := int(icon.ViewBox.W), int(icon.ViewBox.H)
 			raw = image.NewRGBA(image.Rect(0, 0, width, height))
 			scanner := rasterx.NewScannerGV(w, h, raw, raw.Bounds())
 			raster := rasterx.NewDasher(width, height, scanner)


### PR DESCRIPTION
canvas.newGlImageTexture() can panic with nil ptr dereference if it fails to decode the image.

Move the error check above the bits where it dereferences the pixels object.