### PR TITLE
gl/clipboard: remove error log to avoid false positive

### DIFF
--- a/driver/gl/clipboard.go
+++ b/driver/gl/clipboard.go
@@ -1,7 +1,6 @@
 package gl
 
 import (
-	"fyne.io/fyne"
 	"github.com/go-gl/glfw/v3.2/glfw"
 )
 

--- a/driver/gl/clipboard.go
+++ b/driver/gl/clipboard.go
@@ -14,7 +14,6 @@ type clipboard struct {
 func (c *clipboard) Content() string {
 	content, err := c.window.GetClipboardString()
 	if err != nil {
-		fyne.LogError("unable to get clipboard string", err)
 		return ""
 	}
 	return content


### PR DESCRIPTION
The actual glfw clipboard implementation always return `nil` also when the clipboard is empty and no error occur causing to report a false positive:
```
go test fyne.io/fyne/driver/gl -v  -run ^TestWindow_Clipboard

=== RUN   TestWindow_Clipboard
2019/03/22 18:53:44 Fyne error:  unable to get clipboard string
2019/03/22 18:53:44   Cause: FormatUnavailable: X11: Failed to convert clipboard to string
2019/03/22 18:53:44   At: /code/go/src/fyne.io/fyne/driver/gl/clipboard.go:17
2019/03/22 18:53:44 Fyne error:  unable to get clipboard string
2019/03/22 18:53:44   Cause: FormatUnavailable: X11: Failed to convert clipboard to string
2019/03/22 18:53:44   At: /code/go/src/fyne.io/fyne/driver/gl/clipboard.go:17
--- PASS: TestWindow_Clipboard (0.13s)
PASS
ok  	fyne.io/fyne/driver/gl	0.133s
```