### PR TITLE
Destroyed

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -48,6 +48,10 @@ func (app *fyneApp) Run() {
 }
 
 func (app *fyneApp) Quit() {
+	for _, window := range app.driver.AllWindows() {
+		window.Close()
+	}
+
 	app.driver.Quit()
 	app.running = false
 }

--- a/canvas/base.go
+++ b/canvas/base.go
@@ -60,6 +60,10 @@ func (r *baseObject) Hide() {
 	r.Hidden = true
 }
 
+func (r *baseObject) Destroyed() {
+	r = nil
+}
+
 // Refresh instructs the containing canvas to refresh the specified obj.
 func Refresh(obj fyne.CanvasObject) {
 	c := fyne.CurrentApp().Driver().CanvasForObject(obj)

--- a/canvas/circle.go
+++ b/canvas/circle.go
@@ -64,6 +64,11 @@ func (l *Circle) Hide() {
 	Refresh(l)
 }
 
+// Destroyed will free resources
+func (l *Circle) Destroyed() {
+	l.Hidden = true
+}
+
 // NewCircle returns a new Circle instance
 func NewCircle(color color.Color) *Circle {
 	return &Circle{

--- a/canvas/line.go
+++ b/canvas/line.go
@@ -67,6 +67,11 @@ func (l *Line) Hide() {
 	Refresh(l)
 }
 
+// Destroyed will free resources
+func (l *Line) Destroyed() {
+	l.Hidden = true
+}
+
 // NewLine returns a new Line instance
 func NewLine(color color.Color) *Line {
 	return &Line{

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -19,6 +19,9 @@ type CanvasObject interface {
 	Visible() bool
 	Show()
 	Hide()
+
+	// life events
+	Destroyed()
 }
 
 // Themeable indicates that the associated CanvasObject responds to theme

--- a/container.go
+++ b/container.go
@@ -81,6 +81,13 @@ func (c *Container) Hide() {
 	}
 }
 
+func (c *Container) Destroyed() {
+	for _, child := range c.Objects {
+		child.Destroyed()
+	}
+	c = nil
+}
+
 // AddObject adds another CanvasObject to the set this Container holds.
 func (c *Container) AddObject(o CanvasObject) {
 	c.Objects = append(c.Objects, o)

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -2,7 +2,6 @@ package gl
 
 import (
 	"bytes"
-	"fmt"
 	"image"
 	_ "image/png" // for the icon
 	"log"
@@ -331,7 +330,6 @@ func (w *window) closed(viewport *glfw.Window) {
 	viewport.SetShouldClose(true)
 
 	// destroy all elements inside the window
-	fmt.Println("in window.closed(), calling content.Destroyed()")
 	w.canvas.content.Destroyed()
 
 	// trigger callbacks

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -2,11 +2,11 @@ package gl
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	_ "image/png" // for the icon
 	"log"
 	"os"
-	"fmt"
 	"runtime"
 	"strconv"
 

--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -6,6 +6,7 @@ import (
 	_ "image/png" // for the icon
 	"log"
 	"os"
+	"fmt"
 	"runtime"
 	"strconv"
 
@@ -328,6 +329,10 @@ func (w *window) Canvas() fyne.Canvas {
 
 func (w *window) closed(viewport *glfw.Window) {
 	viewport.SetShouldClose(true)
+
+	// destroy all elements inside the window
+	fmt.Println("in window.closed(), calling content.Destroyed()")
+	w.canvas.content.Destroyed()
 
 	// trigger callbacks
 	if w.onClosed != nil {

--- a/layout/spacer.go
+++ b/layout/spacer.go
@@ -69,6 +69,11 @@ func (s *Spacer) Hide() {
 	s.hidden = true
 }
 
+// Destroyed removes this Spacer from layout calculations
+func (s *Spacer) Destroyed() {
+	s.hidden = true
+}
+
 // NewSpacer returns a spacer object which can fill vertical and horizontal
 // space. This is primarily used with a box layout.
 func NewSpacer() fyne.CanvasObject {

--- a/widget.go
+++ b/widget.go
@@ -22,4 +22,6 @@ type WidgetRenderer interface {
 	ApplyTheme()
 	BackgroundColor() color.Color
 	Objects() []CanvasObject
+
+	Destroy()
 }

--- a/widget/box.go
+++ b/widget/box.go
@@ -137,3 +137,7 @@ func (b *boxRenderer) Refresh() {
 
 	canvas.Refresh(b.box)
 }
+
+func (b *boxRenderer) Destroy() {
+	b.box = nil
+}

--- a/widget/box.go
+++ b/widget/box.go
@@ -46,6 +46,10 @@ func (b *Box) Hide() {
 	b.hide(b)
 }
 
+func (b *Box) Destroyed() {
+	b.destroyed(b)
+}
+
 // ApplyTheme updates this box to match the current theme
 func (b *Box) ApplyTheme() {
 	b.background = theme.BackgroundColor()

--- a/widget/button.go
+++ b/widget/button.go
@@ -97,6 +97,12 @@ func (b *buttonRenderer) Objects() []fyne.CanvasObject {
 	return b.objects
 }
 
+func (b *buttonRenderer) Destroy() {
+	b.icon = nil
+	b.label = nil
+	b.button = nil
+}
+
 // Button widget has a text label and triggers an event func when clicked
 type Button struct {
 	baseWidget

--- a/widget/button.go
+++ b/widget/button.go
@@ -144,6 +144,10 @@ func (b *Button) Hide() {
 	b.hide(b)
 }
 
+func (b *Button) Destroyed() {
+	b.destroyed(b)
+}
+
 // Tapped is called when a pointer tapped event is captured and triggers any tap handler
 func (b *Button) Tapped(*fyne.PointEvent) {
 	if b.OnTapped != nil {

--- a/widget/check.go
+++ b/widget/check.go
@@ -116,6 +116,10 @@ func (c *Check) Hide() {
 	c.hide(c)
 }
 
+func (c *Check) Destroyed() {
+	c.destroyed(c)
+}
+
 // Tapped is called when a pointer tapped event is captured and triggers any change handler
 func (c *Check) Tapped(*fyne.PointEvent) {
 	c.SetChecked(!c.Checked)

--- a/widget/check.go
+++ b/widget/check.go
@@ -65,6 +65,12 @@ func (c *checkRenderer) Objects() []fyne.CanvasObject {
 	return c.objects
 }
 
+func (c *checkRenderer) Destroy() {
+	c.icon = nil
+	c.label = nil
+	c.check = nil
+}
+
 // Check widget has a text label and a checked (or unchecked) icon and triggers an event func when toggled
 type Check struct {
 	baseWidget

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -106,6 +106,14 @@ func (e *entryRenderer) Objects() []fyne.CanvasObject {
 	return e.objects
 }
 
+func (e *entryRenderer) Destroy() {
+	e.text = nil
+	e.placeholder = nil
+	e.line = nil
+	e.cursor = nil
+	e.entry = nil
+}
+
 // Entry widget allows simple text to be input when focused.
 type Entry struct {
 	baseWidget

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -155,6 +155,10 @@ func (e *Entry) Hide() {
 	e.hide(e)
 }
 
+func (e *Entry) Destroyed() {
+	e.destroyed(e)
+}
+
 // SetText manually sets the text of the Entry to the given text value.
 func (e *Entry) SetText(text string) {
 	e.textProvider().SetText(text)

--- a/widget/form.go
+++ b/widget/form.go
@@ -52,6 +52,10 @@ func (f *Form) Hide() {
 	f.hide(f)
 }
 
+func (f *Form) Destroyed() {
+	f.destroyed(f)
+}
+
 func (f *Form) createLabel(text string) *Label {
 	return NewLabelWithStyle(text, fyne.TextAlignTrailing, fyne.TextStyle{Bold: true})
 }

--- a/widget/group.go
+++ b/widget/group.go
@@ -48,7 +48,6 @@ func (g *Group) Destroyed() {
 	g.destroyed(g)
 }
 
-
 // Prepend inserts a new CanvasObject at the top of the group
 func (g *Group) Prepend(object fyne.CanvasObject) {
 	g.box.Prepend(object)
@@ -143,4 +142,11 @@ func (g *groupRenderer) Refresh() {
 	g.Layout(g.group.Size())
 
 	canvas.Refresh(g.group)
+}
+
+func (g *groupRenderer) Destroy() {
+	g.label = nil
+	g.line = nil
+	g.labelBg = nil
+	g.group = nil
 }

--- a/widget/group.go
+++ b/widget/group.go
@@ -44,6 +44,11 @@ func (g *Group) Hide() {
 	g.hide(g)
 }
 
+func (g *Group) Destroyed() {
+	g.destroyed(g)
+}
+
+
 // Prepend inserts a new CanvasObject at the top of the group
 func (g *Group) Prepend(object fyne.CanvasObject) {
 	g.box.Prepend(object)

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -124,3 +124,7 @@ func (hl *Hyperlink) Show() {
 func (hl *Hyperlink) Hide() {
 	hl.hide(hl)
 }
+
+func (hl *Hyperlink) Destroyed() {
+	hl.destroyed(hl)
+}

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -87,6 +87,10 @@ func (i *Icon) Hide() {
 	i.hide(i)
 }
 
+func (i *Icon) Destroyed() {
+	i.destroyed(i)
+}
+
 // SetResource updates the resource rendered in this icon widget
 func (i *Icon) SetResource(res fyne.Resource) {
 	i.Resource = res

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -53,6 +53,10 @@ func (i *iconRenderer) Refresh() {
 	canvas.Refresh(i.image)
 }
 
+func (i *iconRenderer) Destroy() {
+	i.image = nil
+}
+
 // Icon widget is a basic image component that load's its resource to match the theme.
 type Icon struct {
 	baseWidget

--- a/widget/label.go
+++ b/widget/label.go
@@ -94,3 +94,7 @@ func (l *Label) Show() {
 func (l *Label) Hide() {
 	l.hide(l)
 }
+
+func (l *Label) Destroyed() {
+	l.destroyed(l)
+}

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -107,6 +107,11 @@ func (p *ProgressBar) Hide() {
 	p.hide(p)
 }
 
+func (p *ProgressBar) Destroyed() {
+	p.hide(p)
+	p.destroyed(p)
+}
+
 // SetValue changes the current value of this progress bar (from p.Min to p.Max).
 // The widget will be refreshed to indicate the change.
 func (p *ProgressBar) SetValue(v float64) {

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -73,6 +73,12 @@ func (p *progressRenderer) Objects() []fyne.CanvasObject {
 	return p.objects
 }
 
+func (p *progressRenderer) Destroy() {
+	p.bar = nil
+	p.label = nil
+	p.progress = nil
+}
+
 // ProgressBar widget creates a horizontal panel that indicates progress
 type ProgressBar struct {
 	baseWidget

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -169,6 +169,11 @@ func (p *ProgressBarInfinite) Hide() {
 	p.hide(p)
 }
 
+func (p *ProgressBarInfinite) Destroyed() {
+	p.Stop()
+	p.destroyed(p)
+}
+
 // Start the infinite progress bar background thread to update it continuously
 func (p *ProgressBarInfinite) Start() {
 	Renderer(p).(*infProgressRenderer).start()

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -134,6 +134,13 @@ func (p *infProgressRenderer) infiniteProgressLoop() {
 	}
 }
 
+func (p *infProgressRenderer) Destroy() {
+	p.stop()
+	p.bar = nil
+	p.tickMutex = nil
+	p.progress = nil
+}
+
 // ProgressBarInfinite widget creates a horizontal panel that indicates waiting indefinitely
 // An infinite progress bar loops 0% -> 100% repeatedly until Stop() is called
 type ProgressBarInfinite struct {

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -143,6 +143,10 @@ func (r *Radio) Hide() {
 	r.hide(r)
 }
 
+func (r *Radio) Destroyed() {
+	r.destroyed(r)
+}
+
 // Tapped is called when a pointer tapped event is captured and triggers any change handler
 func (r *Radio) Tapped(event *fyne.PointEvent) {
 	index := (event.Position.Y - theme.Padding()) / r.itemHeight()

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -106,6 +106,15 @@ func (r *radioRenderer) Objects() []fyne.CanvasObject {
 	return r.objects
 }
 
+func (r *radioRenderer) Destroy() {
+	for _, item := range r.items {
+		item.icon = nil
+		item.label = nil
+	}
+	r.items = nil
+	r.radio = nil
+}
+
 // Radio widget has a list of text labels and radio check icons next to each.
 // Changing the selection (only one can be selected) will trigger the changed func.
 type Radio struct {

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -79,6 +79,11 @@ func (s *scrollRenderer) Objects() []fyne.CanvasObject {
 	return s.objects
 }
 
+func (s *scrollRenderer) Destroy() {
+	s.vertBar = nil
+	s.scroll = nil
+}
+
 // ScrollContainer defines a container that is smaller than the Content.
 // The Offset is used to determine the position of the child widgets within the container.
 type ScrollContainer struct {

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -132,6 +132,10 @@ func (s *ScrollContainer) Hide() {
 	s.hide(s)
 }
 
+func (s *ScrollContainer) Destroyed() {
+	s.destroyed(s)
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to it's renderer
 func (s *ScrollContainer) CreateRenderer() fyne.WidgetRenderer {
 	bar := canvas.NewRectangle(theme.ScrollBarColor())

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -56,6 +56,10 @@ func (t *TabContainer) Hide() {
 	t.hide(t)
 }
 
+func (t *TabContainer) Destroyed() {
+	t.destroyed(t)
+}
+
 // SelectTab sets the specified TabItem to be selected and it's content visible.
 func (t *TabContainer) SelectTab(item *TabItem) {
 	for i, child := range t.Items {

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -210,3 +210,9 @@ func (t *tabContainerRenderer) Refresh() {
 		Renderer(button.(*Button)).Refresh()
 	}
 }
+
+func (t *tabContainerRenderer) Destroy() {
+	t.tabBar = nil
+	t.line = nil
+	t.container = nil
+}

--- a/widget/text.go
+++ b/widget/text.go
@@ -73,6 +73,10 @@ func (t *textProvider) Hide() {
 	t.hide(t)
 }
 
+func (t *textProvider) Destroyed() {
+	t.destroyed(t)
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to it's renderer
 func (t *textProvider) CreateRenderer() fyne.WidgetRenderer {
 	if t.presenter == nil {

--- a/widget/text.go
+++ b/widget/text.go
@@ -276,6 +276,11 @@ func (r *textRenderer) BackgroundColor() color.Color {
 	return color.Transparent
 }
 
+func (r *textRenderer) Destroy() {
+	r.texts = nil
+	r.provider = nil
+}
+
 // lineSize returns the rendered size for the line specified by col and row
 func (r *textRenderer) lineSize(col, row int) (size fyne.Size) {
 	text := r.provider

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -95,6 +95,10 @@ func (t *Toolbar) Hide() {
 	t.hide(t)
 }
 
+func (t *Toolbar) Destroyed() {
+	t.destroyed(t)
+}
+
 func (t *Toolbar) append(item ToolbarItem) {
 	if t.box == nil { // TODO fix smell
 		Renderer(t)

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -2,7 +2,6 @@
 package widget // import "fyne.io/fyne/widget"
 
 import (
-	"fmt"
 	"sync"
 
 	"fyne.io/fyne"
@@ -72,7 +71,6 @@ func (w *baseWidget) hide(parent fyne.Widget) {
 }
 
 func (w *baseWidget) destroyed(parent fyne.Widget) {
-	fmt.Println("in baseWidget.destroyed()")
 	for _, child := range Renderer(parent).Objects() {
 		child.Destroyed()
 	}

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -2,7 +2,7 @@
 package widget // import "fyne.io/fyne/widget"
 
 import (
-"fmt"
+	"fmt"
 	"sync"
 
 	"fyne.io/fyne"
@@ -77,6 +77,7 @@ func (w *baseWidget) destroyed(parent fyne.Widget) {
 		child.Destroyed()
 	}
 	// set renderer and widget to be garbage collected
+	Renderer(parent).Destroy()
 	renderers.Delete(parent)
 	parent = nil
 	w = nil

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -2,6 +2,7 @@
 package widget // import "fyne.io/fyne/widget"
 
 import (
+"fmt"
 	"sync"
 
 	"fyne.io/fyne"
@@ -68,6 +69,17 @@ func (w *baseWidget) hide(parent fyne.Widget) {
 	}
 
 	canvas.Refresh(parent)
+}
+
+func (w *baseWidget) destroyed(parent fyne.Widget) {
+	fmt.Println("in baseWidget.destroyed()")
+	for _, child := range Renderer(parent).Objects() {
+		child.Destroyed()
+	}
+	// set renderer and widget to be garbage collected
+	renderers.Delete(parent)
+	parent = nil
+	w = nil
 }
 
 var renderers sync.Map


### PR DESCRIPTION
An attempt at #131 

fyne.CanvasObject has new method `Destroyed()` (which is inherited up to every widget also)
fyne.WidgetRenderer has new method `Destroy()`
baseWidget has new internal method `destroyed()` which is called by every widget's `Destroyed()` method.  It loops through all children of the widget, destroying them, then deletes it's own renderer from the map.

When `window.closed()` is called, it now calls `w.canvas.content.Destroyed()`, which loops through all children elements and deletes their renderers and widget objects (inside of the baseWidget's `destroyed()` ).

This is currently mainly just setting a lot of elements to nil and waiting for go's GC to sweep by.  I think as elements get more advanced, there will be more logic in the destroy routines.

I tried to keep this out of the gl driver because it seemed like a fyne problem and not a driver-specific problem.  Adding to when a window closed made sense as a good time to destroy an object - if a window is open and an object takes a few seconds to load (like a movie in a tab or something), it could be bad experience to destroy the video every time the tab changes.

Thoughts welcome :) like I said, this is a stab at what I think it could be, that doesn't mean it's what it should be!