### PR TITLE
use sync.Map for safety

### DIFF
--- a/widget/widget.go
+++ b/widget/widget.go
@@ -2,6 +2,8 @@
 package widget // import "fyne.io/fyne/widget"
 
 import (
+	"sync"
+
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 )
@@ -64,16 +66,15 @@ func (w *baseWidget) hide(parent fyne.Widget) {
 	}
 }
 
-var renderers = make(map[fyne.Widget]fyne.WidgetRenderer)
+var renderers sync.Map
 
 // Renderer looks up the render implementation for a widget
 func Renderer(wid fyne.Widget) fyne.WidgetRenderer {
-	renderer := renderers[wid]
-
-	if renderer == nil {
+	renderer, ok := renderers.Load(wid)
+	if !ok {
 		renderer = wid.CreateRenderer()
-		renderers[wid] = renderer
+		renderers.Store(wid, renderer)
 	}
 
-	return renderer
+	return renderer.(fyne.WidgetRenderer)
 }


### PR DESCRIPTION
Use of the global map renderers leaves it open to concurrent map access bugs.

Example - load up the example app, slowly bring up a few new apps, observe that it works without error.

Now click on bringing up an instance of `suduko` as fast as you can (move the main window if need be to allow this).  Observe that it crashes pretty quickly with a concurrent map read write in the `Renderer()` at line 71.

This change applies a sync.Map to prevent concurrent access issues. 