### PR TITLE
remove recursive window.SetTitle() call

### DIFF
--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -36,7 +36,7 @@ func (w *window) Title() string {
 
 func (w *window) SetTitle(title string) {
 	w.title = title
-	w.SetTitle(title)
+	w.viewport.SetTitle(title)
 }
 
 func (w *window) FullScreen() bool {


### PR DESCRIPTION
I was messing around with setting the title on a window, and I kept getting recursion errors.  Turns out, the window.SetTitle() function was calling itself.  Looks like it's supposed to call the GLFW function instead, and it seems to work as expected now :)

btw, as a note, I love the layout of the code.  I've been poking around in it and it's very easy to understand and jump into :+1: 