### PR TITLE
include explicit ref to decoders to get jpeg working in openGL

### DIFF
--- a/driver/gl/gl.go
+++ b/driver/gl/gl.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"image"
 	"image/draw"
+	_ "image/jpeg"
+	_ "image/png"
 	"log"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
XKCD includes some jpgs  (try 66, 68, etc)

Fix for the OpenGL renderer to include jpeg decoding.

Added explicit ref to png as well, for consistency ... I think Go does this automatically anyway, but at least this import makes it clear.