### PR TITLE
Center window

### DIFF
--- a/driver/efl/window.go
+++ b/driver/efl/window.go
@@ -78,6 +78,12 @@ func (w *window) SetFullScreen(full bool) {
 	})
 }
 
+func (w *window) CenterOnScreen() {
+	runOnMain(func() {
+		// TODO
+	})
+}
+
 func (w *window) Resize(size fyne.Size) {
 	scale := w.canvas.Scale()
 	runOnMain(func() {

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -140,21 +140,11 @@ func scaleForDpi(xdpi int) float32 {
 }
 
 func getMonitorForWindow(win *glfw.Window) *glfw.Monitor {
-	winx, winy := win.GetPos()
-	for _, monitor := range glfw.GetMonitors() {
-		x, y := monitor.GetPos()
-
-		if x > winx || y > winy {
-			continue
-		}
-		if x+monitor.GetVideoMode().Width <= winx || y+monitor.GetVideoMode().Height <= winy {
-			continue
-		}
-
-		return monitor
+	mon := win.GetMonitor()
+	if mon == nil {
+		mon = glfw.GetPrimaryMonitor() // so we have something to return
 	}
-
-	return glfw.GetPrimaryMonitor()
+	return mon
 }
 
 func detectScale(win *glfw.Window) float32 {

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -60,6 +60,32 @@ func (w *window) SetFullScreen(full bool) {
 	})
 }
 
+func (w *window) CenterOnScreen() {
+	runOnMainAsync(func() {
+		// get window dimensions in pixels
+		monitor := getMonitorForWindow(w.viewport)
+		monMode := monitor.GetVideoMode()
+		monWidth := monMode.Width
+		monHeight := monMode.Height
+
+		// get current window dimensions in pixels
+		winContentSize := w.Content().MinSize()
+		viewWidth, viewHeight := w.viewport.GetSize()
+
+		// take the larger of the window size and the content
+		// if the window is hidden, the content will be larger
+		viewWidth = fyne.Max(winContentSize.Width, viewWidth)
+		viewHeight = fyne.Max(winContentSize.Height, viewHeight)
+
+		// math them to the middle
+		newX := (monWidth / 2) - (winContentSize.Width / 2)
+		newY := (monHeight / 2) - (winContentSize.Height / 2)
+
+		// set new window coordinates
+		w.viewport.SetPos(newX, newY)
+	})
+}
+
 func (w *window) Resize(size fyne.Size) {
 	runOnMainAsync(func() {
 		scale := w.canvas.Scale()

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -65,11 +65,10 @@ func (w *window) CenterOnScreen() {
 		// get window dimensions in pixels
 		monitor := getMonitorForWindow(w.viewport)
 		monMode := monitor.GetVideoMode()
-		monWidth := monMode.Width
-		monHeight := monMode.Height
-
-		// get current window dimensions in pixels
+		
+		// get current size of content inside the window
 		winContentSize := w.Content().MinSize()
+		// get current window dimensions in pixels
 		viewWidth, viewHeight := w.viewport.GetSize()
 
 		// take the larger of the window size and the content
@@ -78,8 +77,8 @@ func (w *window) CenterOnScreen() {
 		viewHeight = fyne.Max(winContentSize.Height, viewHeight)
 
 		// math them to the middle
-		newX := (monWidth / 2) - (winContentSize.Width / 2)
-		newY := (monHeight / 2) - (winContentSize.Height / 2)
+		newX := (monMode.Width / 2) - (viewWidth / 2)
+		newY := (monMode.Height / 2) - (viewHeight / 2)
 
 		// set new window coordinates
 		w.viewport.SetPos(newX, newY)

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -28,6 +28,8 @@ type window struct {
 
 	mouseX, mouseY float64
 	onClosed       func()
+
+	xpos, ypos int
 }
 
 func (w *window) Title() string {
@@ -46,7 +48,7 @@ func (w *window) FullScreen() bool {
 func (w *window) SetFullScreen(full bool) {
 	runOnMainAsync(func() {
 		w.fullScreen = full
-		monitor := getMonitorForWindow(w.viewport)
+		monitor := w.getMonitorForWindow()
 		mode := monitor.GetVideoMode()
 
 		if full {
@@ -63,21 +65,14 @@ func (w *window) SetFullScreen(full bool) {
 func (w *window) CenterOnScreen() {
 	runOnMainAsync(func() {
 		// get window dimensions in pixels
-		monitor := getMonitorForWindow(w.viewport)
+		monitor := w.getMonitorForWindow()
 		monMode := monitor.GetVideoMode()
 
 		// these come into play when dealing with multiple monitors
 		monX, monY := monitor.GetPos()
 		
-		// get current size of content inside the window
-		winContentSize := w.Content().MinSize()
 		// get current window dimensions in pixels
 		viewWidth, viewHeight := w.viewport.GetSize()
-
-		// take the larger of the window size and the content
-		// if the window is hidden, the content will be larger
-		viewWidth = fyne.Max(winContentSize.Width, viewWidth)
-		viewHeight = fyne.Max(winContentSize.Height, viewHeight)
 
 		// math them to the middle
 		newX := (monMode.Width / 2) - (viewWidth / 2) + monX
@@ -167,25 +162,30 @@ func scaleForDpi(xdpi int) float32 {
 	return float32(1.0)
 }
 
-func getMonitorForWindow(win *glfw.Window) *glfw.Monitor {
-	winx, winy := win.GetPos()
+func (w *window) getMonitorForWindow() *glfw.Monitor {
 	for _, monitor := range glfw.GetMonitors() {
 		x, y := monitor.GetPos()
 
-		if x > winx || y > winy {
+		if x > w.xpos || y > w.ypos {
 			continue
 		}
-		if x+monitor.GetVideoMode().Width <= winx || y+monitor.GetVideoMode().Height <= winy {
+		if x+monitor.GetVideoMode().Width <= w.xpos || y+monitor.GetVideoMode().Height <= w.ypos {
 			continue
 		}
 
 		return monitor
 	}
 
-	return glfw.GetPrimaryMonitor()
+	// try built-in function to detect monitor if above logic didn't succeed
+	// if it doesn't work then return primary monitor as default
+	monitor := w.viewport.GetMonitor()
+	if monitor == nil {
+		monitor = glfw.GetPrimaryMonitor()
+	}
+	return monitor
 }
 
-func detectScale(win *glfw.Window) float32 {
+func (w *window) detectScale() float32 {
 	env := os.Getenv("FYNE_SCALE")
 	if env != "" {
 		scale, err := strconv.ParseFloat(env, 32)
@@ -196,7 +196,7 @@ func detectScale(win *glfw.Window) float32 {
 		}
 	}
 
-	monitor := getMonitorForWindow(win)
+	monitor := w.getMonitorForWindow()
 	widthMm, _ := monitor.GetPhysicalSize()
 	widthPx := monitor.GetVideoMode().Width
 
@@ -242,7 +242,7 @@ func (w *window) resize(size fyne.Size) {
 func (w *window) SetContent(content fyne.CanvasObject) {
 	w.canvas.SetContent(content)
 	min := content.MinSize()
-	w.canvas.SetScale(detectScale(w.viewport))
+	w.canvas.SetScale(w.detectScale())
 
 	if w.Padded() {
 		pad := theme.Padding() * 2
@@ -268,8 +268,10 @@ func (w *window) closed(viewport *glfw.Window) {
 }
 
 func (w *window) moved(viewport *glfw.Window, x, y int) {
+	// save coordinates
+	w.xpos, w.ypos = x, y
 	scale := w.canvas.scale
-	newScale := detectScale(w.viewport)
+	newScale := w.detectScale()
 
 	if scale == newScale {
 		return

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -30,6 +30,10 @@ func (w *testWindow) SetFullScreen(fullScreen bool) {
 	w.fullScreen = fullScreen
 }
 
+func (w *testWindow) CenterOnScreen() {
+	// no-op
+}
+
 func (w *testWindow) Resize(fyne.Size) {
 	// no-op
 }

--- a/window.go
+++ b/window.go
@@ -25,6 +25,9 @@ type Window interface {
 	// size or allow resizing.
 	SetFixedSize(bool)
 
+	// CenterOnScreen places a window at the center of the monitor
+	CenterOnScreen()
+
 	// Padded, normally true, states whether the window should have inner
 	// padding so that components do not touch the window edge.
 	Padded() bool

--- a/window.go
+++ b/window.go
@@ -26,6 +26,7 @@ type Window interface {
 	SetFixedSize(bool)
 
 	// CenterOnScreen places a window at the center of the monitor
+	// the Window object is currently positioned on
 	CenterOnScreen()
 
 	// Padded, normally true, states whether the window should have inner


### PR DESCRIPTION
I feel badly about this, but it turns out https://github.com/fyne-io/fyne/pull/95 wasn't as great as I had thought.  Reading the documentation more says that `win.GetMonitor()` only works when the window is fullscreen.  Your implementation works even when a window is not fullscreen, so it's probably best to revert back to it.  Apologies!

I found that because I made a function to center a window on the screen, and I have a dual-monitor setup that was always using the first (primary) monitor to center to.  Since Window is an interface, I had to make a function for the efl library also, but my desktop apparently doesn't have the correct efl libraries installed so I couldn't build it (I enabled the build configuration correctly for the go files).  If you are not comfortable merging in a TODO for efl, I understand :)