### PR TITLE
Add word wrap support in some widgets

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -24,10 +24,10 @@ func welcomeScreen(a fyne.App) fyne.CanvasObject {
 	}
 
 	return widget.NewVBox(
-		widget.NewLabelWithStyle("Welcome to the Fyne toolkit demo app", fyne.TextAlignCenter, fyne.TextStyle{Bold: true}),
+		widget.NewLabelWithStyle("Welcome to the Fyne toolkit demo app", fyne.TextAlignCenter, fyne.TextStyle{Bold: true}, fyne.TextWrap{}),
 		layout.NewSpacer(),
 		widget.NewHBox(layout.NewSpacer(), logo, layout.NewSpacer()),
-		widget.NewHyperlinkWithStyle("fyne.io", link, fyne.TextAlignCenter, fyne.TextStyle{}),
+		widget.NewHyperlinkWithStyle("fyne.io", link, fyne.TextAlignCenter, fyne.TextStyle{}, fyne.TextWrap{}),
 		layout.NewSpacer(),
 
 		widget.NewGroup("Theme",

--- a/cmd/fyne_demo/screens/layout.go
+++ b/cmd/fyne_demo/screens/layout.go
@@ -20,7 +20,7 @@ func makeBorderLayout() *fyne.Container {
 	bottom := makeCell()
 	left := makeCell()
 	right := makeCell()
-	middle := widget.NewLabelWithStyle("BorderLayout", fyne.TextAlignCenter, fyne.TextStyle{})
+	middle := widget.NewLabelWithStyle("BorderLayout", fyne.TextAlignCenter, fyne.TextStyle{}, fyne.TextWrap{})
 
 	borderLayout := layout.NewBorderLayout(top, bottom, left, right)
 	return fyne.NewContainerWithLayout(borderLayout,

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -54,7 +54,7 @@ func (d *dialog) wait() {
 
 func (d *dialog) setButtons(buttons fyne.CanvasObject) {
 	d.bg = canvas.NewRectangle(theme.BackgroundColor())
-	d.label = widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
+	d.label = widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true}, fyne.TextWrap{})
 
 	var content fyne.CanvasObject
 	if d.icon == nil {
@@ -125,7 +125,7 @@ func newDialog(title, message string, icon fyne.Resource, callback func(bool), p
 }
 
 func newLabel(message string) fyne.CanvasObject {
-	return widget.NewLabelWithStyle(message, fyne.TextAlignCenter, fyne.TextStyle{})
+	return widget.NewLabelWithStyle(message, fyne.TextAlignCenter, fyne.TextStyle{}, fyne.TextWrap{})
 }
 
 func newButtonList(buttons ...*widget.Button) fyne.CanvasObject {

--- a/text.go
+++ b/text.go
@@ -20,3 +20,12 @@ type TextStyle struct {
 	Italic    bool // Should text be italic
 	Monospace bool // Use the system monospace font instead of regular
 }
+
+// TextWrap represents text wrapping properties that can be applied to a text
+// canvas object or text based widget. When Length = 0 doesn't do anything.
+// When Length > 0 each line is split (Truncate=False)
+// or truncated(Truncate=True, only for display!) to Length
+type TextWrap struct {
+	Length   int
+	Truncate bool
+}

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -863,6 +863,11 @@ func (e *Entry) textStyle() fyne.TextStyle {
 	return fyne.TextStyle{}
 }
 
+// textWrap tells the rendering textProvider our wrapping
+func (e *Entry) textWrap() fyne.TextWrap {
+	return fyne.TextWrap{Length: 80, Truncate: false}
+}
+
 // textColor tells the rendering textProvider our color
 func (e *Entry) textColor() color.Color {
 	return theme.TextColor()
@@ -890,6 +895,11 @@ func (p *placeholderPresenter) textAlign() fyne.TextAlign {
 // textStyle tells the rendering textProvider our style
 func (p *placeholderPresenter) textStyle() fyne.TextStyle {
 	return fyne.TextStyle{}
+}
+
+// textWrap tells the rendering textProvider our wrapping
+func (p *placeholderPresenter) textWrap() fyne.TextWrap {
+	return fyne.TextWrap{Length: 80, Truncate: false}
 }
 
 // textColor tells the rendering textProvider our color

--- a/widget/form.go
+++ b/widget/form.go
@@ -54,7 +54,7 @@ func (f *Form) Hide() {
 }
 
 func (f *Form) createLabel(text string) *Label {
-	return NewLabelWithStyle(text, fyne.TextAlignTrailing, fyne.TextStyle{Bold: true})
+	return NewLabelWithStyle(text, fyne.TextAlignTrailing, fyne.TextStyle{Bold: true}, fyne.TextWrap{})
 }
 
 func (f *Form) ensureGrid() {

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -16,20 +16,23 @@ type Hyperlink struct {
 	URL       *url.URL
 	Alignment fyne.TextAlign // The alignment of the Text
 	TextStyle fyne.TextStyle // The style of the hyperlink text
+	TextWrap  fyne.TextWrap  // The wrapping or length-limiting of the hyperlink text
 }
 
 // NewHyperlink creates a new hyperlink widget with the set text content
 func NewHyperlink(text string, url *url.URL) *Hyperlink {
-	return NewHyperlinkWithStyle(text, url, fyne.TextAlignLeading, fyne.TextStyle{})
+	return NewHyperlinkWithStyle(text, url, fyne.TextAlignLeading, fyne.TextStyle{}, fyne.TextWrap{})
 }
 
 // NewHyperlinkWithStyle creates a new hyperlink widget with the set text content
-func NewHyperlinkWithStyle(text string, url *url.URL, alignment fyne.TextAlign, style fyne.TextStyle) *Hyperlink {
+func NewHyperlinkWithStyle(text string, url *url.URL, alignment fyne.TextAlign,
+	style fyne.TextStyle, wrap fyne.TextWrap) *Hyperlink {
 	hl := &Hyperlink{
 		Text:      text,
 		URL:       url,
 		Alignment: alignment,
 		TextStyle: style,
+		TextWrap:  wrap,
 	}
 
 	return hl
@@ -68,7 +71,7 @@ func (hl *Hyperlink) textStyle() fyne.TextStyle {
 
 // textWrap tells the rendering textProvider our wrapping
 func (hl *Hyperlink) textWrap() fyne.TextWrap {
-	return fyne.TextWrap{}
+	return hl.TextWrap
 }
 
 // textColor tells the rendering textProvider our color

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -66,6 +66,11 @@ func (hl *Hyperlink) textStyle() fyne.TextStyle {
 	return hl.TextStyle
 }
 
+// textWrap tells the rendering textProvider our wrapping
+func (hl *Hyperlink) textWrap() fyne.TextWrap {
+	return fyne.TextWrap{}
+}
+
 // textColor tells the rendering textProvider our color
 func (hl *Hyperlink) textColor() color.Color {
 	return theme.HyperlinkColor()

--- a/widget/label.go
+++ b/widget/label.go
@@ -47,6 +47,11 @@ func (l *Label) textStyle() fyne.TextStyle {
 	return l.TextStyle
 }
 
+// textWrap tells the rendering textProvider our wrapping
+func (l *Label) textWrap() fyne.TextWrap {
+	return fyne.TextWrap{}
+}
+
 // textColor tells the rendering textProvider our color
 func (l *Label) textColor() color.Color {
 	return theme.TextColor()

--- a/widget/label.go
+++ b/widget/label.go
@@ -13,19 +13,21 @@ type Label struct {
 	Text      string
 	Alignment fyne.TextAlign // The alignment of the Text
 	TextStyle fyne.TextStyle // The style of the label text
+	TextWrap  fyne.TextWrap  // The wrapping or length-limiting of the label text
 }
 
 // NewLabel creates a new label widget with the set text content
 func NewLabel(text string) *Label {
-	return NewLabelWithStyle(text, fyne.TextAlignLeading, fyne.TextStyle{})
+	return NewLabelWithStyle(text, fyne.TextAlignLeading, fyne.TextStyle{}, fyne.TextWrap{})
 }
 
 // NewLabelWithStyle creates a new label widget with the set text content
-func NewLabelWithStyle(text string, alignment fyne.TextAlign, style fyne.TextStyle) *Label {
+func NewLabelWithStyle(text string, alignment fyne.TextAlign, style fyne.TextStyle, wrap fyne.TextWrap) *Label {
 	l := &Label{
 		Text:      text,
 		Alignment: alignment,
 		TextStyle: style,
+		TextWrap:  wrap,
 	}
 
 	return l
@@ -49,7 +51,7 @@ func (l *Label) textStyle() fyne.TextStyle {
 
 // textWrap tells the rendering textProvider our wrapping
 func (l *Label) textWrap() fyne.TextWrap {
-	return fyne.TextWrap{}
+	return l.TextWrap
 }
 
 // textColor tells the rendering textProvider our color

--- a/widget/text.go
+++ b/widget/text.go
@@ -104,14 +104,16 @@ func (t *textProvider) updateRowBounds() {
 			/* Truncating mode */
 			for i, r := range t.buffer {
 				highBound = i
-				if r != '\n' {
-					continue
-				}
 				if highBound-lowBound > wrap.Length {
 					highBound = lowBound + wrap.Length
 				}
+				if r != '\n' {
+					continue
+				}
+
 				t.rowBounds = append(t.rowBounds, [2]int{lowBound, highBound})
-				lowBound = i + 1
+				highBound = i + 1
+				lowBound = highBound
 			}
 		} else {
 			/* Soft wrapping mode*/

--- a/widget/text_test.go
+++ b/widget/text_test.go
@@ -18,6 +18,7 @@ type testTextParent struct {
 	fg    color.Color
 	style fyne.TextStyle
 	align fyne.TextAlign
+	wrap  fyne.TextWrap
 }
 
 func (t *testTextParent) textAlign() fyne.TextAlign {
@@ -26,6 +27,10 @@ func (t *testTextParent) textAlign() fyne.TextAlign {
 
 func (t *testTextParent) textStyle() fyne.TextStyle {
 	return t.style
+}
+
+func (t *testTextParent) textWrap() fyne.TextWrap {
+	return t.wrap
 }
 
 func (t *testTextParent) textColor() color.Color {


### PR DESCRIPTION
Added word wrap and truncation support for text widgets -- entry, label and hyperlink
Modified entry cursor movement to support that.
Truncation is useful mostly for links and labels, word wrap seems useful for all three.
P.S. tested on master branch and cherry-picked to develop 'cause fyne_demos & examples not working normally on develop (bug? tested on archlinux go1.12.7 linux/amd64)