### PR TITLE
Add FormLayout

### DIFF
--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -1,0 +1,125 @@
+package layout
+
+import (
+	"math"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/theme"
+)
+
+const formLayoutCols = 2
+
+// formLayout is two column grid where each row has a label and a widget.
+type formLayout struct {
+}
+
+func (f *formLayout) countRows(objects []fyne.CanvasObject) int {
+	return int(math.Ceil(float64(len(objects)) / float64(formLayoutCols)))
+}
+
+// tableCellsSize defines the size for all the cells of the form table.
+// The height of each row will be set as the max value between the label and content cell heights.
+// The width of the label column will be set as the max width value between all the label cells.
+// The width of the content column will be set as the max width value between all the content cells.
+func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject) [][2]fyne.Size {
+	rows := f.countRows(objects)
+	table := make([][2]fyne.Size, rows)
+
+	if (len(objects))%formLayoutCols != 0 {
+		return table
+	}
+
+	lowBound := 0
+	highBound := 2
+	labelCellMaxWidth := 0
+	contentCellMaxWidth := 0
+	for row := 0; row < rows; row++ {
+		currentRow := objects[lowBound:highBound]
+
+		labelCell := currentRow[0].MinSize()
+		labelCellMaxWidth = fyne.Max(labelCellMaxWidth, labelCell.Width)
+
+		contentCell := currentRow[1].MinSize()
+		contentCellMaxWidth = fyne.Max(contentCellMaxWidth, contentCell.Width)
+
+		rowHeight := fyne.Max(labelCell.Height, contentCell.Height)
+
+		labelCell.Height = rowHeight
+		contentCell.Height = rowHeight
+
+		table[row][0] = labelCell
+		table[row][1] = contentCell
+
+		lowBound = highBound
+		highBound += 2
+	}
+
+	for row := 0; row < rows; row++ {
+		table[row][0].Width = labelCellMaxWidth
+		table[row][1].Width = contentCellMaxWidth
+	}
+
+	return table
+}
+
+// Layout is called to pack all child objects into a table format with two columns.
+func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+
+	var cellWidth float64
+	var cellHeight float64
+
+	table := f.tableCellsSize(objects)
+
+	row := 0
+	x, y := 0, 0
+	deltaY := 0
+
+	for i, child := range objects {
+		if row > 0 {
+			deltaY = table[row-1][0].Height + theme.Padding()
+		}
+
+		tableRow := table[row]
+		cellHeight = float64(tableRow[0].Height)
+		if (i)%formLayoutCols == 0 {
+			x = 0
+			y += deltaY
+			cellWidth = float64(tableRow[0].Width)
+		} else {
+			x = theme.Padding() + tableRow[0].Width
+			cellWidth = float64(tableRow[1].Width)
+			row++
+		}
+
+		child.Move(fyne.NewPos(x, y))
+		child.Resize(fyne.NewSize(int(cellWidth), int(cellHeight)))
+	}
+}
+
+// MinSize finds the smallest size that satisfies all the child objects.
+// For a FormLayout this is the width of the widest label and content items and the height is
+// the sum of all column children combined with padding between each.
+func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+
+	table := f.tableCellsSize(objects)
+
+	minSize := fyne.NewSize(0, 0)
+
+	if len(table) == 0 {
+		return minSize
+	}
+
+	minSize.Width = table[0][0].Width + table[0][1].Width + theme.Padding()
+	for row := 0; row < len(table); row++ {
+		minSize.Height += table[row][0].Height
+		if row > 0 {
+			minSize.Height += theme.Padding()
+		}
+	}
+	return minSize
+}
+
+// NewFormLayout returns a new FormLayout instance
+func NewFormLayout() fyne.Layout {
+	return &formLayout{}
+}

--- a/layout/formlayout_test.go
+++ b/layout/formlayout_test.go
@@ -1,0 +1,62 @@
+package layout
+
+import (
+	"image/color"
+	"testing"
+
+	"fyne.io/fyne/theme"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormLayout(t *testing.T) {
+	gridSize := fyne.NewSize(125, 125)
+
+	label1 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	label1.SetMinSize(fyne.NewSize(50, 50))
+	content1 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	content1.SetMinSize(fyne.NewSize(100, 100))
+
+	label2 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	label2.SetMinSize(fyne.NewSize(70, 30))
+	content2 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	content2.SetMinSize(fyne.NewSize(120, 80))
+
+	container := &fyne.Container{
+		Objects: []fyne.CanvasObject{label1, content1, label2, content2},
+	}
+	container.Resize(gridSize)
+
+	NewFormLayout().Layout(container.Objects, gridSize)
+
+	assert.Equal(t, fyne.NewSize(70, 100), label1.Size())
+	assert.Equal(t, fyne.NewSize(120, 100), content1.Size())
+	assert.Equal(t, fyne.NewSize(70, 80), label2.Size())
+	assert.Equal(t, fyne.NewSize(120, 80), content2.Size())
+
+}
+
+func TestFormLayoutMinSize(t *testing.T) {
+
+	label1 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	label1.SetMinSize(fyne.NewSize(50, 50))
+	content1 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	content1.SetMinSize(fyne.NewSize(100, 100))
+
+	label2 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	label2.SetMinSize(fyne.NewSize(70, 30))
+	content2 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
+	content2.SetMinSize(fyne.NewSize(120, 80))
+
+	container := &fyne.Container{
+		Objects: []fyne.CanvasObject{label1, content1, label2, content2},
+	}
+
+	layout := NewFormLayout()
+	layoutMin := layout.MinSize(container.Objects)
+	expectedRowWidth := 70 + 120 + theme.Padding()
+	expectedRowHeight := 100 + 80 + theme.Padding()
+	assert.Equal(t, fyne.NewSize(expectedRowWidth, expectedRowHeight), layoutMin)
+}

--- a/widget/form.go
+++ b/widget/form.go
@@ -65,7 +65,7 @@ func (f *Form) ensureGrid() {
 		return
 	}
 
-	f.itemGrid = fyne.NewContainerWithLayout(layout.NewGridLayout(2), []fyne.CanvasObject{}...)
+	f.itemGrid = fyne.NewContainerWithLayout(layout.NewFormLayout(), []fyne.CanvasObject{}...)
 }
 
 // Append adds a new row to the form, using the text as a label next to the specified Widget


### PR DESCRIPTION
This PR adds a FormLayout that is a two column grid where each row has a label and a widget.
Layot size is defined as below:
- the height of each row will be set as the max value between the label and content cell heights
- the width of the label column will be set as the max width value between all the label cells
- the width of the content column will be set as the max width value between all the content cells
