### PR TITLE
switch gradient's center offset to float64

### DIFF
--- a/canvas/gradient_test.go
+++ b/canvas/gradient_test.go
@@ -4,14 +4,14 @@ import (
 	"image/color"
 	"testing"
 
-	"fyne.io/fyne"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewLinearGradient(t *testing.T) {
 	// Horizontal
 	horizontal := NewLinearGradient(color.Black, color.Transparent, GradientDirectionHorizontal)
-	assert.Equal(t, horizontal.CenterOffset, fyne.NewPos(0, 0))
+	assert.Equal(t, horizontal.CenterOffsetX, 0.0)
+	assert.Equal(t, horizontal.CenterOffsetY, 0.0)
 
 	img := horizontal.Generator(50, 5)
 	assert.Equal(t, img.At(0, 0), color.RGBA{0, 0, 0, 0xff})
@@ -19,8 +19,10 @@ func TestNewLinearGradient(t *testing.T) {
 		assert.Equal(t, img.At(25, i), color.RGBA{0, 0, 0, 0x7f})
 	}
 	assert.Equal(t, img.At(50, 0), color.RGBA{0, 0, 0, 0x00})
-	horizontal.CenterOffset = fyne.NewPos(3, 3)
-	assert.Equal(t, horizontal.CenterOffset, fyne.NewPos(3, 3))
+	horizontal.CenterOffsetX = -0.4
+	horizontal.CenterOffsetY = 0.35
+	assert.Equal(t, horizontal.CenterOffsetX, -0.4)
+	assert.Equal(t, horizontal.CenterOffsetY, 0.35)
 
 	// Vertical
 	vertical := NewLinearGradient(color.Black, color.Transparent, GradientDirectionVertical)
@@ -40,7 +42,8 @@ func TestNewLinearGradient(t *testing.T) {
 	assert.Equal(t, imgCircle.At(2, 5), color.RGBA{0, 0, 0, 0x66})
 	assert.Equal(t, imgCircle.At(1, 5), color.RGBA{0, 0, 0, 0x33})
 
-	circle.CenterOffset = fyne.NewPos(1, 1)
+	circle.CenterOffsetX = 0.1
+	circle.CenterOffsetY = 0.1
 	imgCircleOffset := circle.Generator(10, 10)
 	assert.Equal(t, imgCircleOffset.At(5, 5), color.RGBA{0, 0, 0, 0xc3})
 	assert.Equal(t, imgCircleOffset.At(4, 5), color.RGBA{0, 0, 0, 0xa0})
@@ -48,7 +51,8 @@ func TestNewLinearGradient(t *testing.T) {
 	assert.Equal(t, imgCircleOffset.At(2, 5), color.RGBA{0, 0, 0, 0x50})
 	assert.Equal(t, imgCircleOffset.At(1, 5), color.RGBA{0, 0, 0, 0x26})
 
-	circle.CenterOffset = fyne.NewPos(-1, -1)
+	circle.CenterOffsetX = -0.1
+	circle.CenterOffsetY = -0.1
 	imgCircleOffset = circle.Generator(10, 10)
 	assert.Equal(t, imgCircleOffset.At(5, 5), color.RGBA{0, 0, 0, 0xc3})
 	assert.Equal(t, imgCircleOffset.At(4, 5), color.RGBA{0, 0, 0, 0xd5})

--- a/widget/shadow.go
+++ b/widget/shadow.go
@@ -83,7 +83,8 @@ func (r *shadowRenderer) createShadows() {
 			color.Transparent,
 			canvas.GradientDirectionCircular,
 		)
-		r.tl.CenterOffset = fyne.NewPos(theme.Padding(), theme.Padding())
+		r.tl.CenterOffsetX = 0.5
+		r.tl.CenterOffsetY = 0.5
 		r.t = canvas.NewLinearGradient(
 			color.Transparent,
 			theme.ShadowColor(),
@@ -94,7 +95,8 @@ func (r *shadowRenderer) createShadows() {
 			color.Transparent,
 			canvas.GradientDirectionCircular,
 		)
-		r.tr.CenterOffset = fyne.NewPos(-theme.Padding(), theme.Padding())
+		r.tr.CenterOffsetX = -0.5
+		r.tr.CenterOffsetY = 0.5
 		r.r = canvas.NewLinearGradient(
 			theme.ShadowColor(),
 			color.Transparent,
@@ -105,7 +107,8 @@ func (r *shadowRenderer) createShadows() {
 			color.Transparent,
 			canvas.GradientDirectionCircular,
 		)
-		r.br.CenterOffset = fyne.NewPos(-theme.Padding(), -theme.Padding())
+		r.br.CenterOffsetX = -0.5
+		r.br.CenterOffsetY = -0.5
 		r.b = canvas.NewLinearGradient(
 			theme.ShadowColor(),
 			color.Transparent,
@@ -116,7 +119,8 @@ func (r *shadowRenderer) createShadows() {
 			color.Transparent,
 			canvas.GradientDirectionCircular,
 		)
-		r.bl.CenterOffset = fyne.NewPos(theme.Padding(), -theme.Padding())
+		r.bl.CenterOffsetX = 0.5
+		r.bl.CenterOffsetY = -0.5
 		r.l = canvas.NewLinearGradient(
 			color.Transparent,
 			theme.ShadowColor(),

--- a/widget/shadow_test.go
+++ b/widget/shadow_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var shadowWidth = 5
+
 func TestShadow_TopShadow(t *testing.T) {
-	shadowWidth := 2 * theme.Padding()
 	s := newShadow(shadowTop, shadowWidth)
 	r := Renderer(s).(*shadowRenderer)
 	r.Layout(fyne.NewSize(100, 100))
@@ -25,7 +26,6 @@ func TestShadow_TopShadow(t *testing.T) {
 }
 
 func TestShadow_BottomShadow(t *testing.T) {
-	shadowWidth := 2 * theme.Padding()
 	s := newShadow(shadowBottom, shadowWidth)
 	r := Renderer(s).(*shadowRenderer)
 	r.Layout(fyne.NewSize(100, 100))
@@ -39,7 +39,6 @@ func TestShadow_BottomShadow(t *testing.T) {
 }
 
 func TestShadow_AroundShadow(t *testing.T) {
-	shadowWidth := 2 * theme.Padding()
 	s := newShadow(shadowAround, shadowWidth)
 	r := Renderer(s).(*shadowRenderer)
 	r.Layout(fyne.NewSize(100, 100))
@@ -53,7 +52,8 @@ func TestShadow_AroundShadow(t *testing.T) {
 	assert.Equal(t, cornerSize, r.tl.Size())
 	assert.Equal(t, fyne.NewPos(-shadowWidth, -shadowWidth), r.tl.Position())
 	assert.Equal(t, canvas.GradientDirectionCircular, r.tl.Direction)
-	assert.Equal(t, fyne.NewPos(shadowWidth/2, shadowWidth/2), r.tl.CenterOffset)
+	assert.Equal(t, 0.5, r.tl.CenterOffsetX)
+	assert.Equal(t, 0.5, r.tl.CenterOffsetY)
 	assert.Equal(t, theme.ShadowColor(), r.tl.StartColor)
 	assert.Equal(t, color.Transparent, r.tl.EndColor)
 
@@ -66,7 +66,8 @@ func TestShadow_AroundShadow(t *testing.T) {
 	assert.Equal(t, cornerSize, r.tr.Size())
 	assert.Equal(t, fyne.NewPos(100, -shadowWidth), r.tr.Position())
 	assert.Equal(t, canvas.GradientDirectionCircular, r.tr.Direction)
-	assert.Equal(t, fyne.NewPos(-shadowWidth/2, shadowWidth/2), r.tr.CenterOffset)
+	assert.Equal(t, -0.5, r.tr.CenterOffsetX)
+	assert.Equal(t, 0.5, r.tr.CenterOffsetY)
 	assert.Equal(t, theme.ShadowColor(), r.tr.StartColor)
 	assert.Equal(t, color.Transparent, r.tr.EndColor)
 
@@ -79,7 +80,8 @@ func TestShadow_AroundShadow(t *testing.T) {
 	assert.Equal(t, cornerSize, r.br.Size())
 	assert.Equal(t, fyne.NewPos(100, 100), r.br.Position())
 	assert.Equal(t, canvas.GradientDirectionCircular, r.br.Direction)
-	assert.Equal(t, fyne.NewPos(-shadowWidth/2, -shadowWidth/2), r.br.CenterOffset)
+	assert.Equal(t, -0.5, r.br.CenterOffsetX)
+	assert.Equal(t, -0.5, r.br.CenterOffsetY)
 	assert.Equal(t, theme.ShadowColor(), r.br.StartColor)
 	assert.Equal(t, color.Transparent, r.br.EndColor)
 
@@ -92,7 +94,8 @@ func TestShadow_AroundShadow(t *testing.T) {
 	assert.Equal(t, cornerSize, r.bl.Size())
 	assert.Equal(t, fyne.NewPos(-shadowWidth, 100), r.bl.Position())
 	assert.Equal(t, canvas.GradientDirectionCircular, r.bl.Direction)
-	assert.Equal(t, fyne.NewPos(shadowWidth/2, -shadowWidth/2), r.bl.CenterOffset)
+	assert.Equal(t, 0.5, r.bl.CenterOffsetX)
+	assert.Equal(t, -0.5, r.bl.CenterOffsetY)
 	assert.Equal(t, theme.ShadowColor(), r.bl.StartColor)
 	assert.Equal(t, color.Transparent, r.bl.EndColor)
 
@@ -104,7 +107,6 @@ func TestShadow_AroundShadow(t *testing.T) {
 }
 
 func TestShadow_ApplyTheme(t *testing.T) {
-	shadowWidth := 2 * theme.Padding()
 	fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
 	s := newShadow(shadowAround, shadowWidth)
 	r := Renderer(s).(*shadowRenderer)


### PR DESCRIPTION
This fixes shadows with an odd width and (implicitly) shadows with a width different from `theme.Padding()/2`.