### PR TITLE
fix a bug with mouseIn events not being triggered

### DIFF
--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -13,7 +13,7 @@ type FocusManager struct {
 func (f *FocusManager) nextInChain(current fyne.Focusable) fyne.Focusable {
 	var first, next fyne.Focusable
 	found := current == nil // if we have no starting point then pretend we matched already
-	driver.WalkObjectTree(f.canvas.Content(), fyne.NewPos(0, 0), func(obj fyne.CanvasObject, position fyne.Position) bool {
+	driver.WalkObjectTree(f.canvas.Content(), fyne.NewPos(0, 0), func(obj fyne.CanvasObject, _ fyne.Position) bool {
 		focus, ok := obj.(fyne.Focusable)
 		if !ok {
 			return false
@@ -43,7 +43,7 @@ func (f *FocusManager) nextInChain(current fyne.Focusable) fyne.Focusable {
 func (f *FocusManager) previousInChain(current fyne.Focusable) fyne.Focusable {
 	var last, previous fyne.Focusable
 	found := false
-	driver.WalkObjectTree(f.canvas.Content(), fyne.NewPos(0, 0), func(obj fyne.CanvasObject, position fyne.Position) bool {
+	driver.WalkObjectTree(f.canvas.Content(), fyne.NewPos(0, 0), func(obj fyne.CanvasObject, _ fyne.Position) bool {
 		focus, ok := obj.(fyne.Focusable)
 		if !ok {
 			return false

--- a/internal/driver/gl/canvas.go
+++ b/internal/driver/gl/canvas.go
@@ -231,7 +231,7 @@ func (c *glCanvas) paint(size fyne.Size) {
 		}
 		return false
 	}
-	afterPaint := func(obj fyne.CanvasObject, pos fyne.Position, _ bool) {
+	afterPaint := func(obj fyne.CanvasObject, _ fyne.Position, _ bool) {
 		if _, ok := obj.(*widget.ScrollContainer); ok {
 			gl.Disable(gl.SCISSOR_TEST)
 		}

--- a/internal/driver/gl/draw.go
+++ b/internal/driver/gl/draw.go
@@ -247,11 +247,10 @@ func (c *glCanvas) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Siz
 	c.freeCoords(vao, vbo)
 }
 
-func (c *glCanvas) drawObject(o fyne.CanvasObject, offset fyne.Position, frame fyne.Size) {
+func (c *glCanvas) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.Size) {
 	canvasMutex.Lock()
 	canvases[o] = c
 	canvasMutex.Unlock()
-	pos := o.Position().Add(offset)
 	switch obj := o.(type) {
 	case *canvas.Circle:
 		c.drawCircle(obj, pos, frame)
@@ -268,6 +267,6 @@ func (c *glCanvas) drawObject(o fyne.CanvasObject, offset fyne.Position, frame f
 	case *canvas.Gradient:
 		c.drawGradient(obj, pos, frame)
 	case fyne.Widget:
-		c.drawWidget(obj, offset, frame)
+		c.drawWidget(obj, pos, frame)
 	}
 }

--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -584,7 +584,8 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 			} else {
 				if w.mouseOver != nil {
 					w.mouseOver.MouseOut()
-				} else if obj != nil {
+				}
+				if obj != nil {
 					obj.MouseIn(ev)
 				}
 				w.mouseOver = obj

--- a/internal/driver/gl/window_test.go
+++ b/internal/driver/gl/window_test.go
@@ -77,20 +77,6 @@ func TestWindow_Padded(t *testing.T) {
 }
 
 func TestWindow_SetPadded(t *testing.T) {
-	// w := d.CreateWindow("Test")
-	// content := canvas.NewRectangle(color.White)
-	// w.Canvas().SetScale(1.0)
-	// w.SetContent(content)
-
-	// w.SetPadded(false)
-	// width, _ := w.(*window).minSizeOnScreen()
-	// assert.Equal(t, width, content.MinSize().Width)
-	// assert.Equal(t, 0, content.Position().X)
-
-	// w.SetPadded(true)
-	// width, _ = w.(*window).minSizeOnScreen()
-	// assert.Equal(t, width, theme.Padding()*2+content.MinSize().Width)
-	// assert.Equal(t, theme.Padding(), content.Position().X)
 	var menuHeight int
 	if hasNativeMenu() {
 		menuHeight = 0

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -17,39 +17,35 @@ import (
 // - if a walk has been stopped, the after function is called with the third argument set to true
 func WalkObjectTree(
 	obj fyne.CanvasObject,
-	pos fyne.Position,
+	offset fyne.Position,
 	beforeChildren func(fyne.CanvasObject, fyne.Position) bool,
 	afterChildren func(fyne.CanvasObject, fyne.Position, bool),
 ) bool {
 	var children []fyne.CanvasObject
-	var offset fyne.Position
 	switch co := obj.(type) {
 	case *fyne.Container:
-		offset = co.Position().Add(pos)
 		children = co.Objects
 	case fyne.Widget:
-		offset = co.Position().Add(pos)
 		children = widget.Renderer(co).Objects()
-	default:
-		offset = pos
 	}
 
+	pos := obj.Position().Add(offset)
 	if beforeChildren != nil {
-		if beforeChildren(obj, offset) {
+		if beforeChildren(obj, pos) {
 			return true
 		}
 	}
 
 	cancelled := false
 	for _, child := range children {
-		if WalkObjectTree(child, offset, beforeChildren, afterChildren) {
+		if WalkObjectTree(child, pos, beforeChildren, afterChildren) {
 			cancelled = true
 			break
 		}
 	}
 
 	if afterChildren != nil {
-		afterChildren(obj, offset, cancelled)
+		afterChildren(obj, pos, cancelled)
 	}
 	return cancelled
 }


### PR DESCRIPTION
This includes the fix of an inconsistency in the tree walker's position handling which was (probably unintentionally) circumvented at some places.