### PR TITLE
Deprecated: cache svg raster scans for performance

### DIFF
--- a/driver/gl/canvas.go
+++ b/driver/gl/canvas.go
@@ -2,6 +2,7 @@ package gl
 
 import (
 	"math"
+	"sync"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/theme"
@@ -9,6 +10,7 @@ import (
 )
 
 type glCanvas struct {
+	sync.RWMutex
 	window  *window
 	content fyne.CanvasObject
 	focused fyne.FocusableObject
@@ -40,11 +42,16 @@ func unscaleInt(c fyne.Canvas, v int) int {
 }
 
 func (c *glCanvas) Content() fyne.CanvasObject {
-	return c.content
+	c.RLock()
+	retval := c.content
+	c.RUnlock()
+	return retval
 }
 
 func (c *glCanvas) SetContent(content fyne.CanvasObject) {
+	c.Lock()
 	c.content = content
+	c.Unlock()
 
 	var w, h = c.window.viewport.GetSize()
 

--- a/driver/gl/gl.go
+++ b/driver/gl/gl.go
@@ -25,7 +25,6 @@ import (
 	"github.com/goki/freetype/truetype"
 	"github.com/srwiley/oksvg"
 	"github.com/srwiley/rasterx"
-	"github.com/steveoc64/memdebug"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )
@@ -219,7 +218,6 @@ func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
 			defer rasterMutex.Unlock()
 			info := rasters[img.Resource]
 			if info == nil || info.w != width || info.h != height || info.alpha != img.Alpha() {
-				memdebug.Print(time.Now(), "is not cached", name)
 				icon, err := oksvg.ReadIconStream(file)
 				if err != nil {
 					log.Println("SVG Load error:", err)
@@ -252,7 +250,6 @@ func (c *glCanvas) newGlImageTexture(obj fyne.CanvasObject) uint32 {
 					}
 				}
 			} else {
-				memdebug.Print(time.Now(), "CACHED", name)
 				raw = info.pix
 				info.expires = time.Now().Add(cacheDuration)
 			}

--- a/driver/gl/raster_cache.go
+++ b/driver/gl/raster_cache.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"fyne.io/fyne"
-	"github.com/steveoc64/memdebug"
 )
 
 type rasterInfo struct {
@@ -18,16 +17,11 @@ type rasterInfo struct {
 }
 
 var cacheDuration = (time.Minute * 5)
-var rasters map[fyne.Resource]*rasterInfo
+var rasters = make(map[fyne.Resource]*rasterInfo)
 var rasterMutex sync.RWMutex
 
 func init() {
-	memdebug.Print(time.Now(), "init rasters")
-	rasters = make(map[fyne.Resource]*rasterInfo)
-
 	if t, err := time.ParseDuration(os.Getenv("FYNE_CACHE")); err == nil {
-		t1 := time.Now()
-		memdebug.Print(t1, "parsed duration", os.Getenv("FYNE_CACHE"), t)
 		cacheDuration = t
 	}
 
@@ -39,12 +33,10 @@ func init() {
 		for {
 			time.Sleep(delay)
 			now := time.Now()
-			memdebug.Print(now, "check exp")
 			rasterMutex.Lock()
 			for k, v := range rasters {
 				if v.expires.Before(now) {
 					delete(rasters, k)
-					memdebug.Print(time.Now(), "expires", v.expires)
 				}
 			}
 			rasterMutex.Unlock()

--- a/driver/gl/raster_cache.go
+++ b/driver/gl/raster_cache.go
@@ -1,0 +1,63 @@
+package gl
+
+import (
+	"image"
+	"sync"
+	"time"
+
+	"fyne.io/fyne"
+	"github.com/steveoc64/memdebug"
+)
+
+type rasterInfo struct {
+	pix     *image.RGBA
+	w, h    int
+	alpha   float64
+	expires time.Time
+}
+
+var cacheDuration = (time.Minute * 5)
+var rasters map[fyne.Resource]*rasterInfo
+var rasterMutex sync.RWMutex
+
+// CacheHoldDuration returns the cache hold duration (default 5 mins)
+func CacheDuration() time.Duration {
+	rasterMutex.RLock()
+	defer rasterMutex.RUnlock()
+	return cacheDuration
+}
+
+// SetCacheHoldDuration sets the new cache hold duration
+func SetCacheDuration(t time.Duration) {
+	rasterMutex.Lock()
+	defer rasterMutex.Unlock()
+	cacheDuration = t
+}
+
+func init() {
+	memdebug.Print(time.Now(), "init rasters")
+	rasters = make(map[fyne.Resource]*rasterInfo)
+
+	janitor := func() {
+		for {
+			if cacheDuration < time.Second {
+				time.Sleep(time.Second)
+			} else {
+				time.Sleep(cacheDuration)
+			}
+			now := time.Now()
+			memdebug.Print(now, "check exp")
+			rasterMutex.Lock()
+			for k, v := range rasters {
+				if v.expires.Before(now) {
+					delete(rasters, k)
+					memdebug.Print(time.Now(), "expires", v.expires)
+				}
+			}
+			rasterMutex.Unlock()
+		}
+	}
+
+	go janitor()
+
+}

--- a/driver/gl/raster_cache.go
+++ b/driver/gl/raster_cache.go
@@ -27,13 +27,17 @@ func init() {
 
 	if t, err := time.ParseDuration(os.Getenv("FYNE_CACHE")); err == nil {
 		t1 := time.Now()
-		memdebug.Print(t1, "parsed duration", t)
+		memdebug.Print(t1, "parsed duration", os.Getenv("FYNE_CACHE"), t)
 		cacheDuration = t
 	}
 
 	janitor := func() {
+		delay := cacheDuration / 2
+		if delay < time.Second {
+			delay = time.Second
+		}
 		for {
-			time.Sleep(time.Minute)
+			time.Sleep(delay)
 			now := time.Now()
 			memdebug.Print(now, "check exp")
 			rasterMutex.Lock()

--- a/driver/gl/raster_cache.go
+++ b/driver/gl/raster_cache.go
@@ -2,6 +2,7 @@ package gl
 
 import (
 	"image"
+	"os"
 	"sync"
 	"time"
 
@@ -20,24 +21,15 @@ var cacheDuration = (time.Minute * 5)
 var rasters map[fyne.Resource]*rasterInfo
 var rasterMutex sync.RWMutex
 
-// CacheHoldDuration returns the cache hold duration (default 5 mins)
-func CacheDuration() time.Duration {
-	rasterMutex.RLock()
-	defer rasterMutex.RUnlock()
-	return cacheDuration
-}
-
-// SetCacheHoldDuration sets the new cache hold duration
-func SetCacheDuration(t time.Duration) {
-	rasterMutex.Lock()
-	defer rasterMutex.Unlock()
-	memdebug.Print(time.Now(), "cache duration set to", t)
-	cacheDuration = t
-}
-
 func init() {
 	memdebug.Print(time.Now(), "init rasters")
 	rasters = make(map[fyne.Resource]*rasterInfo)
+
+	if t, err := time.ParseDuration(os.Getenv("FYNE_CACHE")); err == nil {
+		t1 := time.Now()
+		memdebug.Print(t1, "parsed duration", t)
+		cacheDuration = t
+	}
 
 	janitor := func() {
 		for {

--- a/driver/gl/raster_cache.go
+++ b/driver/gl/raster_cache.go
@@ -31,6 +31,7 @@ func CacheDuration() time.Duration {
 func SetCacheDuration(t time.Duration) {
 	rasterMutex.Lock()
 	defer rasterMutex.Unlock()
+	memdebug.Print(time.Now(), "cache duration set to", t)
 	cacheDuration = t
 }
 
@@ -40,11 +41,7 @@ func init() {
 
 	janitor := func() {
 		for {
-			if cacheDuration < time.Second {
-				time.Sleep(time.Second)
-			} else {
-				time.Sleep(cacheDuration)
-			}
+			time.Sleep(time.Minute)
 			now := time.Now()
 			memdebug.Print(now, "check exp")
 			rasterMutex.Lock()

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -143,7 +143,7 @@ func (w *window) SetIcon(icon fyne.Resource) {
 }
 
 func (w *window) fitContent() {
-	if w.canvas.content == nil {
+	if w.canvas.Content() == nil {
 		return
 	}
 


### PR DESCRIPTION
Superceded by : https://github.com/fyne-io/fyne/pull/130

This starts as a straight, unedited copy of Andy's SVG caching patch. Tested and :+1: from me.

Once cached, the image is cached for the life of the program, so be careful of memleaks.  

So, if the canvasObject is discarded, and GC'd at some point, then the rasterized cache remains in memory. If you are careful with the way you manage canvasObjects in your app, this is OK.  But otherwise, lots of memory leaks.

So, Ive updated the cache here to hold onto rastered images for some arbitrary time period (default = 5 minutes), and discard them if they havent been accessed for that time.  If they are needed again, they are re-scanned.

You can set the cacheHoldTime by setting the env var `FYNE_CACHE=<some value>`
where `some value` is any valid string that can be parsed by https://golang.org/pkg/time/#ParseDuration

The expiry janitor runs at twice this frequency, with a minimum time of 1 second (so the expiry janitor doesnt end up spinning the CPU out of control)

If you set FYNE_CACHE=0   this will turn all SVG caching off in the GL driver.
