### PR TITLE
Feature/preferences

### DIFF
--- a/app.go
+++ b/app.go
@@ -37,8 +37,15 @@ type App interface {
 	// Typically not needed for day to day work, mostly internal functionality.
 	Driver() Driver
 
-	// Settings return the application settings, determining theme and so on.
+	// UniqueID returns the application unique identifier, if set.
+	// This must be set for use of the Preferences() functions... see NewWithId(string)
+	UniqueID() string
+
+	// Settings return the globally set settings, determining theme and so on.
 	Settings() Settings
+
+	// Preferences returns the application preferences, used for storing configuration and state
+	Preferences() Preferences
 }
 
 var app App

--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/internal"
 	helper "fyne.io/fyne/internal/app"
 	"fyne.io/fyne/theme"
 )
@@ -16,10 +17,12 @@ import (
 var _ fyne.App = (*fyneApp)(nil)
 
 type fyneApp struct {
-	driver fyne.Driver
-	icon   fyne.Resource
+	driver   fyne.Driver
+	icon     fyne.Resource
+	uniqueID string
 
 	settings *settings
+	prefs    fyne.Preferences
 	running  bool
 	runMutex sync.Mutex
 	exec     func(name string, arg ...string) *exec.Cmd
@@ -31,6 +34,10 @@ func (app *fyneApp) Icon() fyne.Resource {
 
 func (app *fyneApp) SetIcon(icon fyne.Resource) {
 	app.icon = icon
+}
+
+func (app *fyneApp) UniqueID() string {
+	return app.uniqueID
 }
 
 func (app *fyneApp) NewWindow(title string) fyne.Window {
@@ -70,11 +77,22 @@ func (app *fyneApp) Settings() fyne.Settings {
 	return app.settings
 }
 
+func (app *fyneApp) Preferences() fyne.Preferences {
+	return app.prefs
+}
+
+// New returns a new application instance with the default driver and no unique ID
+func New() fyne.App {
+	internal.LogHint("Applications should be created with a unique ID using app.NewWithID()")
+	return NewWithID("")
+}
+
 // NewAppWithDriver initialises a new Fyne application using the specified
-// driver and returns a handle to that App.
+// driver and returns a handle to that App. The id should be globally unique to this app
 // Built in drivers are provided in the "driver" package.
-func NewAppWithDriver(d fyne.Driver) fyne.App {
-	newApp := &fyneApp{driver: d, icon: theme.FyneLogo(), settings: loadSettings(), exec: exec.Command}
+func NewAppWithDriver(d fyne.Driver, id string) fyne.App {
+	newApp := &fyneApp{driver: d, icon: theme.FyneLogo(), settings: loadSettings(),
+		prefs: loadPreferences(id), exec: exec.Command}
 	fyne.SetCurrentApp(newApp)
 
 	listener := make(chan fyne.Settings)

--- a/app/app_gl.go
+++ b/app/app_gl.go
@@ -7,7 +7,8 @@ import (
 	"fyne.io/fyne/internal/driver/glfw"
 )
 
-// New returns a new app instance using the OpenGL driver.
-func New() fyne.App {
-	return NewAppWithDriver(glfw.NewGLDriver())
+// NewWithID returns a new app instance using the OpenGL driver.
+// The ID string should be globally unique to this app.
+func NewWithID(id string) fyne.App {
+	return NewAppWithDriver(glfw.NewGLDriver(), id)
 }

--- a/app/app_software.go
+++ b/app/app_software.go
@@ -8,7 +8,8 @@ import (
 	"fyne.io/fyne/test"
 )
 
-// New returns a new app instance using the test (headless) driver.
-func New() fyne.App {
+// NewWithID returns a new app instance using the test (headless) driver.
+// The ID string should be globally unique to this app.
+func NewWithID(id string) fyne.App {
 	return NewAppWithDriver(test.NewDriverWithPainter(software.NewPainter()))
 }

--- a/app/app_software.go
+++ b/app/app_software.go
@@ -11,5 +11,5 @@ import (
 // NewWithID returns a new app instance using the test (headless) driver.
 // The ID string should be globally unique to this app.
 func NewWithID(id string) fyne.App {
-	return NewAppWithDriver(test.NewDriverWithPainter(software.NewPainter()))
+	return NewAppWithDriver(test.NewDriverWithPainter(software.NewPainter()), id)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -12,20 +12,20 @@ import (
 )
 
 func TestDummyApp(t *testing.T) {
-	app := New()
+	app := NewWithID("io.fyne.test")
 
 	app.Quit()
 }
 
 func TestCurrentApp(t *testing.T) {
-	app := New()
+	app := NewWithID("io.fyne.test")
 
 	assert.Equal(t, app, fyne.CurrentApp())
 }
 
 func TestFyneApp_OpenURL(t *testing.T) {
 	opened := ""
-	app := New()
+	app := NewWithID("io.fyne.test")
 	app.(*fyneApp).exec = func(cmd string, arg ...string) *exec.Cmd {
 		opened = arg[len(arg)-1]
 		return exec.Command("")

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -57,7 +57,8 @@ func (p *preferences) saveToFile(path string) error {
 	}
 	encode := json.NewEncoder(file)
 
-	return encode.Encode(&p.InMemoryPreferences.Values)
+	values := p.InMemoryPreferences.Values()
+	return encode.Encode(&values)
 }
 
 func (p *preferences) load() {
@@ -78,7 +79,8 @@ func (p *preferences) loadFromFile(path string) error {
 	}
 	decode := json.NewDecoder(file)
 
-	return decode.Decode(&p.InMemoryPreferences.Values)
+	values := p.InMemoryPreferences.Values()
+	return decode.Decode(&values)
 }
 
 func newPreferences() *preferences {

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/internal"
+)
+
+type preferences struct {
+	*internal.InMemoryPreferences
+
+	appID string
+}
+
+// Declare conformity with Preferences interface
+var _ fyne.Preferences = (*preferences)(nil)
+
+func (p *preferences) uniqueID() string {
+	if p.appID != "" {
+		return p.appID
+	}
+
+	fyne.LogError("Preferences API requires a unique ID, use app.NewWithID()", nil)
+	p.appID = "TODO" // TODO generate a unique ID
+	return p.appID
+}
+
+// storagePath returns the location of the settings storage
+func (p *preferences) storagePath() string {
+	return filepath.Join(rootConfigDir(), p.uniqueID(), "preferences.json")
+}
+
+func (p *preferences) save() error {
+	return p.saveToFile(p.storagePath())
+}
+
+func (p *preferences) saveToFile(path string) error {
+	err := os.MkdirAll(filepath.Dir(path), 0700)
+	if err != nil { // this is not an exists error according to docs
+		return err
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+		file, err = os.Open(path)
+		if err != nil {
+			return err
+		}
+	}
+	encode := json.NewEncoder(file)
+
+	return encode.Encode(&p.InMemoryPreferences.Values)
+}
+
+func (p *preferences) load() {
+	err := p.loadFromFile(p.storagePath())
+	if err != nil {
+		fyne.LogError("Preferences load error:", err)
+	}
+}
+
+func (p *preferences) loadFromFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			os.MkdirAll(filepath.Dir(path), 0700)
+			return nil
+		}
+		return err
+	}
+	decode := json.NewDecoder(file)
+
+	return decode.Decode(&p.InMemoryPreferences.Values)
+}
+
+func newPreferences() *preferences {
+	p := &preferences{}
+	p.InMemoryPreferences = internal.NewInMemoryPreferences()
+	return p
+}
+
+func loadPreferences(id string) *preferences {
+	p := newPreferences()
+	p.appID = id
+	p.OnChange = func() {
+		p.save()
+	}
+	p.load()
+
+	return p
+}

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/internal"
@@ -24,7 +26,7 @@ func (p *preferences) uniqueID() string {
 	}
 
 	fyne.LogError("Preferences API requires a unique ID, use app.NewWithID()", nil)
-	p.appID = "TODO" // TODO generate a unique ID
+	p.appID = fmt.Sprintf("missing-id-%d", time.Now().Unix()) // This is a fake unique - it just has to not be reused...
 	return p.appID
 }
 

--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreferences_Save(t *testing.T) {
+	p := loadPreferences("dummy")
+	p.Values["keyString"] = "value"
+	p.Values["keyInt"] = 4
+	p.Values["keyFloat"] = 3.5
+	p.Values["keyBool"] = true
+
+	path := filepath.Join(os.TempDir(), "fynePrefs.json")
+	defer os.Remove(path)
+	p.saveToFile(path)
+
+	expected, err := ioutil.ReadFile(filepath.Join("testdata", "preferences.json"))
+	if err != nil {
+		assert.Fail(t, "Failed to load, %v", err)
+	}
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		assert.Fail(t, "Failed to load, %v", err)
+	}
+	assert.JSONEq(t, string(expected), string(content))
+}
+
+func TestPreferences_Load(t *testing.T) {
+	p := loadPreferences("dummy")
+	p.loadFromFile(filepath.Join("testdata", "preferences.json"))
+
+	assert.Equal(t, "value", p.String("keyString"))
+	assert.Equal(t, 4, p.Int("keyInt"))
+	assert.Equal(t, 3.5, p.Float("keyFloat"))
+	assert.Equal(t, true, p.Bool("keyBool"))
+}

--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestPreferences_Save(t *testing.T) {
 	p := loadPreferences("dummy")
-	p.Values["keyString"] = "value"
-	p.Values["keyInt"] = 4
-	p.Values["keyFloat"] = 3.5
-	p.Values["keyBool"] = true
+	p.Values()["keyString"] = "value"
+	p.Values()["keyInt"] = 4
+	p.Values()["keyFloat"] = 3.5
+	p.Values()["keyBool"] = true
 
 	path := filepath.Join(os.TempDir(), "fynePrefs.json")
 	defer os.Remove(path)

--- a/app/testdata/preferences.json
+++ b/app/testdata/preferences.json
@@ -1,0 +1,6 @@
+{
+  "keyString": "value",
+  "keyInt": 4,
+  "keyFloat": 3.5,
+  "keyBool": true
+}

--- a/app_test.go
+++ b/app_test.go
@@ -34,7 +34,15 @@ func (dummyApp) Driver() Driver {
 	return nil
 }
 
+func (dummyApp) UniqueID() string {
+	return "dummy"
+}
+
 func (dummyApp) Settings() Settings {
+	return nil
+}
+
+func (dummyApp) Preferences() Preferences {
 	return nil
 }
 

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -14,6 +14,8 @@ import (
 	"fyne.io/fyne/widget"
 )
 
+const preferenceCurrentTab = "currentTab"
+
 func welcomeScreen(a fyne.App) fyne.CanvasObject {
 	logo := canvas.NewImageFromResource(theme.FyneLogo())
 	logo.SetMinSize(fyne.NewSize(128, 128))
@@ -44,7 +46,7 @@ func welcomeScreen(a fyne.App) fyne.CanvasObject {
 }
 
 func main() {
-	a := app.New()
+	a := app.NewWithID("io.fyne.demo")
 	w := a.NewWindow("Fyne Demo")
 	w.SetMainMenu(fyne.NewMainMenu(fyne.NewMenu("File",
 		fyne.NewMenuItem("New", func() { fmt.Println("Menu New") }),
@@ -62,7 +64,9 @@ func main() {
 		widget.NewTabItemWithIcon("Windows", theme.ViewFullScreenIcon(), screens.DialogScreen(w)),
 		widget.NewTabItemWithIcon("Advanced", theme.SettingsIcon(), screens.AdvancedScreen(w)))
 	tabs.SetTabLocation(widget.TabLocationLeading)
+	tabs.SelectTabIndex(a.Preferences().Int(preferenceCurrentTab))
 	w.SetContent(tabs)
 
 	w.ShowAndRun()
+	a.Preferences().SetInt(preferenceCurrentTab, tabs.CurrentTabIndex())
 }

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -23,9 +23,14 @@ func (p *InMemoryPreferences) fireChange() {
 
 // Bool looks up a boolean value for the key
 func (p *InMemoryPreferences) Bool(key string) bool {
+	return p.BoolWithFallback(key, false)
+}
+
+// BoolWithFallback looks up a boolean value and returns the given fallback if not found
+func (p *InMemoryPreferences) BoolWithFallback(key string, fallback bool) bool {
 	value, ok := p.Values[key]
 	if !ok {
-		return false
+		return fallback
 	}
 
 	return value.(bool)
@@ -39,9 +44,14 @@ func (p *InMemoryPreferences) SetBool(key string, value bool) {
 
 // Float looks up a float64 value for the key
 func (p *InMemoryPreferences) Float(key string) float64 {
+	return p.FloatWithFallback(key, 0.0)
+}
+
+// FloatWithFallback looks up a float64 value and returns the given fallback if not found
+func (p *InMemoryPreferences) FloatWithFallback(key string, fallback float64) float64 {
 	value, ok := p.Values[key]
 	if !ok {
-		return 0.0
+		return fallback
 	}
 
 	return value.(float64)
@@ -55,9 +65,14 @@ func (p *InMemoryPreferences) SetFloat(key string, value float64) {
 
 // Int looks up an integer value for the key
 func (p *InMemoryPreferences) Int(key string) int {
+	return p.IntWithFallback(key, 0)
+}
+
+// IntWithFallback looks up an integer value and returns the given fallback if not found
+func (p *InMemoryPreferences) IntWithFallback(key string, fallback int) int {
 	value, ok := p.Values[key]
 	if !ok {
-		return 0
+		return fallback
 	}
 
 	// integers can be de-serialised as floats, so support both
@@ -75,9 +90,14 @@ func (p *InMemoryPreferences) SetInt(key string, value int) {
 
 // String looks up a string value for the key
 func (p *InMemoryPreferences) String(key string) string {
+	return p.StringWithFallback(key, "")
+}
+
+// StringWithFallback looks up a string value and returns the given fallback if not found
+func (p *InMemoryPreferences) StringWithFallback(key, fallback string) string {
 	value, ok := p.Values[key]
 	if !ok {
-		return ""
+		return fallback
 	}
 
 	return value.(string)

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -1,0 +1,97 @@
+package internal
+
+import (
+	"fyne.io/fyne"
+)
+
+// InMemoryPreferences provides an implementation of the fyne.Preferences API that is stored in memory.
+type InMemoryPreferences struct {
+	Values   map[string]interface{}
+	OnChange func()
+}
+
+// Declare conformity with Preferences interface
+var _ fyne.Preferences = (*InMemoryPreferences)(nil)
+
+func (p *InMemoryPreferences) fireChange() {
+	if p.OnChange == nil {
+		return
+	}
+
+	p.OnChange()
+}
+
+// Bool looks up a boolean value for the key
+func (p *InMemoryPreferences) Bool(key string) bool {
+	value, ok := p.Values[key]
+	if !ok {
+		return false
+	}
+
+	return value.(bool)
+}
+
+// SetBool saves a boolean value for the given key
+func (p *InMemoryPreferences) SetBool(key string, value bool) {
+	p.Values[key] = value
+	p.fireChange()
+}
+
+// Float looks up a float64 value for the key
+func (p *InMemoryPreferences) Float(key string) float64 {
+	value, ok := p.Values[key]
+	if !ok {
+		return 0.0
+	}
+
+	return value.(float64)
+}
+
+// SetFloat saves a float64 value for the given key
+func (p *InMemoryPreferences) SetFloat(key string, value float64) {
+	p.Values[key] = value
+	p.fireChange()
+}
+
+// Int looks up an integer value for the key
+func (p *InMemoryPreferences) Int(key string) int {
+	value, ok := p.Values[key]
+	if !ok {
+		return 0
+	}
+
+	// integers can be de-serialised as floats, so support both
+	if intVal, ok := value.(int); ok {
+		return intVal
+	}
+	return int(value.(float64))
+}
+
+// SetInt saves an integer value for the given key
+func (p *InMemoryPreferences) SetInt(key string, value int) {
+	p.Values[key] = value
+	p.fireChange()
+}
+
+// String looks up a string value for the key
+func (p *InMemoryPreferences) String(key string) string {
+	value, ok := p.Values[key]
+	if !ok {
+		return ""
+	}
+
+	return value.(string)
+}
+
+// SetString saves a string value for the given key
+func (p *InMemoryPreferences) SetString(key string, value string) {
+	p.Values[key] = value
+	p.fireChange()
+}
+
+// NewInMemoryPreferences creates a new preferences implementation stored in memory
+func NewInMemoryPreferences() *InMemoryPreferences {
+	p := &InMemoryPreferences{}
+	p.Values = make(map[string]interface{})
+	return p
+}

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -32,6 +32,7 @@ func (p *InMemoryPreferences) get(key string) (interface{}, bool) {
 	return v, err
 }
 
+// Values provides access to the underlying value map - for internal use only...
 func (p *InMemoryPreferences) Values() map[string]interface{} {
 	p.lock.RLock()
 	defer p.lock.RUnlock()

--- a/internal/preferences_test.go
+++ b/internal/preferences_test.go
@@ -20,6 +20,14 @@ func TestPrefs_Bool(t *testing.T) {
 	assert.Equal(t, true, p.Bool("testBool"))
 }
 
+func TestPrefs_BoolWithFallback(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, true, p.BoolWithFallback("testBool", true))
+	p.SetBool("testBool", false)
+	assert.Equal(t, false, p.BoolWithFallback("testBool", true))
+}
+
 func TestPrefs_Bool_Zero(t *testing.T) {
 	p := NewInMemoryPreferences()
 
@@ -38,6 +46,14 @@ func TestPrefs_Float(t *testing.T) {
 	p.Values["testFloat"] = 1.2
 
 	assert.Equal(t, 1.2, p.Float("testFloat"))
+}
+
+func TestPrefs_FloatWithFallback(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, 1.0, p.FloatWithFallback("testFloat", 1.0))
+	p.Values["testFloat"] = 1.2
+	assert.Equal(t, 1.2, p.FloatWithFallback("testFloat", 1.0))
 }
 
 func TestPrefs_Float_Zero(t *testing.T) {
@@ -60,6 +76,14 @@ func TestPrefs_Int(t *testing.T) {
 	assert.Equal(t, 5, p.Int("testInt"))
 }
 
+func TestPrefs_IntWithFallback(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, 2, p.IntWithFallback("testInt", 2))
+	p.Values["testInt"] = 5
+	assert.Equal(t, 5, p.IntWithFallback("testInt", 2))
+}
+
 func TestPrefs_Int_Zero(t *testing.T) {
 	p := NewInMemoryPreferences()
 
@@ -78,6 +102,14 @@ func TestPrefs_String(t *testing.T) {
 	p.Values["test"] = "value"
 
 	assert.Equal(t, "value", p.String("test"))
+}
+
+func TestPrefs_StringWithFallback(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, "default", p.StringWithFallback("test", "default"))
+	p.Values["test"] = "value"
+	assert.Equal(t, "value", p.StringWithFallback("test", "default"))
 }
 
 func TestPrefs_String_Zero(t *testing.T) {

--- a/internal/preferences_test.go
+++ b/internal/preferences_test.go
@@ -15,7 +15,7 @@ func TestPrefs_SetBool(t *testing.T) {
 
 func TestPrefs_Bool(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values["testBool"] = true
+	p.Values()["testBool"] = true
 
 	assert.Equal(t, true, p.Bool("testBool"))
 }
@@ -43,7 +43,7 @@ func TestPrefs_SetFloat(t *testing.T) {
 
 func TestPrefs_Float(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values["testFloat"] = 1.2
+	p.Values()["testFloat"] = 1.2
 
 	assert.Equal(t, 1.2, p.Float("testFloat"))
 }
@@ -52,7 +52,7 @@ func TestPrefs_FloatWithFallback(t *testing.T) {
 	p := NewInMemoryPreferences()
 
 	assert.Equal(t, 1.0, p.FloatWithFallback("testFloat", 1.0))
-	p.Values["testFloat"] = 1.2
+	p.Values()["testFloat"] = 1.2
 	assert.Equal(t, 1.2, p.FloatWithFallback("testFloat", 1.0))
 }
 
@@ -71,7 +71,7 @@ func TestPrefs_SetInt(t *testing.T) {
 
 func TestPrefs_Int(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values["testInt"] = 5
+	p.Values()["testInt"] = 5
 
 	assert.Equal(t, 5, p.Int("testInt"))
 }
@@ -80,7 +80,7 @@ func TestPrefs_IntWithFallback(t *testing.T) {
 	p := NewInMemoryPreferences()
 
 	assert.Equal(t, 2, p.IntWithFallback("testInt", 2))
-	p.Values["testInt"] = 5
+	p.Values()["testInt"] = 5
 	assert.Equal(t, 5, p.IntWithFallback("testInt", 2))
 }
 
@@ -99,7 +99,7 @@ func TestPrefs_SetString(t *testing.T) {
 
 func TestPrefs_String(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values["test"] = "value"
+	p.Values()["test"] = "value"
 
 	assert.Equal(t, "value", p.String("test"))
 }
@@ -108,7 +108,7 @@ func TestPrefs_StringWithFallback(t *testing.T) {
 	p := NewInMemoryPreferences()
 
 	assert.Equal(t, "default", p.StringWithFallback("test", "default"))
-	p.Values["test"] = "value"
+	p.Values()["test"] = "value"
 	assert.Equal(t, "value", p.StringWithFallback("test", "default"))
 }
 

--- a/internal/preferences_test.go
+++ b/internal/preferences_test.go
@@ -1,0 +1,99 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefs_SetBool(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.SetBool("testBool", true)
+
+	assert.Equal(t, true, p.Bool("testBool"))
+}
+
+func TestPrefs_Bool(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.Values["testBool"] = true
+
+	assert.Equal(t, true, p.Bool("testBool"))
+}
+
+func TestPrefs_Bool_Zero(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, false, p.Bool("testBool"))
+}
+
+func TestPrefs_SetFloat(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.SetFloat("testFloat", 1.7)
+
+	assert.Equal(t, 1.7, p.Float("testFloat"))
+}
+
+func TestPrefs_Float(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.Values["testFloat"] = 1.2
+
+	assert.Equal(t, 1.2, p.Float("testFloat"))
+}
+
+func TestPrefs_Float_Zero(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, 0.0, p.Float("testFloat"))
+}
+
+func TestPrefs_SetInt(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.SetInt("testInt", 5)
+
+	assert.Equal(t, 5, p.Int("testInt"))
+}
+
+func TestPrefs_Int(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.Values["testInt"] = 5
+
+	assert.Equal(t, 5, p.Int("testInt"))
+}
+
+func TestPrefs_Int_Zero(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, 0, p.Int("testInt"))
+}
+
+func TestPrefs_SetString(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.SetString("test", "value")
+
+	assert.Equal(t, "value", p.String("test"))
+}
+
+func TestPrefs_String(t *testing.T) {
+	p := NewInMemoryPreferences()
+	p.Values["test"] = "value"
+
+	assert.Equal(t, "value", p.String("test"))
+}
+
+func TestPrefs_String_Zero(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	assert.Equal(t, "", p.String("test"))
+}
+
+func TestInMemoryPreferences_OnChange(t *testing.T) {
+	p := NewInMemoryPreferences()
+	called := false
+	p.OnChange = func() {
+		called = true
+	}
+
+	p.SetString("dummy", "another")
+
+	assert.True(t, called)
+}

--- a/preferences.go
+++ b/preferences.go
@@ -4,21 +4,29 @@ package fyne
 type Preferences interface {
 	// Bool looks up a boolean value for the key
 	Bool(key string) bool
+	// BoolWithFallback looks up a boolean value and returns the given fallback if not found
+	BoolWithFallback(key string, fallback bool) bool
 	// SetBool saves a boolean value for the given key
 	SetBool(key string, value bool)
 
 	// Float looks up a float64 value for the key
 	Float(key string) float64
+	// FloatWithFallback looks up a float64 value and returns the given fallback if not found
+	FloatWithFallback(key string, fallback float64) float64
 	// SetFloat saves a float64 value for the given key
 	SetFloat(key string, value float64)
 
 	// Int looks up an integer value for the key
 	Int(key string) int
+	// IntWithFallback looks up an integer value and returns the given fallback if not found
+	IntWithFallback(key string, fallback int) int
 	// SetInt saves an integer value for the given key
 	SetInt(key string, value int)
 
 	// String looks up a string value for the key
 	String(key string) string
+	// StringWithFallback looks up a string value and returns the given fallback if not found
+	StringWithFallback(key, fallback string) string
 	// SetString saves a string value for the given key
 	SetString(key string, value string)
 }

--- a/preferences.go
+++ b/preferences.go
@@ -1,0 +1,24 @@
+package fyne
+
+// Preferences describes the ways that an app can save and load user preferences
+type Preferences interface {
+	// Bool looks up a boolean value for the key
+	Bool(key string) bool
+	// SetBool saves a boolean value for the given key
+	SetBool(key string, value bool)
+
+	// Float looks up a float64 value for the key
+	Float(key string) float64
+	// SetFloat saves a float64 value for the given key
+	SetFloat(key string, value float64)
+
+	// Int looks up an integer value for the key
+	Int(key string) int
+	// SetInt saves an integer value for the given key
+	SetInt(key string, value int)
+
+	// String looks up a string value for the key
+	String(key string) string
+	// SetString saves a string value for the given key
+	SetString(key string, value string)
+}

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/internal"
 )
 
 // ensure we have a dummy app loaded and ready to test
@@ -17,6 +18,7 @@ func init() {
 type testApp struct {
 	driver   *testDriver
 	settings fyne.Settings
+	prefs    fyne.Preferences
 }
 
 func (a *testApp) Icon() fyne.Resource {
@@ -42,6 +44,10 @@ func (a *testApp) Run() {
 
 func (a *testApp) Quit() {
 	// no-op
+}
+
+func (a *testApp) UniqueID() string {
+	return "testApp" // TODO should this be randomised?
 }
 
 func (a *testApp) applyThemeTo(content fyne.CanvasObject, canvas fyne.Canvas) {
@@ -82,13 +88,18 @@ func (a *testApp) Settings() fyne.Settings {
 	return a.settings
 }
 
+func (a *testApp) Preferences() fyne.Preferences {
+	return a.prefs
+}
+
 // NewApp returns a new dummy app used for testing..
 // It loads a test driver which creates a virtual window in memory for testing.
 func NewApp() fyne.App {
 	settings := &testSettings{}
 	settings.theme = &dummyTheme{}
 	settings.listenerMutex = &sync.Mutex{}
-	test := &testApp{settings: settings}
+	prefs := internal.NewInMemoryPreferences()
+	test := &testApp{settings: settings, prefs: prefs}
 	fyne.SetCurrentApp(test)
 	test.driver = NewDriver().(*testDriver)
 


### PR DESCRIPTION
Implement the basic preferences API.

This requires a UniqueID so we can store app data in a sandbox. This is introduced with a new API and apps are reminded to use it if Preferences APIs are accessed without setting it.
This satisfies most of the Settings doc (global was in already, this is app based).
Remaining is secure preferences (later) and file storage (separate issue).
Fixes #158 