### PR TITLE
fix just the refresh queue

### DIFF
--- a/driver/gl/canvas.go
+++ b/driver/gl/canvas.go
@@ -61,7 +61,12 @@ func (c *glCanvas) SetContent(content fyne.CanvasObject) {
 }
 
 func (c *glCanvas) Refresh(obj fyne.CanvasObject) {
-	refreshQueue <- obj
+	select {
+	case refreshQueue <- obj:
+		// all good
+	default:
+		// queue is full, ignore
+	}
 	c.setDirty()
 }
 


### PR DESCRIPTION
Interesting bug with resizing a window manually with the mouse.

In the GL main loop, as long as the mouse button is pressed, it continues to hit glfw.PollEvents() whilst the refreshQueue continues to grow. ie - loop doesnt get the object := <-refreshQueue whilst the mouse button is pressed. (use Println's in the loop code to observe this behaviour)

So this results the refreshQueue filling up, which causes a canvas.Refresh to block.

You can test this behaviour by resize a small bit at a time, when you release the mouse button, the GL loop then gets breathing space to process the refreshQueue, so it doesnt lock up.

Hold the button down, keep dragging, and the refreshQueue is ignored, so the whole program locks up.

Dont quite understand that behaviour in glfw.PollEvents() - but thats what its doing, at least on MacOSX / Mojave.

Simple fix - when adding to the refreshQueue, check for overflows.