### PR TITLE
fix #339: Send mouse events to the original object when mouse dragging

### DIFF
--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -593,6 +593,7 @@ func (w *window) mouseClicked(viewport *glfw.Window, button glfw.MouseButton, ac
 	ev := new(fyne.PointEvent)
 	ev.Position = fyne.NewPos(x, y)
 
+	coMouse := co
 	// Switch the mouse target to the dragging object if one is set
 	if w.mouseDragged != nil && !w.objIsDragged(co) {
 		co, _ = w.mouseDragged.(fyne.CanvasObject)
@@ -672,7 +673,7 @@ func (w *window) mouseClicked(viewport *glfw.Window, button glfw.MouseButton, ac
 	}
 	if action == glfw.Release && w.mouseDragged != nil {
 		w.mouseDragged.DragEnd()
-		if w.objIsDragged(w.mouseOver) && !w.objIsDragged(co) {
+		if w.objIsDragged(w.mouseOver) && !w.objIsDragged(coMouse) {
 			w.mouseOut()
 		}
 		w.mouseDragged = nil

--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -593,6 +593,12 @@ func (w *window) mouseClicked(viewport *glfw.Window, button glfw.MouseButton, ac
 	ev := new(fyne.PointEvent)
 	ev.Position = fyne.NewPos(x, y)
 
+	// Switch the mouse target to the dragging object if one is set
+	if w.mouseDragged != nil && !w.objIsDragged(co) {
+		co, _ = w.mouseDragged.(fyne.CanvasObject)
+		ev.Position = w.mousePos.Subtract(w.mouseDraggedOffset).Subtract(co.Position())
+	}
+
 	if wid, ok := co.(desktop.Mouseable); ok {
 		mev := new(desktop.MouseEvent)
 		mev.Position = ev.Position

--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"sync"
 	"time"
 
 	"fyne.io/fyne"
@@ -67,6 +68,7 @@ type window struct {
 	ignoreResize  bool
 
 	eventQueue chan func()
+	eventWait  sync.WaitGroup
 }
 
 func (w *window) Title() string {
@@ -528,7 +530,7 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 
 		if hovered, ok := obj.(desktop.Hoverable); ok {
 			if hovered == w.mouseOver {
-				hovered.MouseMoved(ev)
+				w.queueEvent(func() { hovered.MouseMoved(ev) })
 			} else {
 				w.mouseOut()
 				w.mouseIn(hovered, ev)
@@ -545,7 +547,8 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 			ev.Position = w.mousePos.Subtract(w.mouseDraggedOffset).Subtract(draggedObjPos)
 			ev.DraggedX = w.mousePos.X - w.mouseDragPos.X
 			ev.DraggedY = w.mousePos.Y - w.mouseDragPos.Y
-			w.mouseDragged.Dragged(ev)
+			wd := w.mouseDragged
+			w.queueEvent(func() { wd.Dragged(ev) })
 
 			w.mouseDragPos = w.mousePos
 		}
@@ -561,17 +564,21 @@ func (w *window) objIsDragged(obj interface{}) bool {
 }
 
 func (w *window) mouseIn(obj desktop.Hoverable, ev *desktop.MouseEvent) {
-	if obj != nil {
-		obj.MouseIn(ev)
-	}
-	w.mouseOver = obj
+	w.queueEvent(func() {
+		if obj != nil {
+			obj.MouseIn(ev)
+		}
+		w.mouseOver = obj
+	})
 }
 
 func (w *window) mouseOut() {
-	if w.mouseOver != nil {
-		w.mouseOver.MouseOut()
-		w.mouseOver = nil
-	}
+	w.queueEvent(func() {
+		if w.mouseOver != nil {
+			w.mouseOver.MouseOut()
+			w.mouseOver = nil
+		}
+	})
 }
 
 func (w *window) mouseClicked(viewport *glfw.Window, button glfw.MouseButton, action glfw.Action, _ glfw.ModifierKey) {
@@ -1008,13 +1015,19 @@ func (w *window) runWithContext(f func()) {
 // Use this method to queue up a callback that handles an event. This ensures
 // user interaction events for a given window are processed in order.
 func (w *window) queueEvent(fn func()) {
+	w.eventWait.Add(1)
 	w.eventQueue <- fn
 }
 
 func (w *window) runEventQueue() {
 	for fn := range w.eventQueue {
 		fn()
+		w.eventWait.Done()
 	}
+}
+
+func (w *window) waitForEvents() {
+	w.eventWait.Wait()
 }
 
 func (d *gLDriver) CreateWindow(title string) fyne.Window {


### PR DESCRIPTION
- Prevents window Focus changes on mouse release
- MouseOut is still sent on mouse release

I'm not sure about the ramifications of the new logic in `mouseClicked`. I've done a fair amount of testing against fyne_demo and can't see any new weird behaviour or regressions.

The MouseUp/Down events are driven by `window.runEventQueue` unlike MouseIn/Out so the unittests use a 200 millisecond timeout to wait for them to trigger. A better approach might be for unittesting to force event queue processing. 