### PR TITLE
Fix goroutine leak in infiniteprogressbar

### DIFF
--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -112,7 +112,6 @@ func (p *infProgressRenderer) stop() {
 		p.ticker.Stop()
 		p.tickerStop <- true
 		p.running.Store(false)
-		p.ticker = nil
 	}
 }
 
@@ -182,7 +181,12 @@ func (p *ProgressBarInfinite) Stop() {
 
 // Running returns the current state of the infinite progress animation
 func (p *ProgressBarInfinite) Running() bool {
-	return Renderer(p).(*infProgressRenderer).running.Load().(bool)
+	renderer, ok := renderers.Load(p)
+	if !ok {
+		return false
+	}
+
+	return renderer.(*infProgressRenderer).running.Load().(bool)
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to it's renderer
@@ -195,7 +199,6 @@ func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 	}
 	render.running.Store(false)
 	render.start()
-	// dont start it yet - start it on the first call to Show()
 	return render
 }
 

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -194,6 +194,7 @@ func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 		progress: p,
 	}
 	render.running.Store(false)
+	render.start()
 	// dont start it yet - start it on the first call to Show()
 	return render
 }

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -18,11 +18,11 @@ const (
 )
 
 type infProgressRenderer struct {
-	objects   []fyne.CanvasObject
-	bar       *canvas.Rectangle
-	ticker    *time.Ticker
+	objects    []fyne.CanvasObject
+	bar        *canvas.Rectangle
+	ticker     *time.Ticker
 	tickerStop chan bool
-	running atomic.Value
+	running    atomic.Value
 
 	progress *ProgressBarInfinite
 }
@@ -123,8 +123,8 @@ func (p *infProgressRenderer) infiniteProgressLoop() {
 		case <-p.ticker.C:
 			p.Refresh()
 			break
-			case <- p.tickerStop:
-				return // quit the infinite loop
+		case <-p.tickerStop:
+			return // quit the infinite loop
 
 		}
 	}
@@ -193,8 +193,8 @@ func (p *ProgressBarInfinite) Running() bool {
 func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 	bar := canvas.NewRectangle(theme.PrimaryColor())
 	render := &infProgressRenderer{
-		objects: []fyne.CanvasObject{bar},
-		bar: bar,
+		objects:  []fyne.CanvasObject{bar},
+		bar:      bar,
 		progress: p,
 	}
 	render.running.Store(false)

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -2,7 +2,7 @@ package widget
 
 import (
 	"image/color"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"fyne.io/fyne"
@@ -21,7 +21,8 @@ type infProgressRenderer struct {
 	objects   []fyne.CanvasObject
 	bar       *canvas.Rectangle
 	ticker    *time.Ticker
-	tickMutex *sync.Mutex
+	tickerStop chan bool
+	running atomic.Value
 
 	progress *ProgressBarInfinite
 }
@@ -94,19 +95,12 @@ func (p *infProgressRenderer) Objects() []fyne.CanvasObject {
 	return p.objects
 }
 
-func (p *infProgressRenderer) tickerSafe() *time.Ticker {
-	p.tickMutex.Lock()
-	defer p.tickMutex.Unlock()
-
-	return p.ticker
-}
-
 // Start the infinite progress bar background thread to update it continuously
 func (p *infProgressRenderer) start() {
-	if p.ticker == nil {
-		p.tickMutex.Lock()
+	if !p.running.Load().(bool) {
 		p.ticker = time.NewTicker(infiniteRefreshRate)
-		p.tickMutex.Unlock()
+		p.tickerStop = make(chan bool, 1)
+		p.running.Store(true)
 
 		go p.infiniteProgressLoop()
 	}
@@ -114,22 +108,25 @@ func (p *infProgressRenderer) start() {
 
 // Stop the infinite progress goroutine and sets value to the Max
 func (p *infProgressRenderer) stop() {
-	if p.tickerSafe() != nil {
-		p.tickMutex.Lock()
+	if p.running.Load().(bool) {
 		p.ticker.Stop()
+		p.tickerStop <- true
+		p.running.Store(false)
 		p.ticker = nil
-		p.tickMutex.Unlock()
 	}
 }
 
 // infiniteProgressLoop should be called as a goroutine to update the inner infinite progress bar
 // the function can be exited by calling Stop()
 func (p *infProgressRenderer) infiniteProgressLoop() {
-	for p.tickerSafe() != nil {
+	for p.running.Load().(bool) {
 		select {
-		case <-p.tickerSafe().C:
+		case <-p.ticker.C:
 			p.Refresh()
 			break
+			case <- p.tickerStop:
+				return // quit the infinite loop
+
 		}
 	}
 }
@@ -185,14 +182,19 @@ func (p *ProgressBarInfinite) Stop() {
 
 // Running returns the current state of the infinite progress animation
 func (p *ProgressBarInfinite) Running() bool {
-	return Renderer(p).(*infProgressRenderer).tickerSafe() != nil
+	return Renderer(p).(*infProgressRenderer).running.Load().(bool)
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to it's renderer
 func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 	bar := canvas.NewRectangle(theme.PrimaryColor())
-	render := &infProgressRenderer{[]fyne.CanvasObject{bar}, bar, nil, &sync.Mutex{}, p}
-	render.start()
+	render := &infProgressRenderer{
+		objects: []fyne.CanvasObject{bar},
+		bar: bar,
+		progress: p,
+	}
+	render.running.Store(false)
+	// dont start it yet - start it on the first call to Show()
 	return render
 }
 

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -18,12 +18,12 @@ func TestProgressBarInfinite_Destroy(t *testing.T) {
 	bar := NewProgressBarInfinite()
 	_, found := renderers.Load(bar)
 	assert.True(t, found)
-	rend := Renderer(bar).(*infProgressRenderer)
-	assert.NotNil(t, rend.ticker)
+	assert.True(t, bar.Running())
 
 	// check that it stopped
 	DestroyRenderer(bar)
-	assert.Nil(t, rend.ticker)
+	assert.False(t, bar.Running())
+
 	// and that the cache was removed
 	_, found = renderers.Load(bar)
 	assert.False(t, found)

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestProgressBarInfinite_Creation(t *testing.T) {
 	bar := NewProgressBarInfinite()
+	bar.Show()
 	// ticker should start automatically
 	assert.True(t, bar.Running())
 }
@@ -19,6 +20,7 @@ func TestProgressBarInfinite_Destroy(t *testing.T) {
 	_, found := renderers.Load(bar)
 	assert.True(t, found)
 	rend := Renderer(bar).(*infProgressRenderer)
+	bar.Show()
 	assert.NotNil(t, rend.ticker)
 
 	// check that it stopped
@@ -31,6 +33,7 @@ func TestProgressBarInfinite_Destroy(t *testing.T) {
 
 func TestProgressBarInfinite_Reshown(t *testing.T) {
 	bar := NewProgressBarInfinite()
+	bar.Show()
 
 	assert.True(t, bar.Running())
 	bar.Hide()
@@ -47,6 +50,7 @@ func TestProgressBarInfinite_Reshown(t *testing.T) {
 
 func TestInfiniteProgressRenderer_Layout(t *testing.T) {
 	bar := NewProgressBarInfinite()
+	bar.Show()
 	width := 100.0
 	bar.Resize(fyne.NewSize(int(width), 10))
 

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestProgressBarInfinite_Creation(t *testing.T) {
 	bar := NewProgressBarInfinite()
-	bar.Show()
 	// ticker should start automatically
 	assert.True(t, bar.Running())
 }
@@ -20,7 +19,6 @@ func TestProgressBarInfinite_Destroy(t *testing.T) {
 	_, found := renderers.Load(bar)
 	assert.True(t, found)
 	rend := Renderer(bar).(*infProgressRenderer)
-	bar.Show()
 	assert.NotNil(t, rend.ticker)
 
 	// check that it stopped
@@ -33,7 +31,6 @@ func TestProgressBarInfinite_Destroy(t *testing.T) {
 
 func TestProgressBarInfinite_Reshown(t *testing.T) {
 	bar := NewProgressBarInfinite()
-	bar.Show()
 
 	assert.True(t, bar.Running())
 	bar.Hide()
@@ -50,7 +47,6 @@ func TestProgressBarInfinite_Reshown(t *testing.T) {
 
 func TestInfiniteProgressRenderer_Layout(t *testing.T) {
 	bar := NewProgressBarInfinite()
-	bar.Show()
 	width := 100.0
 	bar.Resize(fyne.NewSize(int(width), 10))
 


### PR DESCRIPTION
Progress bar can leak goroutines, and continues to update the widget after its closed / hidden.

fyne_demo - open the widgets window, then close the app == crash on master, fixed after this PR

Also - the scrollable widget is causing a segfault on exit, yet to track that down. If you comment out the scrollable test widget in fyne_demo to remove the problem, you can see that this patch exits cleanly now with no crashes.