### PR TITLE
Always execute certain event callbacks serially

### DIFF
--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -1003,11 +1003,9 @@ func (w *window) dispatchSerialEvent(fn func()) {
 }
 
 func (w *window) runSerialEvents() {
-	fyne.LogError("running serial events", nil)
 	for fn := range w.serialEvents {
 		fn()
 	}
-	fyne.LogError("closing serial events", nil)
 }
 
 func (d *gLDriver) CreateWindow(title string) fyne.Window {

--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -972,9 +972,9 @@ func (w *window) charModInput(viewport *glfw.Window, char rune, mods glfw.Modifi
 	}
 
 	if w.canvas.Focused() != nil {
-		w.canvas.Focused().TypedRune(char)
+		w.queueEvent(func() { w.canvas.Focused().TypedRune(char) })
 	} else if w.canvas.onTypedRune != nil {
-		w.canvas.onTypedRune(char)
+		w.queueEvent(func() { w.canvas.onTypedRune(char) })
 	}
 }
 


### PR DESCRIPTION
This is to fix crashes and inconsistent behavior when events come in
rapidly. If you went to the multiline form widget, for example, and
mashed some keys and the return key very quickly, you could easily make
it crash because sometimes the key handler and rune handler happened at
the same time, causing a data race.

I'm including mouse events because I imagine people hitting shift and
clicking quickly, or just plain clicking quickly and the mouse down event
happening after (or at the same time as) the mouse up event.