### PR TITLE
fix gradients computation

### DIFF
--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -19,43 +19,36 @@ type LinearGradient struct {
 // Generate calculates an image of the gradient with the specified width and height.
 func (g *LinearGradient) Generate(w, h int) image.Image {
 	var generator func(x, y, w, h float64) float64
-	if g.Angle == 90 {
-		// horizontal flipped
+	switch g.Angle {
+	case 90: // horizontal flipped
 		generator = func(x, _, w, _ float64) float64 {
 			return ((w - 1) - x) / (w - 1)
 		}
-	} else if g.Angle == 270 {
-		// horizontal
+	case 270: // horizontal
 		generator = func(x, _, w, _ float64) float64 {
 			return x / (w - 1)
 		}
-	} else if g.Angle == 45 {
-		// diagonal negative flipped
+	case 45: // diagonal negative flipped
 		generator = func(x, y, w, h float64) float64 {
 			return math.Abs(((w-1)+(h-1))-(x+((h-1)-y))) / math.Abs((w-1)+(h-1))
 		}
-	} else if g.Angle == 225 {
-		// diagonal negative
+	case 225: // diagonal negative
 		generator = func(x, y, w, h float64) float64 {
 			return math.Abs(x+((h-1)-y)) / math.Abs((w-1)+(h-1))
 		}
-	} else if g.Angle == 135 {
-		// diagonal positive flipped
+	case 135: // diagonal positive flipped
 		generator = func(x, y, w, h float64) float64 {
 			return math.Abs(((w-1)+(h-1))-(x+y)) / math.Abs((w-1)+(h-1))
 		}
-	} else if g.Angle == 315 {
-		// diagonal positive
+	case 315: // diagonal positive
 		generator = func(x, y, w, h float64) float64 {
 			return math.Abs(x+y) / math.Abs((w-1)+(h-1))
 		}
-	} else if g.Angle == 180 {
-		// vertical flipped
+	case 180: // vertical flipped
 		generator = func(_, y, _, h float64) float64 {
 			return ((h - 1) - y) / (h - 1)
 		}
-	} else {
-		// vertical
+	default: // vertical
 		generator = func(_, y, _, h float64) float64 {
 			return y / (h - 1)
 		}

--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -23,35 +23,35 @@ func (g *LinearGradient) Generate(iw, ih int) image.Image {
 	switch g.Angle {
 	case 90: // horizontal flipped
 		generator = func(x, _ float64) float64 {
-			return ((w - 1) - x) / (w - 1)
+			return (w - x) / w
 		}
 	case 270: // horizontal
 		generator = func(x, _ float64) float64 {
-			return x / (w - 1)
+			return x / w
 		}
 	case 45: // diagonal negative flipped
 		generator = func(x, y float64) float64 {
-			return math.Abs(((w-1)+(h-1))-(x+((h-1)-y))) / math.Abs((w-1)+(h-1))
+			return math.Abs((w+h)-(x+h-y)) / math.Abs(w+h)
 		}
 	case 225: // diagonal negative
 		generator = func(x, y float64) float64 {
-			return math.Abs(x+((h-1)-y)) / math.Abs((w-1)+(h-1))
+			return math.Abs(x+h-y) / math.Abs(w+h)
 		}
 	case 135: // diagonal positive flipped
 		generator = func(x, y float64) float64 {
-			return math.Abs(((w-1)+(h-1))-(x+y)) / math.Abs((w-1)+(h-1))
+			return math.Abs((w+h)-(x+y)) / math.Abs(w+h)
 		}
 	case 315: // diagonal positive
 		generator = func(x, y float64) float64 {
-			return math.Abs(x+y) / math.Abs((w-1)+(h-1))
+			return math.Abs(x+y) / math.Abs(w+h)
 		}
 	case 180: // vertical flipped
 		generator = func(_, y float64) float64 {
-			return ((h - 1) - y) / (h - 1)
+			return (h - y) / h
 		}
 	default: // vertical
 		generator = func(_, y float64) float64 {
-			return y / (h - 1)
+			return y / h
 		}
 	}
 	return computeGradient(generator, iw, ih, g.StartColor, g.EndColor)
@@ -136,7 +136,7 @@ func computeGradient(generator func(x, y float64) float64, w, h int, startColor,
 
 	for x := 0; x < w; x++ {
 		for y := 0; y < h; y++ {
-			distance := generator(float64(x), float64(y))
+			distance := generator(float64(x)+0.5, float64(y)+0.5)
 			img.Set(x, y, calculatePixel(distance, startColor, endColor))
 		}
 	}

--- a/canvas/gradient_test.go
+++ b/canvas/gradient_test.go
@@ -54,9 +54,9 @@ func TestNewVerticalGradient_Flipped(t *testing.T) {
 }
 
 func TestNewLinearGradient_45(t *testing.T) {
-	positive := NewLinearGradient(color.Black, color.Transparent, 45.0)
+	negative := NewLinearGradient(color.Black, color.Transparent, 45.0)
 
-	img := positive.Generate(51, 51)
+	img := negative.Generate(51, 51)
 	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, img.At(50, 0))
 	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, img.At(0, 50))
 	for i := 0; i < 5; i++ {
@@ -67,9 +67,9 @@ func TestNewLinearGradient_45(t *testing.T) {
 }
 
 func TestNewLinearGradient_315(t *testing.T) {
-	negative := NewLinearGradient(color.Black, color.Transparent, 315.0)
+	positive := NewLinearGradient(color.Black, color.Transparent, 315.0)
 
-	img := negative.Generate(51, 51)
+	img := positive.Generate(51, 51)
 	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, img.At(0, 0))
 	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, img.At(50, 50))
 	for i := 0; i < 5; i++ {

--- a/canvas/gradient_test.go
+++ b/canvas/gradient_test.go
@@ -1,6 +1,7 @@
 package canvas
 
 import (
+	"fmt"
 	"image/color"
 	"testing"
 
@@ -10,55 +11,125 @@ import (
 func TestNewHorizontalGradient(t *testing.T) {
 	horizontal := NewHorizontalGradient(color.Black, color.Transparent)
 
+	smallImg := horizontal.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0xe6, 0xb3, 0x7f, 0x4c, 0x19},
+		{0xe6, 0xb3, 0x7f, 0x4c, 0x19},
+		{0xe6, 0xb3, 0x7f, 0x4c, 0x19},
+		{0xe6, 0xb3, 0x7f, 0x4c, 0x19},
+		{0xe6, 0xb3, 0x7f, 0x4c, 0x19},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
 	img := horizontal.Generate(51, 5)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, img.At(0, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, img.At(0, 0))
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(25, i))
 	}
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, img.At(50, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, img.At(50, 0))
 }
 
 func TestNewHorizontalGradient_Flipped(t *testing.T) {
 	horizontal := NewHorizontalGradient(color.Black, color.Transparent)
 	horizontal.Angle -= 180
 
+	smallImg := horizontal.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0x19, 0x4c, 0x7f, 0xb3, 0xe6},
+		{0x19, 0x4c, 0x7f, 0xb3, 0xe6},
+		{0x19, 0x4c, 0x7f, 0xb3, 0xe6},
+		{0x19, 0x4c, 0x7f, 0xb3, 0xe6},
+		{0x19, 0x4c, 0x7f, 0xb3, 0xe6},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
 	img := horizontal.Generate(51, 5)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, img.At(0, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, img.At(0, 0))
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(25, i))
 	}
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, img.At(50, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, img.At(50, 0))
 }
 
 func TestNewVerticalGradient(t *testing.T) {
 	vertical := NewVerticalGradient(color.Black, color.Transparent)
 
+	smallImg := vertical.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0xe6, 0xe6, 0xe6, 0xe6, 0xe6},
+		{0xb3, 0xb3, 0xb3, 0xb3, 0xb3},
+		{0x7f, 0x7f, 0x7f, 0x7f, 0x7f},
+		{0x4c, 0x4c, 0x4c, 0x4c, 0x4c},
+		{0x19, 0x19, 0x19, 0x19, 0x19},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
 	imgVert := vertical.Generate(5, 51)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, imgVert.At(0, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, imgVert.At(0, 0))
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, imgVert.At(i, 25))
 	}
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, imgVert.At(0, 50))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, imgVert.At(0, 50))
 }
 
 func TestNewVerticalGradient_Flipped(t *testing.T) {
 	vertical := NewVerticalGradient(color.Black, color.Transparent)
 	vertical.Angle += 180
 
+	smallImg := vertical.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0x19, 0x19, 0x19, 0x19, 0x19},
+		{0x4c, 0x4c, 0x4c, 0x4c, 0x4c},
+		{0x7f, 0x7f, 0x7f, 0x7f, 0x7f},
+		{0xb3, 0xb3, 0xb3, 0xb3, 0xb3},
+		{0xe6, 0xe6, 0xe6, 0xe6, 0xe6},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
 	imgVert := vertical.Generate(5, 51)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, imgVert.At(0, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, imgVert.At(0, 0))
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, imgVert.At(i, 25))
 	}
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, imgVert.At(0, 50))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, imgVert.At(0, 50))
 }
 
 func TestNewLinearGradient_45(t *testing.T) {
 	negative := NewLinearGradient(color.Black, color.Transparent, 45.0)
 
+	smallImg := negative.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0x7f, 0x99, 0xb3, 0xcc, 0xe6},
+		{0x66, 0x7f, 0x99, 0xb3, 0xcc},
+		{0x4c, 0x66, 0x7f, 0x99, 0xb3},
+		{0x33, 0x4c, 0x66, 0x7f, 0x99},
+		{0x19, 0x33, 0x4c, 0x66, 0x7f},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
 	img := negative.Generate(51, 51)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, img.At(50, 0))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, img.At(0, 50))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, img.At(50, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, img.At(0, 50))
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(i, i))
 	}
@@ -66,12 +137,80 @@ func TestNewLinearGradient_45(t *testing.T) {
 	assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(50, 50))
 }
 
+func TestNewLinearGradient_225(t *testing.T) {
+	negative := NewLinearGradient(color.Black, color.Transparent, 225.0)
+
+	smallImg := negative.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0x7f, 0x66, 0x4c, 0x33, 0x19},
+		{0x99, 0x7f, 0x66, 0x4c, 0x33},
+		{0xb3, 0x99, 0x7f, 0x66, 0x4c},
+		{0xcc, 0xb3, 0x99, 0x7f, 0x66},
+		{0xe6, 0xcc, 0xb3, 0x99, 0x7f},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
+	img := negative.Generate(51, 51)
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, img.At(50, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, img.At(0, 50))
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(i, i))
+	}
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(0, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(50, 50))
+}
+
+func TestNewLinearGradient_135(t *testing.T) {
+	positive := NewLinearGradient(color.Black, color.Transparent, 135.0)
+
+	smallImg := positive.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0x19, 0x33, 0x4c, 0x66, 0x7f},
+		{0x33, 0x4c, 0x66, 0x7f, 0x99},
+		{0x4c, 0x66, 0x7f, 0x99, 0xb3},
+		{0x66, 0x7f, 0x99, 0xb3, 0xcc},
+		{0x7f, 0x99, 0xb3, 0xcc, 0xe6},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
+	img := positive.Generate(51, 51)
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, img.At(0, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, img.At(50, 50))
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(50-i, i))
+	}
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(50, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(0, 50))
+}
+
 func TestNewLinearGradient_315(t *testing.T) {
 	positive := NewLinearGradient(color.Black, color.Transparent, 315.0)
 
+	smallImg := positive.Generate(5, 5)
+	expectedAlphaValues := [][]uint8{
+		{0xe6, 0xcc, 0xb3, 0x99, 0x7f},
+		{0xcc, 0xb3, 0x99, 0x7f, 0x66},
+		{0xb3, 0x99, 0x7f, 0x66, 0x4c},
+		{0x99, 0x7f, 0x66, 0x4c, 0x33},
+		{0x7f, 0x66, 0x4c, 0x33, 0x19},
+	}
+	for y, xv := range expectedAlphaValues {
+		for x, v := range xv {
+			assert.Equal(t, color.RGBA{0, 0, 0, v}, smallImg.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+		}
+	}
+
 	img := positive.Generate(51, 51)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, img.At(0, 0))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x00}, img.At(50, 50))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xfd}, img.At(0, 0))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x02}, img.At(50, 50))
 	for i := 0; i < 5; i++ {
 		assert.Equal(t, color.RGBA{0, 0, 0, 0x7f}, img.At(50-i, i))
 	}
@@ -81,28 +220,67 @@ func TestNewLinearGradient_315(t *testing.T) {
 
 func TestNewRadialGradient(t *testing.T) {
 	circle := NewRadialGradient(color.Black, color.Transparent)
+
+	{
+		imgOddDiameter := circle.Generate(5, 5)
+		expectedAlphaValues := [][]uint8{
+			{0x00, 0x1b, 0x33, 0x1b, 0x00},
+			{0x1b, 0x6f, 0x99, 0x6f, 0x1b},
+			{0x33, 0x99, 0xff, 0x99, 0x33},
+			{0x1b, 0x6f, 0x99, 0x6f, 0x1b},
+			{0x00, 0x1b, 0x33, 0x1b, 0x00},
+		}
+		for y, xv := range expectedAlphaValues {
+			for x, v := range xv {
+				assert.Equal(t, color.RGBA{0, 0, 0, v}, imgOddDiameter.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+			}
+		}
+	}
+
+	{
+		imgEvenDiameter := circle.Generate(6, 6)
+		expectedAlphaValues := [][]uint8{
+			{0x00, 0x07, 0x26, 0x26, 0x07, 0x00},
+			{0x07, 0x4a, 0x79, 0x79, 0x4a, 0x07},
+			{0x26, 0x79, 0xc3, 0xc3, 0x79, 0x26},
+			{0x26, 0x79, 0xc3, 0xc3, 0x79, 0x26},
+			{0x07, 0x4a, 0x79, 0x79, 0x4a, 0x07},
+			{0x00, 0x07, 0x26, 0x26, 0x07, 0x00},
+		}
+		for y, xv := range expectedAlphaValues {
+			for x, v := range xv {
+				assert.Equal(t, color.RGBA{0, 0, 0, v}, imgEvenDiameter.At(x, y), fmt.Sprintf("alpha value at %d,%d", x, y))
+			}
+		}
+	}
+
 	imgCircle := circle.Generate(10, 10)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xff}, imgCircle.At(5, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xcc}, imgCircle.At(4, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x99}, imgCircle.At(3, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x66}, imgCircle.At(2, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x33}, imgCircle.At(1, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x18}, imgCircle.At(9, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x4a}, imgCircle.At(8, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x7d}, imgCircle.At(7, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xaf}, imgCircle.At(6, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xdb}, imgCircle.At(5, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xdb}, imgCircle.At(4, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xaf}, imgCircle.At(3, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x7d}, imgCircle.At(2, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x4a}, imgCircle.At(1, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x18}, imgCircle.At(0, 5))
 
 	circle.CenterOffsetX = 0.1
 	circle.CenterOffsetY = 0.1
 	imgCircleOffset := circle.Generate(10, 10)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xc3}, imgCircleOffset.At(5, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xa0}, imgCircleOffset.At(4, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x79}, imgCircleOffset.At(3, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x50}, imgCircleOffset.At(2, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x26}, imgCircleOffset.At(1, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xe1}, imgCircleOffset.At(5, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xbc}, imgCircleOffset.At(4, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x93}, imgCircleOffset.At(3, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x69}, imgCircleOffset.At(2, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x3e}, imgCircleOffset.At(1, 5))
 
 	circle.CenterOffsetX = -0.1
 	circle.CenterOffsetY = -0.1
 	imgCircleOffset = circle.Generate(10, 10)
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xc3}, imgCircleOffset.At(5, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xd5}, imgCircleOffset.At(4, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xc3}, imgCircleOffset.At(3, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0xa0}, imgCircleOffset.At(2, 5))
-	assert.Equal(t, color.RGBA{0, 0, 0, 0x79}, imgCircleOffset.At(1, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xa5}, imgCircleOffset.At(5, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xbc}, imgCircleOffset.At(4, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xbc}, imgCircleOffset.At(3, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0xa5}, imgCircleOffset.At(2, 5))
+	assert.Equal(t, color.RGBA{0, 0, 0, 0x83}, imgCircleOffset.At(1, 5))
 }


### PR DESCRIPTION
## Description

### The problem

radial gradients:
The centre of a circle with diameter 4 is at (2,2). This is not the centre
of the pixel at the coordinates (2,2) because the pixel coordinates are the
top left corner of the pixel's square. Therefore the centre of pixel (2,2)
is at (2.5,2.5). The same goes for all other pixels.

linear gradients:
Analogous to the radial gradients the distance of a pixel to an edge is not
x or (w-1)-x or y or (h-1)-y but x+0.5 or w-(x+0.5) or y+0.5 or h-(y+0.5).

### The solution

The distance computation now uses the pixel centre
(pixel coordinate + (0.5,0.5)) for computation.
Radial gradients are now centred properly.
Linear gradients don't need to reduce the width or height anymore.

## Checklist

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass
