### PR TITLE
fix vram memory leak

### DIFF
--- a/driver/gl/loop.go
+++ b/driver/gl/loop.go
@@ -97,9 +97,11 @@ func (d *gLDriver) runGL() {
 				if !canvas.isDirty() {
 					continue
 				}
-				d.freeDirtyTextures(canvas)
 
 				viewport.MakeContextCurrent()
+
+				d.freeDirtyTextures(canvas)
+
 				gl.UseProgram(canvas.program)
 
 				view := win.(*window)


### PR DESCRIPTION
Hey again,
when using Fyne and drawing in a Raster on Linux, I would get out-of-memory condition after a while. After running `radeontop`, I could see that VRAM usage increases. By running it under [apitrace](https://github.com/apitrace/apitrace), I noticed a context switch just after `glDeleteTextures` and it started to be clear, that the context must be set current before deleting textures. :) 

Re my other PR: I will try to return to it soon