### PR TITLE
on closing windows, build new window slice and reassign

### DIFF
--- a/driver/gl/loop.go
+++ b/driver/gl/loop.go
@@ -75,21 +75,25 @@ func (d *gLDriver) runGL() {
 			clearFontCache()
 		case <-fps.C:
 			glfw.PollEvents()
-			for i, win := range d.windows {
+			newWindows := []fyne.Window{}
+			reassign := false
+			for _, win := range d.windows {
 				viewport := win.(*window).viewport
 
 				canvas := win.(*window).canvas
 				d.freeDirtyTextures(canvas)
 
 				if viewport.ShouldClose() {
+					reassign = true
 					// remove window from window list
-					d.windows = append(d.windows[:i], d.windows[i+1:]...)
 					viewport.Destroy()
 
 					if win.(*window).master {
 						d.Quit()
 					}
 					continue
+				} else {
+					newWindows = append(newWindows, win)
 				}
 
 				if !canvas.isDirty() {
@@ -105,6 +109,9 @@ func (d *gLDriver) runGL() {
 
 				view.viewport.SwapBuffers()
 				glfw.DetachCurrentContext()
+			}
+			if reassign {
+				d.windows = newWindows
 			}
 		}
 	}


### PR DESCRIPTION
When loop finds windows that need closing, then rebuild the slice of active windows at the end, otherwise the value of i gets out of sync if there are multiple windows to close.