### PR TITLE
typo fix

### DIFF
--- a/dialog/confirm.go
+++ b/dialog/confirm.go
@@ -20,7 +20,7 @@ func (d *ConfirmDialog) SetConfirmText(label string) {
 }
 
 // NewConfirm creates a dialog over the specified window for user confirmation.
-// The title is used for the ialog window and message is the content.
+// The title is used for the dialog window and message is the content.
 // The callback is executed when the user decides. After creation you should call Show().
 func NewConfirm(title, message string, callback func(bool), parent fyne.Window) *ConfirmDialog {
 	d := newDialog(title, message, theme.QuestionIcon(), callback, parent)


### PR DESCRIPTION
Just a typo fix. Dialog doesn't seem to have any test files as well, maybe we'd like to add it later? It helps when looking for implementation examples. 