### PR TITLE
Customizable no select message

### DIFF
--- a/widget/select.go
+++ b/widget/select.go
@@ -9,7 +9,7 @@ import (
 	"fyne.io/fyne/theme"
 )
 
-const noSelection = "(Select one)"
+const defaultNoSelectionMessage = "(Select one)"
 
 type selectRenderer struct {
 	icon   *Icon
@@ -23,7 +23,7 @@ type selectRenderer struct {
 // MinSize calculates the minimum size of a select button.
 // This is based on the selected text, the drop icon and a standard amount of padding added.
 func (s *selectRenderer) MinSize() fyne.Size {
-	min := textMinSize(noSelection, s.label.TextSize, s.label.TextStyle)
+	min := textMinSize(s.combo.NoSelectionMessage, s.label.TextSize, s.label.TextStyle)
 
 	for _, option := range s.combo.Options {
 		optionMin := textMinSize(option, s.label.TextSize, s.label.TextStyle)
@@ -67,7 +67,7 @@ func (s *selectRenderer) BackgroundColor() color.Color {
 
 func (s *selectRenderer) Refresh() {
 	if s.combo.Selected == "" {
-		s.label.Text = noSelection
+		s.label.Text = s.combo.NoSelectionMessage
 	} else {
 		s.label.Text = s.combo.Selected
 	}
@@ -98,12 +98,12 @@ func (s *selectRenderer) Destroy() {
 // Select widget has a list of options, with the current one shown, and triggers an event func when clicked
 type Select struct {
 	baseWidget
-	Selected string
-	Options  []string
-
-	OnChanged func(string) `json:"-"`
-	hovered   bool
-	popUp     *PopUp
+	Selected           string
+	Options            []string
+	OnChanged          func(string) `json:"-"`
+	hovered            bool
+	popUp              *PopUp
+	NoSelectionMessage string
 }
 
 // Resize sets a new size for a widget.
@@ -187,8 +187,13 @@ func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 	icon := NewIcon(theme.MenuDropDownIcon())
 
 	text := canvas.NewText(s.Selected, theme.TextColor())
+
+	if s.NoSelectionMessage == "" {
+		s.NoSelectionMessage = defaultNoSelectionMessage
+	}
+
 	if s.Selected == "" {
-		text.Text = noSelection
+		text.Text = s.NoSelectionMessage
 	}
 	text.Alignment = fyne.TextAlignLeading
 
@@ -217,7 +222,7 @@ func (s *Select) SetSelected(text string) {
 
 // NewSelect creates a new select widget with the set list of options and changes handler
 func NewSelect(options []string, changed func(string)) *Select {
-	combo := &Select{baseWidget{}, "", options, changed, false, nil}
+	combo := &Select{baseWidget{}, "", options, changed, false, nil, ""}
 
 	Renderer(combo).Layout(combo.MinSize())
 	return combo

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -17,6 +17,25 @@ func TestNewSelect(t *testing.T) {
 	assert.Equal(t, "", combo.Selected)
 }
 
+func TestEmptySelect(t *testing.T) {
+	combo := NewSelect([]string{}, func(string) {})
+
+	assert.Equal(t, 0, len(combo.Options))
+	assert.Equal(t, "(Select one)", combo.NoSelectionMessage)
+	assert.Equal(t, "", combo.Selected)
+}
+
+func TestSelect_SetNoSelectionMessage(t *testing.T) {
+	combo := NewSelect([]string{}, func(string) {})
+
+	assert.Equal(t, 0, len(combo.Options))
+	assert.Equal(t, "(Select one)", combo.NoSelectionMessage)
+	assert.Equal(t, "", combo.Selected)
+	combo.NoSelectionMessage = "Please Choose Something!"
+	assert.Equal(t, "Please Choose Something!", combo.NoSelectionMessage)
+
+}
+
 func TestSelect_SetSelected(t *testing.T) {
 	combo := NewSelect([]string{"1", "2"}, func(string) {})
 	combo.SetSelected("2")
@@ -66,22 +85,17 @@ func TestSelect_Tapped(t *testing.T) {
 }
 
 func TestSelect_Tapped_Constrained(t *testing.T) {
-	// fresh app for this test
-	test.NewApp()
-	// don't let our app hang around for too long
-	defer test.NewApp()
-
 	combo := NewSelect([]string{"1", "2"}, func(s string) {})
-	canvas := fyne.CurrentApp().Driver().CanvasForObject(combo)
-	canvas.(test.WindowlessCanvas).Resize(fyne.NewSize(100, 100))
-
-	combo.Move(fyne.NewPos(canvas.Size().Width-10, canvas.Size().Height-10))
+	win := test.NewWindow(combo)
+	win.Resize(fyne.NewSize(20, 20))
 	test.Tap(combo)
 
-	comboPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(combo)
-	cont := canvas.Overlay().(*PopUp).Content
-	assert.Less(t, cont.Position().Y, comboPos.Y, "window too small so we render higher up")
-	assert.Less(t, cont.Position().X, comboPos.X, "window too small so we render to the left")
+	over := fyne.CurrentApp().Driver().CanvasForObject(combo).Overlay()
+	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
+
+	cont := over.(*PopUp).Content
+	assert.True(t, cont.Position().Y <= pos.Y+theme.Padding()) // window was too small so we render higher up
+	assert.True(t, cont.Position().X > pos.X)                  // but X position is unaffected
 }
 
 func TestSelectRenderer_ApplyTheme(t *testing.T) {


### PR DESCRIPTION
**Description**

Ability to customize the No select message with no changes to previous version, which use a constant.

Fixes #(issue)

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

