### PR TITLE
Add basic pagedown/pageup support to entry widget

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -794,7 +794,7 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 			e.Unlock()
 			e.selecting = false
 			return true
-		case fyne.KeyUp, fyne.KeyDown, fyne.KeyEnd, fyne.KeyHome:
+		case fyne.KeyUp, fyne.KeyDown, fyne.KeyEnd, fyne.KeyHome, fyne.KeyPageUp, fyne.KeyPageDown:
 			// cursor movement without left or right shift -- clear selection and return unhandled
 			e.selecting = false
 			return false
@@ -918,6 +918,22 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	case fyne.KeyHome:
 		e.Lock()
 		e.CursorColumn = 0
+		e.Unlock()
+	case fyne.KeyPageUp:
+		e.Lock()
+		if e.MultiLine {
+			e.CursorRow = 0
+		}
+		e.CursorColumn = 0
+		e.Unlock()
+	case fyne.KeyPageDown:
+		e.Lock()
+		if e.MultiLine {
+			e.CursorRow = provider.rows() - 1
+			e.CursorColumn = provider.rowLength(e.CursorRow)
+		} else {
+			e.CursorColumn = provider.len()
+		}
 		e.Unlock()
 	default:
 		return

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1319,3 +1319,57 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 	assert.Equal(t, "Hié™שרה", entry.Text)
 	assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
 }
+
+func TestEntry_PageUpDown(t *testing.T) {
+	t.Run("single line", func(*testing.T) {
+		e := NewEntry()
+		e.SetText("Testing")
+		// move right, press & hold shift and pagedown
+		typeKeys(e, fyne.KeyRight, keyShiftLeftDown, fyne.KeyPageDown)
+		a, b := e.selection()
+		assert.Equal(t, 1, a)
+		assert.Equal(t, 7, b)
+		assert.Equal(t, "esting", e.selectedText())
+		assert.Equal(t, 0, e.CursorRow)
+		assert.Equal(t, 7, e.CursorColumn)
+		// while shift is held press pageup
+		typeKeys(e, fyne.KeyPageUp)
+		a, b = e.selection()
+		assert.Equal(t, 0, a)
+		assert.Equal(t, 1, b)
+		assert.Equal(t, "T", e.selectedText())
+		assert.Equal(t, 0, e.CursorRow)
+		assert.Equal(t, 0, e.CursorColumn)
+		// release shift and press pagedown
+		typeKeys(e, keyShiftLeftUp, fyne.KeyPageDown)
+		assert.Equal(t, "", e.selectedText())
+		assert.Equal(t, 0, e.CursorRow)
+		assert.Equal(t, 7, e.CursorColumn)
+	})
+
+	t.Run("page down single line", func(*testing.T) {
+		e := NewMultiLineEntry()
+		e.SetText("Testing\nTesting\nTesting")
+		// move right, press & hold shift and pagedown
+		typeKeys(e, fyne.KeyRight, keyShiftLeftDown, fyne.KeyPageDown)
+		a, b := e.selection()
+		assert.Equal(t, 1, a)
+		assert.Equal(t, 23, b)
+		assert.Equal(t, "esting\nTesting\nTesting", e.selectedText())
+		assert.Equal(t, 2, e.CursorRow)
+		assert.Equal(t, 7, e.CursorColumn)
+		// while shift is held press pageup
+		typeKeys(e, fyne.KeyPageUp)
+		a, b = e.selection()
+		assert.Equal(t, 0, a)
+		assert.Equal(t, 1, b)
+		assert.Equal(t, "T", e.selectedText())
+		assert.Equal(t, 0, e.CursorRow)
+		assert.Equal(t, 0, e.CursorColumn)
+		// release shift and press pagedown
+		typeKeys(e, keyShiftLeftUp, fyne.KeyPageDown)
+		assert.Equal(t, "", e.selectedText())
+		assert.Equal(t, 2, e.CursorRow)
+		assert.Equal(t, 7, e.CursorColumn)
+	})
+}


### PR DESCRIPTION
**Description**

Add basic pagedown/pageup support to entry widget

Fixes #338 

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

