### PR TITLE
Absolute position for point event

### DIFF
--- a/event.go
+++ b/event.go
@@ -8,7 +8,8 @@ type KeyEvent struct {
 // PointEvent describes a pointer input event. The position is relative to the
 // top-left of the CanvasObject this is triggered on.
 type PointEvent struct {
-	Position Position // The position of the event
+	AbsolutePosition Position // The absolute position of the event
+	Position         Position // The relative position of the event
 }
 
 // ScrollEvent defines the parameters of a pointer or other scroll event.

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -580,6 +580,7 @@ func (w *window) mouseClicked(viewport *glfw.Window, btn glfw.MouseButton, actio
 	})
 	ev := new(fyne.PointEvent)
 	ev.Position = pos
+	ev.AbsolutePosition = w.mousePos
 
 	coMouse := co
 	// Switch the mouse target to the dragging object if one is set

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -12,11 +12,11 @@ import (
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/internal"
+	"fyne.io/fyne/layout"
 	_ "fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
 
-	"fyne.io/fyne/layout"
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -348,6 +348,26 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 	w.waitForEvents()
 	assert.NotNil(t, dh.popMouseOutEvent())
+}
+
+func TestWindow_Tapped(t *testing.T) {
+	w := d.CreateWindow("Test").(*window)
+	rect := canvas.NewRectangle(color.White)
+	rect.SetMinSize(fyne.NewSize(100, 100))
+	o := &tappableObject{Rectangle: canvas.NewRectangle(color.White)}
+	o.SetMinSize(fyne.NewSize(100, 100))
+	w.SetContent(widget.NewVBox(rect, o))
+
+	w.mousePos = fyne.NewPos(50, 160)
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.waitForEvents()
+
+	assert.Nil(t, o.popSecondaryTapEvent(), "no secondary tap")
+	if e, _ := o.popTapEvent().(*fyne.PointEvent); assert.NotNil(t, e, "tapped") {
+		assert.Equal(t, fyne.NewPos(50, 160), e.AbsolutePosition)
+		assert.Equal(t, fyne.NewPos(46, 52), e.Position)
+	}
 }
 
 func TestWindow_TappedIgnoresScrollerClip(t *testing.T) {
@@ -756,6 +776,36 @@ type draggableMouseableObject struct {
 	*canvas.Rectangle
 	draggable
 	mouseable
+}
+
+type tappableObject struct {
+	*canvas.Rectangle
+	tappable
+}
+
+var _ fyne.Tappable = (*tappable)(nil)
+
+type tappable struct {
+	tapEvents          []interface{}
+	secondaryTapEvents []interface{}
+}
+
+func (t *tappable) Tapped(e *fyne.PointEvent) {
+	t.tapEvents = append(t.tapEvents, e)
+}
+
+func (t *tappable) TappedSecondary(e *fyne.PointEvent) {
+	t.secondaryTapEvents = append(t.secondaryTapEvents, e)
+}
+
+func (t *tappable) popTapEvent() (e interface{}) {
+	e, t.tapEvents = pop(t.tapEvents)
+	return
+}
+
+func (t *tappable) popSecondaryTapEvent() (e interface{}) {
+	e, t.secondaryTapEvents = pop(t.secondaryTapEvents)
+	return
 }
 
 //

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -285,6 +285,7 @@ func (c *mobileCanvas) tapUp(pos fyne.Position,
 
 	ev := new(fyne.PointEvent)
 	ev.Position = objPos
+	ev.AbsolutePosition = pos
 
 	if wid, ok := co.(fyne.Tappable); ok {
 		// TODO move event queue to common code w.queueEvent(func() { wid.Tapped(ev) })

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -28,7 +28,7 @@ type mobileCanvas struct {
 	shortcut    fyne.ShortcutHandler
 
 	inited, dirty  bool
-	lastTapDown    int64
+	lastTapDown    time.Time
 	lastTapDownPos fyne.Position
 	dragging       fyne.Draggable
 	refreshQueue   chan fyne.CanvasObject
@@ -192,7 +192,7 @@ func (c *mobileCanvas) findObjectMatching(test func(object fyne.CanvasObject) bo
 }
 
 func (c *mobileCanvas) tapDown(pos fyne.Position) {
-	c.lastTapDown = time.Now().UnixNano()
+	c.lastTapDown = time.Now()
 	c.lastTapDownPos = pos
 	c.dragging = nil
 
@@ -265,7 +265,7 @@ func (c *mobileCanvas) tapUp(pos fyne.Position,
 		c.dragging = nil
 	}
 
-	duration := time.Now().UnixNano() - c.lastTapDown
+	duration := time.Since(c.lastTapDown)
 
 	if c.menu != nil && c.overlay == nil && pos.X > c.menu.Size().Width {
 		c.menu.Hide()

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -2,6 +2,7 @@ package gomobile
 
 import (
 	"testing"
+	"time"
 
 	"fyne.io/fyne"
 	_ "fyne.io/fyne/test"
@@ -12,6 +13,7 @@ import (
 
 func TestCanvas_Tapped(t *testing.T) {
 	tapped := false
+	altTapped := false
 	buttonTap := false
 	var tappedObj fyne.Tappable
 	button := widget.NewButton("Test", func() {
@@ -27,19 +29,22 @@ func TestCanvas_Tapped(t *testing.T) {
 		tappedObj = wid
 		wid.Tapped(ev)
 	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
+		altTapped = true
 		wid.TappedSecondary(ev)
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
 
-	assert.True(t, tapped)
-	assert.True(t, buttonTap)
+	assert.True(t, tapped, "tap primary")
+	assert.False(t, altTapped, "don't tap secondary")
+	assert.True(t, buttonTap, "button should be tapped")
 	assert.Equal(t, button, tappedObj)
 }
 
 func TestCanvas_TappedSecondary(t *testing.T) {
 	tapped := false
+	altTapped := false
 	buttonTap := false
-	var tappedObj fyne.Tappable
+	var altTappedObj fyne.Tappable
 	button := widget.NewButton("Test", func() {
 		buttonTap = false
 	})
@@ -48,20 +53,21 @@ func TestCanvas_TappedSecondary(t *testing.T) {
 
 	tapPos := fyne.NewPos(6, 6)
 	c.tapDown(tapPos)
+	time.Sleep(310 * time.Millisecond)
 	c.tapUp(tapPos, func(wid fyne.Tappable, ev *fyne.PointEvent) {
 		tapped = true
-		tappedObj = wid
 		wid.Tapped(ev)
 	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
-		tapped = true
-		tappedObj = wid
+		altTapped = true
+		altTappedObj = wid
 		wid.TappedSecondary(ev)
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
 
-	assert.True(t, tapped)
-	assert.False(t, buttonTap)
-	assert.Equal(t, button, tappedObj)
+	assert.False(t, tapped, "don't tap primary")
+	assert.True(t, altTapped, "tap secondary")
+	assert.False(t, buttonTap, "button should not be tapped (primary)")
+	assert.Equal(t, button, altTappedObj)
 }
 
 func TestCanvas_Dragged(t *testing.T) {

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -15,18 +15,21 @@ func TestCanvas_Tapped(t *testing.T) {
 	tapped := false
 	altTapped := false
 	buttonTap := false
+	var pointEvent *fyne.PointEvent
 	var tappedObj fyne.Tappable
 	button := widget.NewButton("Test", func() {
 		buttonTap = true
 	})
 	c := &mobileCanvas{content: button}
 	c.resize(fyne.NewSize(36, 24))
+	button.Move(fyne.NewPos(3, 3))
 
 	tapPos := fyne.NewPos(6, 6)
 	c.tapDown(tapPos)
 	c.tapUp(tapPos, func(wid fyne.Tappable, ev *fyne.PointEvent) {
 		tapped = true
 		tappedObj = wid
+		pointEvent = ev
 		wid.Tapped(ev)
 	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
 		altTapped = true
@@ -38,18 +41,24 @@ func TestCanvas_Tapped(t *testing.T) {
 	assert.False(t, altTapped, "don't tap secondary")
 	assert.True(t, buttonTap, "button should be tapped")
 	assert.Equal(t, button, tappedObj)
+	if assert.NotNil(t, pointEvent) {
+		assert.Equal(t, fyne.NewPos(6, 6), pointEvent.AbsolutePosition)
+		assert.Equal(t, fyne.NewPos(3, 3), pointEvent.Position)
+	}
 }
 
 func TestCanvas_TappedSecondary(t *testing.T) {
 	tapped := false
 	altTapped := false
 	buttonTap := false
+	var pointEvent *fyne.PointEvent
 	var altTappedObj fyne.Tappable
 	button := widget.NewButton("Test", func() {
 		buttonTap = false
 	})
 	c := &mobileCanvas{content: button}
 	c.resize(fyne.NewSize(36, 24))
+	button.Move(fyne.NewPos(3, 3))
 
 	tapPos := fyne.NewPos(6, 6)
 	c.tapDown(tapPos)
@@ -60,6 +69,7 @@ func TestCanvas_TappedSecondary(t *testing.T) {
 	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
 		altTapped = true
 		altTappedObj = wid
+		pointEvent = ev
 		wid.TappedSecondary(ev)
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
@@ -68,6 +78,10 @@ func TestCanvas_TappedSecondary(t *testing.T) {
 	assert.True(t, altTapped, "tap secondary")
 	assert.False(t, buttonTap, "button should not be tapped (primary)")
 	assert.Equal(t, button, altTappedObj)
+	if assert.NotNil(t, pointEvent) {
+		assert.Equal(t, fyne.NewPos(6, 6), pointEvent.AbsolutePosition)
+		assert.Equal(t, fyne.NewPos(3, 3), pointEvent.Position)
+	}
 }
 
 func TestCanvas_Dragged(t *testing.T) {

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -21,7 +21,7 @@ import (
 	"fyne.io/fyne/theme"
 )
 
-const tapSecondaryDelay = 300000000 // nanoseconds
+const tapSecondaryDelay = 300 * time.Millisecond
 
 type mobileDriver struct {
 	app   app.App


### PR DESCRIPTION
**Description**

The `fyne.PointEvent` now includes the absolute position. This allows to move overlays (such as menus) to the position of the event.

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass
