### PR TITLE
Declare interface conformity for structs to their respective interfaces

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -12,6 +12,9 @@ import (
 	"fyne.io/fyne/theme"
 )
 
+// Declare conformity with App interface
+var _ fyne.App = (*fyneApp)(nil)
+
 type fyneApp struct {
 	driver fyne.Driver
 	icon   fyne.Resource

--- a/app/settings.go
+++ b/app/settings.go
@@ -6,6 +6,9 @@ import (
 	"fyne.io/fyne"
 )
 
+// Declare conformity with Settings interface
+var _ fyne.Settings = (*settings)(nil)
+
 type settings struct {
 	themeLock sync.RWMutex
 	theme     fyne.Theme

--- a/canvas/base.go
+++ b/canvas/base.go
@@ -3,6 +3,9 @@ package canvas // import "fyne.io/fyne/canvas"
 
 import "fyne.io/fyne"
 
+// Declare conformity with CanvasObject interface
+var _ fyne.CanvasObject = (*baseObject)(nil)
+
 type baseObject struct {
 	size     fyne.Size     // The current size of the Rectangle
 	position fyne.Position // The current position of the Rectangle

--- a/canvas/circle.go
+++ b/canvas/circle.go
@@ -6,6 +6,9 @@ import (
 	"fyne.io/fyne"
 )
 
+// Declare conformity with CanvasObject interface
+var _ fyne.CanvasObject = (*Circle)(nil)
+
 // Circle describes a coloured circle primitive in a Fyne canvas
 type Circle struct {
 	Position1 fyne.Position // The current top-left position of the Circle

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -24,6 +24,9 @@ const (
 	ImageFillOriginal
 )
 
+// Declare conformity with CanvasObject interface
+var _ fyne.CanvasObject = (*Image)(nil)
+
 // Image describes a drawable image area that can render in a Fyne canvas
 // The image may be a vector or a bitmap representation and it will fill the area.
 // The fill mode can be changed by setting FillMode to a different ImageFill.

--- a/canvas/line.go
+++ b/canvas/line.go
@@ -7,6 +7,9 @@ import (
 	"fyne.io/fyne"
 )
 
+// Declare conformity with CanvasObject interface
+var _ fyne.CanvasObject = (*Line)(nil)
+
 // Line describes a coloured line primitive in a Fyne canvas.
 // Lines are special as they can have a negative width or height to indicate
 // an inverse slope (i.e. slope up vs down).

--- a/canvas/raster.go
+++ b/canvas/raster.go
@@ -4,7 +4,12 @@ import (
 	"image"
 	"image/color"
 	"image/draw"
+
+	"fyne.io/fyne"
 )
+
+// Declare conformity with CanvasObject interface
+var _ fyne.CanvasObject = (*Raster)(nil)
 
 // Raster describes a raster image area that can render in a Fyne canvas
 type Raster struct {

--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -1,6 +1,13 @@
 package canvas
 
-import "image/color"
+import (
+	"image/color"
+
+	"fyne.io/fyne"
+)
+
+// Declare conformity with CanvasObject interface
+var _ fyne.CanvasObject = (*Rectangle)(nil)
 
 // Rectangle describes a coloured rectangle primitive in a Fyne canvas
 type Rectangle struct {

--- a/canvas/text.go
+++ b/canvas/text.go
@@ -7,6 +7,9 @@ import (
 	"fyne.io/fyne/theme"
 )
 
+// Declare conformity with CanvasObject interface
+var _ fyne.CanvasObject = (*Text)(nil)
+
 // Text describes a text primitive in a Fyne canvas.
 // A text object can have a style set which will apply to the whole string.
 // No formatting or text parsing will be performed

--- a/cmd/fyne/bundle.go
+++ b/cmd/fyne/bundle.go
@@ -13,6 +13,9 @@ import (
 	"fyne.io/fyne"
 )
 
+// Declare conformity to command interface
+var _ command = (*bundler)(nil)
+
 type bundler struct {
 	name, pkg string
 	prefix    string

--- a/cmd/fyne/package.go
+++ b/cmd/fyne/package.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"fyne.io/fyne"
-	"github.com/Kodeworks/golang-image-ico"
+	ico "github.com/Kodeworks/golang-image-ico"
 	"github.com/jackmordaunt/icns"
 	"github.com/josephspurrier/goversioninfo"
 )
@@ -64,6 +64,9 @@ func copyFileMode(src, tgt string, perm os.FileMode) error {
 	_, err = io.Copy(target, source)
 	return err
 }
+
+// Declare conformity to command interface
+var _ command = (*packager)(nil)
 
 type packager struct {
 	os, name, dir, exe, icon string

--- a/container.go
+++ b/container.go
@@ -1,5 +1,8 @@
 package fyne
 
+// Declare conformity to CanvasObject
+var _ CanvasObject = (*Container)(nil)
+
 // Container is a CanvasObject that contains a collection of child objects.
 // The layout of the children is set by the specified Layout.
 type Container struct {

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -22,6 +22,9 @@ type Dialog interface {
 	SetDismissText(label string)
 }
 
+// Declare confirmity to Dialog interface
+var _ Dialog = (*dialog)(nil)
+
 type dialog struct {
 	win      fyne.Window
 	callback func(bool)

--- a/driver/desktop/shortcut.go
+++ b/driver/desktop/shortcut.go
@@ -7,6 +7,9 @@ import (
 	"fyne.io/fyne"
 )
 
+// Declare conformity with Shortcut interface
+var _ fyne.Shortcut = (*CustomShortcut)(nil)
+
 // CustomShortcut describes a shortcut desktop event.
 type CustomShortcut struct {
 	fyne.KeyName

--- a/internal/driver/gl/canvas.go
+++ b/internal/driver/gl/canvas.go
@@ -14,6 +14,9 @@ import (
 	"github.com/go-gl/gl/v3.2-core/gl"
 )
 
+// Declare conformity with Canvas interface
+var _ fyne.Canvas = (*glCanvas)(nil)
+
 type glCanvas struct {
 	sync.RWMutex
 	window                 *window

--- a/internal/driver/gl/clipboard.go
+++ b/internal/driver/gl/clipboard.go
@@ -1,8 +1,12 @@
 package gl
 
 import (
+	"fyne.io/fyne"
 	"github.com/go-gl/glfw/v3.2/glfw"
 )
+
+// Declare conformity with Clipboard interface
+var _ fyne.Clipboard = (*clipboard)(nil)
 
 // clipboard represents the system clipboard
 type clipboard struct {

--- a/internal/driver/gl/driver.go
+++ b/internal/driver/gl/driver.go
@@ -16,6 +16,9 @@ var canvases = make(map[fyne.CanvasObject]fyne.Canvas)
 
 const textDPI = 78
 
+// Declare conformity with Driver
+var _ fyne.Driver = (*gLDriver)(nil)
+
 type gLDriver struct {
 	windows []fyne.Window
 	done    chan interface{}

--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -32,6 +32,9 @@ func initCursors() {
 	hyperlinkCursor = glfw.CreateStandardCursor(glfw.HandCursor)
 }
 
+// Declare conformity to Window interface
+var _ fyne.Window = (*window)(nil)
+
 type window struct {
 	viewport *glfw.Window
 	painted  int // part of the macOS GL fix, updated GLFW should fix this

--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -5,6 +5,9 @@ import (
 	"fyne.io/fyne/theme"
 )
 
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*borderLayout)(nil)
+
 type borderLayout struct {
 	top, bottom, left, right fyne.CanvasObject
 }

--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -5,6 +5,9 @@ import (
 	"fyne.io/fyne/theme"
 )
 
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*boxLayout)(nil)
+
 type boxLayout struct {
 	horizontal bool
 }

--- a/layout/centerlayout.go
+++ b/layout/centerlayout.go
@@ -2,6 +2,9 @@ package layout
 
 import "fyne.io/fyne"
 
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*centerLayout)(nil)
+
 type centerLayout struct {
 }
 

--- a/layout/fixedgridlayout.go
+++ b/layout/fixedgridlayout.go
@@ -7,6 +7,9 @@ import (
 	"fyne.io/fyne/theme"
 )
 
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*fixedGridLayout)(nil)
+
 type fixedGridLayout struct {
 	CellSize fyne.Size
 }

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -9,6 +9,9 @@ import (
 
 const formLayoutCols = 2
 
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*formLayout)(nil)
+
 // formLayout is two column grid where each row has a label and a widget.
 type formLayout struct {
 }

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -7,6 +7,9 @@ import (
 	"fyne.io/fyne/theme"
 )
 
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*gridLayout)(nil)
+
 type gridLayout struct {
 	Cols int
 }

--- a/layout/maxlayout.go
+++ b/layout/maxlayout.go
@@ -3,6 +3,9 @@ package layout // import "fyne.io/fyne/layout"
 
 import "fyne.io/fyne"
 
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*maxLayout)(nil)
+
 type maxLayout struct {
 }
 


### PR DESCRIPTION
Using `var _ INTERFACE = (*Struct)(nil)` you are able to declare conformity with a struct.

Operationally this helps prevent breaking struct conformity on future development,  raising errors / failing to build if interface conformity is broken.

ex.
<img width="495" alt="Screen Shot 2019-05-26 at 10 05 00 PM" src="https://user-images.githubusercontent.com/1619591/58396621-57a17600-8002-11e9-9042-74968ed227f6.png">
