### PR TITLE
fix paste popup position to equal cursor position

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -15,16 +15,14 @@ func Tap(obj fyne.Tappable) {
 }
 
 // TapSecondary simulates a right mouse click on the specified object.
-func TapSecondary(obj fyne.Tappable) (ev *fyne.PointEvent) {
+func TapSecondary(obj fyne.Tappable, ev *fyne.PointEvent) {
 	if focus, ok := obj.(fyne.Focusable); ok {
 		if focus != Canvas().Focused() {
 			Canvas().Focus(focus)
 		}
 	}
 
-	ev = &fyne.PointEvent{Position: fyne.NewPos(1, 1)}
 	obj.TappedSecondary(ev)
-	return
 }
 
 func typeChars(chars []rune, keyDown func(rune)) {

--- a/test/util.go
+++ b/test/util.go
@@ -15,15 +15,16 @@ func Tap(obj fyne.Tappable) {
 }
 
 // TapSecondary simulates a right mouse click on the specified object.
-func TapSecondary(obj fyne.Tappable) {
+func TapSecondary(obj fyne.Tappable) (ev *fyne.PointEvent) {
 	if focus, ok := obj.(fyne.Focusable); ok {
 		if focus != Canvas().Focused() {
 			Canvas().Focus(focus)
 		}
 	}
 
-	ev := &fyne.PointEvent{Position: fyne.NewPos(1, 1)}
+	ev = &fyne.PointEvent{Position: fyne.NewPos(1, 1)}
 	obj.TappedSecondary(ev)
+	return
 }
 
 func typeChars(chars []rune, keyDown func(rune)) {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -485,7 +485,7 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	if e.ReadOnly {
 		return
 	}
-	
+
 	c := fyne.CurrentApp().Driver().CanvasForObject(e)
 
 	item := fyne.NewMenuItem("Paste", func() {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -481,7 +481,7 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 // TappedSecondary is called when right or alternative tap is invoked.
 //
 // Opens the PopUpMenu with `Paste` item to paste text from the clipboard.
-func (e *Entry) TappedSecondary(_ *fyne.PointEvent) {
+func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	c := fyne.CurrentApp().Driver().CanvasForObject(e)
 
 	item := fyne.NewMenuItem("Paste", func() {
@@ -491,7 +491,7 @@ func (e *Entry) TappedSecondary(_ *fyne.PointEvent) {
 	popUp := NewPopUpMenu(fyne.NewMenu("", item), c)
 
 	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(e)
-	popUpPos := entryPos.Add(fyne.NewPos(0, e.Size().Height))
+	popUpPos := entryPos.Add(fyne.NewPos(pe.Position.X, e.Size().Height))
 
 	popUp.Move(popUpPos)
 }

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -482,6 +482,10 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 //
 // Opens the PopUpMenu with `Paste` item to paste text from the clipboard.
 func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
+	if e.ReadOnly {
+		return
+	}
+	
 	c := fyne.CurrentApp().Driver().CanvasForObject(e)
 
 	item := fyne.NewMenuItem("Paste", func() {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -384,14 +384,14 @@ func TestEntry_PasteFromClipboard(t *testing.T) {
 
 func TestEntry_TappedSecondary(t *testing.T) {
 	entry := NewEntry()
-	test.TapSecondary(entry)
+	pointEv := test.TapSecondary(entry)
 
 	over := fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 	assert.NotNil(t, over)
 
 	cont := over.(*PopUp).Content
-	assert.Equal(t, cont.Position().X, pos.X+theme.Padding())
+	assert.Equal(t, cont.Position().X, pos.X+theme.Padding()+pointEv.Position.X)
 	assert.True(t, cont.Position().Y > pos.Y)
 
 	items := cont.(*Box).Children

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -384,7 +384,8 @@ func TestEntry_PasteFromClipboard(t *testing.T) {
 
 func TestEntry_TappedSecondary(t *testing.T) {
 	entry := NewEntry()
-	pointEv := test.TapSecondary(entry)
+	pointEv := &fyne.PointEvent{Position: fyne.NewPos(1, 1)}
+	test.TapSecondary(entry, pointEv)
 
 	over := fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)


### PR DESCRIPTION
Add paste popup x cordinate position to equal the cursor position

The behavior: the paste popup when mouse is right clicked is directly below the cursor.