### PR TITLE
widget/entry: fixed popup hanging

### DIFF
--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -399,6 +399,36 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	assert.Equal(t, 1, len(items)) // Paste
 }
 
+func TestEntry_PopUp(t *testing.T) {
+	entry := NewEntry()
+	pointEv := &fyne.PointEvent{Position: fyne.NewPos(1, 1)}
+
+	// entry stays focused if popUp hovered
+	test.TapSecondary(entry, pointEv)
+	entry.popUp.MouseOut()
+	entry.FocusLost()
+	assert.True(t, entry.Focused())
+	assert.False(t, entry.popUp.Hidden)
+
+	entry = NewEntry()
+	// entry loses the focus if popUp is not hovered
+	test.TapSecondary(entry, pointEv)
+	entry.popUp.MouseIn(nil)
+	entry.FocusLost()
+	assert.False(t, entry.Focused())
+	assert.True(t, entry.popUp.Hidden)
+
+	entry = NewEntry()
+	test.TapSecondary(entry, pointEv)
+	entry.TypedRune(' ')
+	assert.True(t, entry.popUp.Hidden)
+
+	entry = NewEntry()
+	test.TapSecondary(entry, pointEv)
+	entry.TypedKey(&fyne.KeyEvent{})
+	assert.True(t, entry.popUp.Hidden)
+}
+
 func TestEntry_MouseClickAndDragAfterRow(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("A\nB\n")

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -2,9 +2,11 @@ package widget
 
 import (
 	"image/color"
+	"sync"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/theme"
 )
@@ -19,6 +21,9 @@ type PopUp struct {
 	Canvas  fyne.Canvas
 
 	modal bool
+
+	sync.RWMutex
+	hovered bool
 }
 
 // Hide this widget, if it was previously visible
@@ -87,6 +92,34 @@ func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
 	bg := canvas.NewRectangle(theme.BackgroundColor())
 	objects := []fyne.CanvasObject{shadow, bg, p.Content}
 	return &popUpRenderer{popUp: p, shadow: shadow, bg: bg, objects: objects}
+}
+
+// MouseIn is called when a desktop pointer enters the widget.
+func (p *PopUp) MouseIn(_ *desktop.MouseEvent) {
+	p.Lock()
+	p.hovered = false
+	p.Unlock()
+
+	Refresh(p)
+}
+
+// MouseOut is called when a desktop pointer exits the widget.
+func (p *PopUp) MouseOut() {
+	p.Lock()
+	p.hovered = true
+	p.Unlock()
+
+	Refresh(p)
+}
+
+// MouseMoved is called when a desktop pointer hovers over the widget.
+func (p *PopUp) MouseMoved(_ *desktop.MouseEvent) {}
+
+// Hovered returns whether or not this PopUp is hovered.
+func (p *PopUp) Hovered() bool {
+	p.RLock()
+	defer p.RUnlock()
+	return p.hovered
 }
 
 // NewPopUp creates a new popUp for the specified content and displays it on the passed canvas.

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -3,6 +3,8 @@ package widget
 import (
 	"testing"
 
+	"fyne.io/fyne/driver/desktop"
+
 	"fyne.io/fyne"
 	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
@@ -110,4 +112,15 @@ func TestModalPopUp_TappedSecondary(t *testing.T) {
 	test.TapSecondary(pop)
 	assert.True(t, pop.Visible())
 	assert.Equal(t, pop, test.Canvas().Overlay())
+}
+
+func TestPopUp_Hovered(t *testing.T) {
+	c := test.NewCanvas()
+	popUp := NewPopUp(NewLabel("Test"), c)
+
+	popUp.MouseIn(&desktop.MouseEvent{})
+	assert.False(t, popUp.Hovered())
+
+	popUp.MouseOut()
+	assert.True(t, popUp.Hovered())
 }


### PR DESCRIPTION
Regarding to the issue:
> Oh, I also noticed that the popup does not dismiss if you right click on another entry...

The initial idea of how to fix it:
> to fix that I think we need to attach the popUp to the Entry object and destroy the popUp, when focus lost.

This is not working, because the popUp is out of Entry widget canvas. If we destroy popUp on the entry focus lost, we're loosing the functionality of popUp also. 

I was thinking how can I keep the entry focused, when popUp is hovered. And I propose to implement `desktop.Hoverable` interface for the PopUp widget. So we can know is popUpMenu tapped or not, when an entry losses the focus. And in this case, if popUp is hovered then keep an entry focused, otherwise to hide/destroy the popUp.

Also I added a hide of popUp on any typing. 

Everything seems working, but the only thing confuses me:
 `MouseIn/MouseOut` catch the mouse movement with the opposite meaning. With `MouseOut` it gets hovered (or maybe I'm loosing the point).

Is there a better way to keep Entry focused with the popUp area?