### PR TITLE
relayout containers on shrinking min size of children

### DIFF
--- a/internal/driver/gl/loop.go
+++ b/internal/driver/gl/loop.go
@@ -132,6 +132,7 @@ func (d *gLDriver) freeDirtyTextures(canvas *glCanvas) {
 					gl.DeleteTextures(1, &texture)
 					delete(textures, obj)
 				}
+				delete(canvas.minSizes, obj)
 				return false
 			}
 			driver.WalkObjectTree(object, freeWalked, nil)


### PR DESCRIPTION
Attention!
This introduces a memory leak similar to the textures cache
memory leak: If a container changes its children, the cache entries of
the disappeared children are not removed.