### PR TITLE
Gl resize image

### DIFF
--- a/canvas/image.go
+++ b/canvas/image.go
@@ -31,9 +31,8 @@ type Image struct {
 	PixelColor  func(x, y, w, h int) color.Color // Render the image from code
 	PixelAspect float32                          // Set an aspect ratio for pixel based images
 
-	Translucency float64    // Set a translucency value > 0.0 to fade the image
-	FillMode     ImageFill  // Specify how the image should scale to fill or fit
-	ImageSize    *fyne.Size // Size of the underlying object, or nil if not determined
+	Translucency float64   // Set a translucency value > 0.0 to fade the image
+	FillMode     ImageFill // Specify how the image should scale to fill or fit
 }
 
 // Alpha is a convenience function that returns the alpha value for an image

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -31,6 +31,8 @@ type Image struct {
 
 	Translucency float64   // Set a translucency value > 0.0 to fade the image
 	FillMode     ImageFill // Specify how the image should scale to fill or fit
+
+	ImageSize fyne.Size // original image size - only supported on GL so far ???
 }
 
 // Alpha is a convenience function that returns the alpha value for an image

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -18,6 +18,8 @@ const (
 	// centrally and maintaining aspect ratio.
 	// There may be transparent sections top and bottom or left and right.
 	ImageFillContain //(Fit)
+	// ImageFillResize will resize the canvas to fix the original image.
+	ImageFillResize
 )
 
 // Image describes a raster image area that can render in a Fyne canvas
@@ -29,10 +31,9 @@ type Image struct {
 	PixelColor  func(x, y, w, h int) color.Color // Render the image from code
 	PixelAspect float32                          // Set an aspect ratio for pixel based images
 
-	Translucency float64   // Set a translucency value > 0.0 to fade the image
-	FillMode     ImageFill // Specify how the image should scale to fill or fit
-
-	ImageSize fyne.Size // original image size - only supported on GL so far ???
+	Translucency float64    // Set a translucency value > 0.0 to fade the image
+	FillMode     ImageFill  // Specify how the image should scale to fill or fit
+	ImageSize    *fyne.Size // Size of the underlying object, or nil if not determined
 }
 
 // Alpha is a convenience function that returns the alpha value for an image

--- a/driver/gl/gl.go
+++ b/driver/gl/gl.go
@@ -144,14 +144,14 @@ func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
 	if img.File != "" {
 		if strings.ToLower(filepath.Ext(img.File)) == ".svg" {
 			icon, err := oksvg.ReadIcon(img.File)
-			icon.SetTarget(0, 0, float64(width), float64(height))
-
-			w, h := int(icon.ViewBox.W), int(icon.ViewBox.H)
 			if err != nil {
 				log.Println("SVG Load error:", err, img.File)
 
 				return 0
 			}
+			icon.SetTarget(0, 0, float64(width), float64(height))
+
+			w, h := int(icon.ViewBox.W), int(icon.ViewBox.H)
 			raw = image.NewRGBA(image.Rect(0, 0, width, height))
 			scanner := rasterx.NewScannerGV(w, h, raw, raw.Bounds())
 			raster := rasterx.NewDasher(width, height, scanner)
@@ -160,14 +160,15 @@ func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
 		} else {
 			file, _ := os.Open(img.File)
 			pixels, _, err := image.Decode(file)
-			// this is used by our render code, so let's set it to the file aspect
-			img.PixelAspect = float32(pixels.Bounds().Size().X) / float32(pixels.Bounds().Size().Y)
-
 			if err != nil {
 				log.Println("image err", err)
 
 				return 0
 			}
+			bs := pixels.Bounds().Size()
+			// this is used by our render code, so let's set it to the file aspect
+			img.PixelAspect = float32(bs.X) / float32(bs.Y)
+			img.ImageSize = fyne.Size{bs.X, bs.Y}
 
 			raw = image.NewRGBA(pixels.Bounds())
 			draw.Draw(raw, pixels.Bounds(), pixels, image.ZP, draw.Src)

--- a/driver/gl/gl.go
+++ b/driver/gl/gl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"image/draw"
+	_ "image/jpeg"
 	"log"
 	"os"
 	"path/filepath"
@@ -129,7 +130,12 @@ func renderGlImagePortion(point image.Point, width, height int,
 }
 
 func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
-	img := obj.(*canvas.Image)
+	img, ok := obj.(*canvas.Image)
+	if !ok {
+		log.Println("obj is not an image")
+		return 0
+	}
+
 	texture := newTexture()
 	gl.Enable(gl.BLEND)
 	gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
@@ -168,7 +174,9 @@ func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
 			bs := pixels.Bounds().Size()
 			// this is used by our render code, so let's set it to the file aspect
 			img.PixelAspect = float32(bs.X) / float32(bs.Y)
-			img.ImageSize = fyne.Size{bs.X, bs.Y}
+			if img.FillMode == canvas.ImageFillResize {
+				img.SetMinSize(fyne.Size{bs.X, bs.Y})
+			}
 
 			raw = image.NewRGBA(pixels.Bounds())
 			draw.Draw(raw, pixels.Bounds(), pixels, image.ZP, draw.Src)


### PR DESCRIPTION
Add a new image fill type - ImageFillResize, which will grow the containing element to match the actual image dimensions.

Useful for loading an image from a resource, and resetting the display to match the dimensions.

Matching PR on the xkcd example to make it work