### PR TITLE
Reduce godoc stutter

### DIFF
--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -1,4 +1,3 @@
-// Package canvas contains all of the primitive CanvasObjects that make up a Fyne GUI
 package canvas
 
 import "image/color"


### PR DESCRIPTION
This PR is to clean up the godoc rendering of the canvas package:
https://godoc.org/fyne.io/fyne/canvas
The other occurrence of this string is found in `base.go`.