### PR TITLE
Improved double click selection behaviour

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	multiLineRows = 3
+	multiLineRows            = 3
+	doubleClickWordSeperator = "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?"
 )
 
 type entryRenderer struct {
@@ -213,6 +214,12 @@ func (e *entryRenderer) Objects() []fyne.CanvasObject {
 
 func (e *entryRenderer) Destroy() {
 }
+
+// Declare conformity with interfaces
+var _ fyne.Draggable = (*Entry)(nil)
+var _ fyne.Tappable = (*Entry)(nil)
+var _ desktop.Mouseable = (*Entry)(nil)
+var _ desktop.Keyable = (*Entry)(nil)
 
 // Entry widget allows simple text to be input when focused.
 type Entry struct {
@@ -519,7 +526,7 @@ func getTextWhitespaceRegion(row []rune, col int) (int, int) {
 			return ' '
 		}
 		// If this rune is a typical word separator then classify it as whitespace
-		if strings.ContainsRune("`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", r) {
+		if strings.ContainsRune(doubleClickWordSeperator, r) {
 			return ' '
 		}
 		return '-'

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -472,6 +472,10 @@ func (e *Entry) Dragged(d *fyne.DragEvent) {
 	e.updateMousePointer(&d.PointEvent, false)
 }
 
+// DragEnd is called at end of a drag event - currently ignored
+func (e *Entry) DragEnd() {
+}
+
 func (e *Entry) updateMousePointer(ev *fyne.PointEvent, startSelect bool) {
 
 	if !e.focused {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -508,10 +508,14 @@ func getTextWhitespaceRegion(row []rune, col int) (int, int) {
 		return -1, -1
 	}
 
-	// maps: " fish 日本語本語日  \t "
-	// into: " ---- ------   "
+	// maps: " fi-sh 日本語本語日  \t "
+	// into: " -- -- ------   "
 	space := func(r rune) rune {
 		if unicode.IsSpace(r) {
+			return ' '
+		}
+		// If this rune is a typical word separator then classify it as whitespace
+		if strings.ContainsRune("`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", r) {
 			return ' '
 		}
 		return '-'

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -464,7 +464,7 @@ func TestEntry_ExpandSelectionForDoubleTap(t *testing.T) {
 func TestEntry_ExpandSelectionWithWordSeparators(t *testing.T) {
 	// select "is_a"
 	str := []rune("This-is_a-test")
-	start, end = getTextWhitespaceRegion(str, 6)
+	start, end := getTextWhitespaceRegion(str, 6)
 	assert.Equal(t, 5, start)
 	assert.Equal(t, 9, end)
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -459,6 +459,12 @@ func TestEntry_ExpandSelectionForDoubleTap(t *testing.T) {
 	start, end = getTextWhitespaceRegion(str, 30)
 	assert.Equal(t, 29, start)
 	assert.Equal(t, len(str), end)
+
+	// select "is_a"
+	str = []rune("This-is_a-test")
+	start, end = getTextWhitespaceRegion(str, 6)
+	assert.Equal(t, 5, start)
+	assert.Equal(t, 9, end)
 }
 
 func TestEntry_DoubleTapped(t *testing.T) {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -12,20 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEntry_InterfaceCompatibilityTest(t *testing.T) {
-	entry := fyne.Widget(NewEntry())
-	var ok bool
-
-	_, ok = entry.(fyne.Draggable)
-	assert.True(t, ok, "Unable to accept drag events")
-	_, ok = entry.(fyne.Tappable)
-	assert.True(t, ok, "Unable to accept tap events")
-	_, ok = entry.(desktop.Mouseable)
-	assert.True(t, ok, "Unable to accept mouse events")
-	_, ok = entry.(desktop.Keyable)
-	assert.True(t, ok, "Unable to accept keyboard events")
-}
-
 func entryRenderTexts(e *Entry) []*canvas.Text {
 	textWid := Renderer(e).(*entryRenderer).text
 	return Renderer(textWid).(*textRenderer).texts
@@ -473,7 +459,9 @@ func TestEntry_ExpandSelectionForDoubleTap(t *testing.T) {
 	start, end = getTextWhitespaceRegion(str, 30)
 	assert.Equal(t, 29, start)
 	assert.Equal(t, len(str), end)
+}
 
+func TestEntry_ExpandSelectionWithWordSeparators(t *testing.T) {
 	// select "is_a"
 	str = []rune("This-is_a-test")
 	start, end = getTextWhitespaceRegion(str, 6)

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -12,6 +12,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEntry_InterfaceCompatibilityTest(t *testing.T) {
+	entry := fyne.Widget(NewEntry())
+	var ok bool
+
+	_, ok = entry.(fyne.Draggable)
+	assert.True(t, ok, "Unable to accept drag events")
+	_, ok = entry.(fyne.Tappable)
+	assert.True(t, ok, "Unable to accept tap events")
+	_, ok = entry.(desktop.Mouseable)
+	assert.True(t, ok, "Unable to accept mouse events")
+	_, ok = entry.(desktop.Keyable)
+	assert.True(t, ok, "Unable to accept keyboard events")
+}
+
 func entryRenderTexts(e *Entry) []*canvas.Text {
 	textWid := Renderer(e).(*entryRenderer).text
 	return Renderer(textWid).(*textRenderer).texts

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -463,7 +463,7 @@ func TestEntry_ExpandSelectionForDoubleTap(t *testing.T) {
 
 func TestEntry_ExpandSelectionWithWordSeparators(t *testing.T) {
 	// select "is_a"
-	str = []rune("This-is_a-test")
+	str := []rune("This-is_a-test")
 	start, end = getTextWhitespaceRegion(str, 6)
 	assert.Equal(t, 5, start)
 	assert.Equal(t, 9, end)


### PR DESCRIPTION
This change instructs double click text selection to treat the following characters as whitespace:
```
`~!@#$%^&*()-=+[{]}\|;:'",.<>/?
```