### PR TITLE
fix entry popup Y position to equal cursor position

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -530,7 +530,7 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	e.popUp = NewPopUpMenu(fyne.NewMenu("", pasteItem, selectAllItem), c)
 
 	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(e)
-	popUpPos := entryPos.Add(fyne.NewPos(pe.Position.X, e.Size().Height))
+	popUpPos := entryPos.Add(fyne.NewPos(pe.Position.X, pe.Position.Y))
 
 	e.popUp.Move(popUpPos)
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -424,7 +424,7 @@ func TestEntry_TappedSecondary(t *testing.T) {
 
 	cont := over.(*PopUp).Content
 	assert.Equal(t, cont.Position().X, pos.X+theme.Padding()+tapPos.X)
-	assert.Greater(t, cont.Position().Y, pos.Y)
+	assert.Equal(t, cont.Position().Y, pos.Y+theme.Padding()+tapPos.Y)
 
 	items := cont.(*Box).Children
 	assert.Equal(t, 2, len(items)) // Paste


### PR DESCRIPTION
**Description**

The entry popup Y position is currently equal to entry height. This may look unnoticeably bad on single line entry and multiline entry with smaller height(2-4 rows). However, on a multline entry with larger height, it becomes a clear bad UI/design. This PR fixes this problem, so entry popup will equal pointer event Y position.


**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

