### PR TITLE
render cache tree in the glfw canvas

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -288,13 +288,21 @@ func (c *glCanvas) walkTrees(
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
 	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
 ) {
-	driver.WalkVisibleObjectTree(c.content, beforeChildren, afterChildren)
+	c.walkTree(c.content, beforeChildren, afterChildren)
 	if c.menu != nil {
-		driver.WalkVisibleObjectTree(c.menu, beforeChildren, afterChildren)
+		c.walkTree(c.menu, beforeChildren, afterChildren)
 	}
 	if c.overlay != nil {
-		driver.WalkVisibleObjectTree(c.overlay, beforeChildren, afterChildren)
+		c.walkTree(c.overlay, beforeChildren, afterChildren)
 	}
+}
+
+func (c *glCanvas) walkTree(
+	obj fyne.CanvasObject,
+	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
+	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
+) {
+	driver.WalkVisibleObjectTree(obj, beforeChildren, afterChildren)
 }
 
 func (c *glCanvas) setDirty(dirty bool) {

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -35,11 +35,31 @@ type glCanvas struct {
 	scale, detectedScale float32
 	painter              gl.Painter
 
-	dirty        bool
-	dirtyMutex   *sync.Mutex
-	minSizes     map[fyne.CanvasObject]fyne.Size
-	refreshQueue chan fyne.CanvasObject
-	context      driver.WithContext
+	dirty                              bool
+	dirtyMutex                         *sync.Mutex
+	refreshQueue                       chan fyne.CanvasObject
+	contentTree, menuTree, overlayTree *renderCacheTree
+	context                            driver.WithContext
+}
+
+type renderCacheTree struct {
+	sync.RWMutex
+	root *renderCacheNode
+}
+
+type renderCacheNode struct {
+	// structural data
+	firstChild  *renderCacheNode
+	nextSibling *renderCacheNode
+	obj         fyne.CanvasObject
+	parent      *renderCacheNode
+	// cache data
+	minSize fyne.Size
+	// painterData is some data from the painter associated with the drawed node
+	// it may for instance point to a GL texture
+	// it should free all associated resources when released
+	// i.e. it should not simply be a texture reference integer
+	painterData interface{}
 }
 
 func (c *glCanvas) Capture() image.Image {
@@ -60,7 +80,7 @@ func (c *glCanvas) Content() fyne.CanvasObject {
 func (c *glCanvas) SetContent(content fyne.CanvasObject) {
 	c.Lock()
 	c.content = content
-	c.minSizes = map[fyne.CanvasObject]fyne.Size{}
+	c.contentTree = &renderCacheTree{root: &renderCacheNode{obj: c.content}}
 	c.Unlock()
 
 	newSize := c.size.Union(c.canvasSize(c.content.MinSize()))
@@ -79,6 +99,7 @@ func (c *glCanvas) Overlay() fyne.CanvasObject {
 func (c *glCanvas) SetOverlay(overlay fyne.CanvasObject) {
 	c.Lock()
 	c.overlay = overlay
+	c.overlayTree = &renderCacheTree{root: &renderCacheNode{obj: c.overlay}}
 	c.Unlock()
 
 	if overlay != nil {
@@ -212,7 +233,8 @@ func (c *glCanvas) ensureMinSize() bool {
 	}
 	var objToLayout fyne.CanvasObject
 	windowNeedsMinSizeUpdate := false
-	ensureMinSize := func(obj fyne.CanvasObject, parent fyne.CanvasObject) {
+	ensureMinSize := func(node *renderCacheNode) {
+		obj := node.obj
 		canvasMutex.Lock()
 		canvases[obj] = c
 		canvasMutex.Unlock()
@@ -221,11 +243,11 @@ func (c *glCanvas) ensureMinSize() bool {
 			return
 		}
 		minSize := obj.MinSize()
-		minSizeChanged := c.minSizes[obj] != minSize
+		minSizeChanged := node.minSize != minSize
 		if minSizeChanged {
-			c.minSizes[obj] = minSize
-			if parent != nil {
-				objToLayout = parent
+			node.minSize = minSize
+			if node.parent != nil {
+				objToLayout = node.parent.obj
 			} else {
 				windowNeedsMinSizeUpdate = true
 				size := obj.Size()
@@ -264,7 +286,8 @@ func (c *glCanvas) paint(size fyne.Size) {
 	c.setDirty(false)
 	c.painter.Clear()
 
-	paint := func(obj fyne.CanvasObject, pos fyne.Position, _ fyne.Position, _ fyne.Size) bool {
+	paint := func(node *renderCacheNode, pos fyne.Position) {
+		obj := node.obj
 		// TODO should this be somehow not scroll container specific?
 		if _, ok := obj.(*widget.ScrollContainer); ok {
 			c.painter.StartClipping(
@@ -273,10 +296,9 @@ func (c *glCanvas) paint(size fyne.Size) {
 			)
 		}
 		c.painter.Paint(obj, pos, size)
-		return false
 	}
-	afterPaint := func(obj, _ fyne.CanvasObject) {
-		if _, ok := obj.(*widget.ScrollContainer); ok {
+	afterPaint := func(node *renderCacheNode) {
+		if _, ok := node.obj.(*widget.ScrollContainer); ok {
 			c.painter.StopClipping()
 		}
 	}
@@ -285,24 +307,70 @@ func (c *glCanvas) paint(size fyne.Size) {
 }
 
 func (c *glCanvas) walkTrees(
-	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
-	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
+	beforeChildren func(*renderCacheNode, fyne.Position),
+	afterChildren func(*renderCacheNode),
 ) {
-	c.walkTree(c.content, beforeChildren, afterChildren)
+	c.walkTree(c.contentTree, beforeChildren, afterChildren)
 	if c.menu != nil {
-		c.walkTree(c.menu, beforeChildren, afterChildren)
+		c.walkTree(c.menuTree, beforeChildren, afterChildren)
 	}
 	if c.overlay != nil {
-		c.walkTree(c.overlay, beforeChildren, afterChildren)
+		c.walkTree(c.overlayTree, beforeChildren, afterChildren)
 	}
 }
 
 func (c *glCanvas) walkTree(
-	obj fyne.CanvasObject,
-	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
-	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
+	tree *renderCacheTree,
+	beforeChildren func(*renderCacheNode, fyne.Position),
+	afterChildren func(*renderCacheNode),
 ) {
-	driver.WalkVisibleObjectTree(obj, beforeChildren, afterChildren)
+	tree.Lock()
+	defer tree.Unlock()
+	var node, parent, prev *renderCacheNode
+	node = tree.root
+
+	bc := func(obj fyne.CanvasObject, pos fyne.Position, _ fyne.Position, _ fyne.Size) bool {
+		if node != nil && node.obj != obj {
+			if parent.firstChild == node {
+				parent.firstChild = nil
+			}
+			node = nil
+		}
+		if node == nil {
+			node = &renderCacheNode{parent: parent, obj: obj}
+			if parent.firstChild == nil {
+				parent.firstChild = node
+			} else {
+				prev.nextSibling = node
+			}
+		}
+		if prev != nil && prev.parent != parent {
+			prev = nil
+		}
+
+		if beforeChildren != nil {
+			beforeChildren(node, pos)
+		}
+
+		parent = node
+		node = parent.firstChild
+		return false
+	}
+	ac := func(obj fyne.CanvasObject, _ fyne.CanvasObject) {
+		node = parent
+		parent = node.parent
+		if prev != nil && prev.parent != parent {
+			prev.nextSibling = nil
+		}
+
+		if afterChildren != nil {
+			afterChildren(node)
+		}
+
+		prev = node
+		node = node.nextSibling
+	}
+	driver.WalkVisibleObjectTree(tree.root.obj, bc, ac)
 }
 
 func (c *glCanvas) setDirty(dirty bool) {
@@ -349,6 +417,7 @@ func (c *glCanvas) buildMenuBar(m *fyne.MainMenu) {
 func (c *glCanvas) setMenuBar(b *widget.Toolbar) {
 	c.Lock()
 	c.menu = b
+	c.menuTree = &renderCacheTree{root: &renderCacheNode{obj: c.menu}}
 	c.Unlock()
 }
 
@@ -398,7 +467,7 @@ func (c *glCanvas) contentPos() fyne.Position {
 func newCanvas() *glCanvas {
 	c := &glCanvas{scale: 1.0}
 	c.content = &canvas.Rectangle{FillColor: theme.BackgroundColor()}
-	c.minSizes = map[fyne.CanvasObject]fyne.Size{}
+	c.contentTree = &renderCacheTree{root: &renderCacheNode{obj: c.content}}
 	c.padded = true
 
 	c.focusMgr = app.NewFocusManager(c)

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -250,7 +250,7 @@ func (c *glCanvas) ensureMinSize() bool {
 			}
 		}
 	}
-	c.walkTree(nil, ensureMinSize)
+	c.walkTrees(nil, ensureMinSize)
 	if windowNeedsMinSizeUpdate && (c.size.Width < c.MinSize().Width || c.size.Height < c.MinSize().Height) {
 		c.Resize(c.Size().Union(c.MinSize()))
 	}
@@ -281,10 +281,10 @@ func (c *glCanvas) paint(size fyne.Size) {
 		}
 	}
 
-	c.walkTree(paint, afterPaint)
+	c.walkTrees(paint, afterPaint)
 }
 
-func (c *glCanvas) walkTree(
+func (c *glCanvas) walkTrees(
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
 	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
 ) {

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -300,6 +300,344 @@ func Test_glCanvas_ContentChangeWithoutMinSizeChangeDoesNotLayout(t *testing.T) 
 	w.ignoreResize = false
 }
 
+func Test_glCanvas_walkTree(t *testing.T) {
+	leftObj1 := canvas.NewRectangle(color.Gray16{Y: 1})
+	leftObj2 := canvas.NewRectangle(color.Gray16{Y: 2})
+	leftCol := &modifiableBox{Box: widget.NewVBox(leftObj1, leftObj2)}
+	rightObj1 := canvas.NewRectangle(color.Gray16{Y: 10})
+	rightObj2 := canvas.NewRectangle(color.Gray16{Y: 20})
+	rightCol := &modifiableBox{Box: widget.NewVBox(rightObj1, rightObj2)}
+	content := fyne.NewContainer(leftCol, rightCol)
+	content.Move(fyne.NewPos(17, 42))
+	leftCol.Move(fyne.NewPos(300, 400))
+	leftObj1.Move(fyne.NewPos(1, 2))
+	leftObj2.Move(fyne.NewPos(20, 30))
+	rightObj1.Move(fyne.NewPos(500, 600))
+	rightObj2.Move(fyne.NewPos(60, 70))
+	rightCol.Move(fyne.NewPos(7, 8))
+
+	tree := &renderCacheTree{root: &renderCacheNode{obj: content}}
+	c := newCanvas()
+
+	type nodeInfo struct {
+		obj                                     fyne.CanvasObject
+		lastBeforeCallIndex, lastAfterCallIndex int
+	}
+	updateInfoBefore := func(node *renderCacheNode, index int) {
+		pd, _ := node.painterData.(nodeInfo)
+		if (pd != nodeInfo{}) && pd.obj != node.obj {
+			panic("node cache does not match node obj - nodes should not be reused for different objects")
+		}
+		pd.obj = node.obj
+		pd.lastBeforeCallIndex = index
+		node.painterData = pd
+	}
+	updateInfoAfter := func(node *renderCacheNode, index int) {
+		pd := node.painterData.(nodeInfo)
+		if pd.obj != node.obj {
+			panic("node cache does not match node obj - nodes should not be reused for different objects")
+		}
+		pd.lastAfterCallIndex = index
+		node.painterData = pd
+	}
+
+	//
+	// test that first walk calls the hooks correctly
+	//
+	type beforeCall struct {
+		node   *renderCacheNode
+		obj    fyne.CanvasObject
+		parent fyne.CanvasObject
+		pos    fyne.Position
+	}
+	beforeCalls := []beforeCall{}
+	type afterCall struct {
+		obj    fyne.CanvasObject
+		parent fyne.CanvasObject
+	}
+	afterCalls := []afterCall{}
+
+	var i int
+	c.walkTree(tree, func(node *renderCacheNode, pos fyne.Position) {
+		var parent fyne.CanvasObject
+		if node.parent != nil {
+			parent = node.parent.obj
+		}
+		i++
+		updateInfoBefore(node, i)
+		beforeCalls = append(beforeCalls, beforeCall{obj: node.obj, parent: parent, pos: pos})
+	}, func(node *renderCacheNode) {
+		var parent fyne.CanvasObject
+		if node.parent != nil {
+			parent = node.parent.obj
+		}
+		i++
+		updateInfoAfter(node, i)
+		node.minSize.Height = node.obj.Position().Y
+		afterCalls = append(afterCalls, afterCall{obj: node.obj, parent: parent})
+	})
+
+	assert.Equal(t, []beforeCall{
+		{obj: content, pos: fyne.NewPos(17, 42)},
+		{obj: leftCol, parent: content, pos: fyne.NewPos(317, 442)},
+		{obj: leftObj1, parent: leftCol, pos: fyne.NewPos(318, 444)},
+		{obj: leftObj2, parent: leftCol, pos: fyne.NewPos(337, 472)},
+		{obj: rightCol, parent: content, pos: fyne.NewPos(24, 50)},
+		{obj: rightObj1, parent: rightCol, pos: fyne.NewPos(524, 650)},
+		{obj: rightObj2, parent: rightCol, pos: fyne.NewPos(84, 120)},
+	}, beforeCalls, "calls before children hook with the correct node and position")
+	assert.Equal(t, []afterCall{
+		{obj: leftObj1, parent: leftCol},
+		{obj: leftObj2, parent: leftCol},
+		{obj: leftCol, parent: content},
+		{obj: rightObj1, parent: rightCol},
+		{obj: rightObj2, parent: rightCol},
+		{obj: rightCol, parent: content},
+		{obj: content},
+	}, afterCalls, "calls after children hook with the correct node")
+
+	//
+	// test that second walk gives access to the cache
+	//
+	secondRunBeforePainterData := []nodeInfo{}
+	secondRunAfterPainterData := []nodeInfo{}
+	nodes := []*renderCacheNode{}
+
+	c.walkTree(tree, func(node *renderCacheNode, pos fyne.Position) {
+		secondRunBeforePainterData = append(secondRunBeforePainterData, node.painterData.(nodeInfo))
+		nodes = append(nodes, node)
+	}, func(node *renderCacheNode) {
+		secondRunAfterPainterData = append(secondRunAfterPainterData, node.painterData.(nodeInfo))
+	})
+
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		nodeInfo{obj: rightObj2, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
+	}, secondRunBeforePainterData, "second run uses cached nodes")
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		nodeInfo{obj: rightObj2, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+	}, secondRunAfterPainterData, "second run uses cached nodes")
+	leftObj1Node := nodes[2]
+	leftObj2Node := nodes[3]
+	assert.Equal(t, leftObj2Node, leftObj1Node.nextSibling, "correct sibling relation")
+	assert.Nil(t, leftObj2Node.nextSibling, "no surplus nodes")
+	rightObj1Node := nodes[5]
+	rightObj2Node := nodes[6]
+	assert.Equal(t, rightObj2Node, rightObj1Node.nextSibling, "correct sibling relation")
+	rightColNode := nodes[4]
+	assert.Nil(t, rightColNode.nextSibling, "no surplus nodes")
+
+	//
+	// test that removal, replacement and adding at the end of a children list works
+	//
+	leftCol.deleteAt(1)
+	leftNewObj2 := canvas.NewRectangle(color.Gray16{Y: 3})
+	leftCol.Append(leftNewObj2)
+	rightCol.deleteAt(1)
+	thirdCol := widget.NewVBox()
+	content.AddObject(thirdCol)
+	thirdRunBeforePainterData := []nodeInfo{}
+	thirdRunAfterPainterData := []nodeInfo{}
+
+	i = 0
+	c.walkTree(tree, func(node *renderCacheNode, pos fyne.Position) {
+		i++
+		updateInfoBefore(node, i)
+		thirdRunBeforePainterData = append(thirdRunBeforePainterData, node.painterData.(nodeInfo))
+	}, func(node *renderCacheNode) {
+		i++
+		updateInfoAfter(node, i)
+		thirdRunAfterPainterData = append(thirdRunAfterPainterData, node.painterData.(nodeInfo))
+	})
+
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node for replaced obj
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 0}, // new node for third column
+	}, thirdRunBeforePainterData, "third run uses cached nodes if possible")
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6}, // new node for replaced obj
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 11},
+		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 13}, // new node for third column
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+	}, thirdRunAfterPainterData, "third run uses cached nodes if possible")
+	assert.NotEqual(t, leftObj2Node, leftObj1Node.nextSibling, "new node for replaced object")
+	assert.Nil(t, rightObj1Node.nextSibling, "node for removed object has been removed, too")
+	assert.NotNil(t, rightColNode.nextSibling, "new node for new object")
+
+	//
+	// test that insertion at the beginnning or in the middle of a children list
+	// removes all following siblings and their subtrees
+	//
+	leftNewObj2a := canvas.NewRectangle(color.Gray16{Y: 4})
+	leftCol.insert(leftNewObj2a, 1)
+	rightNewObj0 := canvas.NewRectangle(color.Gray16{Y: 30})
+	rightCol.Prepend(rightNewObj0)
+	fourthRunBeforePainterData := []nodeInfo{}
+	fourthRunAfterPainterData := []nodeInfo{}
+	nodes = []*renderCacheNode{}
+
+	i = 0
+	c.walkTree(tree, func(node *renderCacheNode, pos fyne.Position) {
+		i++
+		updateInfoBefore(node, i)
+		fourthRunBeforePainterData = append(fourthRunBeforePainterData, node.painterData.(nodeInfo))
+		nodes = append(nodes, node)
+	}, func(node *renderCacheNode) {
+		i++
+		updateInfoAfter(node, i)
+		fourthRunAfterPainterData = append(fourthRunAfterPainterData, node.painterData.(nodeInfo))
+	})
+
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftNewObj2a, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node for inserted obj
+		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 7, lastAfterCallIndex: 0},  // new node because of tail cut
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 10, lastAfterCallIndex: 11},
+		nodeInfo{obj: rightNewObj0, lastBeforeCallIndex: 11, lastAfterCallIndex: 0}, // new node for inserted obj
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 13, lastAfterCallIndex: 0},    // new node because of tail cut
+		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 16, lastAfterCallIndex: 13},
+	}, fourthRunBeforePainterData, "fourth run uses cached nodes if possible")
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftNewObj2a, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 7, lastAfterCallIndex: 8},
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 9},
+		nodeInfo{obj: rightNewObj0, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 13, lastAfterCallIndex: 14},
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 10, lastAfterCallIndex: 15},
+		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 16, lastAfterCallIndex: 17},
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 18},
+	}, fourthRunAfterPainterData, "fourth run uses cached nodes if possible")
+	// check cache tree integrity
+	// content node
+	assert.Equal(t, content, nodes[0].obj)
+	assert.Equal(t, leftCol, nodes[0].firstChild.obj)
+	assert.Nil(t, nodes[0].nextSibling)
+	// leftCol node
+	assert.Equal(t, leftCol, nodes[1].obj)
+	assert.Equal(t, leftObj1, nodes[1].firstChild.obj)
+	assert.Equal(t, rightCol, nodes[1].nextSibling.obj)
+	// leftObj1 node
+	assert.Equal(t, leftObj1, nodes[2].obj)
+	assert.Nil(t, nodes[2].firstChild)
+	assert.Equal(t, leftNewObj2a, nodes[2].nextSibling.obj)
+	// leftNewObj2a node
+	assert.Equal(t, leftNewObj2a, nodes[3].obj)
+	assert.Nil(t, nodes[3].firstChild)
+	assert.Equal(t, leftNewObj2, nodes[3].nextSibling.obj)
+	// leftNewObj2 node
+	assert.Equal(t, leftNewObj2, nodes[4].obj)
+	assert.Nil(t, nodes[4].firstChild)
+	assert.Nil(t, nodes[4].nextSibling)
+	// rightCol node
+	assert.Equal(t, rightCol, nodes[5].obj)
+	assert.Equal(t, rightNewObj0, nodes[5].firstChild.obj)
+	assert.Equal(t, thirdCol, nodes[5].nextSibling.obj)
+	// rightNewObj0 node
+	assert.Equal(t, rightNewObj0, nodes[6].obj)
+	assert.Nil(t, nodes[6].firstChild)
+	assert.Equal(t, rightObj1, nodes[6].nextSibling.obj)
+	// rightObj1 node
+	assert.Equal(t, rightObj1, nodes[7].obj)
+	assert.Nil(t, nodes[7].firstChild)
+	assert.Nil(t, nodes[7].nextSibling)
+	// thirdCol node
+	assert.Equal(t, thirdCol, nodes[8].obj)
+	assert.Nil(t, nodes[8].firstChild)
+	assert.Nil(t, nodes[8].nextSibling)
+
+	//
+	// test that removal at the beginning or in the middle of a children list
+	// removes all following siblings and their subtrees
+	//
+	leftCol.deleteAt(1)
+	rightCol.deleteAt(0)
+	fifthRunBeforePainterData := []nodeInfo{}
+	fifthRunAfterPainterData := []nodeInfo{}
+	nodes = []*renderCacheNode{}
+
+	i = 0
+	c.walkTree(tree, func(node *renderCacheNode, pos fyne.Position) {
+		i++
+		updateInfoBefore(node, i)
+		fifthRunBeforePainterData = append(fifthRunBeforePainterData, node.painterData.(nodeInfo))
+		nodes = append(nodes, node)
+	}, func(node *renderCacheNode) {
+		i++
+		updateInfoAfter(node, i)
+		fifthRunAfterPainterData = append(fifthRunAfterPainterData, node.painterData.(nodeInfo))
+	})
+
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 18},
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 9},
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node because of tail cut
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 15},
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 0}, // new node because of tail cut
+		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 17},
+	}, fifthRunBeforePainterData, "fifth run uses cached nodes if possible")
+	assert.Equal(t, []nodeInfo{
+		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 11},
+		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 13},
+		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+	}, fifthRunAfterPainterData, "fifth run uses cached nodes if possible")
+	// check cache tree integrity
+	// content node
+	assert.Equal(t, content, nodes[0].obj)
+	assert.Equal(t, leftCol, nodes[0].firstChild.obj)
+	assert.Nil(t, nodes[0].nextSibling)
+	// leftCol node
+	assert.Equal(t, leftCol, nodes[1].obj)
+	assert.Equal(t, leftObj1, nodes[1].firstChild.obj)
+	assert.Equal(t, rightCol, nodes[1].nextSibling.obj)
+	// leftObj1 node
+	assert.Equal(t, leftObj1, nodes[2].obj)
+	assert.Nil(t, nodes[2].firstChild)
+	assert.Equal(t, leftNewObj2, nodes[2].nextSibling.obj)
+	// leftNewObj2 node
+	assert.Equal(t, leftNewObj2, nodes[3].obj)
+	assert.Nil(t, nodes[3].firstChild)
+	assert.Nil(t, nodes[3].nextSibling)
+	// rightCol node
+	assert.Equal(t, rightCol, nodes[4].obj)
+	assert.Equal(t, rightObj1, nodes[4].firstChild.obj)
+	assert.Equal(t, thirdCol, nodes[4].nextSibling.obj)
+	// rightObj1 node
+	assert.Equal(t, rightObj1, nodes[5].obj)
+	assert.Nil(t, nodes[5].firstChild)
+	assert.Nil(t, nodes[5].nextSibling)
+	// thirdCol node
+	assert.Equal(t, thirdCol, nodes[6].obj)
+	assert.Nil(t, nodes[6].firstChild)
+	assert.Nil(t, nodes[6].nextSibling)
+}
+
 var _ fyne.Layout = (*recordingLayout)(nil)
 
 type recordingLayout struct {
@@ -317,4 +655,33 @@ func (l *recordingLayout) MinSize([]fyne.CanvasObject) fyne.Size {
 func (l *recordingLayout) popLayoutEvent() (e interface{}) {
 	e, l.layoutEvents = pop(l.layoutEvents)
 	return
+}
+
+type modifiableBox struct {
+	*widget.Box
+}
+
+func (b *modifiableBox) Append(object fyne.CanvasObject) {
+	b.Children = append(b.Children, object)
+	widget.Renderer(b).Refresh()
+}
+
+func (b *modifiableBox) deleteAt(index int) {
+	if index < len(b.Children)-1 {
+		b.Children = append(b.Children[:index], b.Children[index+1:]...)
+	} else {
+		b.Children = b.Children[:index]
+	}
+	widget.Renderer(b).Refresh()
+}
+
+func (b *modifiableBox) insert(object fyne.CanvasObject, index int) {
+	tail := append([]fyne.CanvasObject{object}, b.Children[index:]...)
+	b.Children = append(b.Children[:index], tail...)
+	widget.Renderer(b).Refresh()
+}
+
+func (b *modifiableBox) Prepend(object fyne.CanvasObject) {
+	b.Children = append([]fyne.CanvasObject{object}, b.Children...)
+	widget.Renderer(b).Refresh()
 }

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -411,22 +411,22 @@ func Test_glCanvas_walkTree(t *testing.T) {
 	})
 
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
-		nodeInfo{obj: rightObj2, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
+		{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		{obj: rightObj2, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
 	}, secondRunBeforePainterData, "second run uses cached nodes")
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
-		nodeInfo{obj: rightObj2, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		{obj: rightObj2, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
+		{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
 	}, secondRunAfterPainterData, "second run uses cached nodes")
 	leftObj1Node := nodes[2]
 	leftObj2Node := nodes[3]
@@ -462,22 +462,22 @@ func Test_glCanvas_walkTree(t *testing.T) {
 	})
 
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node for replaced obj
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
-		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 0}, // new node for third column
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node for replaced obj
+		{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 13},
+		{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 0}, // new node for third column
 	}, thirdRunBeforePainterData, "third run uses cached nodes if possible")
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6}, // new node for replaced obj
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 11},
-		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 13}, // new node for third column
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6}, // new node for replaced obj
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 11},
+		{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 13}, // new node for third column
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
 	}, thirdRunAfterPainterData, "third run uses cached nodes if possible")
 	assert.NotEqual(t, leftObj2Node, leftObj1Node.nextSibling, "new node for replaced object")
 	assert.Nil(t, rightObj1Node.nextSibling, "node for removed object has been removed, too")
@@ -508,26 +508,26 @@ func Test_glCanvas_walkTree(t *testing.T) {
 	})
 
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftNewObj2a, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node for inserted obj
-		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 7, lastAfterCallIndex: 0},  // new node because of tail cut
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 10, lastAfterCallIndex: 11},
-		nodeInfo{obj: rightNewObj0, lastBeforeCallIndex: 11, lastAfterCallIndex: 0}, // new node for inserted obj
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 13, lastAfterCallIndex: 0},    // new node because of tail cut
-		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 16, lastAfterCallIndex: 13},
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftNewObj2a, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node for inserted obj
+		{obj: leftNewObj2, lastBeforeCallIndex: 7, lastAfterCallIndex: 0},  // new node because of tail cut
+		{obj: rightCol, lastBeforeCallIndex: 10, lastAfterCallIndex: 11},
+		{obj: rightNewObj0, lastBeforeCallIndex: 11, lastAfterCallIndex: 0}, // new node for inserted obj
+		{obj: rightObj1, lastBeforeCallIndex: 13, lastAfterCallIndex: 0},    // new node because of tail cut
+		{obj: thirdCol, lastBeforeCallIndex: 16, lastAfterCallIndex: 13},
 	}, fourthRunBeforePainterData, "fourth run uses cached nodes if possible")
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftNewObj2a, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
-		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 7, lastAfterCallIndex: 8},
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 9},
-		nodeInfo{obj: rightNewObj0, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 13, lastAfterCallIndex: 14},
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 10, lastAfterCallIndex: 15},
-		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 16, lastAfterCallIndex: 17},
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 18},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftNewObj2a, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		{obj: leftNewObj2, lastBeforeCallIndex: 7, lastAfterCallIndex: 8},
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 9},
+		{obj: rightNewObj0, lastBeforeCallIndex: 11, lastAfterCallIndex: 12},
+		{obj: rightObj1, lastBeforeCallIndex: 13, lastAfterCallIndex: 14},
+		{obj: rightCol, lastBeforeCallIndex: 10, lastAfterCallIndex: 15},
+		{obj: thirdCol, lastBeforeCallIndex: 16, lastAfterCallIndex: 17},
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 18},
 	}, fourthRunAfterPainterData, "fourth run uses cached nodes if possible")
 	// check cache tree integrity
 	// content node
@@ -590,22 +590,22 @@ func Test_glCanvas_walkTree(t *testing.T) {
 	})
 
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 18},
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 9},
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node because of tail cut
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 15},
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 0}, // new node because of tail cut
-		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 17},
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 18},
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 9},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 0}, // new node because of tail cut
+		{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 15},
+		{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 0}, // new node because of tail cut
+		{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 17},
 	}, fifthRunBeforePainterData, "fifth run uses cached nodes if possible")
 	assert.Equal(t, []nodeInfo{
-		nodeInfo{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
-		nodeInfo{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
-		nodeInfo{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
-		nodeInfo{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
-		nodeInfo{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 11},
-		nodeInfo{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 13},
-		nodeInfo{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
+		{obj: leftObj1, lastBeforeCallIndex: 3, lastAfterCallIndex: 4},
+		{obj: leftNewObj2, lastBeforeCallIndex: 5, lastAfterCallIndex: 6},
+		{obj: leftCol, lastBeforeCallIndex: 2, lastAfterCallIndex: 7},
+		{obj: rightObj1, lastBeforeCallIndex: 9, lastAfterCallIndex: 10},
+		{obj: rightCol, lastBeforeCallIndex: 8, lastAfterCallIndex: 11},
+		{obj: thirdCol, lastBeforeCallIndex: 12, lastAfterCallIndex: 13},
+		{obj: content, lastBeforeCallIndex: 1, lastAfterCallIndex: 14},
 	}, fifthRunAfterPainterData, "fifth run uses cached nodes if possible")
 	// check cache tree integrity
 	// content node

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -131,7 +131,6 @@ func (d *gLDriver) freeDirtyTextures(canvas *glCanvas) {
 		case object := <-canvas.refreshQueue:
 			freeWalked := func(obj fyne.CanvasObject, _ fyne.Position, _ fyne.Position, _ fyne.Size) bool {
 				canvas.painter.Free(obj)
-				delete(canvas.minSizes, obj)
 				return false
 			}
 			driver.WalkCompleteObjectTree(object, freeWalked, nil)


### PR DESCRIPTION
This removes the minSize cache memory leak and should in a future extension remove the texture cache memory leak.