### PR TITLE
Sets correct cursor postion for KeyEnd

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -325,7 +325,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 			e.CursorColumn++
 		}
 	case fyne.KeyEnd:
-		e.CursorColumn = provider.len()
+		e.CursorColumn = provider.rowLength(e.CursorRow)
 	case fyne.KeyHome:
 		e.CursorColumn = 0
 	default:

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -237,19 +237,22 @@ func TestEntry_OnKeyDown_DeleteNewline(t *testing.T) {
 }
 
 func TestEntry_OnKeyDown_Home_End(t *testing.T) {
-	entry := &Entry{}
-	entry.SetText("Hi")
+	entry := NewMultiLineEntry()
+	entry.SetText("Hi\ntest")
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 0, entry.CursorColumn)
 
+	down := &fyne.KeyEvent{Name: fyne.KeyDown}
+	entry.TypedKey(down)
+
 	end := &fyne.KeyEvent{Name: fyne.KeyEnd}
 	entry.TypedKey(end)
-	assert.Equal(t, 0, entry.CursorRow)
-	assert.Equal(t, 2, entry.CursorColumn)
+	assert.Equal(t, 1, entry.CursorRow)
+	assert.Equal(t, 4, entry.CursorColumn)
 
 	home := &fyne.KeyEvent{Name: fyne.KeyHome}
 	entry.TypedKey(home)
-	assert.Equal(t, 0, entry.CursorRow)
+	assert.Equal(t, 1, entry.CursorRow)
 	assert.Equal(t, 0, entry.CursorColumn)
 }
 


### PR DESCRIPTION
~Resolves #215~

Tested only with Multi line entry. Single line still uses multiple rows and low/high bounds therefore this solution might not work. Perhaps it should use `provider.len()` for single line and `provider.rowLength(e.CursorRow)` for multi line