### PR TITLE
check that the refresh queue is not full rather than block writing to it

### DIFF
--- a/driver/gl/canvas.go
+++ b/driver/gl/canvas.go
@@ -61,7 +61,12 @@ func (c *glCanvas) SetContent(content fyne.CanvasObject) {
 }
 
 func (c *glCanvas) Refresh(obj fyne.CanvasObject) {
-	refreshQueue <- obj
+	select {
+	case refreshQueue <- obj:
+		// all good
+	default:
+		// refresh queue is full
+	}
 	c.setDirty()
 }
 

--- a/driver/gl/gl.go
+++ b/driver/gl/gl.go
@@ -24,9 +24,12 @@ import (
 )
 
 var textures = make(map[fyne.CanvasObject]uint32)
+var texturesMutex sync.RWMutex
 var refreshQueue = make(chan fyne.CanvasObject, 1024)
 
 func getTexture(object fyne.CanvasObject, creator func(canvasObject fyne.CanvasObject) uint32) uint32 {
+	texturesMutex.Lock()
+	defer texturesMutex.Unlock()
 	texture := textures[object]
 
 	img, skipCache := object.(*canvas.Image)

--- a/driver/gl/loop.go
+++ b/driver/gl/loop.go
@@ -66,8 +66,9 @@ func (d *gLDriver) runGL() {
 					delete(textures, obj)
 				}
 			}
-
+			texturesMutex.Lock()
 			walkObjects(object, fyne.NewPos(0, 0), freeWalked)
+			texturesMutex.Unlock()
 		case <-fps.C:
 			glfw.PollEvents()
 			for i, win := range d.windows {

--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -1,7 +1,9 @@
 package layout
 
-import "github.com/fyne-io/fyne"
-import "github.com/fyne-io/fyne/theme"
+import (
+	"github.com/fyne-io/fyne"
+	"github.com/fyne-io/fyne/theme"
+)
 
 type borderLayout struct {
 	top, bottom, left, right fyne.CanvasObject

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -1,8 +1,11 @@
 package layout
 
-import "math"
-import "github.com/fyne-io/fyne"
-import "github.com/fyne-io/fyne/theme"
+import (
+	"math"
+
+	"github.com/fyne-io/fyne"
+	"github.com/fyne-io/fyne/theme"
+)
 
 type gridLayout struct {
 	Cols int


### PR DESCRIPTION
Interesting bug with resizing a window manually with the mouse.

In the GL main loop, as long as the mouse button is pressed, it continues to hit glfw.PollEvents() whilst the refreshQueue continues to grow. ie - loop doesnt get the `object := <-refreshQueue` whilst the mouse button is pressed.  (use Println's in the loop code to observe this behaviour)

So this results the refreshQueue filling up, which causes a canvas.Refresh to block.

You can test this behaviour by resize a small bit at a time, when you release the mouse button, the GL loop then gets breathing space to process the refreshQueue, so it doesnt lock up.

Hold the button down, keep dragging, and the refreshQueue is ignored, so the whole program locks up.

Dont quite understand that behaviour in glfw.PollEvents() - but thats what its doing, at least on MacOSX / Mojave.

Simple fix - when adding to the refreshQueue, check for overflows.

Also added a mutex around the textures map, just to be on the safe side.