### PR TITLE
fix canvas_test on MacOS

### DIFF
--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -86,14 +86,14 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToRoot(t *testing.T) {
 	content := widget.NewHBox(leftCol, rightCol)
 	w.SetContent(content)
 	w.ignoreResize = true
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	oldCanvasSize := fyne.NewSize(100+3*theme.Padding(), 100+3*theme.Padding())
 	assert.Equal(t, oldCanvasSize, c.Size())
 
 	leftObj1.SetMinSize(fyne.NewSize(60, 60))
 	c.Refresh(leftObj1)
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	expectedCanvasSize := oldCanvasSize.Add(fyne.NewSize(10, 10))
 	assert.Equal(t, expectedCanvasSize, c.Size())
@@ -121,7 +121,7 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToScroll(t *testing.T) {
 	oldCanvasSize := fyne.NewSize(100+3*theme.Padding(), 100+3*theme.Padding())
 	w.Resize(oldCanvasSize)
 	w.ignoreResize = true // for some reason the window manager is intercepting and setting strange values in tests
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	// child size change affects ancestors up to scroll
 	oldCanvasSize = c.Size()
@@ -129,7 +129,7 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToScroll(t *testing.T) {
 	oldRightColSize := rightCol.Size()
 	rightObj1.SetMinSize(fyne.NewSize(50, 100))
 	c.Refresh(rightObj1)
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	assert.Equal(t, oldCanvasSize, c.Size())
 	assert.Equal(t, oldRightScrollSize, rightColScroll.Size())
@@ -163,7 +163,7 @@ func Test_glCanvas_ChildMinSizeChangesInDifferentScrollAffectAncestorsUpToScroll
 	)
 	w.Resize(oldCanvasSize)
 	w.ignoreResize = true // for some reason the window manager is intercepting and setting strange values in tests
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	oldLeftColSize := leftCol.Size()
 	oldLeftScrollSize := leftColScroll.Size()
@@ -173,7 +173,7 @@ func Test_glCanvas_ChildMinSizeChangesInDifferentScrollAffectAncestorsUpToScroll
 	rightObj2.SetMinSize(fyne.NewSize(50, 200))
 	c.Refresh(leftObj2)
 	c.Refresh(rightObj2)
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	assert.Equal(t, oldCanvasSize, c.Size())
 	assert.Equal(t, oldLeftScrollSize, leftColScroll.Size())
@@ -205,7 +205,7 @@ func Test_glCanvas_MinSizeShrinkTriggersLayout(t *testing.T) {
 	oldCanvasSize := fyne.NewSize(100+3*theme.Padding(), 100+3*theme.Padding())
 	assert.Equal(t, oldCanvasSize, c.Size())
 	w.ignoreResize = true // for some reason the window manager is intercepting and setting strange values in tests
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	oldRightColSize := rightCol.Size()
 	leftObj1.SetMinSize(fyne.NewSize(40, 40))
@@ -214,7 +214,7 @@ func Test_glCanvas_MinSizeShrinkTriggersLayout(t *testing.T) {
 	c.Refresh(leftObj1)
 	c.Refresh(rightObj1)
 	c.Refresh(rightObj2)
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 
 	assert.Equal(t, oldCanvasSize, c.Size())
 	expectedRightColSize := oldRightColSize.Subtract(fyne.NewSize(20, 0))
@@ -244,7 +244,7 @@ func Test_glCanvas_ContentChangeWithoutMinSizeChangeDoesNotLayout(t *testing.T) 
 	content.Layout = layout
 	w.SetContent(content)
 
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 	// clear the recorded layouts
 	for layout.popLayoutEvent() != nil {
 	}

--- a/internal/driver/glfw/glfw_test.go
+++ b/internal/driver/glfw/glfw_test.go
@@ -1,0 +1,9 @@
+// +build !ci
+
+package glfw
+
+func repaintWindow(w *window) {
+	runOnMain(func() {
+		d.(*gLDriver).repaintWindow(w)
+	})
+}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -46,7 +46,7 @@ func TestWindow_HandleHoverable(t *testing.T) {
 	h2.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(widget.NewHBox(h1, h2))
 
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 	require.Equal(t, fyne.NewPos(0, 0), h1.Position())
 	require.Equal(t, fyne.NewPos(14, 0), h2.Position())
 
@@ -87,7 +87,7 @@ func TestWindow_HandleDragging(t *testing.T) {
 	d2.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(widget.NewHBox(d1, d2))
 
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 	require.Equal(t, fyne.NewPos(0, 0), d1.Position())
 	require.Equal(t, fyne.NewPos(14, 0), d2.Position())
 
@@ -184,7 +184,7 @@ func TestWindow_DragObjectThatMoves(t *testing.T) {
 	d1.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(widget.NewHBox(d1))
 
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 	require.Equal(t, fyne.NewPos(0, 0), d1.Position())
 
 	// drag -1,-1
@@ -227,7 +227,7 @@ func TestWindow_DragIntoNewObjectKeepingFocus(t *testing.T) {
 	d2.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(widget.NewHBox(d1, d2))
 
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 	require.Equal(t, fyne.NewPos(0, 0), d1.Position())
 
 	// drag from d1 into d2
@@ -265,7 +265,7 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	dh.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(dh)
 
-	d.(*gLDriver).repaintWindow(w)
+	repaintWindow(w)
 	w.mouseMoved(w.viewport, 8, 8)
 	w.waitForEvents()
 	assert.Equal(t,
@@ -559,14 +559,14 @@ func TestWindow_SetPadded(t *testing.T) {
 			oldCanvasSize := fyne.NewSize(100, 100)
 			w.Resize(oldCanvasSize)
 
-			d.(*gLDriver).repaintWindow(w)
+			repaintWindow(w)
 			contentSize := content.Size()
 			expectedCanvasSize := contentSize.
 				Add(fyne.NewSize(2*tt.expectedPad, 2*tt.expectedPad)).
 				Add(fyne.NewSize(0, tt.expectedMenuHeight))
 
 			w.SetPadded(tt.padding)
-			d.(*gLDriver).repaintWindow(w)
+			repaintWindow(w)
 			assert.Equal(t, contentSize, content.Size())
 			assert.Equal(t, fyne.NewPos(tt.expectedPad, tt.expectedPad+tt.expectedMenuHeight), content.Position())
 			assert.Equal(t, expectedCanvasSize, w.Canvas().Size())


### PR DESCRIPTION
**Description**

Running a particular `repaintWindow` in the test thread raised an NSInternalInconsistencyException:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'NSWindow drag regions should only be invalidated on the Main Thread!'
```

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass
