### PR TITLE
bugfixes for refreshing min sizes of components and the window

### DIFF
--- a/internal/driver/gl/canvas.go
+++ b/internal/driver/gl/canvas.go
@@ -187,9 +187,9 @@ func (c *glCanvas) AddShortcut(shortcut fyne.Shortcut, handler func(shortcut fyn
 	c.shortcut.AddShortcut(shortcut, handler)
 }
 
-func (c *glCanvas) paint(size fyne.Size) {
+func (c *glCanvas) paint(size fyne.Size) bool {
 	if c.Content() == nil {
-		return
+		return false
 	}
 	c.setDirty(false)
 
@@ -228,6 +228,7 @@ func (c *glCanvas) paint(size fyne.Size) {
 		}
 	}
 
+	oldSize := c.content.Size()
 	driver.WalkObjectTree(c.content, fyne.NewPos(0, 0), nil, ensureMinSize)
 	driver.WalkObjectTree(c.content, fyne.NewPos(0, 0), paint, afterPaint)
 	if c.menu != nil {
@@ -238,6 +239,7 @@ func (c *glCanvas) paint(size fyne.Size) {
 		driver.WalkObjectTree(c.overlay, fyne.NewPos(0, 0), nil, ensureMinSize)
 		driver.WalkObjectTree(c.overlay, fyne.NewPos(0, 0), paint, afterPaint)
 	}
+	return oldSize != c.content.Size()
 }
 
 func (c *glCanvas) setDirty(dirty bool) {

--- a/internal/driver/gl/canvas.go
+++ b/internal/driver/gl/canvas.go
@@ -198,6 +198,14 @@ func (c *glCanvas) paint(size fyne.Size) {
 	gl.ClearColor(float32(r)/max16bit, float32(g)/max16bit, float32(b)/max16bit, float32(a)/max16bit)
 	gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
 
+	ensureMinSize := func(obj fyne.CanvasObject, _ fyne.Position, _ bool) {
+		if obj.Visible() {
+			expectedSize := obj.MinSize().Union(obj.Size())
+			if expectedSize != obj.Size() {
+				obj.Resize(expectedSize)
+			}
+		}
+	}
 	paint := func(obj fyne.CanvasObject, pos fyne.Position) bool {
 		// TODO should this be somehow not scroll container specific?
 		if _, ok := obj.(*widget.ScrollContainer); ok {
@@ -220,11 +228,14 @@ func (c *glCanvas) paint(size fyne.Size) {
 		}
 	}
 
+	driver.WalkObjectTree(c.content, fyne.NewPos(0, 0), nil, ensureMinSize)
 	driver.WalkObjectTree(c.content, fyne.NewPos(0, 0), paint, afterPaint)
 	if c.menu != nil {
+		driver.WalkObjectTree(c.menu, fyne.NewPos(0, 0), nil, ensureMinSize)
 		driver.WalkObjectTree(c.menu, fyne.NewPos(0, 0), paint, afterPaint)
 	}
 	if c.overlay != nil {
+		driver.WalkObjectTree(c.overlay, fyne.NewPos(0, 0), nil, ensureMinSize)
 		driver.WalkObjectTree(c.overlay, fyne.NewPos(0, 0), paint, afterPaint)
 	}
 }

--- a/internal/driver/gl/loop.go
+++ b/internal/driver/gl/loop.go
@@ -107,8 +107,9 @@ func (d *gLDriver) runGL() {
 				gl.UseProgram(canvas.program)
 
 				updateGLContext(w)
-				size := canvas.Size()
-				canvas.paint(size)
+				if canvas.paint(canvas.Size()) {
+					w.resizeToContent()
+				}
 
 				w.viewport.SwapBuffers()
 				glfw.DetachCurrentContext()

--- a/internal/driver/gl/loop.go
+++ b/internal/driver/gl/loop.go
@@ -107,9 +107,10 @@ func (d *gLDriver) runGL() {
 				gl.UseProgram(canvas.program)
 
 				updateGLContext(w)
-				if canvas.paint(canvas.Size()) {
+				if canvas.ensureMinSize() {
 					w.resizeToContent()
 				}
+				canvas.paint(canvas.Size())
 
 				w.viewport.SwapBuffers()
 				glfw.DetachCurrentContext()

--- a/internal/driver/gl/loop.go
+++ b/internal/driver/gl/loop.go
@@ -79,14 +79,15 @@ func (d *gLDriver) runGL() {
 			newWindows := []fyne.Window{}
 			reassign := false
 			for _, win := range d.windows {
-				viewport := win.(*window).viewport
+				w := win.(*window)
+				viewport := w.viewport
 
 				if viewport.ShouldClose() {
 					reassign = true
 					// remove window from window list
 					viewport.Destroy()
 
-					if win.(*window).master {
+					if w.master {
 						d.Quit()
 					}
 					continue
@@ -94,7 +95,7 @@ func (d *gLDriver) runGL() {
 					newWindows = append(newWindows, win)
 				}
 
-				canvas := win.(*window).canvas
+				canvas := w.canvas
 				if !canvas.isDirty() {
 					continue
 				}
@@ -105,12 +106,11 @@ func (d *gLDriver) runGL() {
 
 				gl.UseProgram(canvas.program)
 
-				view := win.(*window)
-				updateGLContext(view)
+				updateGLContext(w)
 				size := canvas.Size()
 				canvas.paint(size)
 
-				view.viewport.SwapBuffers()
+				w.viewport.SwapBuffers()
 				glfw.DetachCurrentContext()
 			}
 			if reassign {

--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -220,14 +220,12 @@ func (w *window) SetPadded(padded bool) {
 
 	w.canvas.content.Move(w.contentPos())
 
-	w.resizeToContent()
+	runOnMain(w.resizeToContent)
 }
 
 func (w *window) resizeToContent() {
-	runOnMain(func() {
-		w.fitContent()
-		w.viewport.SetSize(w.screenSize(w.Canvas().Content().Size()))
-	})
+	w.fitContent()
+	w.viewport.SetSize(w.screenSize(w.Canvas().Content().Size()))
 }
 
 func (w *window) Icon() fyne.Resource {


### PR DESCRIPTION
this fixes #264 
this removes the effects of and thus practically fixes #265, too

**update**: the effects of #265 are fixed, i.e. the scaling is right now. But because the initial computation of the window size is still wrong, the window is larger than necessary. However, it can be reduced to the actual minSize.