### PR TITLE
Fix demo build example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ It should then look like this:
 To run a showcase of the features of fyne execute the following:
 
     cd $GOPATH/src/fyne.io/fyne/cmd/fyne_demo/
-    go run .
+    go build
+    ./fyne_demo
 
 And you should see something like this (after you click a few buttons):
 


### PR DESCRIPTION
I'm using Windows and "go ." doesn't work.
The combination of "go build" and "./fyne_demo" should work on all systems.