### PR TITLE
Refactor scaling

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -52,8 +52,6 @@ func (s *settings) SetTheme(theme fyne.Theme) {
 }
 
 func (s *settings) Scale() float32 {
-	s.themeLock.RLock()
-	defer s.themeLock.RUnlock()
 	return s.schema.Scale
 }
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -305,7 +305,7 @@ func (w *window) detectScale() float32 {
 	if dpi > 1000 || dpi < 10 {
 		dpi = 96
 	}
-	w.canvas.detectedScale = float32(dpi) / 144.0
+	w.canvas.detectedScale = float32(dpi) / 96.0
 	return w.canvas.detectedScale
 }
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"image"
 	_ "image/png" // for the icon
+	"math"
 	"os"
 	"runtime"
 	"strconv"
@@ -305,7 +306,7 @@ func (w *window) detectScale() float32 {
 	if dpi > 1000 || dpi < 10 {
 		dpi = 96
 	}
-	w.canvas.detectedScale = float32(dpi) / 96.0
+	w.canvas.detectedScale = float32(math.Round(float64(dpi)/96.0*10.0)) / 10.0
 	return w.canvas.detectedScale
 }
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1029,8 +1029,7 @@ func (d *gLDriver) CreateWindow(title string) fyne.Window {
 		ret.canvas.painter = gl.NewPainter(ret.canvas, ret)
 		ret.canvas.painter.Init()
 		ret.canvas.context = ret
-		ret.canvas.detectedScale = ret.detectScale()
-		ret.canvas.scale = ret.canvas.detectedScale
+		ret.canvas.scale = ret.detectScale()
 		ret.SetIcon(ret.icon) // if this is nil we will get the app icon
 		d.windows = append(d.windows, ret)
 


### PR DESCRIPTION
The previous implementation set the scaling to 1.0 at a resolution of 144dpi. That's quite small and unreadable on displays with (much) less dpi like my old 24" screen with 94dpi.

This baseline was changed to 96dpi.

On the mentioned display the resulting scale of 0.98… made the text very blurry. That's why the scaling precision was reduced to 1 so that the effective scale has values like 0.8, 0.9, 1.0, 1.1, 1.2 etc.

The math methods used for the scale computations mostly require `float64` and because there was no requirement to use `float32` anywhere where scale was used, I moved scale, and some other measures that are involved in calculations with scale, to `float64`.