### PR TITLE
Bugfix/scroll container

### DIFF
--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -64,6 +64,9 @@ func (s *scrollRenderer) MinSize() fyne.Size {
 }
 
 func (s *scrollRenderer) Refresh() {
+	c := s.scroll.Content
+	c.Resize(c.MinSize().Union(s.scroll.Size()))
+
 	s.updatePosition()
 }
 

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -55,9 +55,6 @@ func (s *scrollRenderer) Layout(size fyne.Size) {
 	c := s.scroll.Content
 	c.Resize(c.MinSize().Union(size))
 
-	s.vertBar.Resize(fyne.NewSize(theme.ScrollBarSize(), size.Height))
-	s.vertBar.Move(fyne.NewPos(size.Width-theme.ScrollBarSize(), 0))
-
 	s.updatePosition()
 }
 

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -59,7 +59,7 @@ func (s *scrollRenderer) Layout(size fyne.Size) {
 }
 
 func (s *scrollRenderer) MinSize() fyne.Size {
-	// TODO determine if width or height should be resepected based on a which-way-to-scroll flag
+	// TODO determine if width or height should be respected based on a which-way-to-scroll flag
 	return fyne.NewSize(s.scroll.Content.MinSize().Width, 25) // TODO consider the smallest useful scroll view?
 }
 

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -22,6 +22,21 @@ func TestNewScrollContainer(t *testing.T) {
 	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), render.vertBar.Position())
 }
 
+func TestScrollContainer_Refresh(t *testing.T) {
+	rect := canvas.NewRectangle(color.Black)
+	rect.SetMinSize(fyne.NewSize(1000, 1000))
+	scroll := NewScrollContainer(rect)
+	scroll.Resize(fyne.NewSize(100, 100))
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -1000})
+
+	assert.Equal(t, 900, scroll.Offset.Y)
+	assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
+	rect.SetMinSize(fyne.NewSize(1000, 500))
+	Refresh(scroll)
+	assert.Equal(t, 400, scroll.Offset.Y)
+	assert.Equal(t, fyne.NewSize(1000, 500), rect.Size())
+}
+
 func TestScrollContainer_Scrolled(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))


### PR DESCRIPTION
This PR adjusts the `ScrollContainer` to adjust the content's size and position on `Refresh`. Thus it can be used for changing lists.