### PR TITLE
small scrollbar unless hovered

### DIFF
--- a/cmd/fyne_demo/theme.go
+++ b/cmd/fyne_demo/theme.go
@@ -108,6 +108,10 @@ func (customTheme) ScrollBarSize() int {
 	return 10
 }
 
+func (customTheme) ScrollBarSmallSize() int {
+	return 5
+}
+
 func newCustomTheme() fyne.Theme {
 	return &customTheme{}
 }

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -171,6 +171,10 @@ func (dummyTheme) ScrollBarSize() int {
 	return 10
 }
 
+func (dummyTheme) ScrollBarSmallSize() int {
+	return 3
+}
+
 func (dummyTheme) TextFont() fyne.Resource {
 	return nil
 }

--- a/theme.go
+++ b/theme.go
@@ -29,4 +29,5 @@ type Theme interface {
 	Padding() int
 	IconInlineSize() int
 	ScrollBarSize() int
+	ScrollBarSmallSize() int
 }

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -217,6 +217,11 @@ func (t *builtinTheme) ScrollBarSize() int {
 	return 16
 }
 
+// ScrollBarSmallSize is the width (or height) of the minimized bars on a ScrollContainer
+func (t *builtinTheme) ScrollBarSmallSize() int {
+	return 3
+}
+
 func current() fyne.Theme {
 	//	if fyne.CurrentApp().Theme() != nil
 	return fyne.CurrentApp().Settings().Theme()
@@ -336,6 +341,11 @@ func IconInlineSize() int {
 // ScrollBarSize is the width (or height) of the bars on a ScrollContainer
 func ScrollBarSize() int {
 	return current().ScrollBarSize()
+}
+
+// ScrollBarSmallSize is the width (or height) of the minimized bars on a ScrollContainer
+func ScrollBarSmallSize() int {
+	return current().ScrollBarSmallSize()
 }
 
 // DefaultTextFont returns the font resource for the built-in regular font style

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,8 +21,8 @@ func TestNewScrollContainer(t *testing.T) {
 	render := Renderer(scrollBar).(*scrollBarRenderer)
 
 	assert.Equal(t, 0, scroll.Offset.Y)
-	assert.Equal(t, fyne.NewSize(theme.ScrollBarSize(), 100), render.barSizeVertical())
-	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), render.scrollBar.Position())
+	assert.Equal(t, fyne.NewSize(theme.ScrollBarSmallSize(), 100), render.barSizeVertical())
+	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize(), 0), render.scrollBar.Position())
 }
 
 func TestScrollContainer_Refresh(t *testing.T) {
@@ -150,6 +151,41 @@ func TestScrollContainer_HideScrollBarIfContentShrinks(t *testing.T) {
 	assert.False(t, r.vertBar.Visible())
 }
 
+func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
+	rect := canvas.NewRectangle(color.Black)
+	rect.SetMinSize(fyne.NewSize(100, 500))
+	scroll := NewScrollContainer(rect)
+	scroll.Resize(fyne.NewSize(100, 100))
+	r := Renderer(scroll).(*scrollRenderer)
+	require.True(t, r.vertBar.Visible())
+	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+
+	assert.Equal(t, theme.ScrollBarSmallSize(), r.vertBar.Size().Width)
+	assert.Equal(t, theme.ScrollBarSmallSize(), Renderer(r.vertBar).(*scrollBarRenderer).barSizeVertical().Width)
+}
+
+func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing.T) {
+	rect := canvas.NewRectangle(color.Black)
+	rect.SetMinSize(fyne.NewSize(100, 500))
+	scroll := NewScrollContainer(rect)
+	scroll.Resize(fyne.NewSize(100, 100))
+	sr := Renderer(scroll).(*scrollRenderer)
+	bar := sr.vertBar
+	br := Renderer(sr.vertBar).(*scrollBarRenderer)
+	require.True(t, sr.vertBar.Visible())
+	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+	require.Equal(t, theme.ScrollBarSmallSize(), sr.vertBar.Size().Width)
+	require.Equal(t, theme.ScrollBarSmallSize(), br.barSizeVertical().Width)
+
+	bar.MouseIn(&desktop.MouseEvent{})
+	assert.Equal(t, theme.ScrollBarSize(), sr.vertBar.Size().Width)
+	assert.Equal(t, theme.ScrollBarSize(), br.barSizeVertical().Width)
+
+	bar.MouseOut()
+	assert.Equal(t, theme.ScrollBarSmallSize(), sr.vertBar.Size().Width)
+	assert.Equal(t, theme.ScrollBarSmallSize(), br.barSizeVertical().Width)
+}
+
 func TestScrollBarRenderer_BarSize(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(100, 100))
@@ -158,11 +194,11 @@ func TestScrollBarRenderer_BarSize(t *testing.T) {
 	scrollBar := Renderer(scroll).(*scrollRenderer).vertBar
 	render := Renderer(scrollBar).(*scrollBarRenderer)
 
-	assert.Equal(t, fyne.NewSize(theme.ScrollBarSize(), 100), render.barSizeVertical())
+	assert.Equal(t, fyne.NewSize(theme.ScrollBarSmallSize(), 100), render.barSizeVertical())
 
 	// resize so content is twice our size. Bar should therefore be half again.
 	scroll.Resize(fyne.NewSize(50, 50))
-	assert.Equal(t, fyne.NewSize(theme.ScrollBarSize(), 25), render.barSizeVertical())
+	assert.Equal(t, fyne.NewSize(theme.ScrollBarSmallSize(), 25), render.barSizeVertical())
 }
 
 func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
@@ -173,7 +209,7 @@ func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
 	scrollBar := Renderer(scroll).(*scrollRenderer).vertBar
 	render := Renderer(scrollBar).(*scrollBarRenderer)
 
-	assert.Equal(t, fyne.NewSize(theme.ScrollBarSize(), 120), render.barSizeVertical())
+	assert.Equal(t, fyne.NewSize(theme.ScrollBarSmallSize(), 120), render.barSizeVertical())
 }
 
 func TestScrollBar_Dragged_ClickedInside(t *testing.T) {


### PR DESCRIPTION
Scroll bars are small by default.
If hovered they grow to make it easier to hit them.