### PR TITLE
 Fix text widget does not honor color field

### DIFF
--- a/widget/text.go
+++ b/widget/text.go
@@ -234,6 +234,7 @@ func (r *textRenderer) Refresh() {
 		r.objects = append(r.objects, textCanvas)
 	}
 
+	r.ApplyTheme()
 	r.Layout(r.textWidget.Size())
 	canvas.Refresh(r.textWidget)
 }

--- a/widget/text_test.go
+++ b/widget/text_test.go
@@ -1,6 +1,7 @@
 package widget
 
 import (
+	"image/color"
 	"testing"
 
 	"fyne.io/fyne"
@@ -166,4 +167,12 @@ func TestText_DeleteFromTo(t *testing.T) {
 			assert.Equal(t, tt.wantBuffer, text.buffer)
 		})
 	}
+}
+
+func TestText_Color(t *testing.T) {
+	text := newTextWidget("test")
+	text.color = color.White
+	renderer := Renderer(text).(*textRenderer)
+	renderer.Refresh()
+	assert.Equal(t, color.White, renderer.texts[0].Color)
 }


### PR DESCRIPTION
The placeholder text into the form widget shows the text color instead of the placeholder one.
To reproduce the issue run fyne_demo/form
Bug introduced into #56 

