### PR TITLE
Fix Unicode Char Input with Option key on macOS

### DIFF
--- a/driver/gl/window.go
+++ b/driver/gl/window.go
@@ -897,9 +897,6 @@ func desktopModifier(mods glfw.ModifierKey) desktop.Modifier {
 // Unicode character input. Characters do not map 1:1 to physical keys,
 // as a key may produce zero, one or more characters.
 func (w *window) charModInput(viewport *glfw.Window, char rune, mods glfw.ModifierKey) {
-	if mods != 0 && mods != glfw.ModShift { // don't progress if it's part of a combination
-		return
-	}
 	if w.canvas.Focused() == nil && w.canvas.onTypedRune == nil {
 		return
 	}


### PR DESCRIPTION
The GLFW driver seems to behave differenty on Linux and macOS, invoking the charModInput callback with different values of the modifier key. On linux it is passing `0` whereas on macOs is passing `glfw.ModAlt`.

This commit removes the combination check logic relying on the GLFW driver for char input / key combo  detection.

Fixes: #247