### PR TITLE
Entry textProvider is not refreshed on widget.Refresh

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -76,6 +76,12 @@ func makeFormTab() fyne.Widget {
 	email.SetPlaceHolder("test@example.com")
 	password := widget.NewPasswordEntry()
 	password.SetPlaceHolder("Password")
+	showPassword := widget.NewCheck("Show Password", func(on bool) {
+		password.Lock()
+		password.Password = !on
+		password.Unlock()
+		widget.Refresh(password)
+	})
 	largeText := widget.NewMultiLineEntry()
 
 	form := &widget.Form{
@@ -93,6 +99,7 @@ func makeFormTab() fyne.Widget {
 	form.Append("Name", name)
 	form.Append("Email", email)
 	form.Append("Password", password)
+	form.Append("", showPassword)
 	form.Append("Message", largeText)
 
 	return form

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -205,6 +205,7 @@ func (e *entryRenderer) Refresh() {
 		selection.(*canvas.Rectangle).Hidden = !e.entry.focused
 	}
 
+	Refresh(e.text)
 	canvas.Refresh(e.entry)
 }
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1314,10 +1314,8 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 
 	// Reveal password that should be obfuscated until it is refreshed
 	entry.Password = false
-	assert.Equal(t, "Hié™שרה", entry.Text)
-	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
-
 	Refresh(entry)
+
 	assert.Equal(t, "Hié™שרה", entry.Text)
 	assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1304,3 +1304,20 @@ func TestEntry_EraseEmptySelection(t *testing.T) {
 	assert.Equal(t, -1, a)
 	assert.Equal(t, -1, b)
 }
+
+func TestPasswordEntry_Reveal(t *testing.T) {
+	entry := NewPasswordEntry()
+
+	test.Type(entry, "Hié™שרה")
+	assert.Equal(t, "Hié™שרה", entry.Text)
+	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+
+	// Reveal password that should be obfuscated until it is refreshed
+	entry.Password = false
+	assert.Equal(t, "Hié™שרה", entry.Text)
+	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+
+	Refresh(entry)
+	assert.Equal(t, "Hié™שרה", entry.Text)
+	assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
+}


### PR DESCRIPTION
Fixes #452 
Updates widget demo adding a "Show Password" field

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

