### PR TITLE
use built-in function to get current monitor for window

### DIFF
--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -140,21 +140,11 @@ func scaleForDpi(xdpi int) float32 {
 }
 
 func getMonitorForWindow(win *glfw.Window) *glfw.Monitor {
-	winx, winy := win.GetPos()
-	for _, monitor := range glfw.GetMonitors() {
-		x, y := monitor.GetPos()
-
-		if x > winx || y > winy {
-			continue
-		}
-		if x+monitor.GetVideoMode().Width <= winx || y+monitor.GetVideoMode().Height <= winy {
-			continue
-		}
-
-		return monitor
+	mon := win.GetMonitor()
+	if mon == nil {
+		mon = glfw.GetPrimaryMonitor() // so we have something to return
 	}
-
-	return glfw.GetPrimaryMonitor()
+	return mon
 }
 
 func detectScale(win *glfw.Window) float32 {


### PR DESCRIPTION
I was looking at making a centering function, which led me into looking at windows vs monitors, and then your latest commit:  https://github.com/fyne-io/fyne/commit/76576e7ef17fd2bd8f26f4b5eb6642a43afbc276

I think there's a built-in function which would remove the need to loop over all available monitors and do some math, which in the real-world doesn't seem like it'd be too expensive, but is there any reason to not simplify and use the glfw driver function?  https://www.glfw.org/docs/latest/group__window.html#gaeac25e64789974ccbe0811766bd91a16