### PR TITLE
Add SetScale() to window

### DIFF
--- a/internal/driver/gl/window.go
+++ b/internal/driver/gl/window.go
@@ -51,6 +51,8 @@ type window struct {
 	fixedSize  bool
 	centered   bool
 	visible    bool
+    
+	scale      float32	
 
 	mousePos           fyne.Position
 	mouseDragged       fyne.Draggable
@@ -177,6 +179,21 @@ func (w *window) SetFixedSize(fixed bool) {
 	runOnMain(w.fitContent)
 }
 
+func (w *window) SetScale(newScale float32) {
+	w.scale = newScale
+
+	if newScale <= 0 {
+		newScale = w.detectScale()
+	}
+	w.canvas.SetScale(newScale)
+
+	// this can trigger resize events that we need to ignore
+	w.fitContent()
+	
+	newWidth, newHeight := w.screenSize(w.canvas.size)
+	w.viewport.SetSize(newWidth, newHeight)
+}
+
 func (w *window) Padded() bool {
 	return w.canvas.padded
 }
@@ -278,6 +295,10 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 }
 
 func (w *window) detectScale() float32 {
+	if w.scale > 0 {
+		return w.scale
+	}
+
 	env := os.Getenv("FYNE_SCALE")
 	if env != "" {
 		scale, err := strconv.ParseFloat(env, 32)

--- a/window.go
+++ b/window.go
@@ -31,6 +31,10 @@ type Window interface {
 	// size or allow resizing.
 	SetFixedSize(bool)
 
+	// SetScale sets fixed scale for this window, overrides FYNE_SCALE and disables auto scaling
+	// (setting this value to "0" re-enables auto scaling)
+	SetScale(float32)
+
 	// CenterOnScreen places a window at the center of the monitor
 	// the Window object is currently positioned on.
 	CenterOnScreen()


### PR DESCRIPTION
Allows to set fixed scale for window, overrides FYNE_SCALE and disables auto scaling. 
This will also let end users to set correct scaling without the need to modify environmental variables (through app settings etc.).

**Example usage:**
```
    w := app.NewWindow("Hello")
    w.SetScale(1.0)
```

To re-enable auto scaling:
```
    w.SetScale(0)
```



**Reason:**
detectScale() often fails in Windows 7/10, as monitor.GetPhysicalSize() returns incorrect values


By default nothing changes (FYNE_SCALE and then auto scalling).

