### PR TITLE
Fix hidden semantics so children remain hidden when parent shown

### DIFF
--- a/container.go
+++ b/container.go
@@ -70,9 +70,6 @@ func (c *Container) Show() {
 	}
 
 	c.Hidden = false
-	for _, child := range c.Objects {
-		child.Show()
-	}
 }
 
 // Hide sets this container, and all its children, to be not visible.
@@ -82,9 +79,6 @@ func (c *Container) Hide() {
 	}
 
 	c.Hidden = true
-	for _, child := range c.Objects {
-		child.Hide()
-	}
 }
 
 // AddObject adds another CanvasObject to the set this Container holds.

--- a/container_test.go
+++ b/container_test.go
@@ -80,9 +80,11 @@ func TestContainer_Hide(t *testing.T) {
 	box := new(dummyObject)
 	container := NewContainer(box)
 
+	assert.True(t, container.Visible())
 	assert.True(t, box.Visible())
 	container.Hide()
-	assert.False(t, box.Visible())
+	assert.False(t, container.Visible())
+	assert.True(t, box.Visible())
 }
 
 func TestContainer_Show(t *testing.T) {
@@ -90,7 +92,7 @@ func TestContainer_Show(t *testing.T) {
 	container := NewContainer(box)
 
 	container.Hide()
-	assert.False(t, box.Visible())
+	assert.True(t, box.Visible())
 	assert.False(t, container.Visible())
 
 	container.Show()

--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -14,10 +14,7 @@ type FocusManager struct {
 func (f *FocusManager) nextInChain(current fyne.Focusable) fyne.Focusable {
 	var first, next fyne.Focusable
 	found := current == nil // if we have no starting point then pretend we matched already
-	driver.WalkObjectTree(f.canvas.Content(), func(obj fyne.CanvasObject, _ fyne.Position, _ fyne.Position, _ fyne.Size) bool {
-		if !obj.Visible() {
-			return false
-		}
+	driver.WalkVisibleObjectTree(f.canvas.Content(), func(obj fyne.CanvasObject, _ fyne.Position, _ fyne.Position, _ fyne.Size) bool {
 		if w, ok := obj.(fyne.Disableable); ok && w.Disabled() {
 			// disabled widget cannot receive focus
 			return false
@@ -55,10 +52,7 @@ func (f *FocusManager) nextInChain(current fyne.Focusable) fyne.Focusable {
 func (f *FocusManager) previousInChain(current fyne.Focusable) fyne.Focusable {
 	var last, previous fyne.Focusable
 	found := false
-	driver.WalkObjectTree(f.canvas.Content(), func(obj fyne.CanvasObject, _ fyne.Position, _ fyne.Position, _ fyne.Size) bool {
-		if !obj.Visible() {
-			return false
-		}
+	driver.WalkVisibleObjectTree(f.canvas.Content(), func(obj fyne.CanvasObject, _ fyne.Position, _ fyne.Position, _ fyne.Size) bool {
 		if w, ok := obj.(fyne.Disableable); ok && w.Disabled() {
 			// disabled widget cannot receive focus
 			return false

--- a/internal/driver/gl/canvas.go
+++ b/internal/driver/gl/canvas.go
@@ -283,9 +283,8 @@ func (c *glCanvas) paint(size fyne.Size) {
 			gl.Scissor(int32(scrollX), int32(pixHeight-scrollY-scrollHeight), int32(scrollWidth), int32(scrollHeight))
 			gl.Enable(gl.SCISSOR_TEST)
 		}
-		if obj.Visible() {
-			c.drawObject(obj, pos, size)
-		}
+
+		c.drawObject(obj, pos, size)
 		return false
 	}
 	afterPaint := func(obj, _ fyne.CanvasObject) {
@@ -301,12 +300,12 @@ func (c *glCanvas) walkTree(
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
 	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
 ) {
-	driver.WalkObjectTree(c.content, beforeChildren, afterChildren)
+	driver.WalkVisibleObjectTree(c.content, beforeChildren, afterChildren)
 	if c.menu != nil {
-		driver.WalkObjectTree(c.menu, beforeChildren, afterChildren)
+		driver.WalkVisibleObjectTree(c.menu, beforeChildren, afterChildren)
 	}
 	if c.overlay != nil {
-		driver.WalkObjectTree(c.overlay, beforeChildren, afterChildren)
+		driver.WalkVisibleObjectTree(c.overlay, beforeChildren, afterChildren)
 	}
 }
 

--- a/internal/driver/gl/driver.go
+++ b/internal/driver/gl/driver.go
@@ -34,7 +34,7 @@ func (d *gLDriver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position
 	var pos fyne.Position
 	c := fyne.CurrentApp().Driver().CanvasForObject(co).(*glCanvas)
 
-	driver.WalkObjectTree(c.content, func(o fyne.CanvasObject, p fyne.Position, _ fyne.Position, _ fyne.Size) bool {
+	driver.WalkCompleteObjectTree(c.content, func(o fyne.CanvasObject, p fyne.Position, _ fyne.Position, _ fyne.Size) bool {
 		if o == co {
 			pos = p
 			return true

--- a/internal/driver/gl/loop.go
+++ b/internal/driver/gl/loop.go
@@ -132,7 +132,7 @@ func (d *gLDriver) freeDirtyTextures(canvas *glCanvas) {
 				delete(canvas.minSizes, obj)
 				return false
 			}
-			driver.WalkObjectTree(object, freeWalked, nil)
+			driver.WalkCompleteObjectTree(object, freeWalked, nil)
 		default:
 			return
 		}

--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -397,7 +397,7 @@ func (w *window) Canvas() fyne.Canvas {
 func (w *window) closed(viewport *glfw.Window) {
 	viewport.SetShouldClose(true)
 
-	driver.WalkObjectTree(w.canvas.content, nil, func(obj, _ fyne.CanvasObject) {
+	driver.WalkCompleteObjectTree(w.canvas.content, nil, func(obj, _ fyne.CanvasObject) {
 		switch co := obj.(type) {
 		case fyne.Widget:
 			widget.DestroyRenderer(co)
@@ -482,13 +482,13 @@ func (w *window) findObjectAtPositionMatching(canvas *glCanvas, mouse fyne.Posit
 	}
 
 	if canvas.overlay != nil {
-		driver.WalkObjectTree(canvas.overlay, findFunc, nil)
+		driver.WalkVisibleObjectTree(canvas.overlay, findFunc, nil)
 	} else {
 		if canvas.menu != nil {
-			driver.WalkObjectTree(canvas.menu, findFunc, nil)
+			driver.WalkVisibleObjectTree(canvas.menu, findFunc, nil)
 		}
 		if found == nil {
-			driver.WalkObjectTree(canvas.content, findFunc, nil)
+			driver.WalkVisibleObjectTree(canvas.content, findFunc, nil)
 		}
 	}
 

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -7,22 +7,40 @@ import (
 	"fyne.io/fyne/widget"
 )
 
-// WalkObjectTree will walk an object tree executing the passed functions following the following
-// rules:
+// WalkVisibleObjectTree will walk an object tree for all visible objects executing the passed functions following
+// the following rules:
 // - beforeChildren is called for the start obj before traversing its children
-// - the obj's children are traversed by calling walkObjects on each of them
+// - the obj's children are traversed by calling walkObjects on each of the visible items
 // - afterChildren is called for the obj after traversing the obj's children
 // The walk can be aborted by returning true in one of the functions:
 // - if beforeChildren returns true, further traversing is stopped immediately, the after function
 //   will not be called for the obj where the walk stopped, however, it will be called for all its
 //   parents
-func WalkObjectTree(
+func WalkVisibleObjectTree(
 	obj fyne.CanvasObject,
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
 	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
 ) bool {
 	clipSize := fyne.NewSize(math.MaxInt32, math.MaxInt32)
-	return walkObjectTree(obj, nil, fyne.NewPos(0, 0), fyne.NewPos(0, 0), clipSize, beforeChildren, afterChildren)
+	return walkObjectTree(obj, nil, fyne.NewPos(0, 0), fyne.NewPos(0, 0), clipSize, beforeChildren, afterChildren, true)
+}
+
+// WalkCompleteObjectTree will walk an object tree for all objects (ignoring visible state) executing the passed
+// functions following the following rules:
+// - beforeChildren is called for the start obj before traversing its children
+// - the obj's children are traversed by calling walkObjects on each of the items
+// - afterChildren is called for the obj after traversing the obj's children
+// The walk can be aborted by returning true in one of the functions:
+// - if beforeChildren returns true, further traversing is stopped immediately, the after function
+//   will not be called for the obj where the walk stopped, however, it will be called for all its
+//   parents
+func WalkCompleteObjectTree(
+	obj fyne.CanvasObject,
+	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
+	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
+) bool {
+	clipSize := fyne.NewSize(math.MaxInt32, math.MaxInt32)
+	return walkObjectTree(obj, nil, fyne.NewPos(0, 0), fyne.NewPos(0, 0), clipSize, beforeChildren, afterChildren, false)
 }
 
 func walkObjectTree(
@@ -32,7 +50,11 @@ func walkObjectTree(
 	clipSize fyne.Size,
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
 	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
+	requireVisible bool,
 ) bool {
+	if requireVisible && !obj.Visible() {
+		return false
+	}
 	pos := obj.Position().Add(offset)
 
 	var children []fyne.CanvasObject
@@ -56,7 +78,7 @@ func walkObjectTree(
 
 	cancelled := false
 	for _, child := range children {
-		if walkObjectTree(child, obj, pos, clipPos, clipSize, beforeChildren, afterChildren) {
+		if walkObjectTree(child, obj, pos, clipPos, clipSize, beforeChildren, afterChildren, requireVisible) {
 			cancelled = true
 			break
 		}

--- a/internal/driver/util_test.go
+++ b/internal/driver/util_test.go
@@ -13,7 +13,39 @@ import (
 	"fyne.io/fyne/widget"
 )
 
-func TestWalkObjectTree(t *testing.T) {
+func TestWalkVisibleObjectTree(t *testing.T) {
+	rect := canvas.NewRectangle(color.White)
+	rect.SetMinSize(fyne.NewSize(100, 100))
+	child := canvas.NewRectangle(color.Black)
+	child.Hide()
+	base := widget.NewHBox(rect, child)
+
+	walked := 0
+	WalkVisibleObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
+		walked++
+		return false
+	}, nil)
+
+	assert.Equal(t, 2, walked)
+}
+
+func TestWalkWholeObjectTree(t *testing.T) {
+	rect := canvas.NewRectangle(color.White)
+	rect.SetMinSize(fyne.NewSize(100, 100))
+	child := canvas.NewRectangle(color.Black)
+	child.Hide()
+	base := widget.NewHBox(rect, child)
+
+	walked := 0
+	WalkCompleteObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
+		walked++
+		return false
+	}, nil)
+
+	assert.Equal(t, 3, walked)
+}
+
+func TestWalkVisibleObjectTree_Clip(t *testing.T) {
 	rect := canvas.NewRectangle(color.White)
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	child := canvas.NewRectangle(color.Black)
@@ -22,7 +54,7 @@ func TestWalkObjectTree(t *testing.T) {
 	clipPos := fyne.NewPos(0, 0)
 	clipSize := rect.MinSize()
 
-	WalkObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
+	WalkVisibleObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
 		if _, ok := object.(*widget.ScrollContainer); ok {
 			clipPos = clippingPos
 			clipSize = clippingSize

--- a/widget/group.go
+++ b/widget/group.go
@@ -36,13 +36,11 @@ func (g *Group) MinSize() fyne.Size {
 
 // Show this widget, if it was previously hidden
 func (g *Group) Show() {
-	g.content.Show()
 	g.show(g)
 }
 
 // Hide this widget, if it was previously visible
 func (g *Group) Hide() {
-	g.content.Hide()
 	g.hide(g)
 }
 

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -45,9 +45,6 @@ func (i *iconRenderer) Refresh() {
 	if i.image.Resource != nil {
 		raster := canvas.NewImageFromResource(i.image.Resource)
 		raster.FillMode = canvas.ImageFillContain
-		if i.image.Hidden {
-			raster.Hide()
-		}
 
 		i.objects = append(i.objects, raster)
 	}

--- a/widget/icon_test.go
+++ b/widget/icon_test.go
@@ -38,11 +38,9 @@ func TestIcon_MinSize(t *testing.T) {
 
 func TestIconRenderer_ApplyTheme(t *testing.T) {
 	icon := NewIcon(theme.CancelIcon())
-	icon.Hide()
 	render := Renderer(icon).(*iconRenderer)
-
-	assert.False(t, render.objects[0].Visible())
+	visible := render.objects[0].Visible()
 
 	render.ApplyTheme()
-	assert.False(t, render.objects[0].Visible())
+	assert.Equal(t, visible, render.objects[0].Visible())
 }

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -61,10 +61,6 @@ func (w *baseWidget) show(parent fyne.Widget) {
 	}
 
 	w.Hidden = false
-	for _, child := range Renderer(parent).Objects() {
-		child.Show()
-	}
-
 	canvas.Refresh(parent)
 }
 
@@ -74,10 +70,6 @@ func (w *baseWidget) hide(parent fyne.Widget) {
 	}
 
 	w.Hidden = true
-	for _, child := range Renderer(parent).Objects() {
-		child.Hide()
-	}
-
 	canvas.Refresh(parent)
 }
 


### PR DESCRIPTION
(if that was requested)

This is a large change conceptually, widgets no longer control visibility of child items and drivers must stop drawing on encountering a visible element.
Fixes #377

Looking for feedback on this - pretty sure it's right but a fairly large change for a point release