### PR TITLE
Feature/widget inherit

### DIFF
--- a/canvas/base.go
+++ b/canvas/base.go
@@ -3,9 +3,6 @@ package canvas // import "fyne.io/fyne/canvas"
 
 import "fyne.io/fyne"
 
-// Declare conformity with CanvasObject interface
-var _ fyne.CanvasObject = (*baseObject)(nil)
-
 type baseObject struct {
 	size     fyne.Size     // The current size of the Rectangle
 	position fyne.Position // The current position of the Rectangle

--- a/canvas/circle.go
+++ b/canvas/circle.go
@@ -57,13 +57,18 @@ func (l *Circle) Visible() bool {
 func (l *Circle) Show() {
 	l.Hidden = false
 
-	Refresh(l)
+	l.Refresh()
 }
 
 // Hide will set this circle to not be visible
 func (l *Circle) Hide() {
 	l.Hidden = true
 
+	l.Refresh()
+}
+
+// Refresh causes this object to be redrawn in it's current state
+func (l *Circle) Refresh() {
 	Refresh(l)
 }
 

--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -63,6 +63,11 @@ func (g *LinearGradient) Generate(w, h int) image.Image {
 	return computeGradient(generator, w, h, g.StartColor, g.EndColor)
 }
 
+// Refresh causes this object to be redrawn in it's current state
+func (g *LinearGradient) Refresh() {
+	Refresh(g)
+}
+
 // RadialGradient defines a Gradient travelling radially from a center point outward.
 type RadialGradient struct {
 	baseObject
@@ -104,6 +109,11 @@ func (g *RadialGradient) Generate(w, h int) image.Image {
 		return da / a
 	}
 	return computeGradient(generator, w, h, g.StartColor, g.EndColor)
+}
+
+// Refresh causes this object to be redrawn in it's current state
+func (g *RadialGradient) Refresh() {
+	Refresh(g)
 }
 
 func calculatePixel(d float64, startColor, endColor color.Color) *color.RGBA64 {

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -48,6 +48,11 @@ func (i *Image) Alpha() float64 {
 	return 1.0 - i.Translucency
 }
 
+// Refresh causes this object to be redrawn in it's current state
+func (i *Image) Refresh() {
+	Refresh(i)
+}
+
 // NewImageFromFile creates a new image from a local file.
 // Images returned from this method will scale to fit the canvas object.
 // The method for scaling can be set using the Fill field.

--- a/canvas/line.go
+++ b/canvas/line.go
@@ -60,13 +60,18 @@ func (l *Line) Visible() bool {
 func (l *Line) Show() {
 	l.Hidden = false
 
-	Refresh(l)
+	l.Refresh()
 }
 
 // Hide will set this line to not be visible
 func (l *Line) Hide() {
 	l.Hidden = true
 
+	l.Refresh()
+}
+
+// Refresh causes this object to be redrawn in it's current state
+func (l *Line) Refresh() {
 	Refresh(l)
 }
 

--- a/canvas/raster.go
+++ b/canvas/raster.go
@@ -28,6 +28,11 @@ func (r *Raster) Alpha() float64 {
 	return 1.0 - r.Translucency
 }
 
+// Refresh causes this object to be redrawn in it's current state
+func (r *Raster) Refresh() {
+	Refresh(r)
+}
+
 // NewRaster returns a new Image instance that is rendered dynamically using
 // the specified generate function.
 // Images returned from this method should draw dynamically to fill the width

--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -18,6 +18,11 @@ type Rectangle struct {
 	StrokeWidth float32     // The stroke width of the rectangle
 }
 
+// Refresh causes this object to be redrawn in it's current state
+func (r *Rectangle) Refresh() {
+	Refresh(r)
+}
+
 // NewRectangle returns a new Rectangle instance
 func NewRectangle(color color.Color) *Rectangle {
 	return &Rectangle{

--- a/canvas/text.go
+++ b/canvas/text.go
@@ -28,6 +28,11 @@ func (t *Text) MinSize() fyne.Size {
 	return fyne.CurrentApp().Driver().RenderedTextSize(t.Text, t.TextSize, t.TextStyle)
 }
 
+// Refresh causes this object to be redrawn in it's current state
+func (t *Text) Refresh() {
+	Refresh(t)
+}
+
 // NewText returns a new Text implementation
 func NewText(text string, color color.Color) *Text {
 	return &Text{

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -19,6 +19,8 @@ type CanvasObject interface {
 	Visible() bool
 	Show()
 	Hide()
+
+	Refresh()
 }
 
 // Themeable indicates that the associated CanvasObject responds to theme

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -23,13 +23,6 @@ type CanvasObject interface {
 	Refresh()
 }
 
-// Themeable indicates that the associated CanvasObject responds to theme
-// changes. When the settings detect a theme change the object will be informed
-// through the invocation of ApplyTheme().
-type Themeable interface {
-	ApplyTheme()
-}
-
 // Tappable describes any CanvasObject that can also be tapped.
 // This should be implemented by buttons etc that wish to handle pointer interactions.
 type Tappable interface {

--- a/container.go
+++ b/container.go
@@ -87,6 +87,11 @@ func (c *Container) AddObject(o CanvasObject) {
 	c.layout()
 }
 
+// Refresh causes this object to be redrawn in it's current state
+func (c *Container) Refresh() {
+	c.layout()
+}
+
 // NewContainer returns a new Container instance holding the specified CanvasObjects.
 func NewContainer(objects ...CanvasObject) *Container {
 	ret := &Container{

--- a/container.go
+++ b/container.go
@@ -90,6 +90,10 @@ func (c *Container) AddObject(o CanvasObject) {
 // Refresh causes this object to be redrawn in it's current state
 func (c *Container) Refresh() {
 	c.layout()
+
+	for _, child := range c.Objects {
+		child.Refresh()
+	}
 }
 
 // NewContainer returns a new Container instance holding the specified CanvasObjects.

--- a/container_test.go
+++ b/container_test.go
@@ -137,3 +137,6 @@ func (d *dummyObject) Show() {
 func (d *dummyObject) Hide() {
 	d.hidden = true
 }
+
+func (d *dummyObject) Refresh() {
+}

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -77,10 +77,10 @@ func (d *dialog) setButtons(buttons fyne.CanvasObject) {
 	}
 
 	d.win = widget.NewModalPopUp(content, d.parent.Canvas())
+	d.applyTheme()
 }
 
 func (d *dialog) Layout(obj []fyne.CanvasObject, size fyne.Size) {
-	d.ApplyTheme() // we are not really a widget so simulate the applyTheme call
 	d.bg.Move(fyne.NewPos(-theme.Padding(), -theme.Padding()))
 	d.bg.Resize(size.Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
 
@@ -109,7 +109,7 @@ func (d *dialog) MinSize(obj []fyne.CanvasObject) fyne.Size {
 		textMin.Height+btnMin.Height+d.label.MinSize().Height+theme.Padding()+padHeight*2)
 }
 
-func (d *dialog) ApplyTheme() {
+func (d *dialog) applyTheme() {
 	r, g, b, _ := theme.BackgroundColor().RGBA()
 	bg := &color.RGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: 230}
 	d.bg.FillColor = bg

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -2,30 +2,12 @@ package app
 
 import (
 	"fyne.io/fyne"
-	"fyne.io/fyne/widget"
 )
 
 // ApplyThemeTo ensures that the specified canvasobject and all widgets and themeable objects will
 // be updated for the current theme.
-func ApplyThemeTo(content fyne.CanvasObject, canvas fyne.Canvas) {
-	if themed, ok := content.(fyne.Themeable); ok {
-		themed.ApplyTheme()
-		canvas.Refresh(content)
-	}
-	if wid, ok := content.(fyne.Widget); ok {
-		widget.Renderer(wid).ApplyTheme()
-		canvas.Refresh(content)
-
-		for _, o := range widget.Renderer(wid).Objects() {
-			ApplyThemeTo(o, canvas)
-		}
-	}
-	if c, ok := content.(*fyne.Container); ok {
-		for _, o := range c.Objects {
-			ApplyThemeTo(o, canvas)
-		}
-		canvas.Refresh(c)
-	}
+func ApplyThemeTo(content fyne.CanvasObject, _ fyne.Canvas) {
+	content.Refresh()
 }
 
 // ApplySettings ensures that all widgets and themeable objects in an application will be updated for the current theme.

--- a/internal/cache/widget.go
+++ b/internal/cache/widget.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"sync"
+
+	"fyne.io/fyne"
+)
+
+var renderers sync.Map
+
+type isBaseWidget interface {
+	ExtendBaseWidget(fyne.Widget)
+	super() fyne.Widget
+}
+
+// Renderer looks up the render implementation for a widget
+func Renderer(wid fyne.Widget) fyne.WidgetRenderer {
+	if wid == nil {
+		return nil
+	}
+
+	if wd, ok := wid.(isBaseWidget); ok {
+		if wd.super() != nil {
+			wid = wd.super()
+		}
+	}
+	renderer, ok := renderers.Load(wid)
+	if !ok {
+		renderer = wid.CreateRenderer()
+		renderers.Store(wid, renderer)
+	}
+
+	return renderer.(fyne.WidgetRenderer)
+}
+
+// DestroyRenderer frees a render implementation for a widget.
+// This is typically for internal use only.
+func DestroyRenderer(wid fyne.Widget) {
+	Renderer(wid).Destroy()
+
+	renderers.Delete(wid)
+}
+
+// IsRendered returns true of the widget currently has a renderer.
+// One will be created the first time a widget is shown but may be removed after it is hidden.
+func IsRendered(wid fyne.Widget) bool {
+	_, found := renderers.Load(wid)
+	return found
+}

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/internal/app"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/internal/driver"
 	"fyne.io/fyne/internal/painter/gl"
 	"fyne.io/fyne/theme"
@@ -156,6 +157,7 @@ func (c *glCanvas) Resize(size fyne.Size) {
 	c.content.Move(c.contentPos())
 
 	if c.menu != nil {
+		c.menu.Refresh()
 		c.menu.Resize(fyne.NewSize(size.Width, c.menu.MinSize().Height))
 	}
 	c.Refresh(c.content)
@@ -268,7 +270,7 @@ func (c *glCanvas) ensureMinSize() bool {
 					cont.Layout.Layout(cont.Objects, cont.Size())
 				}
 			case fyne.Widget:
-				widget.Renderer(cont).Layout(cont.Size())
+				cache.Renderer(cont).Layout(cont.Size())
 			default:
 				fmt.Printf("implementation error - unknown container type: %T\n", cont)
 			}
@@ -397,6 +399,7 @@ func (c *glCanvas) setupThemeListener() {
 			<-listener
 			if c.menu != nil {
 				app.ApplyThemeTo(c.menu, c) // Ensure our menu gets the theme change message as it's out-of-tree
+				c.Refresh(c.menu)
 			}
 
 			c.SetPadded(c.padded) // refresh the padding for potential theme differences

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -15,6 +15,7 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/internal"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/internal/driver"
 	"fyne.io/fyne/internal/painter/gl"
 	"fyne.io/fyne/widget"
@@ -407,7 +408,7 @@ func (w *window) closed(viewport *glfw.Window) {
 	w.canvas.walkTrees(nil, func(node *renderCacheNode) {
 		switch co := node.obj.(type) {
 		case fyne.Widget:
-			widget.DestroyRenderer(co)
+			cache.DestroyRenderer(co)
 		}
 	})
 

--- a/internal/driver/gomobile/window.go
+++ b/internal/driver/gomobile/window.go
@@ -2,6 +2,7 @@ package gomobile
 
 import (
 	"fyne.io/fyne"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
@@ -143,7 +144,7 @@ func (w *window) Close() {
 	w.canvas.walkTree(nil, func(obj, _ fyne.CanvasObject) {
 		switch co := obj.(type) {
 		case fyne.Widget:
-			widget.DestroyRenderer(co)
+			cache.DestroyRenderer(co)
 		}
 	})
 

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/widget"
 )
 
@@ -62,7 +63,7 @@ func walkObjectTree(
 	case *fyne.Container:
 		children = co.Objects
 	case fyne.Widget:
-		children = widget.Renderer(co).Objects()
+		children = cache.Renderer(co).Objects()
 
 		if scroll, ok := obj.(*widget.ScrollContainer); ok {
 			clipPos = pos

--- a/layout/spacer.go
+++ b/layout/spacer.go
@@ -69,6 +69,10 @@ func (s *Spacer) Hide() {
 	s.hidden = true
 }
 
+// Refresh does nothing for a spacer but is part of the CanvasObject definition
+func (s *Spacer) Refresh() {
+}
+
 // NewSpacer returns a spacer object which can fill vertical and horizontal
 // space. This is primarily used with a box layout.
 func NewSpacer() fyne.CanvasObject {

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -50,26 +50,12 @@ func (a *testApp) UniqueID() string {
 	return "testApp" // TODO should this be randomised?
 }
 
-func (a *testApp) applyThemeTo(content fyne.CanvasObject, canvas fyne.Canvas) {
-	if themed, ok := content.(fyne.Themeable); ok {
-		themed.ApplyTheme()
-		canvas.Refresh(content)
+func (a *testApp) applyThemeTo(content fyne.CanvasObject, _ fyne.Canvas) {
+	if content == nil {
+		return
 	}
-	if wid, ok := content.(fyne.Widget); ok {
-		// we cannot use the renderer cache as that is in the widget package (import loop)
-		render := wid.CreateRenderer()
-		render.ApplyTheme()
-		canvas.Refresh(content)
 
-		for _, o := range render.Objects() {
-			a.applyThemeTo(o, canvas)
-		}
-	}
-	if c, ok := content.(*fyne.Container); ok {
-		for _, o := range c.Objects {
-			a.applyThemeTo(o, canvas)
-		}
-	}
+	content.Refresh()
 }
 
 func (a *testApp) applyTheme() {

--- a/widget.go
+++ b/widget.go
@@ -19,7 +19,6 @@ type WidgetRenderer interface {
 	MinSize() Size
 
 	Refresh()
-	ApplyTheme()
 	BackgroundColor() color.Color
 	Objects() []CanvasObject
 	Destroy()

--- a/widget/box.go
+++ b/widget/box.go
@@ -109,6 +109,9 @@ func (b *boxRenderer) Objects() []fyne.CanvasObject {
 
 func (b *boxRenderer) Refresh() {
 	b.objects = b.box.Children
+	for _, child := range b.objects {
+		child.Refresh()
+	}
 	b.Layout(b.box.Size())
 
 	canvas.Refresh(b.box)

--- a/widget/box.go
+++ b/widget/box.go
@@ -19,9 +19,11 @@ type Box struct {
 	Children   []fyne.CanvasObject
 }
 
-// ApplyTheme updates this box to match the current theme
-func (b *Box) ApplyTheme() {
+// Refresh updates this box to match the current theme
+func (b *Box) Refresh() {
 	b.background = theme.BackgroundColor()
+
+	b.BaseWidget.refresh(b)
 }
 
 // Prepend inserts a new CanvasObject at the top/left of the box
@@ -71,10 +73,7 @@ func NewHBox(children ...fyne.CanvasObject) *Box {
 
 // NewVBox creates a new vertically aligned box widget with the specified list of child objects
 func NewVBox(children ...fyne.CanvasObject) *Box {
-	box := &Box{BaseWidget: BaseWidget{}, Horizontal: false, Children: children}
-
-	Renderer(box).Layout(box.MinSize())
-	return box
+	return &Box{BaseWidget: BaseWidget{}, Horizontal: false, Children: children}
 }
 
 type boxRenderer struct {
@@ -90,9 +89,6 @@ func (b *boxRenderer) MinSize() fyne.Size {
 
 func (b *boxRenderer) Layout(size fyne.Size) {
 	b.layout.Layout(b.objects, size)
-}
-
-func (b *boxRenderer) ApplyTheme() {
 }
 
 func (b *boxRenderer) BackgroundColor() color.Color {

--- a/widget/box.go
+++ b/widget/box.go
@@ -12,38 +12,11 @@ import (
 // Box widget is a simple list where the child elements are arranged in a single column
 // for vertical or a single row for horizontal arrangement
 type Box struct {
-	baseWidget
+	BaseWidget
 	background color.Color
 
 	Horizontal bool
 	Children   []fyne.CanvasObject
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (b *Box) Resize(size fyne.Size) {
-	b.resize(size, b)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (b *Box) Move(pos fyne.Position) {
-	b.move(pos, b)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (b *Box) MinSize() fyne.Size {
-	return b.minSize(b)
-}
-
-// Show this widget, if it was previously hidden
-func (b *Box) Show() {
-	b.show(b)
-}
-
-// Hide this widget, if it was previously visible
-func (b *Box) Hide() {
-	b.hide(b)
 }
 
 // ApplyTheme updates this box to match the current theme
@@ -65,8 +38,15 @@ func (b *Box) Append(object fyne.CanvasObject) {
 	Refresh(b)
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (b *Box) MinSize() fyne.Size {
+	b.ExtendBaseWidget(b)
+	return b.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (b *Box) CreateRenderer() fyne.WidgetRenderer {
+	b.ExtendBaseWidget(b)
 	var lay fyne.Layout
 	if b.Horizontal {
 		lay = layout.NewHBoxLayout()
@@ -83,7 +63,7 @@ func (b *Box) setBackgroundColor(bg color.Color) {
 
 // NewHBox creates a new horizontally aligned box widget with the specified list of child objects
 func NewHBox(children ...fyne.CanvasObject) *Box {
-	box := &Box{baseWidget: baseWidget{}, Horizontal: true, Children: children}
+	box := &Box{BaseWidget: BaseWidget{}, Horizontal: true, Children: children}
 
 	Renderer(box).Layout(box.MinSize())
 	return box
@@ -91,7 +71,7 @@ func NewHBox(children ...fyne.CanvasObject) *Box {
 
 // NewVBox creates a new vertically aligned box widget with the specified list of child objects
 func NewVBox(children ...fyne.CanvasObject) *Box {
-	box := &Box{baseWidget: baseWidget{}, Horizontal: false, Children: children}
+	box := &Box{BaseWidget: BaseWidget{}, Horizontal: false, Children: children}
 
 	Renderer(box).Layout(box.MinSize())
 	return box

--- a/widget/box.go
+++ b/widget/box.go
@@ -30,14 +30,14 @@ func (b *Box) Refresh() {
 func (b *Box) Prepend(object fyne.CanvasObject) {
 	b.Children = append([]fyne.CanvasObject{object}, b.Children...)
 
-	Refresh(b)
+	b.refresh(b)
 }
 
 // Append adds a new CanvasObject to the end/right of the box
 func (b *Box) Append(object fyne.CanvasObject) {
 	b.Children = append(b.Children, object)
 
-	Refresh(b)
+	b.refresh(b)
 }
 
 // MinSize returns the size that this widget should not shrink below
@@ -65,10 +65,7 @@ func (b *Box) setBackgroundColor(bg color.Color) {
 
 // NewHBox creates a new horizontally aligned box widget with the specified list of child objects
 func NewHBox(children ...fyne.CanvasObject) *Box {
-	box := &Box{BaseWidget: BaseWidget{}, Horizontal: true, Children: children}
-
-	Renderer(box).Layout(box.MinSize())
-	return box
+	return &Box{BaseWidget: BaseWidget{}, Horizontal: true, Children: children}
 }
 
 // NewVBox creates a new vertically aligned box widget with the specified list of child objects

--- a/widget/button.go
+++ b/widget/button.go
@@ -77,15 +77,13 @@ func (b *buttonRenderer) Layout(size fyne.Size) {
 	}
 }
 
-// ApplyTheme is called when the Button may need to update its look
-func (b *buttonRenderer) ApplyTheme() {
+// applyTheme updates this button to match the current theme
+func (b *buttonRenderer) applyTheme() {
 	b.label.TextSize = theme.TextSize()
 	b.label.Color = theme.TextColor()
 	if b.button.Disabled() {
 		b.label.Color = theme.DisabledTextColor()
 	}
-
-	b.Refresh()
 }
 
 func (b *buttonRenderer) BackgroundColor() color.Color {
@@ -102,6 +100,7 @@ func (b *buttonRenderer) BackgroundColor() color.Color {
 }
 
 func (b *buttonRenderer) Refresh() {
+	b.applyTheme()
 	b.label.Text = b.button.Text
 
 	if b.button.Icon != nil && b.button.Visible() {
@@ -163,13 +162,13 @@ const (
 // Enable this widget, if it was previously disabled
 func (b *Button) Enable() {
 	b.enable(b)
-	Renderer(b).ApplyTheme()
+	b.refresh(b)
 }
 
 // Disable this widget, if it was previously enabled
 func (b *Button) Disable() {
 	b.disable(b)
-	Renderer(b).ApplyTheme()
+	b.refresh(b)
 }
 
 // Disabled returns true if the widget is disabled

--- a/widget/button.go
+++ b/widget/button.go
@@ -139,7 +139,7 @@ func (b *buttonRenderer) Destroy() {
 
 // Button widget has a text label and triggers an event func when clicked
 type Button struct {
-	baseWidget
+	BaseWidget
 	Text         string
 	Style        ButtonStyle
 	Icon         fyne.Resource
@@ -159,33 +159,6 @@ const (
 	// PrimaryButton that should be more prominent to the user
 	PrimaryButton
 )
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (b *Button) Resize(size fyne.Size) {
-	b.resize(size, b)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (b *Button) Move(pos fyne.Position) {
-	b.move(pos, b)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (b *Button) MinSize() fyne.Size {
-	return b.minSize(b)
-}
-
-// Show this widget, if it was previously hidden
-func (b *Button) Show() {
-	b.show(b)
-}
-
-// Hide this widget, if it was previously visible
-func (b *Button) Hide() {
-	b.hide(b)
-}
 
 // Enable this widget, if it was previously disabled
 func (b *Button) Enable() {
@@ -231,8 +204,15 @@ func (b *Button) MouseOut() {
 func (b *Button) MouseMoved(*desktop.MouseEvent) {
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (b *Button) MinSize() fyne.Size {
+	b.ExtendBaseWidget(b)
+	return b.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (b *Button) CreateRenderer() fyne.WidgetRenderer {
+	b.ExtendBaseWidget(b)
 	var icon *canvas.Image
 	if b.Icon != nil {
 		icon = canvas.NewImageFromResource(b.Icon)
@@ -278,7 +258,7 @@ func (b *Button) SetIcon(icon fyne.Resource) {
 
 // NewButton creates a new button widget with the set label and tap handler
 func NewButton(label string, tapped func()) *Button {
-	button := &Button{baseWidget{}, label, DefaultButton, nil, nil,
+	button := &Button{BaseWidget{}, label, DefaultButton, nil, nil,
 		tapped, false, false}
 
 	Renderer(button).Layout(button.MinSize())
@@ -287,7 +267,7 @@ func NewButton(label string, tapped func()) *Button {
 
 // NewButtonWithIcon creates a new button widget with the specified label, themed icon and tap handler
 func NewButtonWithIcon(label string, icon fyne.Resource, tapped func()) *Button {
-	button := &Button{baseWidget{}, label, DefaultButton, icon, theme.NewDisabledResource(icon),
+	button := &Button{BaseWidget{}, label, DefaultButton, icon, theme.NewDisabledResource(icon),
 		tapped, false, false}
 
 	Renderer(button).Layout(button.MinSize())

--- a/widget/button_test.go
+++ b/widget/button_test.go
@@ -226,7 +226,7 @@ func TestButtonRenderer_ApplyTheme(t *testing.T) {
 	textSize := render.label.TextSize
 	customTextSize := textSize
 	withTestTheme(func() {
-		render.ApplyTheme()
+		render.applyTheme()
 		customTextSize = render.label.TextSize
 	})
 

--- a/widget/check.go
+++ b/widget/check.go
@@ -95,7 +95,7 @@ func (c *checkRenderer) Destroy() {
 
 // Check widget has a text label and a checked (or unchecked) icon and triggers an event func when toggled
 type Check struct {
-	baseWidget
+	BaseWidget
 	Text    string
 	Checked bool
 
@@ -120,35 +120,14 @@ func (c *Check) SetChecked(checked bool) {
 	Refresh(c)
 }
 
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (c *Check) Resize(size fyne.Size) {
-	c.resize(size, c)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (c *Check) Move(pos fyne.Position) {
-	c.move(pos, c)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (c *Check) MinSize() fyne.Size {
-	return c.minSize(c)
-}
-
-// Show this widget, if it was previously hidden
-func (c *Check) Show() {
-	c.show(c)
-}
-
 // Hide this widget, if it was previously visible
 func (c *Check) Hide() {
 	if c.Focused() {
 		c.FocusLost()
 		fyne.CurrentApp().Driver().CanvasForObject(c).Focus(nil)
 	}
-	c.hide(c)
+
+	c.BaseWidget.Hide()
 }
 
 // Enable this widget, if it was previously disabled
@@ -201,8 +180,15 @@ func (c *Check) Tapped(*fyne.PointEvent) {
 func (c *Check) TappedSecondary(*fyne.PointEvent) {
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (c *Check) MinSize() fyne.Size {
+	c.ExtendBaseWidget(c)
+	return c.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (c *Check) CreateRenderer() fyne.WidgetRenderer {
+	c.ExtendBaseWidget(c)
 	icon := canvas.NewImageFromResource(theme.CheckButtonIcon())
 
 	text := canvas.NewText(c.Text, theme.TextColor())
@@ -215,7 +201,7 @@ func (c *Check) CreateRenderer() fyne.WidgetRenderer {
 // NewCheck creates a new check widget with the set label and change handler
 func NewCheck(label string, changed func(bool)) *Check {
 	c := &Check{
-		baseWidget{},
+		BaseWidget{},
 		label,
 		false,
 		changed,

--- a/widget/check.go
+++ b/widget/check.go
@@ -45,15 +45,13 @@ func (c *checkRenderer) Layout(size fyne.Size) {
 	c.icon.Move(fyne.NewPos(theme.Padding(), (size.Height-theme.IconInlineSize())/2))
 }
 
-// ApplyTheme is called when the Check may need to update its look
-func (c *checkRenderer) ApplyTheme() {
+// applyTheme updates this Check to the current theme
+func (c *checkRenderer) applyTheme() {
 	c.label.Color = theme.TextColor()
 	c.label.TextSize = theme.TextSize()
 	if c.check.Disabled() {
 		c.label.Color = theme.DisabledTextColor()
 	}
-
-	c.Refresh()
 }
 
 func (c *checkRenderer) BackgroundColor() color.Color {
@@ -61,6 +59,7 @@ func (c *checkRenderer) BackgroundColor() color.Color {
 }
 
 func (c *checkRenderer) Refresh() {
+	c.applyTheme()
 	c.label.Text = c.check.Text
 
 	res := theme.CheckButtonIcon()
@@ -133,13 +132,13 @@ func (c *Check) Hide() {
 // Enable this widget, if it was previously disabled
 func (c *Check) Enable() {
 	c.enable(c)
-	Renderer(c).ApplyTheme()
+	c.refresh(c)
 }
 
 // Disable this widget, if it was previously enabled
 func (c *Check) Disable() {
 	c.disable(c)
-	Renderer(c).ApplyTheme()
+	c.refresh(c)
 }
 
 // Disabled returns true if the widget is disabled

--- a/widget/check_test.go
+++ b/widget/check_test.go
@@ -224,7 +224,7 @@ func TestCheckRenderer_ApplyTheme(t *testing.T) {
 	textSize := render.label.TextSize
 	customTextSize := textSize
 	withTestTheme(func() {
-		render.ApplyTheme()
+		render.applyTheme()
 		customTextSize = render.label.TextSize
 	})
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1059,7 +1059,6 @@ func NewEntry() *Entry {
 	e := &Entry{}
 	e.ExtendBaseWidget(e)
 	e.registerShortcut()
-	//	Refresh(e)
 	return e
 }
 
@@ -1067,7 +1066,7 @@ func NewEntry() *Entry {
 func NewMultiLineEntry() *Entry {
 	e := &Entry{MultiLine: true}
 	e.registerShortcut()
-	Refresh(e)
+	e.ExtendBaseWidget(e)
 	return e
 }
 
@@ -1075,6 +1074,6 @@ func NewMultiLineEntry() *Entry {
 func NewPasswordEntry() *Entry {
 	e := &Entry{Password: true}
 	e.registerShortcut()
-	Refresh(e)
+	e.ExtendBaseWidget(e)
 	return e
 }

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -161,9 +161,11 @@ func (e *entryRenderer) Layout(size fyne.Size) {
 	e.moveCursor()
 }
 
-// ApplyTheme is called when the Entry may need to update its look.
-func (e *entryRenderer) ApplyTheme() {
-	Renderer(e.entry.text).ApplyTheme()
+func (e *entryRenderer) BackgroundColor() color.Color {
+	return theme.BackgroundColor()
+}
+
+func (e *entryRenderer) Refresh() {
 	if e.entry.focused {
 		e.line.FillColor = theme.FocusColor()
 	} else {
@@ -171,18 +173,7 @@ func (e *entryRenderer) ApplyTheme() {
 	}
 
 	e.cursor.FillColor = theme.FocusColor()
-	for _, selection := range e.selection {
-		selection.(*canvas.Rectangle).FillColor = theme.FocusColor()
-	}
 
-	e.Refresh()
-}
-
-func (e *entryRenderer) BackgroundColor() color.Color {
-	return theme.BackgroundColor()
-}
-
-func (e *entryRenderer) Refresh() {
 	if e.entry.textProvider().len() == 0 && e.entry.Visible() {
 		e.entry.placeholderProvider().Show()
 	} else if e.entry.placeholderProvider().Visible() {
@@ -199,9 +190,10 @@ func (e *entryRenderer) Refresh() {
 
 	for _, selection := range e.selection {
 		selection.(*canvas.Rectangle).Hidden = !e.entry.focused
+		selection.(*canvas.Rectangle).FillColor = theme.FocusColor()
 	}
 
-	Refresh(e.entry.text)
+	e.entry.text.Refresh()
 	canvas.Refresh(e.entry)
 }
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1059,7 +1059,7 @@ func NewEntry() *Entry {
 	e := &Entry{}
 	e.ExtendBaseWidget(e)
 	e.registerShortcut()
-//	Refresh(e)
+	//	Refresh(e)
 	return e
 }
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -19,8 +19,6 @@ const (
 )
 
 type entryRenderer struct {
-	text         *textProvider
-	placeholder  *textProvider
 	line, cursor *canvas.Rectangle
 	selection    []fyne.CanvasObject
 
@@ -32,15 +30,15 @@ type entryRenderer struct {
 // This is based on the contained text with a standard amount of padding added.
 // If MultiLine is true then we will reserve space for at leasts 3 lines
 func (e *entryRenderer) MinSize() fyne.Size {
-	minSize := e.placeholder.MinSize()
+	minSize := e.entry.placeholderProvider().MinSize()
 
-	if e.text.len() > 0 {
-		minSize = e.text.MinSize()
+	if e.entry.textProvider().len() > 0 {
+		minSize = e.entry.text.MinSize()
 	}
 
 	if e.entry.MultiLine == true {
 		// ensure multiline height is at least charMinSize * multilineRows
-		minSize.Height = fyne.Max(minSize.Height, e.text.charMinSize().Height*multiLineRows)
+		minSize.Height = fyne.Max(minSize.Height, e.entry.text.charMinSize().Height*multiLineRows)
 	}
 
 	return minSize.Add(fyne.NewSize(theme.Padding()*4, theme.Padding()*2))
@@ -54,7 +52,6 @@ func (e *entryRenderer) MinSize() fyne.Size {
 // require movement and resizing. The existing solution creates a new rectangle and then moves/resizes
 // all rectangles to comply with the occurance order as stated above.
 func (e *entryRenderer) buildSelection() {
-
 	e.entry.RLock()
 	cursorRow, cursorCol := e.entry.CursorRow, e.entry.CursorColumn
 	selectRow, selectCol := -1, -1
@@ -66,18 +63,18 @@ func (e *entryRenderer) buildSelection() {
 
 	if selectRow == -1 {
 		e.selection = e.selection[:0]
+
 		return
 	}
 
-	textRenderer := Renderer(e.text).(*textRenderer)
-
+	provider := e.entry.textProvider()
 	// Convert column, row into x,y
 	getCoordinates := func(column int, row int) (int, int) {
-		sz := textRenderer.lineSizeToColumn(column, row)
+		sz := provider.lineSizeToColumn(column, row)
 		return sz.Width + theme.Padding()*2, sz.Height*row + theme.Padding()*2
 	}
 
-	lineHeight := e.text.charMinSize().Height
+	lineHeight := e.entry.text.charMinSize().Height
 
 	minmax := func(a, b int) (int, int) {
 		if a < b {
@@ -117,7 +114,7 @@ func (e *entryRenderer) buildSelection() {
 			startCol = 0
 		}
 		if selectEndRow > row {
-			endCol = textRenderer.provider.rowLength(row)
+			endCol = provider.rowLength(row)
 		}
 
 		// translate columns and row into draw coordinates
@@ -131,9 +128,8 @@ func (e *entryRenderer) buildSelection() {
 }
 
 func (e *entryRenderer) moveCursor() {
-	textRenderer := Renderer(e.text).(*textRenderer)
 	e.entry.RLock()
-	size := textRenderer.lineSizeToColumn(e.entry.CursorColumn, e.entry.CursorRow)
+	size := e.entry.textProvider().lineSizeToColumn(e.entry.CursorColumn, e.entry.CursorRow)
 	xPos := size.Width
 	yPos := size.Height * e.entry.CursorRow
 	e.entry.RUnlock()
@@ -141,7 +137,7 @@ func (e *entryRenderer) moveCursor() {
 	// build e.selection[] if the user has made a selection
 	e.buildSelection()
 
-	lineHeight := e.text.charMinSize().Height
+	lineHeight := e.entry.text.charMinSize().Height
 	e.cursor.Resize(fyne.NewSize(2, lineHeight))
 	e.cursor.Move(fyne.NewPos(xPos-1+theme.Padding()*2, yPos+theme.Padding()*2))
 
@@ -156,18 +152,18 @@ func (e *entryRenderer) Layout(size fyne.Size) {
 	e.line.Resize(fyne.NewSize(size.Width, theme.Padding()))
 	e.line.Move(fyne.NewPos(0, size.Height-theme.Padding()))
 
-	e.text.Resize(size.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
-	e.text.Move(fyne.NewPos(theme.Padding(), theme.Padding()))
+	e.entry.text.Resize(size.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
+	e.entry.text.Move(fyne.NewPos(theme.Padding(), theme.Padding()))
 
-	e.placeholder.Resize(size.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
-	e.placeholder.Move(fyne.NewPos(theme.Padding(), theme.Padding()))
+	e.entry.placeholder.Resize(size.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
+	e.entry.placeholder.Move(fyne.NewPos(theme.Padding(), theme.Padding()))
 
 	e.moveCursor()
 }
 
 // ApplyTheme is called when the Entry may need to update its look.
 func (e *entryRenderer) ApplyTheme() {
-	Renderer(e.text).ApplyTheme()
+	Renderer(e.entry.text).ApplyTheme()
 	if e.entry.focused {
 		e.line.FillColor = theme.FocusColor()
 	} else {
@@ -187,10 +183,10 @@ func (e *entryRenderer) BackgroundColor() color.Color {
 }
 
 func (e *entryRenderer) Refresh() {
-	if e.text.len() == 0 && e.entry.Visible() {
-		e.placeholder.Show()
-	} else if e.placeholder.Visible() {
-		e.placeholder.Hide()
+	if e.entry.textProvider().len() == 0 && e.entry.Visible() {
+		e.entry.placeholderProvider().Show()
+	} else if e.entry.placeholderProvider().Visible() {
+		e.entry.placeholderProvider().Hide()
 	}
 
 	if e.entry.focused {
@@ -205,7 +201,7 @@ func (e *entryRenderer) Refresh() {
 		selection.(*canvas.Rectangle).Hidden = !e.entry.focused
 	}
 
-	Refresh(e.text)
+	Refresh(e.entry.text)
 	canvas.Refresh(e.entry)
 }
 
@@ -234,7 +230,7 @@ var _ desktop.Keyable = (*Entry)(nil)
 
 // Entry widget allows simple text to be input when focused.
 type Entry struct {
-	baseWidget
+	BaseWidget
 	sync.RWMutex
 	shortcut    fyne.ShortcutHandler
 	Text        string
@@ -247,7 +243,9 @@ type Entry struct {
 	CursorRow, CursorColumn int
 	OnCursorChanged         func() `json:"-"`
 
-	focused bool
+	focused     bool
+	text        *textProvider
+	placeholder *textProvider
 
 	// selectRow and selectColumn represent the selection start location
 	// The selection will span from selectRow/Column to CursorRow/Column -- note that the cursor
@@ -263,26 +261,9 @@ type Entry struct {
 	// TODO: Add OnSelectChanged
 }
 
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (e *Entry) Resize(size fyne.Size) {
-	e.resize(size, e)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (e *Entry) Move(pos fyne.Position) {
-	e.move(pos, e)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (e *Entry) MinSize() fyne.Size {
-	return e.minSize(e)
-}
-
 // Show this widget, if it was previously hidden
 func (e *Entry) Show() {
-	e.show(e)
+	e.BaseWidget.Show()
 	if len(e.Text) != 0 {
 		e.placeholderProvider().Hide()
 	}
@@ -299,7 +280,7 @@ func (e *Entry) Hide() {
 	if e.popUp != nil {
 		e.popUp.Hide()
 	}
-	e.hide(e)
+	e.BaseWidget.Hide()
 }
 
 // SetText manually sets the text of the Entry to the given text value.
@@ -697,7 +678,7 @@ func (e *Entry) TypedRune(r rune) {
 	e.CursorColumn += len(runes)
 	e.Unlock()
 	e.updateText(provider.String())
-	Renderer(e).(*entryRenderer).moveCursor()
+	Renderer(e.impl).(*entryRenderer).moveCursor()
 }
 
 // KeyDown handler for keypress events - used to store shift modifier state for text selection
@@ -950,12 +931,24 @@ func (e *Entry) TypedShortcut(shortcut fyne.Shortcut) bool {
 
 // textProvider returns the text handler for this entry
 func (e *Entry) textProvider() *textProvider {
-	return Renderer(e).(*entryRenderer).text
+	if e.text == nil {
+		text := newTextProvider(e.Text, e)
+		text.ExtendBaseWidget(&text)
+		e.text = &text
+	}
+
+	return e.text
 }
 
 // placeholderProvider returns the placeholder text handler for this entry
 func (e *Entry) placeholderProvider() *textProvider {
-	return Renderer(e).(*entryRenderer).placeholder
+	if e.placeholder == nil {
+		text := newTextProvider(e.PlaceHolder, &placeholderPresenter{e})
+		text.ExtendBaseWidget(&text)
+		e.placeholder = &text
+	}
+
+	return e.placeholder
 }
 
 // textAlign tells the rendering textProvider our alignment
@@ -1013,16 +1006,21 @@ func (p *placeholderPresenter) object() fyne.Widget {
 	return nil
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (e *Entry) MinSize() fyne.Size {
+	e.ExtendBaseWidget(e)
+	return e.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
-	text := newTextProvider(e.Text, e)
-	placeholder := newTextProvider(e.PlaceHolder, &placeholderPresenter{e})
+	e.ExtendBaseWidget(e)
 
 	line := canvas.NewRectangle(theme.ButtonColor())
 	cursor := canvas.NewRectangle(theme.FocusColor())
 
-	return &entryRenderer{&text, &placeholder, line, cursor, []fyne.CanvasObject{},
-		[]fyne.CanvasObject{line, &placeholder, &text, cursor}, e}
+	return &entryRenderer{line, cursor, []fyne.CanvasObject{},
+		[]fyne.CanvasObject{line, e.placeholderProvider(), e.textProvider(), cursor}, e}
 }
 
 func (e *Entry) registerShortcut() {
@@ -1059,8 +1057,9 @@ func (e *Entry) registerShortcut() {
 // NewEntry creates a new single line entry widget.
 func NewEntry() *Entry {
 	e := &Entry{}
+	e.ExtendBaseWidget(e)
 	e.registerShortcut()
-	Refresh(e)
+//	Refresh(e)
 	return e
 }
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func entryRenderTexts(e *Entry) []*canvas.Text {
-	textWid := Renderer(e).(*entryRenderer).text
+	textWid := e.text
 	return Renderer(textWid).(*textRenderer).texts
 }
 
 func entryRenderPlaceholderTexts(e *Entry) []*canvas.Text {
-	textWid := Renderer(e).(*entryRenderer).placeholder
+	textWid := e.placeholder
 	return Renderer(textWid).(*textRenderer).texts
 }
 

--- a/widget/form.go
+++ b/widget/form.go
@@ -22,40 +22,13 @@ func NewFormItem(text string, widget fyne.CanvasObject) *FormItem {
 // Setting OnSubmit will set the submit button to be visible and call back the function when tapped.
 // Setting OnCancel will do the same for a cancel button.
 type Form struct {
-	baseWidget
+	BaseWidget
 
 	Items    []*FormItem
 	OnSubmit func()
 	OnCancel func()
 
 	itemGrid *fyne.Container
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (f *Form) Resize(size fyne.Size) {
-	f.resize(size, f)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (f *Form) Move(pos fyne.Position) {
-	f.move(pos, f)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (f *Form) MinSize() fyne.Size {
-	return f.minSize(f)
-}
-
-// Show this widget, if it was previously hidden
-func (f *Form) Show() {
-	f.show(f)
-}
-
-// Hide this widget, if it was previously visible
-func (f *Form) Hide() {
-	f.hide(f)
 }
 
 func (f *Form) createLabel(text string) *Label {
@@ -88,8 +61,15 @@ func (f *Form) AppendItem(item *FormItem) {
 	Refresh(f)
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (f *Form) MinSize() fyne.Size {
+	f.ExtendBaseWidget(f)
+	return f.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (f *Form) CreateRenderer() fyne.WidgetRenderer {
+	f.ExtendBaseWidget(f)
 	f.ensureGrid()
 	for _, item := range f.Items {
 		f.itemGrid.AddObject(f.createLabel(item.Text))
@@ -116,7 +96,7 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 // NewForm creates a new form widget with the specified rows of form items
 // and (if any of them should be shown) a form controls row at the bottom
 func NewForm(items ...*FormItem) *Form {
-	form := &Form{baseWidget: baseWidget{}, Items: items}
+	form := &Form{BaseWidget: BaseWidget{}, Items: items}
 
 	Renderer(form).Layout(form.MinSize())
 	return form

--- a/widget/group.go
+++ b/widget/group.go
@@ -99,12 +99,6 @@ func (g *groupRenderer) Layout(size fyne.Size) {
 	g.group.content.Resize(fyne.NewSize(size.Width, size.Height-labelHeight-theme.Padding()))
 }
 
-func (g *groupRenderer) ApplyTheme() {
-	Renderer(g.label).ApplyTheme()
-	g.line.FillColor = theme.ButtonColor()
-	g.labelBg.FillColor = theme.BackgroundColor()
-}
-
 func (g *groupRenderer) BackgroundColor() color.Color {
 	return theme.BackgroundColor()
 }
@@ -114,6 +108,9 @@ func (g *groupRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (g *groupRenderer) Refresh() {
+	g.line.FillColor = theme.ButtonColor()
+	g.labelBg.FillColor = theme.BackgroundColor()
+
 	g.label.SetText(g.group.Text)
 	g.Layout(g.group.Size())
 

--- a/widget/group.go
+++ b/widget/group.go
@@ -10,38 +10,11 @@ import (
 
 // Group widget is list of widgets that contains a visual border around the list and a group title at the top.
 type Group struct {
-	baseWidget
+	BaseWidget
 
 	Text    string
 	box     *Box
 	content fyne.CanvasObject
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (g *Group) Resize(size fyne.Size) {
-	g.resize(size, g)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (g *Group) Move(pos fyne.Position) {
-	g.move(pos, g)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (g *Group) MinSize() fyne.Size {
-	return g.minSize(g)
-}
-
-// Show this widget, if it was previously hidden
-func (g *Group) Show() {
-	g.show(g)
-}
-
-// Hide this widget, if it was previously visible
-func (g *Group) Hide() {
-	g.hide(g)
 }
 
 // Prepend inserts a new CanvasObject at the top of the group
@@ -58,8 +31,15 @@ func (g *Group) Append(object fyne.CanvasObject) {
 	Refresh(g)
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (g *Group) MinSize() fyne.Size {
+	g.ExtendBaseWidget(g)
+	return g.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (g *Group) CreateRenderer() fyne.WidgetRenderer {
+	g.ExtendBaseWidget(g)
 	label := NewLabel(g.Text)
 	labelBg := canvas.NewRectangle(theme.BackgroundColor())
 	line := canvas.NewRectangle(theme.ButtonColor())
@@ -71,7 +51,7 @@ func (g *Group) CreateRenderer() fyne.WidgetRenderer {
 // NewGroup creates a new grouped list widget with a title and the specified list of child objects.
 func NewGroup(title string, children ...fyne.CanvasObject) *Group {
 	box := NewVBox(children...)
-	group := &Group{baseWidget{}, title, box, box}
+	group := &Group{BaseWidget{}, title, box, box}
 
 	Renderer(group).Layout(group.MinSize())
 	return group
@@ -81,7 +61,7 @@ func NewGroup(title string, children ...fyne.CanvasObject) *Group {
 // This group will scroll when the available space is less than needed to display the items it contains.
 func NewGroupWithScroller(title string, children ...fyne.CanvasObject) *Group {
 	box := NewVBox(children...)
-	group := &Group{baseWidget{}, title, box, NewScrollContainer(box)}
+	group := &Group{BaseWidget{}, title, box, NewScrollContainer(box)}
 
 	Renderer(group).Layout(group.MinSize())
 	return group

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -95,32 +95,12 @@ func (hl *Hyperlink) TappedSecondary(*fyne.PointEvent) {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (hl *Hyperlink) CreateRenderer() fyne.WidgetRenderer {
 	hl.textProvider = newTextProvider(hl.Text, hl)
+	hl.ExtendBaseWidget(hl)
 	return hl.textProvider.CreateRenderer()
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (hl *Hyperlink) Resize(size fyne.Size) {
-	hl.resize(size, hl)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (hl *Hyperlink) Move(pos fyne.Position) {
-	hl.move(pos, hl)
 }
 
 // MinSize returns the smallest size this widget can shrink to
 func (hl *Hyperlink) MinSize() fyne.Size {
-	return hl.minSize(hl)
-}
-
-// Show this widget, if it was previously hidden
-func (hl *Hyperlink) Show() {
-	hl.show(hl)
-}
-
-// Hide this widget, if it was previously visible
-func (hl *Hyperlink) Hide() {
-	hl.hide(hl)
+	hl.ExtendBaseWidget(hl)
+	return hl.BaseWidget.MinSize()
 }

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -66,8 +66,7 @@ type Icon struct {
 // SetResource updates the resource rendered in this icon widget
 func (i *Icon) SetResource(res fyne.Resource) {
 	i.Resource = res
-
-	Refresh(i)
+	i.refresh(i)
 }
 
 // MinSize returns the size that this widget should not shrink below

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -31,10 +31,6 @@ func (i *iconRenderer) Objects() []fyne.CanvasObject {
 	return i.objects
 }
 
-func (i *iconRenderer) ApplyTheme() {
-	i.Refresh()
-}
-
 func (i *iconRenderer) BackgroundColor() color.Color {
 	return color.Transparent
 }

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -58,36 +58,9 @@ func (i *iconRenderer) Destroy() {
 
 // Icon widget is a basic image component that load's its resource to match the theme.
 type Icon struct {
-	baseWidget
+	BaseWidget
 
 	Resource fyne.Resource // The resource for this icon
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (i *Icon) Resize(size fyne.Size) {
-	i.resize(size, i)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (i *Icon) Move(pos fyne.Position) {
-	i.move(pos, i)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (i *Icon) MinSize() fyne.Size {
-	return i.minSize(i)
-}
-
-// Show this widget, if it was previously hidden
-func (i *Icon) Show() {
-	i.show(i)
-}
-
-// Hide this widget, if it was previously visible
-func (i *Icon) Hide() {
-	i.hide(i)
 }
 
 // SetResource updates the resource rendered in this icon widget
@@ -97,8 +70,15 @@ func (i *Icon) SetResource(res fyne.Resource) {
 	Refresh(i)
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (i *Icon) MinSize() fyne.Size {
+	i.ExtendBaseWidget(i)
+	return i.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (i *Icon) CreateRenderer() fyne.WidgetRenderer {
+	i.ExtendBaseWidget(i)
 	render := &iconRenderer{image: i}
 
 	render.objects = []fyne.CanvasObject{}

--- a/widget/icon_test.go
+++ b/widget/icon_test.go
@@ -41,6 +41,6 @@ func TestIconRenderer_ApplyTheme(t *testing.T) {
 	render := Renderer(icon).(*iconRenderer)
 	visible := render.objects[0].Visible()
 
-	render.ApplyTheme()
+	render.Refresh()
 	assert.Equal(t, visible, render.objects[0].Visible())
 }

--- a/widget/label.go
+++ b/widget/label.go
@@ -64,35 +64,14 @@ func (l *Label) object() fyne.Widget {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (l *Label) CreateRenderer() fyne.WidgetRenderer {
+	l.ExtendBaseWidget(l)
 	hidden := l.Hidden
 	l.textProvider = newTextProvider(l.Text, l)
 	l.textProvider.Hidden = hidden
 	return l.textProvider.CreateRenderer()
 }
 
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (l *Label) Resize(size fyne.Size) {
-	l.resize(size, l)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (l *Label) Move(pos fyne.Position) {
-	l.move(pos, l)
-}
-
-// MinSize returns the smallest size this widget can shrink to
 func (l *Label) MinSize() fyne.Size {
-	return l.minSize(l)
-}
-
-// Show this widget, if it was previously hidden
-func (l *Label) Show() {
-	l.show(l)
-}
-
-// Hide this widget, if it was previously visible
-func (l *Label) Hide() {
-	l.hide(l)
+	l.ExtendBaseWidget(l)
+	return l.BaseWidget.MinSize()
 }

--- a/widget/label.go
+++ b/widget/label.go
@@ -71,6 +71,7 @@ func (l *Label) CreateRenderer() fyne.WidgetRenderer {
 	return l.textProvider.CreateRenderer()
 }
 
+// MinSize returns the size that this widget should not shrink below
 func (l *Label) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
 	return l.BaseWidget.MinSize()

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -46,6 +46,7 @@ func (t *menuItemWidget) TappedSecondary(*fyne.PointEvent) {
 }
 
 func (t *menuItemWidget) CreateRenderer() fyne.WidgetRenderer {
+	t.ExtendBaseWidget(t)
 	return &hoverLabelRenderer{t.Label.CreateRenderer().(*textRenderer), t}
 }
 
@@ -69,7 +70,6 @@ func (t *menuItemWidget) MouseMoved(*desktop.MouseEvent) {
 
 func newTappableLabel(label string, tapped func()) *menuItemWidget {
 	ret := &menuItemWidget{NewLabel(label), tapped, false}
-	Renderer(ret).Refresh() // trigger the textProvider to refresh metrics for our MinSize
 	return ret
 }
 

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -13,7 +13,7 @@ import (
 // It wraps any standard elements with padding and a shadow.
 // If it is modal then the shadow will cover the entire canvas it hovers over and block interactions.
 type PopUp struct {
-	baseWidget
+	BaseWidget
 
 	Content fyne.CanvasObject
 	Canvas  fyne.Canvas
@@ -23,13 +23,8 @@ type PopUp struct {
 
 // Hide this widget, if it was previously visible
 func (p *PopUp) Hide() {
-	p.hide(p)
+	p.BaseWidget.Hide()
 	p.Canvas.SetOverlay(nil)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (p *PopUp) MinSize() fyne.Size {
-	return p.minSize(p)
 }
 
 // Move the widget to a new position. A PopUp position is absolute to the top, left of its canvas.
@@ -60,7 +55,7 @@ func (p *PopUp) Move(pos fyne.Position) {
 
 // Resize sets a new size for a widget. Most PopUp widgets are shown at MinSize.
 func (p *PopUp) Resize(size fyne.Size) {
-	p.resize(p.Canvas.Size(), p)
+	p.BaseWidget.Resize(p.Canvas.Size())
 
 	p.Content.Resize(size.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
 	Renderer(p).Layout(p.Size())
@@ -68,7 +63,7 @@ func (p *PopUp) Resize(size fyne.Size) {
 
 // Show this widget, if it was previously hidden
 func (p *PopUp) Show() {
-	p.show(p)
+	p.BaseWidget.Show()
 	p.Canvas.SetOverlay(p)
 }
 
@@ -86,8 +81,15 @@ func (p *PopUp) TappedSecondary(_ *fyne.PointEvent) {
 	}
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (p *PopUp) MinSize() fyne.Size {
+	p.ExtendBaseWidget(p)
+	return p.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
+	p.ExtendBaseWidget(p)
 	if p.modal {
 		bg := canvas.NewRectangle(theme.BackgroundColor())
 		return &modalPopUpRenderer{center: layout.NewCenterLayout(), popUp: p, bg: bg,
@@ -103,6 +105,7 @@ func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
 // NewPopUp creates a new popUp for the specified content and displays it on the passed canvas.
 func NewPopUp(content fyne.CanvasObject, canvas fyne.Canvas) *PopUp {
 	ret := &PopUp{Content: content, Canvas: canvas, modal: false}
+	ret.ExtendBaseWidget(ret)
 	ret.Show()
 	return ret
 }
@@ -111,6 +114,7 @@ func NewPopUp(content fyne.CanvasObject, canvas fyne.Canvas) *PopUp {
 // A modal PopUp blocks interactions with underlying elements, covered with a semi-transparent overlay.
 func NewModalPopUp(content fyne.CanvasObject, canvas fyne.Canvas) *PopUp {
 	ret := &PopUp{Content: content, Canvas: canvas, modal: true}
+	ret.ExtendBaseWidget(ret)
 	ret.Show()
 	return ret
 }

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -144,9 +144,6 @@ func (r *popUpRenderer) MinSize() fyne.Size {
 }
 
 func (r *popUpRenderer) Refresh() {
-}
-
-func (r *popUpRenderer) ApplyTheme() {
 	r.bg.FillColor = theme.BackgroundColor()
 }
 
@@ -180,9 +177,6 @@ func (r *modalPopUpRenderer) MinSize() fyne.Size {
 }
 
 func (r *modalPopUpRenderer) Refresh() {
-}
-
-func (r *modalPopUpRenderer) ApplyTheme() {
 	r.bg.FillColor = theme.BackgroundColor()
 }
 

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -51,13 +51,11 @@ func (p *progressRenderer) Layout(size fyne.Size) {
 	p.updateBar()
 }
 
-// ApplyTheme is called when the progress bar may need to update its look
-func (p *progressRenderer) ApplyTheme() {
+// applyTheme updates the progress bar to match the current theme
+func (p *progressRenderer) applyTheme() {
 	p.bar.FillColor = theme.PrimaryColor()
 	p.label.Color = theme.TextColor()
 	p.label.TextSize = theme.TextSize()
-
-	p.Refresh()
 }
 
 func (p *progressRenderer) BackgroundColor() color.Color {
@@ -65,6 +63,7 @@ func (p *progressRenderer) BackgroundColor() color.Color {
 }
 
 func (p *progressRenderer) Refresh() {
+	p.applyTheme()
 	p.updateBar()
 
 	canvas.Refresh(p.progress)
@@ -88,7 +87,7 @@ type ProgressBar struct {
 // The widget will be refreshed to indicate the change.
 func (p *ProgressBar) SetValue(v float64) {
 	p.Value = v
-	Renderer(p).Refresh()
+	p.refresh(p)
 }
 
 // MinSize returns the size that this widget should not shrink below

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -79,36 +79,9 @@ func (p *progressRenderer) Destroy() {
 
 // ProgressBar widget creates a horizontal panel that indicates progress
 type ProgressBar struct {
-	baseWidget
+	BaseWidget
 
 	Min, Max, Value float64
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (p *ProgressBar) Resize(size fyne.Size) {
-	p.resize(size, p)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (p *ProgressBar) Move(pos fyne.Position) {
-	p.move(pos, p)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (p *ProgressBar) MinSize() fyne.Size {
-	return p.minSize(p)
-}
-
-// Show this widget, if it was previously hidden
-func (p *ProgressBar) Show() {
-	p.show(p)
-}
-
-// Hide this widget, if it was previously visible
-func (p *ProgressBar) Hide() {
-	p.hide(p)
 }
 
 // SetValue changes the current value of this progress bar (from p.Min to p.Max).
@@ -118,8 +91,15 @@ func (p *ProgressBar) SetValue(v float64) {
 	Renderer(p).Refresh()
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (p *ProgressBar) MinSize() fyne.Size {
+	p.ExtendBaseWidget(p)
+	return p.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (p *ProgressBar) CreateRenderer() fyne.WidgetRenderer {
+	p.ExtendBaseWidget(p)
 	if p.Min == 0 && p.Max == 0 {
 		p.Max = 1.0
 	}

--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -51,7 +51,7 @@ func TestProgressRenderer_ApplyTheme(t *testing.T) {
 	textSize := render.label.TextSize
 	customTextSize := textSize
 	withTestTheme(func() {
-		render.ApplyTheme()
+		render.applyTheme()
 		customTextSize = render.label.TextSize
 	})
 

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -131,36 +131,19 @@ func (p *infProgressRenderer) Destroy() {
 // ProgressBarInfinite widget creates a horizontal panel that indicates waiting indefinitely
 // An infinite progress bar loops 0% -> 100% repeatedly until Stop() is called
 type ProgressBarInfinite struct {
-	baseWidget
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (p *ProgressBarInfinite) Resize(size fyne.Size) {
-	p.resize(size, p)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (p *ProgressBarInfinite) Move(pos fyne.Position) {
-	p.move(pos, p)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (p *ProgressBarInfinite) MinSize() fyne.Size {
-	return p.minSize(p)
+	BaseWidget
 }
 
 // Show this widget, if it was previously hidden
 func (p *ProgressBarInfinite) Show() {
 	p.Start()
-	p.show(p)
+	p.BaseWidget.Show()
 }
 
 // Hide this widget, if it was previously visible
 func (p *ProgressBarInfinite) Hide() {
 	p.Stop()
-	p.hide(p)
+	p.BaseWidget.Hide()
 }
 
 // Start the infinite progress bar background thread to update it continuously
@@ -183,8 +166,15 @@ func (p *ProgressBarInfinite) Running() bool {
 	return renderer.(*infProgressRenderer).running.Load().(bool)
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (p *ProgressBarInfinite) MinSize() fyne.Size {
+	p.ExtendBaseWidget(p)
+	return p.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
+	p.ExtendBaseWidget(p)
 	bar := canvas.NewRectangle(theme.PrimaryColor())
 	render := &infProgressRenderer{
 		objects:  []fyne.CanvasObject{bar},

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -76,9 +76,8 @@ func (p *infProgressRenderer) Layout(size fyne.Size) {
 	p.updateBar()
 }
 
-// ApplyTheme is called when the infinite progress bar may need to update its look
-func (p *infProgressRenderer) ApplyTheme() {
-	p.bar.FillColor = theme.PrimaryColor()
+// applyTheme updates the infinite progress bar to match the current theme
+func (p *infProgressRenderer) applyTheme() {
 }
 
 func (p *infProgressRenderer) BackgroundColor() color.Color {
@@ -87,6 +86,8 @@ func (p *infProgressRenderer) BackgroundColor() color.Color {
 
 // Refresh updates the size and position of the horizontal scrolling infinite progress bar
 func (p *infProgressRenderer) Refresh() {
+	p.bar.FillColor = theme.PrimaryColor()
+
 	p.updateBar()
 	canvas.Refresh(p.progress)
 }

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -7,6 +7,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/theme"
 )
 
@@ -148,22 +149,21 @@ func (p *ProgressBarInfinite) Hide() {
 
 // Start the infinite progress bar background thread to update it continuously
 func (p *ProgressBarInfinite) Start() {
-	Renderer(p).(*infProgressRenderer).start()
+	cache.Renderer(p).(*infProgressRenderer).start()
 }
 
 // Stop the infinite progress goroutine and sets value to the Max
 func (p *ProgressBarInfinite) Stop() {
-	Renderer(p).(*infProgressRenderer).stop()
+	cache.Renderer(p).(*infProgressRenderer).stop()
 }
 
 // Running returns the current state of the infinite progress animation
 func (p *ProgressBarInfinite) Running() bool {
-	renderer, ok := renderers.Load(p)
-	if !ok {
+	if !cache.IsRendered(p) {
 		return false
 	}
 
-	return renderer.(*infProgressRenderer).running.Load().(bool)
+	return cache.Renderer(p).(*infProgressRenderer).running.Load().(bool)
 }
 
 // MinSize returns the size that this widget should not shrink below

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/internal/cache"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,17 +17,15 @@ func TestProgressBarInfinite_Creation(t *testing.T) {
 
 func TestProgressBarInfinite_Destroy(t *testing.T) {
 	bar := NewProgressBarInfinite()
-	_, found := renderers.Load(bar)
-	assert.True(t, found)
+	assert.True(t, cache.IsRendered(bar))
 	assert.True(t, bar.Running())
 
 	// check that it stopped
-	DestroyRenderer(bar)
+	cache.DestroyRenderer(bar)
 	assert.False(t, bar.Running())
 
 	// and that the cache was removed
-	_, found = renderers.Load(bar)
-	assert.False(t, found)
+	assert.False(t, cache.IsRendered(bar))
 }
 
 func TestProgressBarInfinite_Reshown(t *testing.T) {

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -164,7 +164,7 @@ func (r *radioRenderer) Destroy() {
 // Radio widget has a list of text labels and radio check icons next to each.
 // Changing the selection (only one can be selected) will trigger the changed func.
 type Radio struct {
-	baseWidget
+	BaseWidget
 	Options  []string
 	Selected string
 
@@ -172,33 +172,6 @@ type Radio struct {
 	Horizontal bool
 
 	hoveredItemIndex int
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (r *Radio) Resize(size fyne.Size) {
-	r.resize(size, r)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (r *Radio) Move(pos fyne.Position) {
-	r.move(pos, r)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (r *Radio) MinSize() fyne.Size {
-	return r.minSize(r)
-}
-
-// Show this widget, if it was previously hidden
-func (r *Radio) Show() {
-	r.show(r)
-}
-
-// Hide this widget, if it was previously visible
-func (r *Radio) Hide() {
-	r.hide(r)
 }
 
 // Enable this widget, if it was previously disabled
@@ -294,8 +267,15 @@ func (r *Radio) Tapped(event *fyne.PointEvent) {
 func (r *Radio) TappedSecondary(*fyne.PointEvent) {
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (r *Radio) MinSize() fyne.Size {
+	r.ExtendBaseWidget(r)
+	return r.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (r *Radio) CreateRenderer() fyne.WidgetRenderer {
+	r.ExtendBaseWidget(r)
 	var items []*radioRenderItem
 	var objects []fyne.CanvasObject
 
@@ -348,7 +328,7 @@ func (r *Radio) removeDuplicateOptions() {
 // NewRadio creates a new radio widget with the set options and change handler
 func NewRadio(options []string, changed func(string)) *Radio {
 	r := &Radio{
-		baseWidget{},
+		BaseWidget{},
 		options,
 		"",
 		changed,

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -89,8 +89,8 @@ func (r *radioRenderer) Layout(size fyne.Size) {
 	}
 }
 
-// ApplyTheme is called when the Radio may need to update its look
-func (r *radioRenderer) ApplyTheme() {
+// applyTheme updates this Radio to match the current system theme
+func (r *radioRenderer) applyTheme() {
 	for _, item := range r.items {
 		item.label.Color = theme.TextColor()
 		item.label.TextSize = theme.TextSize()
@@ -98,8 +98,6 @@ func (r *radioRenderer) ApplyTheme() {
 			item.label.Color = theme.DisabledTextColor()
 		}
 	}
-
-	r.Refresh()
 }
 
 func (r *radioRenderer) BackgroundColor() color.Color {
@@ -107,6 +105,7 @@ func (r *radioRenderer) BackgroundColor() color.Color {
 }
 
 func (r *radioRenderer) Refresh() {
+	r.applyTheme()
 	r.radio.removeDuplicateOptions()
 
 	if len(r.items) < len(r.radio.Options) {
@@ -177,13 +176,13 @@ type Radio struct {
 // Enable this widget, if it was previously disabled
 func (r *Radio) Enable() {
 	r.enable(r)
-	Renderer(r).ApplyTheme()
+	r.refresh(r)
 }
 
 // Disable this widget, if it was previously enabled
 func (r *Radio) Disable() {
 	r.disable(r)
-	Renderer(r).ApplyTheme()
+	r.refresh(r)
 }
 
 // Disabled returns true if the widget is disabled

--- a/widget/radio_test.go
+++ b/widget/radio_test.go
@@ -349,7 +349,7 @@ func TestRadioRenderer_ApplyTheme(t *testing.T) {
 	textSize := item.label.TextSize
 	customTextSize := textSize
 	withTestTheme(func() {
-		render.ApplyTheme()
+		render.applyTheme()
 		customTextSize = item.label.TextSize
 	})
 

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -17,10 +17,6 @@ type scrollBarRenderer struct {
 	objects []fyne.CanvasObject
 }
 
-func (r *scrollBarRenderer) ApplyTheme() {
-	r.color = theme.ScrollBarColor()
-}
-
 func (r *scrollBarRenderer) BackgroundColor() color.Color {
 	return r.color
 }
@@ -40,6 +36,7 @@ func (r *scrollBarRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (r *scrollBarRenderer) Refresh() {
+	r.color = theme.ScrollBarColor()
 }
 
 var _ desktop.Hoverable = (*scrollBar)(nil)
@@ -60,9 +57,7 @@ func (s *scrollBar) MinSize() fyne.Size {
 
 func (s *scrollBar) CreateRenderer() fyne.WidgetRenderer {
 	s.ExtendBaseWidget(s)
-	r := &scrollBarRenderer{scrollBar: s}
-	r.ApplyTheme()
-	return r
+	return &scrollBarRenderer{scrollBar: s}
 }
 
 func (s *scrollBar) DragEnd() {
@@ -98,9 +93,6 @@ type scrollBarAreaRenderer struct {
 	bar  *scrollBar
 
 	objects []fyne.CanvasObject
-}
-
-func (s *scrollBarAreaRenderer) ApplyTheme() {
 }
 
 func (s *scrollBarAreaRenderer) BackgroundColor() color.Color {
@@ -224,9 +216,6 @@ type scrollRenderer struct {
 	topShadow, bottomShadow fyne.CanvasObject
 
 	objects []fyne.CanvasObject
-}
-
-func (s *scrollRenderer) ApplyTheme() {
 }
 
 func (s *scrollRenderer) BackgroundColor() color.Color {

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -46,14 +46,20 @@ var _ desktop.Hoverable = (*scrollBar)(nil)
 var _ fyne.Draggable = (*scrollBar)(nil)
 
 type scrollBar struct {
-	baseWidget
+	BaseWidget
 	area            *scrollBarArea
 	draggedDistance int
 	dragStart       int
 	isDragged       bool
 }
 
+func (s *scrollBar) MinSize() fyne.Size {
+	s.ExtendBaseWidget(s)
+	return s.BaseWidget.MinSize()
+}
+
 func (s *scrollBar) CreateRenderer() fyne.WidgetRenderer {
+	s.ExtendBaseWidget(s)
 	r := &scrollBarRenderer{scrollBar: s}
 	r.ApplyTheme()
 	return r
@@ -72,14 +78,6 @@ func (s *scrollBar) Dragged(e *fyne.DragEvent) {
 	s.area.moveBar(s.draggedDistance + s.dragStart)
 }
 
-func (s *scrollBar) Hide() {
-	s.hide(s)
-}
-
-func (s *scrollBar) MinSize() fyne.Size {
-	return s.minSize(s)
-}
-
 func (s *scrollBar) MouseIn(e *desktop.MouseEvent) {
 	s.area.MouseIn(e)
 }
@@ -89,18 +87,6 @@ func (s *scrollBar) MouseMoved(*desktop.MouseEvent) {
 
 func (s *scrollBar) MouseOut() {
 	s.area.MouseOut()
-}
-
-func (s *scrollBar) Move(pos fyne.Position) {
-	s.move(pos, s)
-}
-
-func (s *scrollBar) Resize(size fyne.Size) {
-	s.resize(size, s)
-}
-
-func (s *scrollBar) Show() {
-	s.show(s)
 }
 
 func newScrollBar(area *scrollBarArea) *scrollBar {
@@ -179,23 +165,21 @@ func (s *scrollBarAreaRenderer) verticalBarHeight() int {
 var _ desktop.Hoverable = (*scrollBarArea)(nil)
 
 type scrollBarArea struct {
-	baseWidget
+	BaseWidget
 
 	isWide bool
 	scroll *ScrollContainer
 }
 
 func (s *scrollBarArea) CreateRenderer() fyne.WidgetRenderer {
+	s.ExtendBaseWidget(s)
 	bar := newScrollBar(s)
 	return &scrollBarAreaRenderer{area: s, bar: bar, objects: []fyne.CanvasObject{bar}}
 }
 
-func (s *scrollBarArea) Hide() {
-	s.hide(s)
-}
-
 func (s *scrollBarArea) MinSize() fyne.Size {
-	return s.minSize(s)
+	s.ExtendBaseWidget(s)
+	return s.BaseWidget.MinSize()
 }
 
 func (s *scrollBarArea) MouseIn(*desktop.MouseEvent) {
@@ -209,11 +193,6 @@ func (s *scrollBarArea) MouseMoved(*desktop.MouseEvent) {
 func (s *scrollBarArea) MouseOut() {
 	s.isWide = false
 	Refresh(s.scroll)
-}
-
-func (s *scrollBarArea) Move(pos fyne.Position) {
-	s.move(pos, s)
-
 }
 
 func (s *scrollBarArea) moveBar(y int) {
@@ -232,14 +211,6 @@ func (s *scrollBarArea) moveBar(y int) {
 	s.scroll.Offset.Y = int(ratio * float32(s.scroll.Content.Size().Height-scrollHeight))
 
 	Refresh(s.scroll)
-}
-
-func (s *scrollBarArea) Resize(size fyne.Size) {
-	s.resize(size, s)
-}
-
-func (s *scrollBarArea) Show() {
-	s.show(s)
 }
 
 func newScrollBarArea(scroll *ScrollContainer) *scrollBarArea {
@@ -324,7 +295,7 @@ func (s *scrollRenderer) updatePosition() {
 // ScrollContainer defines a container that is smaller than the Content.
 // The Offset is used to determine the position of the child widgets within the container.
 type ScrollContainer struct {
-	baseWidget
+	BaseWidget
 
 	Content fyne.CanvasObject
 	Offset  fyne.Position
@@ -332,6 +303,7 @@ type ScrollContainer struct {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (s *ScrollContainer) CreateRenderer() fyne.WidgetRenderer {
+	s.impl = s
 	bar := newScrollBarArea(s)
 	topShadow := newShadow(shadowBottom, theme.Padding()*2)
 	bottomShadow := newShadow(shadowTop, theme.Padding()*2)
@@ -344,26 +316,9 @@ func (s *ScrollContainer) CreateRenderer() fyne.WidgetRenderer {
 	}
 }
 
-// Hide this widget, if it was previously visible
-func (s *ScrollContainer) Hide() {
-	s.hide(s)
-}
-
-// MinSize returns the smallest size this widget can shrink to
 func (s *ScrollContainer) MinSize() fyne.Size {
-	return s.minSize(s)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (s *ScrollContainer) Move(pos fyne.Position) {
-	s.move(pos, s)
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (s *ScrollContainer) Resize(size fyne.Size) {
-	s.resize(size, s)
+	s.ExtendBaseWidget(s)
+	return s.BaseWidget.MinSize()
 }
 
 // Scrolled is called when an input device triggers a scroll event
@@ -383,13 +338,10 @@ func (s *ScrollContainer) Scrolled(ev *fyne.ScrollEvent) {
 	Refresh(s)
 }
 
-// Show this widget, if it was previously hidden
-func (s *ScrollContainer) Show() {
-	s.show(s)
-}
-
 // NewScrollContainer creates a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize to be smaller than that of the passed objects.
 func NewScrollContainer(content fyne.CanvasObject) *ScrollContainer {
-	return &ScrollContainer{Content: content}
+	s := &ScrollContainer{Content: content}
+	s.ExtendBaseWidget(s)
+	return s
 }

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -177,6 +177,7 @@ func (s *scrollBarArea) CreateRenderer() fyne.WidgetRenderer {
 	return &scrollBarAreaRenderer{area: s, bar: bar, objects: []fyne.CanvasObject{bar}}
 }
 
+// MinSize returns the size that this widget should not shrink below
 func (s *scrollBarArea) MinSize() fyne.Size {
 	s.ExtendBaseWidget(s)
 	return s.BaseWidget.MinSize()
@@ -316,6 +317,7 @@ func (s *ScrollContainer) CreateRenderer() fyne.WidgetRenderer {
 	}
 }
 
+// MinSize returns the size that this widget should not shrink below
 func (s *ScrollContainer) MinSize() fyne.Size {
 	s.ExtendBaseWidget(s)
 	return s.BaseWidget.MinSize()

--- a/widget/select.go
+++ b/widget/select.go
@@ -50,14 +50,6 @@ func (s *selectRenderer) Layout(size fyne.Size) {
 		(size.Height-theme.IconInlineSize())/2))
 }
 
-// ApplyTheme is called when the Button may need to update its look
-func (s *selectRenderer) ApplyTheme() {
-	s.label.Color = theme.TextColor()
-	s.label.TextSize = theme.TextSize()
-
-	s.Refresh()
-}
-
 func (s *selectRenderer) BackgroundColor() color.Color {
 	if s.combo.hovered {
 		return theme.HoverColor()
@@ -66,6 +58,9 @@ func (s *selectRenderer) BackgroundColor() color.Color {
 }
 
 func (s *selectRenderer) Refresh() {
+	s.label.Color = theme.TextColor()
+	s.label.TextSize = theme.TextSize()
+
 	if s.combo.PlaceHolder == "" {
 		s.combo.PlaceHolder = defaultPlaceHolder
 	}

--- a/widget/select.go
+++ b/widget/select.go
@@ -101,7 +101,7 @@ func (s *selectRenderer) Destroy() {
 
 // Select widget has a list of options, with the current one shown, and triggers an event func when clicked
 type Select struct {
-	baseWidget
+	BaseWidget
 
 	Selected    string
 	Options     []string
@@ -115,32 +115,11 @@ type Select struct {
 // Resize sets a new size for a widget.
 // Note this should not be used if the widget is being managed by a Layout within a Container.
 func (s *Select) Resize(size fyne.Size) {
-	s.resize(size, s)
+	s.BaseWidget.Resize(size)
 
 	if s.popUp != nil {
 		s.popUp.Content.Resize(fyne.NewSize(size.Width, s.popUp.MinSize().Height))
 	}
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (s *Select) Move(pos fyne.Position) {
-	s.move(pos, s)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (s *Select) MinSize() fyne.Size {
-	return s.minSize(s)
-}
-
-// Show this widget, if it was previously hidden
-func (s *Select) Show() {
-	s.show(s)
-}
-
-// Hide this widget, if it was previously visible
-func (s *Select) Hide() {
-	s.hide(s)
 }
 
 func (s *Select) optionTapped(text string) {
@@ -189,8 +168,14 @@ func (s *Select) MouseOut() {
 func (s *Select) MouseMoved(*desktop.MouseEvent) {
 }
 
+func (s *Select) MinSize() fyne.Size {
+	s.ExtendBaseWidget(s)
+	return s.BaseWidget.MinSize()
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (s *Select) CreateRenderer() fyne.WidgetRenderer {
+	s.ExtendBaseWidget(s)
 	icon := NewIcon(theme.MenuDropDownIcon())
 	text := canvas.NewText(s.Selected, theme.TextColor())
 
@@ -227,7 +212,7 @@ func (s *Select) SetSelected(text string) {
 
 // NewSelect creates a new select widget with the set list of options and changes handler
 func NewSelect(options []string, changed func(string)) *Select {
-	combo := &Select{baseWidget{}, "", options, defaultPlaceHolder, changed, false, nil}
+	combo := &Select{BaseWidget{}, "", options, defaultPlaceHolder, changed, false, nil}
 
 	Renderer(combo).Layout(combo.MinSize())
 	return combo

--- a/widget/select.go
+++ b/widget/select.go
@@ -168,6 +168,7 @@ func (s *Select) MouseOut() {
 func (s *Select) MouseMoved(*desktop.MouseEvent) {
 }
 
+// MinSize returns the size that this widget should not shrink below
 func (s *Select) MinSize() fyne.Size {
 	s.ExtendBaseWidget(s)
 	return s.BaseWidget.MinSize()

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -99,7 +99,7 @@ func TestSelectRenderer_ApplyTheme(t *testing.T) {
 	textSize := render.label.TextSize
 	customTextSize := textSize
 	withTestTheme(func() {
-		render.ApplyTheme()
+		render.Refresh()
 		customTextSize = render.label.TextSize
 	})
 

--- a/widget/shadow.go
+++ b/widget/shadow.go
@@ -77,10 +77,6 @@ func (r *shadowRenderer) createShadows() {
 	}
 }
 
-func (r *shadowRenderer) ApplyTheme() {
-	r.createShadows()
-}
-
 func (r *shadowRenderer) BackgroundColor() color.Color {
 	return color.Transparent
 }
@@ -132,4 +128,5 @@ func (r *shadowRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (r *shadowRenderer) Refresh() {
+	r.createShadows()
 }

--- a/widget/shadow.go
+++ b/widget/shadow.go
@@ -23,35 +23,21 @@ func newShadow(typ shadowType, depth int) *shadow {
 var _ fyne.Widget = (*shadow)(nil)
 
 type shadow struct {
-	baseWidget
+	BaseWidget
 	typ   shadowType
 	depth int
 }
 
+func (s *shadow) MinSize() fyne.Size {
+	s.ExtendBaseWidget(s)
+	return s.BaseWidget.MinSize()
+}
+
 func (s *shadow) CreateRenderer() fyne.WidgetRenderer {
+	s.ExtendBaseWidget(s)
 	r := &shadowRenderer{s: s}
 	r.createShadows()
 	return r
-}
-
-func (s *shadow) Hide() {
-	s.hide(s)
-}
-
-func (s *shadow) MinSize() fyne.Size {
-	return s.minSize(s)
-}
-
-func (s *shadow) Move(p fyne.Position) {
-	s.move(p, s)
-}
-
-func (s *shadow) Resize(size fyne.Size) {
-	s.resize(size, s)
-}
-
-func (s *shadow) Show() {
-	s.show(s)
 }
 
 type shadowRenderer struct {

--- a/widget/shadow_test.go
+++ b/widget/shadow_test.go
@@ -108,7 +108,7 @@ func TestShadow_ApplyTheme(t *testing.T) {
 	assert.Equal(t, theme.ShadowColor(), r.b.StartColor)
 
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
-	r.ApplyTheme()
+	r.Refresh()
 	assert.Equal(t, theme.ShadowColor(), r.b.StartColor)
 }
 

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -112,6 +112,7 @@ func (s *Slider) updateValue(ratio float64) {
 	}
 }
 
+// MinSize returns the size that this widget should not shrink below
 func (s *Slider) MinSize() fyne.Size {
 	s.ExtendBaseWidget(s)
 	return s.BaseWidget.MinSize()

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -146,16 +146,12 @@ type sliderRenderer struct {
 	slider  *Slider
 }
 
-// ApplyTheme is called when the Slider may need to update its look.
-func (s *sliderRenderer) ApplyTheme() {
+// Refresh updates the widget state for drawing.
+func (s *sliderRenderer) Refresh() {
 	s.track.FillColor = theme.ButtonColor()
 	s.thumb.FillColor = theme.TextColor()
 	s.active.FillColor = theme.TextColor()
-	s.Refresh()
-}
 
-// Refresh updates the widget state for drawing.
-func (s *sliderRenderer) Refresh() {
 	s.Layout(s.slider.Size())
 	canvas.Refresh(s.slider)
 }

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -22,7 +22,7 @@ var _ fyne.Draggable = (*Slider)(nil)
 
 // Slider if a widget that can slide between two fixed values.
 type Slider struct {
-	baseWidget
+	BaseWidget
 
 	Value float64
 	Min   float64
@@ -44,31 +44,6 @@ func NewSlider(min, max float64) *Slider {
 	}
 	Renderer(slider).Layout(slider.MinSize())
 	return slider
-}
-
-// Resize sets a new size for a widget.
-func (s *Slider) Resize(size fyne.Size) {
-	s.resize(size, s)
-}
-
-// MinSize returns the smallest size this widget can be.
-func (s *Slider) MinSize() fyne.Size {
-	return s.minSize(s)
-}
-
-// Show this widget, if it was previously hidden.
-func (s *Slider) Show() {
-	s.show(s)
-}
-
-// Hide this widget, if it was previously visible.
-func (s *Slider) Hide() {
-	s.hide(s)
-}
-
-// Move the widget to a new position, relative to its parent.
-func (s *Slider) Move(pos fyne.Position) {
-	s.move(pos, s)
 }
 
 // DragEnd function.
@@ -137,8 +112,14 @@ func (s *Slider) updateValue(ratio float64) {
 	}
 }
 
+func (s *Slider) MinSize() fyne.Size {
+	s.ExtendBaseWidget(s)
+	return s.BaseWidget.MinSize()
+}
+
 // CreateRenderer links this widget to its renderer.
 func (s *Slider) CreateRenderer() fyne.WidgetRenderer {
+	s.ExtendBaseWidget(s)
 	track := canvas.NewRectangle(theme.ButtonColor())
 	active := canvas.NewRectangle(theme.TextColor())
 	thumb := &canvas.Circle{

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -139,6 +139,7 @@ func (t *TabContainer) CreateRenderer() fyne.WidgetRenderer {
 	return &tabContainerRenderer{tabBar: tabBar, line: line, objects: objects, container: t}
 }
 
+// MinSize returns the size that this widget should not shrink below
 func (t *TabContainer) MinSize() fyne.Size {
 	t.ExtendBaseWidget(t)
 	return t.BaseWidget.MinSize()
@@ -362,9 +363,9 @@ type tabButton struct {
 	Text         string
 }
 
-func (t *tabButton) MinSize() fyne.Size {
-	t.ExtendBaseWidget(t)
-	return t.BaseWidget.MinSize()
+func (b *tabButton) MinSize() fyne.Size {
+	b.ExtendBaseWidget(b)
+	return b.BaseWidget.MinSize()
 }
 
 func (b *tabButton) CreateRenderer() fyne.WidgetRenderer {

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -1,13 +1,14 @@
 package widget
 
 import (
+	"image/color"
+
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/internal"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/theme"
-	"image/color"
 )
 
 // TabItem represents a single view in a TabContainer.
@@ -53,7 +54,7 @@ type TabContainer struct {
 func (t *TabContainer) Show() {
 	t.BaseWidget.Show()
 	t.SelectTabIndex(t.current)
-	Renderer(t).Refresh()
+	t.refresh(t)
 }
 
 // SelectTab sets the specified TabItem to be selected and its content visible.
@@ -87,7 +88,7 @@ func (t *TabContainer) SelectTabIndex(index int) {
 		}
 	}
 
-	Refresh(t)
+	t.refresh(t)
 }
 
 // CurrentTabIndex returns the index of the currently selected TabItem.
@@ -205,7 +206,6 @@ func NewTabContainer(items ...*TabItem) *TabContainer {
 	tabs := &TabContainer{BaseWidget: BaseWidget{}, Items: items}
 	tabs.ExtendBaseWidget(tabs)
 
-	Renderer(tabs).Layout(tabs.MinSize())
 	if tabs.mismatchedContent() {
 		internal.LogHint("TabContainer items should all have the same type of content (text, icons or both)")
 	}
@@ -297,10 +297,6 @@ func (t *tabContainerRenderer) Layout(size fyne.Size) {
 	}
 }
 
-func (t *tabContainerRenderer) ApplyTheme() {
-	t.line.FillColor = theme.ButtonColor()
-}
-
 func (t *tabContainerRenderer) BackgroundColor() color.Color {
 	return theme.BackgroundColor()
 }
@@ -310,6 +306,8 @@ func (t *tabContainerRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (t *tabContainerRenderer) Refresh() {
+	t.line.FillColor = theme.ButtonColor()
+
 	t.Layout(t.container.Size().Union(t.container.MinSize()))
 
 	for i, child := range t.container.Items {
@@ -335,7 +333,6 @@ func (t *tabContainerRenderer) Refresh() {
 		} else {
 			button.(*tabButton).Style = DefaultButton
 		}
-		Renderer(button.(*tabButton)).Refresh()
 	}
 }
 
@@ -418,11 +415,6 @@ type tabButtonRenderer struct {
 	objects []fyne.CanvasObject
 }
 
-func (r *tabButtonRenderer) ApplyTheme() {
-	r.label.Color = theme.TextColor()
-	r.label.TextSize = theme.TextSize()
-}
-
 func (r *tabButtonRenderer) BackgroundColor() color.Color {
 	switch {
 	case r.button.Style == PrimaryButton:
@@ -502,6 +494,8 @@ func (r *tabButtonRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (r *tabButtonRenderer) Refresh() {
+	r.label.Color = theme.TextColor()
+	r.label.TextSize = theme.TextSize()
 }
 
 func (r *tabButtonRenderer) padding() fyne.Size {

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -42,40 +42,18 @@ const (
 // TabContainer widget allows switching visible content from a list of TabItems.
 // Each item is represented by a button at the top of the widget.
 type TabContainer struct {
-	baseWidget
+	BaseWidget
 
 	Items       []*TabItem
 	current     int
 	tabLocation TabLocation
 }
 
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (t *TabContainer) Resize(size fyne.Size) {
-	t.resize(size, t)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (t *TabContainer) Move(pos fyne.Position) {
-	t.move(pos, t)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (t *TabContainer) MinSize() fyne.Size {
-	return t.minSize(t)
-}
-
 // Show this widget, if it was previously hidden
 func (t *TabContainer) Show() {
-	t.show(t)
+	t.BaseWidget.Show()
 	t.SelectTabIndex(t.current)
 	Renderer(t).Refresh()
-}
-
-// Hide this widget, if it was previously visible
-func (t *TabContainer) Hide() {
-	t.hide(t)
 }
 
 // SelectTab sets the specified TabItem to be selected and its content visible.
@@ -143,6 +121,7 @@ func (t *TabContainer) Append(item TabItem) {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *TabContainer) CreateRenderer() fyne.WidgetRenderer {
+	t.ExtendBaseWidget(t)
 	var buttons, objects []fyne.CanvasObject
 	for i, item := range t.Items {
 		button := t.makeButton(item)
@@ -158,6 +137,11 @@ func (t *TabContainer) CreateRenderer() fyne.WidgetRenderer {
 	line := canvas.NewRectangle(theme.ButtonColor())
 	objects = append(objects, line, tabBar)
 	return &tabContainerRenderer{tabBar: tabBar, line: line, objects: objects, container: t}
+}
+
+func (t *TabContainer) MinSize() fyne.Size {
+	t.ExtendBaseWidget(t)
+	return t.BaseWidget.MinSize()
 }
 
 func (t *TabContainer) buildTabBar(buttons []fyne.CanvasObject) *fyne.Container {
@@ -217,7 +201,8 @@ func (t *TabContainer) mismatchedContent() bool {
 
 // NewTabContainer creates a new tab bar widget that allows the user to choose between different visible containers
 func NewTabContainer(items ...*TabItem) *TabContainer {
-	tabs := &TabContainer{baseWidget: baseWidget{}, Items: items}
+	tabs := &TabContainer{BaseWidget: BaseWidget{}, Items: items}
+	tabs.ExtendBaseWidget(tabs)
 
 	Renderer(tabs).Layout(tabs.MinSize())
 	if tabs.mismatchedContent() {
@@ -368,7 +353,7 @@ var _ fyne.Tappable = (*tabButton)(nil)
 var _ desktop.Hoverable = (*tabButton)(nil)
 
 type tabButton struct {
-	baseWidget
+	BaseWidget
 	hovered      bool
 	Icon         fyne.Resource
 	IconPosition buttonIconPosition
@@ -377,7 +362,13 @@ type tabButton struct {
 	Text         string
 }
 
+func (t *tabButton) MinSize() fyne.Size {
+	t.ExtendBaseWidget(t)
+	return t.BaseWidget.MinSize()
+}
+
 func (b *tabButton) CreateRenderer() fyne.WidgetRenderer {
+	b.ExtendBaseWidget(b)
 	var icon *canvas.Image
 	if b.Icon != nil {
 		icon = canvas.NewImageFromResource(b.Icon)
@@ -399,14 +390,6 @@ func (b *tabButton) CreateRenderer() fyne.WidgetRenderer {
 	}
 }
 
-func (b *tabButton) Hide() {
-	b.hide(b)
-}
-
-func (b *tabButton) MinSize() fyne.Size {
-	return b.minSize(b)
-}
-
 func (b *tabButton) MouseIn(e *desktop.MouseEvent) {
 	b.hovered = true
 	canvas.Refresh(b)
@@ -418,18 +401,6 @@ func (b *tabButton) MouseMoved(e *desktop.MouseEvent) {
 func (b *tabButton) MouseOut() {
 	b.hovered = false
 	canvas.Refresh(b)
-}
-
-func (b *tabButton) Move(pos fyne.Position) {
-	b.move(pos, b)
-}
-
-func (b *tabButton) Resize(size fyne.Size) {
-	b.resize(size, b)
-}
-
-func (b *tabButton) Show() {
-	b.show(b)
 }
 
 func (b *tabButton) Tapped(e *fyne.PointEvent) {

--- a/widget/tabcontainer_test.go
+++ b/widget/tabcontainer_test.go
@@ -200,7 +200,7 @@ func TestTabContainerRenderer_ApplyTheme(t *testing.T) {
 	barColor := underline.FillColor
 
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
-	Renderer(tabs).ApplyTheme()
+	Renderer(tabs).Refresh()
 	assert.NotEqual(t, barColor, underline.FillColor)
 }
 
@@ -387,7 +387,7 @@ func TestTabButtonRenderer_ApplyTheme(t *testing.T) {
 	textSize := render.label.TextSize
 	customTextSize := textSize
 	withTestTheme(func() {
-		render.ApplyTheme()
+		render.Refresh()
 		customTextSize = render.label.TextSize
 	})
 

--- a/widget/text.go
+++ b/widget/text.go
@@ -249,8 +249,8 @@ func (r *textRenderer) Objects() []fyne.CanvasObject {
 	return r.objects
 }
 
-// ApplyTheme is called when the Label may need to update its look
-func (r *textRenderer) ApplyTheme() {
+// applyTheme updates the label to match the current theme.
+func (r *textRenderer) applyTheme() {
 	c := theme.TextColor()
 	if r.provider.presenter.textColor() != nil {
 		c = r.provider.presenter.textColor()
@@ -296,7 +296,7 @@ func (r *textRenderer) Refresh() {
 		r.texts[index].Text = ""
 	}
 
-	r.ApplyTheme()
+	r.applyTheme()
 	r.Layout(r.provider.Size())
 	if r.provider.presenter.object() == nil {
 		canvas.Refresh(r.provider)

--- a/widget/text.go
+++ b/widget/text.go
@@ -187,8 +187,8 @@ func (t *textProvider) charMinSize() fyne.Size {
 }
 
 // lineSizeToColumn returns the rendered size for the line specified by row up to the col position
-func (r *textProvider) lineSizeToColumn(col, row int) (size fyne.Size) {
-	line := r.row(row)
+func (t *textProvider) lineSizeToColumn(col, row int) (size fyne.Size) {
+	line := t.row(row)
 	if line == nil {
 		return fyne.NewSize(0, 0)
 	}
@@ -198,12 +198,12 @@ func (r *textProvider) lineSizeToColumn(col, row int) (size fyne.Size) {
 	}
 
 	measureText := string(line[0:col])
-	if r.presenter.password() {
+	if t.presenter.password() {
 		measureText = strings.Repeat(passwordChar, col)
 	}
 
 	label := canvas.NewText(measureText, theme.TextColor())
-	label.TextStyle = r.presenter.textStyle()
+	label.TextStyle = t.presenter.textStyle()
 	return label.MinSize()
 }
 

--- a/widget/text.go
+++ b/widget/text.go
@@ -103,7 +103,7 @@ func (t *textProvider) refreshTextRenderer() {
 		obj = t
 	}
 
-	Refresh(obj)
+	obj.Refresh()
 }
 
 // SetText sets the text of the widget

--- a/widget/text.go
+++ b/widget/text.go
@@ -26,7 +26,7 @@ type textPresenter interface {
 
 // textProvider represents the base element for text based widget.
 type textProvider struct {
-	baseWidget
+	BaseWidget
 	presenter textPresenter
 
 	buffer    []rune
@@ -46,37 +46,16 @@ func newTextProvider(text string, pres textPresenter) textProvider {
 	return t
 }
 
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (t *textProvider) Resize(size fyne.Size) {
-	t.resize(size, t)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (t *textProvider) Move(pos fyne.Position) {
-	t.move(pos, t)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (t *textProvider) MinSize() fyne.Size {
-	return t.minSize(t)
-}
-
-// Show this widget, if it was previously hidden
-func (t *textProvider) Show() {
-	t.show(t)
-}
-
-// Hide this widget, if it was previously visible
-func (t *textProvider) Hide() {
-	t.hide(t)
-}
-
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *textProvider) CreateRenderer() fyne.WidgetRenderer {
 	if t.presenter == nil {
 		panic("Cannot render a textProvider without a presenter")
+	}
+
+	if t.presenter.object() == nil {
+		t.ExtendBaseWidget(t)
+	} else {
+		t.ExtendBaseWidget(t.presenter.object())
 	}
 	r := &textRenderer{provider: t}
 
@@ -207,6 +186,27 @@ func (t *textProvider) charMinSize() fyne.Size {
 	return textMinSize(defaultChar, theme.TextSize(), t.presenter.textStyle())
 }
 
+// lineSizeToColumn returns the rendered size for the line specified by row up to the col position
+func (r *textProvider) lineSizeToColumn(col, row int) (size fyne.Size) {
+	line := r.row(row)
+	if line == nil {
+		return fyne.NewSize(0, 0)
+	}
+
+	if col >= len(line) {
+		col = len(line)
+	}
+
+	measureText := string(line[0:col])
+	if r.presenter.password() {
+		measureText = strings.Repeat(passwordChar, col)
+	}
+
+	label := canvas.NewText(measureText, theme.TextColor())
+	label.TextStyle = r.presenter.textStyle()
+	return label.MinSize()
+}
+
 // Renderer
 type textRenderer struct {
 	objects []fyne.CanvasObject
@@ -307,29 +307,6 @@ func (r *textRenderer) Refresh() {
 
 func (r *textRenderer) BackgroundColor() color.Color {
 	return color.Transparent
-}
-
-// lineSizeToColumn returns the rendered size for the line specified by row up to the col position
-func (r *textRenderer) lineSizeToColumn(col, row int) (size fyne.Size) {
-	text := r.provider
-
-	line := text.row(row)
-	if line == nil {
-		return fyne.NewSize(0, 0)
-	}
-
-	if col >= len(line) {
-		col = len(line)
-	}
-
-	measureText := string(line[0:col])
-	if r.provider.presenter.password() {
-		measureText = strings.Repeat(passwordChar, col)
-	}
-
-	label := canvas.NewText(measureText, theme.TextColor())
-	label.TextStyle = r.provider.presenter.textStyle()
-	return label.MinSize()
 }
 
 func (r *textRenderer) Destroy() {

--- a/widget/text_test.go
+++ b/widget/text_test.go
@@ -244,7 +244,7 @@ func TestTextRenderer_ApplyTheme(t *testing.T) {
 	customTextSize1 := text1.TextSize
 	customTextSize2 := text2.TextSize
 	withTestTheme(func() {
-		render.ApplyTheme()
+		render.applyTheme()
 		customTextSize1 = text1.TextSize
 		customTextSize2 = text2.TextSize
 	})

--- a/widget/text_test.go
+++ b/widget/text_test.go
@@ -253,11 +253,12 @@ func TestTextRenderer_ApplyTheme(t *testing.T) {
 	assert.Equal(t, testTextSize, customTextSize2)
 }
 
-func TestTextRenderer_LineSizeToColumn(t *testing.T) {
+func TestTextProvider_LineSizeToColumn(t *testing.T) {
 	label := NewLabel("Test")
-	render := Renderer(label).(*textRenderer)
+	label.CreateRenderer() // TODO make this a simple refresh call once it's in
+	provider := label.textProvider
 
-	fullSize := render.lineSizeToColumn(4, 0)
-	assert.Equal(t, fullSize, render.lineSizeToColumn(10, 0))
-	assert.Greater(t, fullSize.Width, render.lineSizeToColumn(2, 0).Width)
+	fullSize := provider.lineSizeToColumn(4, 0)
+	assert.Equal(t, fullSize, provider.lineSizeToColumn(10, 0))
+	assert.Greater(t, fullSize.Width, provider.lineSizeToColumn(2, 0).Width)
 }

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -64,38 +64,11 @@ func NewToolbarSeparator() ToolbarItem {
 
 // Toolbar widget creates a horizontal list of tool buttons
 type Toolbar struct {
-	baseWidget
+	BaseWidget
 
 	Items []ToolbarItem
 
 	box *Box
-}
-
-// Resize sets a new size for a widget.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (t *Toolbar) Resize(size fyne.Size) {
-	t.resize(size, t)
-}
-
-// Move the widget to a new position, relative to its parent.
-// Note this should not be used if the widget is being managed by a Layout within a Container.
-func (t *Toolbar) Move(pos fyne.Position) {
-	t.move(pos, t)
-}
-
-// MinSize returns the smallest size this widget can shrink to
-func (t *Toolbar) MinSize() fyne.Size {
-	return t.minSize(t)
-}
-
-// Show this widget, if it was previously hidden
-func (t *Toolbar) Show() {
-	t.show(t)
-}
-
-// Hide this widget, if it was previously visible
-func (t *Toolbar) Hide() {
-	t.hide(t)
 }
 
 func (t *Toolbar) append(item ToolbarItem) {
@@ -116,6 +89,7 @@ func (t *Toolbar) prepend(item ToolbarItem) {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *Toolbar) CreateRenderer() fyne.WidgetRenderer {
+	t.ExtendBaseWidget(t)
 	t.box = NewHBox()
 	t.box.setBackgroundColor(theme.ButtonColor())
 	for _, item := range t.Items {

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -105,11 +105,18 @@ func (t *Toolbar) Prepend(item ToolbarItem) {
 	t.prepend(item)
 }
 
+// MinSize returns the size that this widget should not shrink below
+func (t *Toolbar) MinSize() fyne.Size {
+	t.ExtendBaseWidget(t)
+	return t.BaseWidget.MinSize()
+}
+
 // NewToolbar creates a new toolbar widget.
 func NewToolbar(items ...ToolbarItem) *Toolbar {
 	t := &Toolbar{Items: items}
+	t.ExtendBaseWidget(t)
 
-	Renderer(t).Layout(t.MinSize())
+	t.Refresh()
 	return t
 }
 

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -61,7 +61,6 @@ func (w *BaseWidget) Move(pos fyne.Position) {
 // MinSize for the widget - it should never be resized below this value.
 func (w *BaseWidget) MinSize() fyne.Size {
 	if w.impl == nil || Renderer(w.impl) == nil {
-		//	fyne.LogError("Renderer not configured, perhaps missing call to ExtendBaseWidget()?", nil)
 		return fyne.NewSize(0, 0)
 	}
 	return Renderer(w.impl).MinSize()
@@ -138,11 +137,6 @@ func (w *BaseWidget) refresh(wid fyne.Widget) {
 		child.Refresh()
 	}
 	render.Layout(w.impl.Size())
-	//
-	//c := fyne.CurrentApp().Driver().CanvasForObject(wid)
-	//if c != nil {
-	//	c.Refresh(wid)
-	//}
 }
 
 func (w *BaseWidget) super() fyne.Widget {

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -88,7 +88,7 @@ func (w *BaseWidget) Show() {
 	if w.impl == nil {
 		return
 	}
-	Refresh(w.impl)
+	w.impl.Refresh()
 }
 
 // Hide this widget so it is no lonver visible
@@ -101,7 +101,7 @@ func (w *BaseWidget) Hide() {
 	if w.impl == nil {
 		return
 	}
-	Refresh(w.impl)
+	w.impl.Refresh()
 }
 
 func (w *BaseWidget) enable(parent fyne.Widget) {
@@ -110,7 +110,7 @@ func (w *BaseWidget) enable(parent fyne.Widget) {
 	}
 
 	w.disabled = false
-	Refresh(parent)
+	parent.Refresh()
 }
 
 func (w *BaseWidget) disable(parent fyne.Widget) {
@@ -119,7 +119,7 @@ func (w *BaseWidget) disable(parent fyne.Widget) {
 	}
 
 	w.disabled = true
-	Refresh(parent)
+	parent.Refresh()
 }
 
 // Refresh causes this widget to be redrawn in it's current state
@@ -132,13 +132,17 @@ func (w *BaseWidget) Refresh() {
 }
 
 func (w *BaseWidget) refresh(wid fyne.Widget) {
-	cache.Renderer(wid).Refresh()
-	cache.Renderer(wid).Layout(w.impl.Size())
-
-	c := fyne.CurrentApp().Driver().CanvasForObject(wid)
-	if c != nil {
-		c.Refresh(wid)
+	render := cache.Renderer(wid)
+	render.Refresh()
+	for _, child := range render.Objects() {
+		child.Refresh()
 	}
+	render.Layout(w.impl.Size())
+	//
+	//c := fyne.CurrentApp().Driver().CanvasForObject(wid)
+	//if c != nil {
+	//	c.Refresh(wid)
+	//}
 }
 
 func (w *BaseWidget) super() fyne.Widget {

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -10,7 +10,7 @@ import (
 
 var renderers sync.Map
 
-// A base widget class to define the standard widget behaviours.
+// BaseWidget provides a helper that handles basic widget behaviours.
 type BaseWidget struct {
 	size     fyne.Size
 	position fyne.Position
@@ -29,7 +29,7 @@ func (w *BaseWidget) ExtendBaseWidget(wid fyne.Widget) {
 	w.impl = wid
 }
 
-// Get the current size of this widget.
+// Size gets the current size of this widget.
 func (w *BaseWidget) Size() fyne.Size {
 	return w.size
 }
@@ -64,16 +64,19 @@ func (w *BaseWidget) Move(pos fyne.Position) {
 // MinSize for the widget - it should never be resized below this value.
 func (w *BaseWidget) MinSize() fyne.Size {
 	if w.impl == nil || Renderer(w.impl) == nil {
-	//	fyne.LogError("Renderer not configured, perhaps missing call to ExtendBaseWidget()?", nil)
+		//	fyne.LogError("Renderer not configured, perhaps missing call to ExtendBaseWidget()?", nil)
 		return fyne.NewSize(0, 0)
 	}
 	return Renderer(w.impl).MinSize()
 }
 
+// CreateRenderer of BaseWidget does nothing, it must be overridden
 func (w *BaseWidget) CreateRenderer() fyne.WidgetRenderer {
 	return nil
 }
 
+// Visible returns whether or not this widget should be visible.
+// Note that this may not mean it is currently visible if a parent has been hidden.
 func (w *BaseWidget) Visible() bool {
 	return !w.Hidden
 }
@@ -122,8 +125,8 @@ func (w *BaseWidget) disable(parent fyne.Widget) {
 	Refresh(parent)
 }
 
-func (b *BaseWidget) super() fyne.Widget {
-	return b.impl
+func (w *BaseWidget) super() fyne.Widget {
+	return w.impl
 }
 
 type isBaseWidget interface {

--- a/widget/widget_test.go
+++ b/widget/widget_test.go
@@ -14,7 +14,7 @@ import (
 type myWidget struct {
 	BaseWidget
 
-	applied chan bool
+	refreshed chan bool
 }
 
 func (m *myWidget) Enable() {
@@ -29,8 +29,8 @@ func (m *myWidget) Disabled() bool {
 	return m.disabled
 }
 
-func (m *myWidget) ApplyTheme() {
-	m.applied <- true
+func (m *myWidget) Refresh() {
+	m.refreshed <- true
 }
 
 func (m *myWidget) CreateRenderer() fyne.WidgetRenderer {
@@ -39,38 +39,38 @@ func (m *myWidget) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func TestApplyThemeCalled(t *testing.T) {
-	widget := &myWidget{applied: make(chan bool)}
+	widget := &myWidget{refreshed: make(chan bool)}
 
 	window := test.NewWindow(widget)
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
 
 	func() {
 		select {
-		case <-widget.applied:
+		case <-widget.refreshed:
 		case <-time.After(1 * time.Second):
 			assert.Fail(t, "Timed out waiting for theme apply")
 		}
 	}()
 
-	close(widget.applied)
+	close(widget.refreshed)
 	window.Close()
 }
 
 func TestApplyThemeCalledChild(t *testing.T) {
-	child := &myWidget{applied: make(chan bool)}
+	child := &myWidget{refreshed: make(chan bool)}
 	parent := NewVBox(child)
 
 	window := test.NewWindow(parent)
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
 	func() {
 		select {
-		case <-child.applied:
+		case <-child.refreshed:
 		case <-time.After(1 * time.Second):
 			assert.Fail(t, "Timed out waiting for child theme apply")
 		}
 	}()
 
-	close(child.applied)
+	close(child.refreshed)
 	window.Close()
 }
 

--- a/widget/widget_test.go
+++ b/widget/widget_test.go
@@ -12,29 +12,9 @@ import (
 )
 
 type myWidget struct {
-	baseWidget
+	BaseWidget
 
 	applied chan bool
-}
-
-func (m *myWidget) Resize(size fyne.Size) {
-	m.resize(size, m)
-}
-
-func (m *myWidget) Move(pos fyne.Position) {
-	m.move(pos, m)
-}
-
-func (m *myWidget) MinSize() fyne.Size {
-	return m.minSize(m)
-}
-
-func (m *myWidget) Show() {
-	m.show(m)
-}
-
-func (m *myWidget) Hide() {
-	m.hide(m)
 }
 
 func (m *myWidget) Enable() {
@@ -54,6 +34,7 @@ func (m *myWidget) ApplyTheme() {
 }
 
 func (m *myWidget) CreateRenderer() fyne.WidgetRenderer {
+	m.ExtendBaseWidget(m)
 	return (&Box{}).CreateRenderer()
 }
 

--- a/widget/widget_test.go
+++ b/widget/widget_test.go
@@ -52,7 +52,6 @@ func TestApplyThemeCalled(t *testing.T) {
 		}
 	}()
 
-	close(widget.refreshed)
 	window.Close()
 }
 
@@ -70,7 +69,6 @@ func TestApplyThemeCalledChild(t *testing.T) {
 		}
 	}()
 
-	close(child.refreshed)
 	window.Close()
 }
 


### PR DESCRIPTION
**Description**

Fixup widget APIs - hide the renderer references, add simple Refresh() function to everything and add BaseWidget that can be inherited easily.

Fixes #324

**Checklist**

- [ ] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [x] Public APIs match existing style
- [x] Any breaking changes have a deprecation path or have been discussed

