### PR TITLE
retain selecting on mouse right click

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -541,10 +541,10 @@ func (e *Entry) MouseDown(m *desktop.MouseEvent) {
 	if e.selectKeyDown {
 		e.selecting = true
 	}
-	if e.selecting && e.selectKeyDown == false {
+	if e.selecting && e.selectKeyDown == false && m.Button == desktop.LeftMouseButton {
 		e.selecting = false
 	}
-	e.updateMousePointer(&m.PointEvent, e.selecting == false)
+	e.updateMousePointer(&m.PointEvent, m.Button == desktop.RightMouseButton)
 }
 
 // MouseUp called on mouse release
@@ -567,7 +567,7 @@ func (e *Entry) Dragged(d *fyne.DragEvent) {
 func (e *Entry) DragEnd() {
 }
 
-func (e *Entry) updateMousePointer(ev *fyne.PointEvent, startSelect bool) {
+func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
 
 	if !e.focused {
 		e.FocusGained()
@@ -586,9 +586,12 @@ func (e *Entry) updateMousePointer(ev *fyne.PointEvent, startSelect bool) {
 	}
 
 	e.Lock()
-	e.CursorRow = row
-	e.CursorColumn = col
-	if startSelect {
+	if !rightClick || !e.selecting {
+		e.CursorRow = row
+		e.CursorColumn = col
+	}
+
+	if !e.selecting {
 		e.selectRow = row
 		e.selectColumn = col
 	}

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -586,7 +586,7 @@ func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
 	}
 
 	e.Lock()
-	if !rightClick || !e.selecting {
+	if !rightClick || rightClick && !e.selecting {
 		e.CursorRow = row
 		e.CursorColumn = col
 	}

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -453,6 +453,28 @@ func TestEntry_HidePopUpOnEntry(t *testing.T) {
 	assert.Equal(t, true, entry.popUp.Hidden)
 }
 
+func TestEntry_MouseDownOnSelect(t *testing.T) {
+	entry := NewEntry()
+	entry.SetText("Ahnj\nBuki\n")
+	entry.selectAll()
+
+	testCharSize := theme.TextSize()
+	pos := fyne.NewPos(testCharSize, testCharSize*4) // tap below rows
+	ev := &fyne.PointEvent{Position: pos}
+
+	me := &desktop.MouseEvent{PointEvent: *ev, Button: desktop.RightMouseButton}
+	entry.MouseDown(me)
+	entry.MouseUp(me)
+
+	assert.Equal(t, entry.selectedText(), "Ahnj\nBuki\n")
+
+	me = &desktop.MouseEvent{PointEvent: *ev, Button: desktop.LeftMouseButton}
+	entry.MouseDown(me)
+	entry.MouseUp(me)
+
+	assert.Equal(t, entry.selectedText(), "")
+}
+
 func TestEntry_MouseClickAndDragAfterRow(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("A\nB\n")


### PR DESCRIPTION
**Description**

Currently, when you right click after selecting, the selected text tends to disappear and selecting turns to false. This is not a driver issue as we may have thought. This issue is as a result of selecting being set to false when select key isn't typed.

Fixes #430 2

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

