### PR TITLE
Scroller Improvements - Add horizontal scrolling and mobile scrolling.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Luca Corbo <lu.corbo@gmail.com>
 Paul Hovey <paul@paulhovey.org>
 Charles Corbett <nafredy@gmail.com>
 Tilo Prütz <tilo@pruetz.net>
+Stephen Houston <smhouston88@gmail.com>

--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -121,10 +121,10 @@ func makeScrollTab() fyne.CanvasObject {
 		}))
 	}
 
-	scroll := widget.NewScrollContainerWithMode(list, widget.ScrollModeHorizontal)
+	scroll := widget.NewScrollContainerWithDirection(list, widget.ScrollDirectionHorizontal)
 	scroll.Resize(fyne.NewSize(200, 300))
 
-	scroll2 := widget.NewScrollContainerWithMode(list2, widget.ScrollModeVertical)
+	scroll2 := widget.NewScrollContainerWithDirection(list2, widget.ScrollDirectionVertical)
 	scroll2.Resize(fyne.NewSize(200, 100))
 
 	return fyne.NewContainerWithLayout(layout.NewBorderLayout(scroll, nil, nil, nil), scroll, scroll2)
@@ -134,7 +134,7 @@ func makeScrollBothTab() fyne.CanvasObject {
 	logo := canvas.NewImageFromResource(theme.FyneLogo())
 	logo.SetMinSize(fyne.NewSize(800, 800))
 
-	scroll := widget.NewScrollContainerWithMode(logo, widget.ScrollModeBoth)
+	scroll := widget.NewScrollContainerWithDirection(logo, widget.ScrollDirectionBoth)
 	scroll.Resize(fyne.NewSize(400, 400))
 
 	return scroll

--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -121,10 +121,10 @@ func makeScrollTab() fyne.CanvasObject {
 		}))
 	}
 
-	scroll := widget.NewScrollContainerWithDirection(list, widget.ScrollDirectionHorizontal)
+	scroll := widget.NewScrollContainer(list)
 	scroll.Resize(fyne.NewSize(200, 300))
 
-	scroll2 := widget.NewScrollContainerWithDirection(list2, widget.ScrollDirectionVertical)
+	scroll2 := widget.NewScrollContainer(list2)
 	scroll2.Resize(fyne.NewSize(200, 100))
 
 	return fyne.NewContainerWithLayout(layout.NewBorderLayout(scroll, nil, nil, nil), scroll, scroll2)
@@ -134,7 +134,7 @@ func makeScrollBothTab() fyne.CanvasObject {
 	logo := canvas.NewImageFromResource(theme.FyneLogo())
 	logo.SetMinSize(fyne.NewSize(800, 800))
 
-	scroll := widget.NewScrollContainerWithDirection(logo, widget.ScrollDirectionBoth)
+	scroll := widget.NewScrollContainer(logo)
 	scroll.Resize(fyne.NewSize(400, 400))
 
 	return scroll
@@ -158,7 +158,7 @@ func WidgetScreen() fyne.CanvasObject {
 			widget.NewTabItem("Progress", makeProgressTab()),
 			widget.NewTabItem("Form", makeFormTab()),
 			widget.NewTabItem("Scroll", makeScrollTab()),
-			widget.NewTabItem("Scroll Both", makeScrollBothTab()),
+			widget.NewTabItem("Full Scroll", makeScrollBothTab()),
 		),
 	)
 }

--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -105,19 +105,37 @@ func makeFormTab() fyne.Widget {
 	return form
 }
 
-func makeScrollTab() fyne.Widget {
+func makeScrollTab() fyne.CanvasObject {
 	logo := canvas.NewImageFromResource(theme.FyneLogo())
 	logo.SetMinSize(fyne.NewSize(320, 320))
-	list := widget.NewVBox()
+	list := widget.NewHBox()
+	list2 := widget.NewVBox()
+
 	for i := 1; i <= 20; i++ {
 		index := i // capture
 		list.Append(widget.NewButton(fmt.Sprintf("Button %d", index), func() {
 			fmt.Println("Tapped", index)
 		}))
+		list2.Append(widget.NewButton(fmt.Sprintf("Button %d", index), func() {
+			fmt.Println("Tapped", index)
+		}))
 	}
 
-	scroll := widget.NewScrollContainer(list)
-	scroll.Resize(fyne.NewSize(200, 200))
+	scroll := widget.NewScrollContainerWithMode(list, widget.ScrollModeHorizontal)
+	scroll.Resize(fyne.NewSize(200, 300))
+
+	scroll2 := widget.NewScrollContainerWithMode(list2, widget.ScrollModeVertical)
+	scroll2.Resize(fyne.NewSize(200, 100))
+
+	return fyne.NewContainerWithLayout(layout.NewBorderLayout(scroll, nil, nil, nil), scroll, scroll2)
+}
+
+func makeScrollBothTab() fyne.CanvasObject {
+	logo := canvas.NewImageFromResource(theme.FyneLogo())
+	logo.SetMinSize(fyne.NewSize(800, 800))
+
+	scroll := widget.NewScrollContainerWithMode(logo, widget.ScrollModeBoth)
+	scroll.Resize(fyne.NewSize(400, 400))
 
 	return scroll
 }
@@ -140,6 +158,7 @@ func WidgetScreen() fyne.CanvasObject {
 			widget.NewTabItem("Progress", makeProgressTab()),
 			widget.NewTabItem("Form", makeFormTab()),
 			widget.NewTabItem("Scroll", makeScrollTab()),
+			widget.NewTabItem("Scroll Both", makeScrollBothTab()),
 		),
 	)
 }

--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -127,7 +127,7 @@ func makeScrollTab() fyne.CanvasObject {
 	scroll2 := widget.NewScrollContainer(list2)
 	scroll2.Resize(fyne.NewSize(200, 100))
 
-	return fyne.NewContainerWithLayout(layout.NewBorderLayout(scroll, nil, nil, nil), scroll, scroll2)
+	return fyne.NewContainerWithLayout(layout.NewGridLayout(1), scroll, scroll2)
 }
 
 func makeScrollBothTab() fyne.CanvasObject {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -678,7 +678,6 @@ func (w *window) mouseScrolled(viewport *glfw.Window, xoff float64, yoff float64
 		_, ok := object.(fyne.Scrollable)
 		return ok
 	})
-
 	switch wid := co.(type) {
 	case fyne.Scrollable:
 		ev := &fyne.ScrollEvent{}

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -9,6 +9,25 @@ import (
 	"fyne.io/fyne/theme"
 )
 
+// ScrollMode contains the list of scrolling orientations to enable for the widget
+type ScrollMode int
+type scrollBarOrientation int
+
+// We default to vertical as 0 due to that being the original orientation offered
+const (
+	scrollBarOrientationVertical   scrollBarOrientation = 0
+	scrollBarOrientationHorizontal scrollBarOrientation = 1
+)
+
+const (
+	// ScrollModeVertical will only scroll vertically
+	ScrollModeVertical ScrollMode = 0
+	// ScrollModeHorizontal will only scroll horizontally
+	ScrollModeHorizontal ScrollMode = 1
+	// ScrollModeBoth will scroll in both directions
+	ScrollModeBoth ScrollMode = 2
+)
+
 type scrollBarRenderer struct {
 	scrollBar *scrollBar
 
@@ -44,10 +63,13 @@ var _ fyne.Draggable = (*scrollBar)(nil)
 
 type scrollBar struct {
 	BaseWidget
-	area            *scrollBarArea
-	draggedDistance int
-	dragStart       int
-	isDragged       bool
+	area                 *scrollBarArea
+	draggedDistanceHoriz int
+	draggedDistanceVert  int
+	dragStartHoriz       int
+	dragStartVert        int
+	isDragged            bool
+	orientation          scrollBarOrientation
 }
 
 func (s *scrollBar) MinSize() fyne.Size {
@@ -66,11 +88,29 @@ func (s *scrollBar) DragEnd() {
 func (s *scrollBar) Dragged(e *fyne.DragEvent) {
 	if !s.isDragged {
 		s.isDragged = true
-		s.dragStart = s.Position().Y
-		s.draggedDistance = 0
+		switch s.orientation {
+		case scrollBarOrientationHorizontal:
+			s.dragStartHoriz = s.Position().X
+		case scrollBarOrientationVertical:
+			s.dragStartVert = s.Position().Y
+		default:
+			s.dragStartVert = s.Position().Y
+		}
+		s.draggedDistanceHoriz = 0
+		s.draggedDistanceVert = 0
 	}
-	s.draggedDistance += e.DraggedY
-	s.area.moveBar(s.draggedDistance + s.dragStart)
+
+	switch s.orientation {
+	case scrollBarOrientationHorizontal:
+		s.draggedDistanceHoriz += e.DraggedX
+		s.area.moveHorizontalBar(s.draggedDistanceHoriz + s.dragStartHoriz)
+	case scrollBarOrientationVertical:
+		s.draggedDistanceVert += e.DraggedY
+		s.area.moveVerticalBar(s.draggedDistanceVert + s.dragStartVert)
+	default:
+		s.draggedDistanceVert += e.DraggedY
+		s.area.moveVerticalBar(s.draggedDistanceVert + s.dragStartVert)
+	}
 }
 
 func (s *scrollBar) MouseIn(e *desktop.MouseEvent) {
@@ -84,13 +124,14 @@ func (s *scrollBar) MouseOut() {
 	s.area.MouseOut()
 }
 
-func newScrollBar(area *scrollBarArea) *scrollBar {
-	return &scrollBar{area: area}
+func newScrollBar(area *scrollBarArea, orientation scrollBarOrientation) *scrollBar {
+	return &scrollBar{area: area, orientation: orientation}
 }
 
 type scrollBarAreaRenderer struct {
-	area *scrollBarArea
-	bar  *scrollBar
+	area        *scrollBarArea
+	bar         *scrollBar
+	orientation scrollBarOrientation
 
 	objects []fyne.CanvasObject
 }
@@ -103,17 +144,36 @@ func (s *scrollBarAreaRenderer) Destroy() {
 }
 
 func (s *scrollBarAreaRenderer) Layout(size fyne.Size) {
-	s.updateBarPosition()
+	switch s.orientation {
+	case scrollBarOrientationHorizontal:
+		s.updateHorizontalBarPosition()
+	case scrollBarOrientationVertical:
+		s.updateVerticalBarPosition()
+	default:
+		s.updateVerticalBarPosition()
+	}
 }
 
 func (s *scrollBarAreaRenderer) MinSize() fyne.Size {
-	var minWidth int
-	if s.area.isWide {
-		minWidth = theme.ScrollBarSize()
-	} else {
-		minWidth = theme.ScrollBarSmallSize() * 2
+	var min int
+	min = theme.ScrollBarSize()
+	switch s.orientation {
+	case scrollBarOrientationHorizontal:
+		if !s.area.isTall {
+			min = theme.ScrollBarSmallSize() * 2
+		}
+		return fyne.NewSize(theme.ScrollBarSize(), min)
+	case scrollBarOrientationVertical:
+		if !s.area.isWide {
+			min = theme.ScrollBarSmallSize() * 2
+		}
+		return fyne.NewSize(min, theme.ScrollBarSize())
+	default:
+		if !s.area.isWide {
+			min = theme.ScrollBarSmallSize() * 2
+		}
+		return fyne.NewSize(min, theme.ScrollBarSize())
 	}
-	return fyne.NewSize(minWidth, theme.ScrollBarSize())
 }
 
 func (s *scrollBarAreaRenderer) Objects() []fyne.CanvasObject {
@@ -121,11 +181,38 @@ func (s *scrollBarAreaRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (s *scrollBarAreaRenderer) Refresh() {
-	s.updateBarPosition()
+	switch s.orientation {
+	case scrollBarOrientationHorizontal:
+		s.updateHorizontalBarPosition()
+	case scrollBarOrientationVertical:
+		s.updateVerticalBarPosition()
+	default:
+		s.updateVerticalBarPosition()
+	}
 	canvas.Refresh(s.bar)
 }
 
-func (s *scrollBarAreaRenderer) updateBarPosition() {
+func (s *scrollBarAreaRenderer) updateHorizontalBarPosition() {
+	barWidth := s.horizontalBarWidth()
+	barRatio := float32(0.0)
+	if s.area.scroll.Offset.X != 0 {
+		barRatio = float32(s.area.scroll.Offset.X) / float32(s.area.scroll.Content.Size().Width-s.area.scroll.Size().Width)
+	}
+	barX := int(float32(s.area.scroll.size.Width-barWidth) * barRatio)
+
+	var barY, barHeight int
+	if s.area.isTall {
+		barHeight = theme.ScrollBarSize()
+	} else {
+		barY = theme.ScrollBarSmallSize()
+		barHeight = theme.ScrollBarSmallSize()
+	}
+
+	s.bar.Resize(fyne.NewSize(barWidth, barHeight))
+	s.bar.Move(fyne.NewPos(barX, barY))
+}
+
+func (s *scrollBarAreaRenderer) updateVerticalBarPosition() {
 	barHeight := s.verticalBarHeight()
 	barRatio := float32(0.0)
 	if s.area.scroll.Offset.Y != 0 {
@@ -145,6 +232,15 @@ func (s *scrollBarAreaRenderer) updateBarPosition() {
 	s.bar.Move(fyne.NewPos(barX, barY))
 }
 
+func (s *scrollBarAreaRenderer) horizontalBarWidth() int {
+	portion := float32(s.area.size.Width) / float32(s.area.scroll.Content.Size().Width)
+	if portion > 1.0 {
+		portion = 1.0
+	}
+
+	return int(float32(s.area.size.Width) * portion)
+}
+
 func (s *scrollBarAreaRenderer) verticalBarHeight() int {
 	portion := float32(s.area.size.Height) / float32(s.area.scroll.Content.Size().Height)
 	if portion > 1.0 {
@@ -159,14 +255,16 @@ var _ desktop.Hoverable = (*scrollBarArea)(nil)
 type scrollBarArea struct {
 	BaseWidget
 
-	isWide bool
-	scroll *ScrollContainer
+	isWide      bool
+	isTall      bool
+	scroll      *ScrollContainer
+	orientation scrollBarOrientation
 }
 
 func (s *scrollBarArea) CreateRenderer() fyne.WidgetRenderer {
 	s.ExtendBaseWidget(s)
-	bar := newScrollBar(s)
-	return &scrollBarAreaRenderer{area: s, bar: bar, objects: []fyne.CanvasObject{bar}}
+	bar := newScrollBar(s, s.orientation)
+	return &scrollBarAreaRenderer{area: s, bar: bar, orientation: s.orientation, objects: []fyne.CanvasObject{bar}}
 }
 
 // MinSize returns the size that this widget should not shrink below
@@ -176,7 +274,14 @@ func (s *scrollBarArea) MinSize() fyne.Size {
 }
 
 func (s *scrollBarArea) MouseIn(*desktop.MouseEvent) {
-	s.isWide = true
+	switch s.orientation {
+	case scrollBarOrientationHorizontal:
+		s.isTall = true
+	case scrollBarOrientationVertical:
+		s.isWide = true
+	default:
+		s.isWide = true
+	}
 	Refresh(s.scroll)
 }
 
@@ -184,11 +289,36 @@ func (s *scrollBarArea) MouseMoved(*desktop.MouseEvent) {
 }
 
 func (s *scrollBarArea) MouseOut() {
-	s.isWide = false
+	switch s.orientation {
+	case scrollBarOrientationHorizontal:
+		s.isTall = false
+	case scrollBarOrientationVertical:
+		s.isWide = false
+	default:
+		s.isWide = false
+	}
 	Refresh(s.scroll)
 }
 
-func (s *scrollBarArea) moveBar(y int) {
+func (s *scrollBarArea) moveHorizontalBar(x int) {
+	render := Renderer(s).(*scrollBarAreaRenderer)
+	barWidth := render.horizontalBarWidth()
+	scrollWidth := s.scroll.Size().Width
+	maxX := scrollWidth - barWidth
+
+	if x < 0 {
+		x = 0
+	} else if x > maxX {
+		x = maxX
+	}
+
+	ratio := float32(x) / float32(maxX)
+	s.scroll.Offset.X = int(ratio * float32(s.scroll.Content.Size().Width-scrollWidth))
+
+	Refresh(s.scroll)
+}
+
+func (s *scrollBarArea) moveVerticalBar(y int) {
 	render := Renderer(s).(*scrollBarAreaRenderer)
 	barHeight := render.verticalBarHeight()
 	scrollHeight := s.scroll.Size().Height
@@ -206,14 +336,17 @@ func (s *scrollBarArea) moveBar(y int) {
 	Refresh(s.scroll)
 }
 
-func newScrollBarArea(scroll *ScrollContainer) *scrollBarArea {
-	return &scrollBarArea{scroll: scroll}
+func newScrollBarArea(scroll *ScrollContainer, orientation scrollBarOrientation) *scrollBarArea {
+	return &scrollBarArea{scroll: scroll, orientation: orientation}
 }
 
 type scrollRenderer struct {
 	scroll                  *ScrollContainer
 	vertArea                *scrollBarArea
+	horizArea               *scrollBarArea
+	leftShadow, rightShadow fyne.CanvasObject
 	topShadow, bottomShadow fyne.CanvasObject
+	ScrollMode              ScrollMode
 
 	objects []fyne.CanvasObject
 }
@@ -227,11 +360,18 @@ func (s *scrollRenderer) Destroy() {
 
 func (s *scrollRenderer) Layout(size fyne.Size) {
 	// The scroll bar needs to be resized and moved on the far right
-	scrollBarArea := s.vertArea
-	scrollBarArea.Resize(fyne.NewSize(scrollBarArea.MinSize().Width, size.Height))
-	scrollBarArea.Move(fyne.NewPos(s.scroll.Size().Width-scrollBarArea.Size().Width, 0))
+	s.horizArea.Resize(fyne.NewSize(size.Width, s.horizArea.MinSize().Height))
+	s.vertArea.Resize(fyne.NewSize(s.vertArea.MinSize().Width, size.Height))
+
+	s.horizArea.Move(fyne.NewPos(0, s.scroll.Size().Height-s.horizArea.Size().Height))
+	s.vertArea.Move(fyne.NewPos(s.scroll.Size().Width-s.vertArea.Size().Width, 0))
+
+	s.leftShadow.Resize(fyne.NewSize(0, size.Height))
+	s.rightShadow.Resize(fyne.NewSize(0, size.Height))
 	s.topShadow.Resize(fyne.NewSize(size.Width, 0))
 	s.bottomShadow.Resize(fyne.NewSize(size.Width, 0))
+
+	s.rightShadow.Move(fyne.NewPos(s.scroll.size.Width, 0))
 	s.bottomShadow.Move(fyne.NewPos(0, s.scroll.size.Height))
 
 	c := s.scroll.Content
@@ -241,8 +381,16 @@ func (s *scrollRenderer) Layout(size fyne.Size) {
 }
 
 func (s *scrollRenderer) MinSize() fyne.Size {
-	// TODO determine if width or height should be respected based on a which-way-to-scroll flag
-	return fyne.NewSize(s.scroll.Content.MinSize().Width, 25) // TODO consider the smallest useful scroll view?
+	switch s.ScrollMode {
+	case ScrollModeHorizontal:
+		return fyne.NewSize(25, s.scroll.Content.MinSize().Height)
+	case ScrollModeVertical:
+		return fyne.NewSize(s.scroll.Content.MinSize().Width, 25)
+	case ScrollModeBoth:
+		return fyne.NewSize(25, 25)
+	default:
+		return fyne.NewSize(s.scroll.Content.MinSize().Width, 25) // TODO consider the smallest useful scroll view?
+	}
 }
 
 func (s *scrollRenderer) Objects() []fyne.CanvasObject {
@@ -253,33 +401,58 @@ func (s *scrollRenderer) Refresh() {
 	s.Layout(s.scroll.Size())
 }
 
-func (s *scrollRenderer) updatePosition() {
-	scrollHeight := s.scroll.Size().Height
-	contentHeight := s.scroll.Content.Size().Height
-	if contentHeight <= scrollHeight {
-		s.scroll.Offset.Y = 0
-		s.vertArea.Hide()
+func (s *scrollRenderer) calculateScrollPosition(contentSize int, scrollSize int, offset int, area *scrollBarArea) {
+	if contentSize <= scrollSize {
+		if area == s.horizArea {
+			s.scroll.Offset.X = 0
+		} else {
+			s.scroll.Offset.Y = 0
+		}
+		area.Hide()
 	} else if s.scroll.Visible() {
-		s.vertArea.Show()
-		if contentHeight-s.scroll.Offset.Y < scrollHeight {
-			s.scroll.Offset.Y = contentHeight - scrollHeight
+		area.Show()
+		if contentSize-offset < scrollSize {
+			if area == s.horizArea {
+				s.scroll.Offset.X = contentSize - scrollSize
+			} else {
+				s.scroll.Offset.Y = contentSize - scrollSize
+			}
 		}
 	}
+}
+
+func (s *scrollRenderer) calculateShadows(offset int, contentSize int, scrollSize int, shadowStart fyne.CanvasObject, shadowEnd fyne.CanvasObject) {
+	if !s.scroll.Visible() {
+		return
+	}
+	if offset > 0 {
+		shadowStart.Show()
+	} else {
+		shadowStart.Hide()
+	}
+	if offset < contentSize-scrollSize {
+		shadowEnd.Show()
+	} else {
+		shadowEnd.Hide()
+	}
+}
+
+func (s *scrollRenderer) updatePosition() {
+	scrollWidth := s.scroll.Size().Width
+	contentWidth := s.scroll.Content.Size().Width
+	scrollHeight := s.scroll.Size().Height
+	contentHeight := s.scroll.Content.Size().Height
+	s.calculateScrollPosition(contentWidth, scrollWidth, s.scroll.Offset.X, s.horizArea)
+	s.calculateScrollPosition(contentHeight, scrollHeight, s.scroll.Offset.Y, s.vertArea)
+
 	s.scroll.Content.Move(fyne.NewPos(-s.scroll.Offset.X, -s.scroll.Offset.Y))
 	canvas.Refresh(s.scroll.Content)
 
-	if s.scroll.Offset.Y > 0 && s.scroll.Visible() {
-		s.topShadow.Show()
-	} else {
-		s.topShadow.Hide()
-	}
-	if s.scroll.Offset.Y < contentHeight-scrollHeight && s.scroll.Visible() {
-		s.bottomShadow.Show()
-	} else {
-		s.bottomShadow.Hide()
-	}
+	s.calculateShadows(s.scroll.Offset.X, contentWidth, scrollWidth, s.leftShadow, s.rightShadow)
+	s.calculateShadows(s.scroll.Offset.Y, contentHeight, scrollHeight, s.topShadow, s.bottomShadow)
 
 	Renderer(s.vertArea).Layout(s.scroll.size)
+	Renderer(s.horizArea).Layout(s.scroll.size)
 }
 
 // ScrollContainer defines a container that is smaller than the Content.
@@ -287,26 +460,84 @@ func (s *scrollRenderer) updatePosition() {
 type ScrollContainer struct {
 	BaseWidget
 
-	Content fyne.CanvasObject
-	Offset  fyne.Position
+	Content                   fyne.CanvasObject
+	Offset                    fyne.Position
+	horizontalDraggedDistance int
+	verticalDraggedDistance   int
+	hbar                      *scrollBarArea
+	vbar                      *scrollBarArea
+	ScrollMode                ScrollMode
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (s *ScrollContainer) CreateRenderer() fyne.WidgetRenderer {
 	s.impl = s
-	bar := newScrollBarArea(s)
+	s.hbar = newScrollBarArea(s, scrollBarOrientationHorizontal)
+	s.vbar = newScrollBarArea(s, scrollBarOrientationVertical)
+	leftShadow := newShadow(shadowRight, theme.Padding()*2)
+	rightShadow := newShadow(shadowLeft, theme.Padding()*2)
 	topShadow := newShadow(shadowBottom, theme.Padding()*2)
 	bottomShadow := newShadow(shadowTop, theme.Padding()*2)
 	return &scrollRenderer{
-		objects:      []fyne.CanvasObject{s.Content, bar, topShadow, bottomShadow},
+		objects:      []fyne.CanvasObject{s.Content, s.hbar, s.vbar, topShadow, bottomShadow},
 		scroll:       s,
-		vertArea:     bar,
+		ScrollMode:   s.ScrollMode,
+		horizArea:    s.hbar,
+		vertArea:     s.vbar,
+		leftShadow:   leftShadow,
+		rightShadow:  rightShadow,
 		topShadow:    topShadow,
 		bottomShadow: bottomShadow,
 	}
 }
 
-// MinSize returns the size that this widget should not shrink below
+// DragEnd will stop scrolling on mobile has stopped
+func (s *ScrollContainer) DragEnd() {
+}
+
+// Dragged will scroll on any drag - bar or otherwise - for mobile
+func (s *ScrollContainer) Dragged(e *fyne.DragEvent) {
+	if !fyne.CurrentDevice().IsMobile() {
+		return
+	}
+
+	render := Renderer(s.vbar).(*scrollBarAreaRenderer)
+	barWidth := render.horizontalBarWidth()
+	barHeight := render.verticalBarHeight()
+	scrollWidth := s.Size().Width
+	scrollHeight := s.Size().Height
+	maxX := scrollWidth - barWidth
+	maxY := scrollHeight - barHeight
+
+	s.horizontalDraggedDistance += e.DraggedX
+	s.verticalDraggedDistance += e.DraggedY
+
+	if s.horizontalDraggedDistance > maxX {
+		s.horizontalDraggedDistance = maxX
+	} else if s.horizontalDraggedDistance < 0 {
+		s.horizontalDraggedDistance = 0
+	}
+
+	if s.verticalDraggedDistance > maxY {
+		s.verticalDraggedDistance = maxY
+	} else if s.verticalDraggedDistance < 0 {
+		s.verticalDraggedDistance = 0
+	}
+
+	switch s.ScrollMode {
+	case ScrollModeHorizontal:
+		s.hbar.moveHorizontalBar(s.hbar.position.X + s.horizontalDraggedDistance)
+	case ScrollModeVertical:
+		s.vbar.moveVerticalBar(s.vbar.position.Y + s.verticalDraggedDistance)
+	case ScrollModeBoth:
+		s.hbar.moveHorizontalBar(s.hbar.position.X + s.horizontalDraggedDistance)
+		s.vbar.moveVerticalBar(s.vbar.position.Y + s.verticalDraggedDistance)
+	default:
+		s.vbar.moveVerticalBar(s.vbar.position.Y + s.verticalDraggedDistance)
+	}
+}
+
+// MinSize returns the smallest size this widget can shrink to
 func (s *ScrollContainer) MinSize() fyne.Size {
 	s.ExtendBaseWidget(s)
 	return s.BaseWidget.MinSize()
@@ -314,19 +545,56 @@ func (s *ScrollContainer) MinSize() fyne.Size {
 
 // Scrolled is called when an input device triggers a scroll event
 func (s *ScrollContainer) Scrolled(ev *fyne.ScrollEvent) {
-	if s.Content.Size().Height <= s.Size().Height {
+	if s.Content.Size().Width <= s.Size().Width &&
+		s.Content.Size().Height <= s.Size().Height {
 		return
 	}
+	switch s.ScrollMode {
+	case ScrollModeHorizontal:
+		s.Offset.X -= ev.DeltaX
+		if s.Offset.X < 0 {
+			s.Offset.X = 0
+		} else if s.Offset.X+s.Size().Width >= s.Content.Size().Width {
+			s.Offset.X = s.Content.Size().Width - s.Size().Width
+		}
+	case ScrollModeVertical:
+		s.Offset.Y -= ev.DeltaY
+		if s.Offset.Y < 0 {
+			s.Offset.Y = 0
+		} else if s.Offset.Y+s.Size().Height >= s.Content.Size().Height {
+			s.Offset.Y = s.Content.Size().Height - s.Size().Height
+		}
+	case ScrollModeBoth:
+		s.Offset.X -= ev.DeltaX
+		s.Offset.Y -= ev.DeltaY
+		if s.Offset.X < 0 {
+			s.Offset.X = 0
+		} else if s.Offset.X+s.Size().Width >= s.Content.Size().Width {
+			s.Offset.X = s.Content.Size().Width - s.Size().Width
+		}
+		if s.Offset.Y < 0 {
+			s.Offset.Y = 0
+		} else if s.Offset.Y+s.Size().Height >= s.Content.Size().Height {
+			s.Offset.Y = s.Content.Size().Height - s.Size().Height
+		}
+	default:
+		s.Offset.Y -= ev.DeltaY
+		if s.Offset.Y < 0 {
+			s.Offset.Y = 0
+		} else if s.Offset.Y+s.Size().Height >= s.Content.Size().Height {
+			s.Offset.Y = s.Content.Size().Height - s.Size().Height
+		}
 
-	s.Offset.Y -= ev.DeltaY
-
-	if s.Offset.Y < 0 {
-		s.Offset.Y = 0
-	} else if s.Offset.Y+s.Size().Height >= s.Content.Size().Height {
-		s.Offset.Y = s.Content.Size().Height - s.Size().Height
 	}
 
 	Refresh(s)
+}
+
+// NewScrollContainerWithMode is the same as NewScrollContainer but takes a ScrollMode argument
+func NewScrollContainerWithMode(content fyne.CanvasObject, scrollMode ScrollMode) *ScrollContainer {
+	s := &ScrollContainer{Content: content, ScrollMode: scrollMode}
+	s.ExtendBaseWidget(s)
+	return s
 }
 
 // NewScrollContainer creates a scrollable parent wrapping the specified content.

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -145,13 +145,12 @@ func (s *scrollBarAreaRenderer) MinSize() fyne.Size {
 			min = theme.ScrollBarSmallSize() * 2
 		}
 		return fyne.NewSize(theme.ScrollBarSize(), min)
-	case scrollBarOrientationVertical:
+	default:
 		if !s.area.isWide {
 			min = theme.ScrollBarSmallSize() * 2
 		}
 		return fyne.NewSize(min, theme.ScrollBarSize())
 	}
-	return fyne.NewSize(min, theme.ScrollBarSize())
 }
 
 func (s *scrollBarAreaRenderer) Objects() []fyne.CanvasObject {
@@ -162,8 +161,6 @@ func (s *scrollBarAreaRenderer) Refresh() {
 	switch s.orientation {
 	case scrollBarOrientationHorizontal:
 		s.updateHorizontalBarPosition()
-	case scrollBarOrientationVertical:
-		s.updateVerticalBarPosition()
 	default:
 		s.updateVerticalBarPosition()
 	}

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -9,8 +9,8 @@ import (
 	"fyne.io/fyne/theme"
 )
 
-// ScrollMode contains the list of scrolling orientations to enable for the widget
-type ScrollMode int
+// ScrollDirection contains the list of scrolling orientations to enable for the widget
+type ScrollDirection int
 type scrollBarOrientation int
 
 // We default to vertical as 0 due to that being the original orientation offered
@@ -20,12 +20,12 @@ const (
 )
 
 const (
-	// ScrollModeVertical will only scroll vertically
-	ScrollModeVertical ScrollMode = 0
-	// ScrollModeHorizontal will only scroll horizontally
-	ScrollModeHorizontal ScrollMode = 1
-	// ScrollModeBoth will scroll in both directions
-	ScrollModeBoth ScrollMode = 2
+	// ScrollDirectionVertical will only scroll vertically
+	ScrollDirectionVertical ScrollDirection = 0
+	// ScrollDirectionHorizontal will only scroll horizontally
+	ScrollDirectionHorizontal ScrollDirection = 1
+	// ScrollDirectionBoth will scroll in both directions
+	ScrollDirectionBoth ScrollDirection = 2
 )
 
 type scrollBarRenderer struct {
@@ -346,7 +346,7 @@ type scrollRenderer struct {
 	horizArea               *scrollBarArea
 	leftShadow, rightShadow fyne.CanvasObject
 	topShadow, bottomShadow fyne.CanvasObject
-	ScrollMode              ScrollMode
+	ScrollDirection         ScrollDirection
 
 	objects []fyne.CanvasObject
 }
@@ -381,12 +381,12 @@ func (s *scrollRenderer) Layout(size fyne.Size) {
 }
 
 func (s *scrollRenderer) MinSize() fyne.Size {
-	switch s.ScrollMode {
-	case ScrollModeHorizontal:
+	switch s.ScrollDirection {
+	case ScrollDirectionHorizontal:
 		return fyne.NewSize(25, s.scroll.Content.MinSize().Height)
-	case ScrollModeVertical:
+	case ScrollDirectionVertical:
 		return fyne.NewSize(s.scroll.Content.MinSize().Width, 25)
-	case ScrollModeBoth:
+	case ScrollDirectionBoth:
 		return fyne.NewSize(25, 25)
 	default:
 		return fyne.NewSize(s.scroll.Content.MinSize().Width, 25) // TODO consider the smallest useful scroll view?
@@ -466,7 +466,7 @@ type ScrollContainer struct {
 	verticalDraggedDistance   int
 	hbar                      *scrollBarArea
 	vbar                      *scrollBarArea
-	ScrollMode                ScrollMode
+	ScrollDirection           ScrollDirection
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
@@ -479,15 +479,15 @@ func (s *ScrollContainer) CreateRenderer() fyne.WidgetRenderer {
 	topShadow := newShadow(shadowBottom, theme.Padding()*2)
 	bottomShadow := newShadow(shadowTop, theme.Padding()*2)
 	return &scrollRenderer{
-		objects:      []fyne.CanvasObject{s.Content, s.hbar, s.vbar, topShadow, bottomShadow},
-		scroll:       s,
-		ScrollMode:   s.ScrollMode,
-		horizArea:    s.hbar,
-		vertArea:     s.vbar,
-		leftShadow:   leftShadow,
-		rightShadow:  rightShadow,
-		topShadow:    topShadow,
-		bottomShadow: bottomShadow,
+		objects:         []fyne.CanvasObject{s.Content, s.hbar, s.vbar, topShadow, bottomShadow},
+		scroll:          s,
+		ScrollDirection: s.ScrollDirection,
+		horizArea:       s.hbar,
+		vertArea:        s.vbar,
+		leftShadow:      leftShadow,
+		rightShadow:     rightShadow,
+		topShadow:       topShadow,
+		bottomShadow:    bottomShadow,
 	}
 }
 
@@ -524,12 +524,12 @@ func (s *ScrollContainer) Dragged(e *fyne.DragEvent) {
 		s.verticalDraggedDistance = 0
 	}
 
-	switch s.ScrollMode {
-	case ScrollModeHorizontal:
+	switch s.ScrollDirection {
+	case ScrollDirectionHorizontal:
 		s.hbar.moveHorizontalBar(s.hbar.position.X + s.horizontalDraggedDistance)
-	case ScrollModeVertical:
+	case ScrollDirectionVertical:
 		s.vbar.moveVerticalBar(s.vbar.position.Y + s.verticalDraggedDistance)
-	case ScrollModeBoth:
+	case ScrollDirectionBoth:
 		s.hbar.moveHorizontalBar(s.hbar.position.X + s.horizontalDraggedDistance)
 		s.vbar.moveVerticalBar(s.vbar.position.Y + s.verticalDraggedDistance)
 	default:
@@ -549,22 +549,22 @@ func (s *ScrollContainer) Scrolled(ev *fyne.ScrollEvent) {
 		s.Content.Size().Height <= s.Size().Height {
 		return
 	}
-	switch s.ScrollMode {
-	case ScrollModeHorizontal:
+	switch s.ScrollDirection {
+	case ScrollDirectionHorizontal:
 		s.Offset.X -= ev.DeltaX
 		if s.Offset.X < 0 {
 			s.Offset.X = 0
 		} else if s.Offset.X+s.Size().Width >= s.Content.Size().Width {
 			s.Offset.X = s.Content.Size().Width - s.Size().Width
 		}
-	case ScrollModeVertical:
+	case ScrollDirectionVertical:
 		s.Offset.Y -= ev.DeltaY
 		if s.Offset.Y < 0 {
 			s.Offset.Y = 0
 		} else if s.Offset.Y+s.Size().Height >= s.Content.Size().Height {
 			s.Offset.Y = s.Content.Size().Height - s.Size().Height
 		}
-	case ScrollModeBoth:
+	case ScrollDirectionBoth:
 		s.Offset.X -= ev.DeltaX
 		s.Offset.Y -= ev.DeltaY
 		if s.Offset.X < 0 {
@@ -590,10 +590,10 @@ func (s *ScrollContainer) Scrolled(ev *fyne.ScrollEvent) {
 	Refresh(s)
 }
 
-// NewScrollContainerWithMode is the same as NewScrollContainer but takes a ScrollMode argument
-func NewScrollContainerWithMode(content fyne.CanvasObject, scrollMode ScrollMode) *ScrollContainer {
-	s := &ScrollContainer{Content: content, ScrollMode: scrollMode}
-	s.ExtendBaseWidget(s)
+// NewScrollContainerWithMode is the same as NewScrollContainer but takes a ScrollDirection argument
+func NewScrollContainerWithDirection(content fyne.CanvasObject, scrollDirection ScrollDirection) *ScrollContainer {
+	s := NewScrollContainer(content)
+	s.ScrollDirection = scrollDirection
 	return s
 }
 

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -485,8 +485,9 @@ func (s *ScrollContainer) Dragged(e *fyne.DragEvent) {
 	} else if s.verticalDraggedDistance < 0 {
 		s.verticalDraggedDistance = 0
 	}
-	s.hbar.moveHorizontalBar(s.hbar.position.X + s.horizontalDraggedDistance)
-	s.vbar.moveVerticalBar(s.vbar.position.Y + s.verticalDraggedDistance)
+	s.Offset.X = s.horizontalDraggedDistance
+	s.Offset.Y = s.verticalDraggedDistance
+	s.Refresh()
 
 }
 

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -462,14 +462,8 @@ func (s *ScrollContainer) Dragged(e *fyne.DragEvent) {
 	if !fyne.CurrentDevice().IsMobile() {
 		return
 	}
-
-	render := Renderer(s.vbar).(*scrollBarAreaRenderer)
-	barWidth := render.horizontalBarWidth()
-	barHeight := render.verticalBarHeight()
-	scrollWidth := s.Size().Width
-	scrollHeight := s.Size().Height
-	maxX := scrollWidth - barWidth
-	maxY := scrollHeight - barHeight
+	maxX := s.Content.Size().Width
+	maxY := s.Content.Size().Height
 
 	s.horizontalDraggedDistance -= e.DraggedX
 	s.verticalDraggedDistance -= e.DraggedY

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var modes = []ScrollMode{ScrollModeHorizontal, ScrollModeVertical, ScrollModeBoth}
+var directions = []ScrollDirection{ScrollDirectionHorizontal, ScrollDirectionVertical, ScrollDirectionBoth}
 
 func TestNewScrollContainer(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
@@ -29,14 +29,14 @@ func TestNewScrollContainer(t *testing.T) {
 	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
 }
 
-func TestNewScrollContainerWithMode(t *testing.T) {
-	for _, mode := range modes {
+func TestNewScrollContainerWithDirection(t *testing.T) {
+	for _, direction := range directions {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(10, 10))
-		scroll := NewScrollContainerWithMode(rect, mode)
+		scroll := NewScrollContainerWithDirection(rect, direction)
 		scroll.Resize(fyne.NewSize(100, 100))
-		switch mode {
-		case ScrollModeHorizontal:
+		switch direction {
+		case ScrollDirectionHorizontal:
 			barArea := Renderer(scroll).(*scrollRenderer).horizArea
 			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
 			assert.Equal(t, 0, scroll.Offset.X)
@@ -44,7 +44,7 @@ func TestNewScrollContainerWithMode(t *testing.T) {
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
 			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), barArea.Position())
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			barArea := Renderer(scroll).(*scrollRenderer).vertArea
 			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
 			assert.Equal(t, 0, scroll.Offset.Y)
@@ -52,7 +52,7 @@ func TestNewScrollContainerWithMode(t *testing.T) {
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
 			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			barArea := Renderer(scroll).(*scrollRenderer).vertArea
 			barArea2 := Renderer(scroll).(*scrollRenderer).horizArea
 			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
@@ -73,11 +73,11 @@ func TestNewScrollContainerWithMode(t *testing.T) {
 
 func TestScrollContainer_Refresh(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1000})
 			assert.Equal(t, 900, scroll.Offset.X)
@@ -85,9 +85,9 @@ func TestScrollContainer_Refresh(t *testing.T) {
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			Refresh(scroll)
 			assert.Equal(t, 400, scroll.Offset.X)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -1000})
 			assert.Equal(t, 900, scroll.Offset.Y)
@@ -95,9 +95,9 @@ func TestScrollContainer_Refresh(t *testing.T) {
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			Refresh(scroll)
 			assert.Equal(t, 400, scroll.Offset.Y)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1000, DeltaY: -1000})
 			assert.Equal(t, 900, scroll.Offset.X)
@@ -113,25 +113,25 @@ func TestScrollContainer_Refresh(t *testing.T) {
 
 func TestScrollContainer_Scrolled(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			assert.Equal(t, 0, scroll.Offset.X)
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -10})
 			assert.Equal(t, 10, scroll.Offset.X)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			assert.Equal(t, 0, scroll.Offset.Y)
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -10})
 			assert.Equal(t, 10, scroll.Offset.Y)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			assert.Equal(t, 0, scroll.Offset.X)
 			assert.Equal(t, 0, scroll.Offset.Y)
@@ -145,17 +145,17 @@ func TestScrollContainer_Scrolled(t *testing.T) {
 func TestScrollContainer_Scrolled_Limit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(100, 100))
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
 		scroll.Resize(fyne.NewSize(80, 80))
-		switch mode {
-		case ScrollModeHorizontal:
+		switch direction {
+		case ScrollDirectionHorizontal:
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -25})
 			assert.Equal(t, 20, scroll.Offset.X)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -25})
 			assert.Equal(t, 20, scroll.Offset.Y)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -25, DeltaY: -25})
 			assert.Equal(t, 20, scroll.Offset.X)
 			assert.Equal(t, 20, scroll.Offset.Y)
@@ -165,25 +165,25 @@ func TestScrollContainer_Scrolled_Limit(t *testing.T) {
 
 func TestScrollContainer_Scrolled_Back(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Offset.X = 10
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 10})
 			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Offset.Y = 10
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 10})
 			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll := NewScrollContainerWithDirection(rect, direction)
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Offset.X = 10
 			scroll.Offset.Y = 10
@@ -196,22 +196,22 @@ func TestScrollContainer_Scrolled_Back(t *testing.T) {
 
 func TestScrollContainer_Scrolled_BackLimit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Offset.X = 10
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 20})
 			assert.Equal(t, 0, scroll.Offset.X)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Offset.Y = 10
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 20})
 			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(1000, 1000))
 			scroll.Resize(fyne.NewSize(100, 100))
 			scroll.Offset.X = 10
@@ -225,22 +225,22 @@ func TestScrollContainer_Scrolled_BackLimit(t *testing.T) {
 
 func TestScrollContainer_Resize(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(80, 80))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20})
 			scroll.Resize(fyne.NewSize(100, 80))
 			assert.Equal(t, 0, scroll.Offset.X)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(80, 80))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
 			scroll.Resize(fyne.NewSize(80, 100))
 			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(80, 80))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
@@ -253,22 +253,22 @@ func TestScrollContainer_Resize(t *testing.T) {
 
 func TestScrollContainer_ResizeOffset(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(80, 80))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20})
 			scroll.Resize(fyne.NewSize(90, 80))
 			assert.Equal(t, 10, scroll.Offset.X)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(80, 80))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
 			scroll.Resize(fyne.NewSize(80, 90))
 			assert.Equal(t, 10, scroll.Offset.Y)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(80, 80))
 			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
@@ -302,25 +302,25 @@ func TestScrollContainer_ScrollBarForSmallContentIsHidden(t *testing.T) {
 
 func TestScrollContainer_ShowHiddenScrollBarIfContentGrows(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
 		r := Renderer(scroll).(*scrollRenderer)
-		switch mode {
-		case ScrollModeHorizontal:
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(200, 100))
 			require.False(t, r.horizArea.Visible())
 			rect.SetMinSize(fyne.NewSize(300, 100))
 			r.Layout(scroll.Size())
 			assert.True(t, r.horizArea.Visible())
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(100, 200))
 			require.False(t, r.vertArea.Visible())
 			rect.SetMinSize(fyne.NewSize(100, 300))
 			r.Layout(scroll.Size())
 			assert.True(t, r.vertArea.Visible())
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(100, 100))
 			scroll.Resize(fyne.NewSize(200, 200))
 			require.False(t, r.horizArea.Visible())
@@ -335,25 +335,25 @@ func TestScrollContainer_ShowHiddenScrollBarIfContentGrows(t *testing.T) {
 
 func TestScrollContainer_HideScrollBarIfContentShrinks(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
 		r := Renderer(scroll).(*scrollRenderer)
-		switch mode {
-		case ScrollModeHorizontal:
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(300, 300))
 			scroll.Resize(fyne.NewSize(200, 300))
 			require.True(t, r.horizArea.Visible())
 			rect.SetMinSize(fyne.NewSize(200, 300))
 			r.Layout(scroll.Size())
 			assert.False(t, r.horizArea.Visible())
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(300, 300))
 			scroll.Resize(fyne.NewSize(300, 200))
 			require.True(t, r.vertArea.Visible())
 			rect.SetMinSize(fyne.NewSize(300, 200))
 			r.Layout(scroll.Size())
 			assert.False(t, r.vertArea.Visible())
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(300, 300))
 			scroll.Resize(fyne.NewSize(200, 200))
 			require.True(t, r.horizArea.Visible())
@@ -368,10 +368,10 @@ func TestScrollContainer_HideScrollBarIfContentShrinks(t *testing.T) {
 
 func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			scroll.Resize(fyne.NewSize(100, 100))
 			area := Renderer(scroll).(*scrollRenderer).horizArea
@@ -383,7 +383,7 @@ func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
 			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			scroll.Resize(fyne.NewSize(100, 100))
 			area := Renderer(scroll).(*scrollRenderer).vertArea
@@ -395,7 +395,7 @@ func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
 			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			scroll.Resize(fyne.NewSize(100, 100))
 			areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
@@ -420,10 +420,10 @@ func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
 
 func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, mode := range modes {
-		scroll := NewScrollContainerWithMode(rect, mode)
-		switch mode {
-		case ScrollModeHorizontal:
+	for _, direction := range directions {
+		scroll := NewScrollContainerWithDirection(rect, direction)
+		switch direction {
+		case ScrollDirectionHorizontal:
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			scroll.Resize(fyne.NewSize(100, 100))
 			area := Renderer(scroll).(*scrollRenderer).horizArea
@@ -446,7 +446,7 @@ func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing
 			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
-		case ScrollModeVertical:
+		case ScrollDirectionVertical:
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			scroll.Resize(fyne.NewSize(100, 100))
 			area := Renderer(scroll).(*scrollRenderer).vertArea
@@ -469,7 +469,7 @@ func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing
 			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
 			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
-		case ScrollModeBoth:
+		case ScrollDirectionBoth:
 			rect.SetMinSize(fyne.NewSize(500, 500))
 			scroll.Resize(fyne.NewSize(100, 100))
 			areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
@@ -520,7 +520,7 @@ func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing
 func TestScrollContainer_ShowShadowOnLeftIfContentIsScrolled(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(500, 100))
-	scroll := NewScrollContainerWithMode(rect, ScrollModeHorizontal)
+	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionHorizontal)
 	scroll.Resize(fyne.NewSize(100, 100))
 	r := Renderer(scroll).(*scrollRenderer)
 	assert.False(t, r.leftShadow.Visible())
@@ -536,7 +536,7 @@ func TestScrollContainer_ShowShadowOnLeftIfContentIsScrolled(t *testing.T) {
 func TestScrollContainer_ShowShadowOnRightIfContentCanScroll(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(500, 100))
-	scroll := NewScrollContainerWithMode(rect, ScrollModeHorizontal)
+	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionHorizontal)
 	scroll.Resize(fyne.NewSize(100, 100))
 	r := Renderer(scroll).(*scrollRenderer)
 	assert.True(t, r.rightShadow.Visible())
@@ -584,7 +584,7 @@ func TestScrollContainer_ShowShadowOnBottomIfContentCanScroll(t *testing.T) {
 func TestScrollBarRenderer_BarSize(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(100, 100))
-	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
+	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
 	areaHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer)
 	areaVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer)
@@ -613,7 +613,7 @@ func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
 func TestScrollBar_Dragged_ClickedInside(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
+	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
 	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
 	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
@@ -633,7 +633,7 @@ func TestScrollBar_Dragged_ClickedInside(t *testing.T) {
 func TestScrollBar_DraggedBack_ClickedInside(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
+	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
 	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
 	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
@@ -710,7 +710,7 @@ func TestScrollBar_Dragged_Limit(t *testing.T) {
 func TestScrollBar_Dragged_BackLimit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
+	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
 	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
 	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var directions = []ScrollDirection{ScrollDirectionHorizontal, ScrollDirectionVertical, ScrollDirectionBoth}
-
 func TestNewScrollContainer(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(10, 10))
@@ -21,7 +19,6 @@ func TestNewScrollContainer(t *testing.T) {
 	scroll.Resize(fyne.NewSize(100, 100))
 	barArea := Renderer(scroll).(*scrollRenderer).vertArea
 	bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
-
 	assert.Equal(t, 0, scroll.Offset.Y)
 	assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Width)
 	assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
@@ -29,254 +26,88 @@ func TestNewScrollContainer(t *testing.T) {
 	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
 }
 
-func TestNewScrollContainerWithDirection(t *testing.T) {
-	for _, direction := range directions {
-		rect := canvas.NewRectangle(color.Black)
-		rect.SetMinSize(fyne.NewSize(10, 10))
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		scroll.Resize(fyne.NewSize(100, 100))
-		switch direction {
-		case ScrollDirectionHorizontal:
-			barArea := Renderer(scroll).(*scrollRenderer).horizArea
-			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
-			assert.Equal(t, 0, scroll.Offset.X)
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), barArea.Position())
-		case ScrollDirectionVertical:
-			barArea := Renderer(scroll).(*scrollRenderer).vertArea
-			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
-			assert.Equal(t, 0, scroll.Offset.Y)
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
-		case ScrollDirectionBoth:
-			barArea := Renderer(scroll).(*scrollRenderer).vertArea
-			barArea2 := Renderer(scroll).(*scrollRenderer).horizArea
-			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
-			bar2 := Renderer(barArea2).(*scrollBarAreaRenderer).bar
-			assert.Equal(t, 0, scroll.Offset.X)
-			assert.Equal(t, 0, scroll.Offset.Y)
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea2.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar2.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar2.Position().Y)
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), barArea2.Position())
-		}
-	}
-}
-
 func TestScrollContainer_Refresh(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1000})
-			assert.Equal(t, 900, scroll.Offset.X)
-			assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			Refresh(scroll)
-			assert.Equal(t, 400, scroll.Offset.X)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -1000})
-			assert.Equal(t, 900, scroll.Offset.Y)
-			assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			Refresh(scroll)
-			assert.Equal(t, 400, scroll.Offset.Y)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1000, DeltaY: -1000})
-			assert.Equal(t, 900, scroll.Offset.X)
-			assert.Equal(t, 900, scroll.Offset.Y)
-			assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			Refresh(scroll)
-			assert.Equal(t, 400, scroll.Offset.X)
-			assert.Equal(t, 400, scroll.Offset.Y)
-		}
-	}
+	rect.SetMinSize(fyne.NewSize(1000, 1000))
+	scroll := NewScrollContainer(rect)
+	scroll.Resize(fyne.NewSize(100, 100))
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1000, DeltaY: -1000})
+	assert.Equal(t, 900, scroll.Offset.X)
+	assert.Equal(t, 900, scroll.Offset.Y)
+	assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
+	rect.SetMinSize(fyne.NewSize(500, 500))
+	Refresh(scroll)
+	assert.Equal(t, 400, scroll.Offset.X)
 }
 
 func TestScrollContainer_Scrolled(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			assert.Equal(t, 0, scroll.Offset.X)
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -10})
-			assert.Equal(t, 10, scroll.Offset.X)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			assert.Equal(t, 0, scroll.Offset.Y)
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -10})
-			assert.Equal(t, 10, scroll.Offset.Y)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			assert.Equal(t, 0, scroll.Offset.X)
-			assert.Equal(t, 0, scroll.Offset.Y)
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -10, DeltaY: -10})
-			assert.Equal(t, 10, scroll.Offset.X)
-			assert.Equal(t, 10, scroll.Offset.Y)
-		}
-	}
+	rect.SetMinSize(fyne.NewSize(1000, 1000))
+	scroll := NewScrollContainer(rect)
+	scroll.Resize(fyne.NewSize(100, 100))
+	assert.Equal(t, 0, scroll.Offset.X)
+	assert.Equal(t, 0, scroll.Offset.Y)
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -10, DeltaY: -10})
+	assert.Equal(t, 10, scroll.Offset.X)
+	assert.Equal(t, 10, scroll.Offset.Y)
+
 }
 
 func TestScrollContainer_Scrolled_Limit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(100, 100))
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		scroll.Resize(fyne.NewSize(80, 80))
-		switch direction {
-		case ScrollDirectionHorizontal:
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -25})
-			assert.Equal(t, 20, scroll.Offset.X)
-		case ScrollDirectionVertical:
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -25})
-			assert.Equal(t, 20, scroll.Offset.Y)
-		case ScrollDirectionBoth:
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -25, DeltaY: -25})
-			assert.Equal(t, 20, scroll.Offset.X)
-			assert.Equal(t, 20, scroll.Offset.Y)
-		}
-	}
+	scroll := NewScrollContainer(rect)
+	scroll.Resize(fyne.NewSize(80, 80))
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -25, DeltaY: -25})
+	assert.Equal(t, 20, scroll.Offset.X)
 }
 
 func TestScrollContainer_Scrolled_Back(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Offset.X = 10
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 10})
-			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Offset.Y = 10
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 10})
-			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll := NewScrollContainerWithDirection(rect, direction)
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Offset.X = 10
-			scroll.Offset.Y = 10
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 10, DeltaY: 10})
-			assert.Equal(t, 0, scroll.Offset.X)
-			assert.Equal(t, 0, scroll.Offset.Y)
-		}
-	}
+	rect.SetMinSize(fyne.NewSize(1000, 1000))
+	scroll := NewScrollContainer(rect)
+	scroll.Resize(fyne.NewSize(100, 100))
+	scroll.Offset.X = 10
+	scroll.Offset.Y = 10
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 10, DeltaY: 10})
+	assert.Equal(t, 0, scroll.Offset.X)
+	assert.Equal(t, 0, scroll.Offset.Y)
 }
 
 func TestScrollContainer_Scrolled_BackLimit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Offset.X = 10
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 20})
-			assert.Equal(t, 0, scroll.Offset.X)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Offset.Y = 10
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 20})
-			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(1000, 1000))
-			scroll.Resize(fyne.NewSize(100, 100))
-			scroll.Offset.X = 10
-			scroll.Offset.Y = 10
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 20, DeltaY: 20})
-			assert.Equal(t, 0, scroll.Offset.X)
-			assert.Equal(t, 0, scroll.Offset.Y)
-		}
-	}
+	scroll := NewScrollContainer(rect)
+	rect.SetMinSize(fyne.NewSize(1000, 1000))
+	scroll.Resize(fyne.NewSize(100, 100))
+	scroll.Offset.X = 10
+	scroll.Offset.Y = 10
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 20, DeltaY: 20})
+	assert.Equal(t, 0, scroll.Offset.X)
+	assert.Equal(t, 0, scroll.Offset.Y)
+
 }
 
 func TestScrollContainer_Resize(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(80, 80))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20})
-			scroll.Resize(fyne.NewSize(100, 80))
-			assert.Equal(t, 0, scroll.Offset.X)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(80, 80))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
-			scroll.Resize(fyne.NewSize(80, 100))
-			assert.Equal(t, 0, scroll.Offset.Y)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(80, 80))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
-			scroll.Resize(fyne.NewSize(100, 100))
-			assert.Equal(t, 0, scroll.Offset.X)
-			assert.Equal(t, 0, scroll.Offset.Y)
-		}
-	}
+	scroll := NewScrollContainer(rect)
+	rect.SetMinSize(fyne.NewSize(100, 100))
+	scroll.Resize(fyne.NewSize(80, 80))
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
+	scroll.Resize(fyne.NewSize(100, 100))
+	assert.Equal(t, 0, scroll.Offset.X)
+	assert.Equal(t, 0, scroll.Offset.Y)
+
 }
 
 func TestScrollContainer_ResizeOffset(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(80, 80))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20})
-			scroll.Resize(fyne.NewSize(90, 80))
-			assert.Equal(t, 10, scroll.Offset.X)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(80, 80))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
-			scroll.Resize(fyne.NewSize(80, 90))
-			assert.Equal(t, 10, scroll.Offset.Y)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(80, 80))
-			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
-			scroll.Resize(fyne.NewSize(90, 90))
-			assert.Equal(t, 10, scroll.Offset.X)
-			assert.Equal(t, 10, scroll.Offset.Y)
-		}
-	}
+	scroll := NewScrollContainer(rect)
+	rect.SetMinSize(fyne.NewSize(100, 100))
+	scroll.Resize(fyne.NewSize(80, 80))
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
+	scroll.Resize(fyne.NewSize(90, 90))
+	assert.Equal(t, 10, scroll.Offset.X)
+	assert.Equal(t, 10, scroll.Offset.Y)
 }
 
 func TestScrollContainer_ResizeExpand(t *testing.T) {
@@ -284,7 +115,6 @@ func TestScrollContainer_ResizeExpand(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(120, 140))
-
 	assert.Equal(t, 120, rect.Size().Width)
 	assert.Equal(t, 140, rect.Size().Height)
 }
@@ -294,7 +124,6 @@ func TestScrollContainer_ScrollBarForSmallContentIsHidden(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 200))
-
 	r := Renderer(scroll).(*scrollRenderer)
 	assert.False(t, r.vertArea.Visible())
 	assert.False(t, r.horizArea.Visible())
@@ -302,225 +131,103 @@ func TestScrollContainer_ScrollBarForSmallContentIsHidden(t *testing.T) {
 
 func TestScrollContainer_ShowHiddenScrollBarIfContentGrows(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		r := Renderer(scroll).(*scrollRenderer)
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(200, 100))
-			require.False(t, r.horizArea.Visible())
-			rect.SetMinSize(fyne.NewSize(300, 100))
-			r.Layout(scroll.Size())
-			assert.True(t, r.horizArea.Visible())
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(100, 200))
-			require.False(t, r.vertArea.Visible())
-			rect.SetMinSize(fyne.NewSize(100, 300))
-			r.Layout(scroll.Size())
-			assert.True(t, r.vertArea.Visible())
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(100, 100))
-			scroll.Resize(fyne.NewSize(200, 200))
-			require.False(t, r.horizArea.Visible())
-			require.False(t, r.vertArea.Visible())
-			rect.SetMinSize(fyne.NewSize(300, 300))
-			r.Layout(scroll.Size())
-			assert.True(t, r.horizArea.Visible())
-			assert.True(t, r.vertArea.Visible())
-		}
-	}
+	scroll := NewScrollContainer(rect)
+	r := Renderer(scroll).(*scrollRenderer)
+	rect.SetMinSize(fyne.NewSize(100, 100))
+	scroll.Resize(fyne.NewSize(200, 200))
+	require.False(t, r.horizArea.Visible())
+	require.False(t, r.vertArea.Visible())
+	rect.SetMinSize(fyne.NewSize(300, 300))
+	r.Layout(scroll.Size())
+	assert.True(t, r.horizArea.Visible())
+	assert.True(t, r.vertArea.Visible())
 }
 
 func TestScrollContainer_HideScrollBarIfContentShrinks(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		r := Renderer(scroll).(*scrollRenderer)
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(300, 300))
-			scroll.Resize(fyne.NewSize(200, 300))
-			require.True(t, r.horizArea.Visible())
-			rect.SetMinSize(fyne.NewSize(200, 300))
-			r.Layout(scroll.Size())
-			assert.False(t, r.horizArea.Visible())
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(300, 300))
-			scroll.Resize(fyne.NewSize(300, 200))
-			require.True(t, r.vertArea.Visible())
-			rect.SetMinSize(fyne.NewSize(300, 200))
-			r.Layout(scroll.Size())
-			assert.False(t, r.vertArea.Visible())
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(300, 300))
-			scroll.Resize(fyne.NewSize(200, 200))
-			require.True(t, r.horizArea.Visible())
-			require.True(t, r.vertArea.Visible())
-			rect.SetMinSize(fyne.NewSize(200, 200))
-			r.Layout(scroll.Size())
-			assert.False(t, r.horizArea.Visible())
-			assert.False(t, r.vertArea.Visible())
-		}
-	}
+	scroll := NewScrollContainer(rect)
+	r := Renderer(scroll).(*scrollRenderer)
+	rect.SetMinSize(fyne.NewSize(300, 300))
+	scroll.Resize(fyne.NewSize(200, 200))
+	require.True(t, r.horizArea.Visible())
+	require.True(t, r.vertArea.Visible())
+	rect.SetMinSize(fyne.NewSize(200, 200))
+	r.Layout(scroll.Size())
+	assert.False(t, r.horizArea.Visible())
+	assert.False(t, r.vertArea.Visible())
 }
 
 func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			scroll.Resize(fyne.NewSize(100, 100))
-			area := Renderer(scroll).(*scrollRenderer).horizArea
-			bar := Renderer(area).(*scrollBarAreaRenderer).bar
-			require.True(t, area.Visible())
-			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+	scroll := NewScrollContainer(rect)
+	rect.SetMinSize(fyne.NewSize(500, 500))
+	scroll.Resize(fyne.NewSize(100, 100))
+	areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
+	areaVert := Renderer(scroll).(*scrollRenderer).vertArea
+	barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
+	barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
+	require.True(t, areaHoriz.Visible())
+	require.True(t, areaVert.Visible())
+	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
 
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Height)
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			scroll.Resize(fyne.NewSize(100, 100))
-			area := Renderer(scroll).(*scrollRenderer).vertArea
-			bar := Renderer(area).(*scrollBarAreaRenderer).bar
-			require.True(t, area.Visible())
-			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+	assert.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
+	assert.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
+	assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
+	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
+	assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
+	assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
+	assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
+	assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
 
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			scroll.Resize(fyne.NewSize(100, 100))
-			areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
-			areaVert := Renderer(scroll).(*scrollRenderer).vertArea
-			barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
-			barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
-			require.True(t, areaHoriz.Visible())
-			require.True(t, areaVert.Visible())
-			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
-
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
-			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
-			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
-		}
-	}
 }
 
 func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	for _, direction := range directions {
-		scroll := NewScrollContainerWithDirection(rect, direction)
-		switch direction {
-		case ScrollDirectionHorizontal:
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			scroll.Resize(fyne.NewSize(100, 100))
-			area := Renderer(scroll).(*scrollRenderer).horizArea
-			bar := Renderer(area).(*scrollBarAreaRenderer).bar
-			require.True(t, bar.Visible())
-			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
-			require.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Height)
-			require.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
-			require.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
-			require.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
-
-			bar.MouseIn(&desktop.MouseEvent{})
-			assert.Equal(t, theme.ScrollBarSize(), area.Size().Height)
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSize()), area.Position())
-			assert.Equal(t, theme.ScrollBarSize(), bar.Size().Height)
-			assert.Equal(t, 0, bar.Position().Y)
-
-			bar.MouseOut()
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Height)
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
-		case ScrollDirectionVertical:
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			scroll.Resize(fyne.NewSize(100, 100))
-			area := Renderer(scroll).(*scrollRenderer).vertArea
-			bar := Renderer(area).(*scrollBarAreaRenderer).bar
-			require.True(t, bar.Visible())
-			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
-			require.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
-			require.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
-			require.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-			require.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
-
-			bar.MouseIn(&desktop.MouseEvent{})
-			assert.Equal(t, theme.ScrollBarSize(), area.Size().Width)
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), area.Position())
-			assert.Equal(t, theme.ScrollBarSize(), bar.Size().Width)
-			assert.Equal(t, 0, bar.Position().X)
-
-			bar.MouseOut()
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
-		case ScrollDirectionBoth:
-			rect.SetMinSize(fyne.NewSize(500, 500))
-			scroll.Resize(fyne.NewSize(100, 100))
-			areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
-			areaVert := Renderer(scroll).(*scrollRenderer).vertArea
-			barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
-			barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
-			require.True(t, barHoriz.Visible())
-			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
-			require.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
-			require.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
-			require.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
-			require.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
-
-			barHoriz.MouseIn(&desktop.MouseEvent{})
-			assert.Equal(t, theme.ScrollBarSize(), areaHoriz.Size().Height)
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSize()), areaHoriz.Position())
-			assert.Equal(t, theme.ScrollBarSize(), barHoriz.Size().Height)
-			assert.Equal(t, 0, barHoriz.Position().Y)
-
-			barHoriz.MouseOut()
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
-			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
-			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
-			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
-
-			require.True(t, barVert.Visible())
-			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
-			require.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
-			require.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
-			require.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
-			require.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
-
-			barVert.MouseIn(&desktop.MouseEvent{})
-			assert.Equal(t, theme.ScrollBarSize(), areaVert.Size().Width)
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), areaVert.Position())
-			assert.Equal(t, theme.ScrollBarSize(), barVert.Size().Width)
-			assert.Equal(t, 0, barVert.Position().X)
-
-			barVert.MouseOut()
-			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
-			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
-			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
-			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
-		}
-	}
+	scroll := NewScrollContainer(rect)
+	rect.SetMinSize(fyne.NewSize(500, 500))
+	scroll.Resize(fyne.NewSize(100, 100))
+	areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
+	areaVert := Renderer(scroll).(*scrollRenderer).vertArea
+	barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
+	barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
+	require.True(t, barHoriz.Visible())
+	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+	require.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
+	require.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
+	require.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
+	require.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
+	barHoriz.MouseIn(&desktop.MouseEvent{})
+	assert.Equal(t, theme.ScrollBarSize(), areaHoriz.Size().Height)
+	assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSize()), areaHoriz.Position())
+	assert.Equal(t, theme.ScrollBarSize(), barHoriz.Size().Height)
+	assert.Equal(t, 0, barHoriz.Position().Y)
+	barHoriz.MouseOut()
+	assert.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
+	assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
+	assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
+	assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
+	require.True(t, barVert.Visible())
+	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+	require.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
+	require.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
+	require.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
+	require.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
+	barVert.MouseIn(&desktop.MouseEvent{})
+	assert.Equal(t, theme.ScrollBarSize(), areaVert.Size().Width)
+	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), areaVert.Position())
+	assert.Equal(t, theme.ScrollBarSize(), barVert.Size().Width)
+	assert.Equal(t, 0, barVert.Position().X)
+	barVert.MouseOut()
+	assert.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
+	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
+	assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
+	assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
 }
 
 func TestScrollContainer_ShowShadowOnLeftIfContentIsScrolled(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(500, 100))
-	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionHorizontal)
+	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
 	r := Renderer(scroll).(*scrollRenderer)
 	assert.False(t, r.leftShadow.Visible())
@@ -536,7 +243,7 @@ func TestScrollContainer_ShowShadowOnLeftIfContentIsScrolled(t *testing.T) {
 func TestScrollContainer_ShowShadowOnRightIfContentCanScroll(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(500, 100))
-	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionHorizontal)
+	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
 	r := Renderer(scroll).(*scrollRenderer)
 	assert.True(t, r.rightShadow.Visible())
@@ -584,7 +291,7 @@ func TestScrollContainer_ShowShadowOnBottomIfContentCanScroll(t *testing.T) {
 func TestScrollBarRenderer_BarSize(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(100, 100))
-	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
+	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
 	areaHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer)
 	areaVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer)
@@ -613,7 +320,7 @@ func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
 func TestScrollBar_Dragged_ClickedInside(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
+	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
 	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
 	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
@@ -633,7 +340,7 @@ func TestScrollBar_Dragged_ClickedInside(t *testing.T) {
 func TestScrollBar_DraggedBack_ClickedInside(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
+	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
 	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
 	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
@@ -710,7 +417,7 @@ func TestScrollBar_Dragged_Limit(t *testing.T) {
 func TestScrollBar_Dragged_BackLimit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainerWithDirection(rect, ScrollDirectionBoth)
+	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
 	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
 	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -233,10 +233,10 @@ func TestScrollContainer_ShowShadowOnLeftIfContentIsScrolled(t *testing.T) {
 	assert.False(t, r.leftShadow.Visible())
 	assert.Equal(t, fyne.NewPos(0, 0), r.leftShadow.Position())
 
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1})
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -1})
 	assert.True(t, r.leftShadow.Visible())
 
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 1})
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 1})
 	assert.False(t, r.leftShadow.Visible())
 }
 
@@ -249,10 +249,10 @@ func TestScrollContainer_ShowShadowOnRightIfContentCanScroll(t *testing.T) {
 	assert.True(t, r.rightShadow.Visible())
 	assert.Equal(t, scroll.size.Width, r.rightShadow.Position().X+r.rightShadow.Size().Width)
 
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -400})
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -400})
 	assert.False(t, r.rightShadow.Visible())
 
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 100})
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 100})
 	assert.True(t, r.rightShadow.Visible())
 }
 

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var modes = []ScrollMode{ScrollModeHorizontal, ScrollModeVertical, ScrollModeBoth}
+
 func TestNewScrollContainer(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(10, 10))
@@ -27,84 +29,254 @@ func TestNewScrollContainer(t *testing.T) {
 	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
 }
 
+func TestNewScrollContainerWithMode(t *testing.T) {
+	for _, mode := range modes {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(10, 10))
+		scroll := NewScrollContainerWithMode(rect, mode)
+		scroll.Resize(fyne.NewSize(100, 100))
+		switch mode {
+		case ScrollModeHorizontal:
+			barArea := Renderer(scroll).(*scrollRenderer).horizArea
+			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
+			assert.Equal(t, 0, scroll.Offset.X)
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), barArea.Position())
+		case ScrollModeVertical:
+			barArea := Renderer(scroll).(*scrollRenderer).vertArea
+			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
+			assert.Equal(t, 0, scroll.Offset.Y)
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
+		case ScrollModeBoth:
+			barArea := Renderer(scroll).(*scrollRenderer).vertArea
+			barArea2 := Renderer(scroll).(*scrollRenderer).horizArea
+			bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
+			bar2 := Renderer(barArea2).(*scrollBarAreaRenderer).bar
+			assert.Equal(t, 0, scroll.Offset.X)
+			assert.Equal(t, 0, scroll.Offset.Y)
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea2.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar2.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar2.Position().Y)
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), barArea.Position())
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), barArea2.Position())
+		}
+	}
+}
+
 func TestScrollContainer_Refresh(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(100, 100))
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -1000})
-
-	assert.Equal(t, 900, scroll.Offset.Y)
-	assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
-	rect.SetMinSize(fyne.NewSize(1000, 500))
-	Refresh(scroll)
-	assert.Equal(t, 400, scroll.Offset.Y)
-	assert.Equal(t, fyne.NewSize(1000, 500), rect.Size())
+	for _, mode := range modes {
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1000})
+			assert.Equal(t, 900, scroll.Offset.X)
+			assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			Refresh(scroll)
+			assert.Equal(t, 400, scroll.Offset.X)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -1000})
+			assert.Equal(t, 900, scroll.Offset.Y)
+			assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			Refresh(scroll)
+			assert.Equal(t, 400, scroll.Offset.Y)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1000, DeltaY: -1000})
+			assert.Equal(t, 900, scroll.Offset.X)
+			assert.Equal(t, 900, scroll.Offset.Y)
+			assert.Equal(t, fyne.NewSize(1000, 1000), rect.Size())
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			Refresh(scroll)
+			assert.Equal(t, 400, scroll.Offset.X)
+			assert.Equal(t, 400, scroll.Offset.Y)
+		}
+	}
 }
 
 func TestScrollContainer_Scrolled(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(100, 100))
-
-	assert.Equal(t, 0, scroll.Offset.Y)
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -10})
-	assert.Equal(t, 10, scroll.Offset.Y)
+	for _, mode := range modes {
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			assert.Equal(t, 0, scroll.Offset.X)
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -10})
+			assert.Equal(t, 10, scroll.Offset.X)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			assert.Equal(t, 0, scroll.Offset.Y)
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -10})
+			assert.Equal(t, 10, scroll.Offset.Y)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			assert.Equal(t, 0, scroll.Offset.X)
+			assert.Equal(t, 0, scroll.Offset.Y)
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -10, DeltaY: -10})
+			assert.Equal(t, 10, scroll.Offset.X)
+			assert.Equal(t, 10, scroll.Offset.Y)
+		}
+	}
 }
 
 func TestScrollContainer_Scrolled_Limit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(100, 100))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(80, 80))
-
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -25})
-	assert.Equal(t, 20, scroll.Offset.Y)
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		scroll.Resize(fyne.NewSize(80, 80))
+		switch mode {
+		case ScrollModeHorizontal:
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -25})
+			assert.Equal(t, 20, scroll.Offset.X)
+		case ScrollModeVertical:
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -25})
+			assert.Equal(t, 20, scroll.Offset.Y)
+		case ScrollModeBoth:
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -25, DeltaY: -25})
+			assert.Equal(t, 20, scroll.Offset.X)
+			assert.Equal(t, 20, scroll.Offset.Y)
+		}
+	}
 }
 
 func TestScrollContainer_Scrolled_Back(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(100, 100))
-	scroll.Offset.Y = 10
-
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 10})
-	assert.Equal(t, 0, scroll.Offset.Y)
+	for _, mode := range modes {
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Offset.X = 10
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 10})
+			assert.Equal(t, 0, scroll.Offset.Y)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Offset.Y = 10
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 10})
+			assert.Equal(t, 0, scroll.Offset.Y)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll := NewScrollContainerWithMode(rect, mode)
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Offset.X = 10
+			scroll.Offset.Y = 10
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 10, DeltaY: 10})
+			assert.Equal(t, 0, scroll.Offset.X)
+			assert.Equal(t, 0, scroll.Offset.Y)
+		}
+	}
 }
 
 func TestScrollContainer_Scrolled_BackLimit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(100, 100))
-	scroll.Offset.Y = 10
-
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 20})
-	assert.Equal(t, 0, scroll.Offset.Y)
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Offset.X = 10
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 20})
+			assert.Equal(t, 0, scroll.Offset.X)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Offset.Y = 10
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: 20})
+			assert.Equal(t, 0, scroll.Offset.Y)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(1000, 1000))
+			scroll.Resize(fyne.NewSize(100, 100))
+			scroll.Offset.X = 10
+			scroll.Offset.Y = 10
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 20, DeltaY: 20})
+			assert.Equal(t, 0, scroll.Offset.X)
+			assert.Equal(t, 0, scroll.Offset.Y)
+		}
+	}
 }
 
 func TestScrollContainer_Resize(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(100, 100))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(80, 80))
-
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
-	scroll.Resize(fyne.NewSize(80, 100))
-	assert.Equal(t, 0, scroll.Offset.Y)
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(80, 80))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20})
+			scroll.Resize(fyne.NewSize(100, 80))
+			assert.Equal(t, 0, scroll.Offset.X)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(80, 80))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
+			scroll.Resize(fyne.NewSize(80, 100))
+			assert.Equal(t, 0, scroll.Offset.Y)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(80, 80))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
+			scroll.Resize(fyne.NewSize(100, 100))
+			assert.Equal(t, 0, scroll.Offset.X)
+			assert.Equal(t, 0, scroll.Offset.Y)
+		}
+	}
 }
 
 func TestScrollContainer_ResizeOffset(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(100, 100))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(80, 80))
-
-	scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
-	scroll.Resize(fyne.NewSize(80, 90))
-	assert.Equal(t, 10, scroll.Offset.Y)
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(80, 80))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20})
+			scroll.Resize(fyne.NewSize(90, 80))
+			assert.Equal(t, 10, scroll.Offset.X)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(80, 80))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaY: -20})
+			scroll.Resize(fyne.NewSize(80, 90))
+			assert.Equal(t, 10, scroll.Offset.Y)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(80, 80))
+			scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -20, DeltaY: -20})
+			scroll.Resize(fyne.NewSize(90, 90))
+			assert.Equal(t, 10, scroll.Offset.X)
+			assert.Equal(t, 10, scroll.Offset.Y)
+		}
+	}
 }
 
 func TestScrollContainer_ResizeExpand(t *testing.T) {
@@ -125,75 +297,256 @@ func TestScrollContainer_ScrollBarForSmallContentIsHidden(t *testing.T) {
 
 	r := Renderer(scroll).(*scrollRenderer)
 	assert.False(t, r.vertArea.Visible())
+	assert.False(t, r.horizArea.Visible())
 }
 
 func TestScrollContainer_ShowHiddenScrollBarIfContentGrows(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(100, 100))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(100, 200))
-	r := Renderer(scroll).(*scrollRenderer)
-	require.False(t, r.vertArea.Visible())
-
-	rect.SetMinSize(fyne.NewSize(100, 300))
-	r.Layout(scroll.Size())
-	assert.True(t, r.vertArea.Visible())
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		r := Renderer(scroll).(*scrollRenderer)
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(200, 100))
+			require.False(t, r.horizArea.Visible())
+			rect.SetMinSize(fyne.NewSize(300, 100))
+			r.Layout(scroll.Size())
+			assert.True(t, r.horizArea.Visible())
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(100, 200))
+			require.False(t, r.vertArea.Visible())
+			rect.SetMinSize(fyne.NewSize(100, 300))
+			r.Layout(scroll.Size())
+			assert.True(t, r.vertArea.Visible())
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(100, 100))
+			scroll.Resize(fyne.NewSize(200, 200))
+			require.False(t, r.horizArea.Visible())
+			require.False(t, r.vertArea.Visible())
+			rect.SetMinSize(fyne.NewSize(300, 300))
+			r.Layout(scroll.Size())
+			assert.True(t, r.horizArea.Visible())
+			assert.True(t, r.vertArea.Visible())
+		}
+	}
 }
 
 func TestScrollContainer_HideScrollBarIfContentShrinks(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(100, 300))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(100, 200))
-	r := Renderer(scroll).(*scrollRenderer)
-	require.True(t, r.vertArea.Visible())
-
-	rect.SetMinSize(fyne.NewSize(100, 100))
-	r.Layout(scroll.Size())
-	assert.False(t, r.vertArea.Visible())
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		r := Renderer(scroll).(*scrollRenderer)
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(300, 300))
+			scroll.Resize(fyne.NewSize(200, 300))
+			require.True(t, r.horizArea.Visible())
+			rect.SetMinSize(fyne.NewSize(200, 300))
+			r.Layout(scroll.Size())
+			assert.False(t, r.horizArea.Visible())
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(300, 300))
+			scroll.Resize(fyne.NewSize(300, 200))
+			require.True(t, r.vertArea.Visible())
+			rect.SetMinSize(fyne.NewSize(300, 200))
+			r.Layout(scroll.Size())
+			assert.False(t, r.vertArea.Visible())
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(300, 300))
+			scroll.Resize(fyne.NewSize(200, 200))
+			require.True(t, r.horizArea.Visible())
+			require.True(t, r.vertArea.Visible())
+			rect.SetMinSize(fyne.NewSize(200, 200))
+			r.Layout(scroll.Size())
+			assert.False(t, r.horizArea.Visible())
+			assert.False(t, r.vertArea.Visible())
+		}
+	}
 }
 
 func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(100, 500))
-	scroll := NewScrollContainer(rect)
-	scroll.Resize(fyne.NewSize(100, 100))
-	area := Renderer(scroll).(*scrollRenderer).vertArea
-	bar := Renderer(area).(*scrollBarAreaRenderer).bar
-	require.True(t, area.Visible())
-	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			scroll.Resize(fyne.NewSize(100, 100))
+			area := Renderer(scroll).(*scrollRenderer).horizArea
+			bar := Renderer(area).(*scrollBarAreaRenderer).bar
+			require.True(t, area.Visible())
+			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
 
-	assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
-	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
-	assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-	assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Height)
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			scroll.Resize(fyne.NewSize(100, 100))
+			area := Renderer(scroll).(*scrollRenderer).vertArea
+			bar := Renderer(area).(*scrollBarAreaRenderer).bar
+			require.True(t, area.Visible())
+			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			scroll.Resize(fyne.NewSize(100, 100))
+			areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
+			areaVert := Renderer(scroll).(*scrollRenderer).vertArea
+			barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
+			barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
+			require.True(t, areaHoriz.Visible())
+			require.True(t, areaVert.Visible())
+			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
+			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
+			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
+		}
+	}
 }
 
 func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
-	rect.SetMinSize(fyne.NewSize(100, 500))
-	scroll := NewScrollContainer(rect)
+	for _, mode := range modes {
+		scroll := NewScrollContainerWithMode(rect, mode)
+		switch mode {
+		case ScrollModeHorizontal:
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			scroll.Resize(fyne.NewSize(100, 100))
+			area := Renderer(scroll).(*scrollRenderer).horizArea
+			bar := Renderer(area).(*scrollBarAreaRenderer).bar
+			require.True(t, bar.Visible())
+			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+			require.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Height)
+			require.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
+			require.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
+			require.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
+
+			bar.MouseIn(&desktop.MouseEvent{})
+			assert.Equal(t, theme.ScrollBarSize(), area.Size().Height)
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSize()), area.Position())
+			assert.Equal(t, theme.ScrollBarSize(), bar.Size().Height)
+			assert.Equal(t, 0, bar.Position().Y)
+
+			bar.MouseOut()
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Height)
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), area.Position())
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().Y)
+		case ScrollModeVertical:
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			scroll.Resize(fyne.NewSize(100, 100))
+			area := Renderer(scroll).(*scrollRenderer).vertArea
+			bar := Renderer(area).(*scrollBarAreaRenderer).bar
+			require.True(t, bar.Visible())
+			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+			require.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
+			require.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
+			require.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
+			require.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+
+			bar.MouseIn(&desktop.MouseEvent{})
+			assert.Equal(t, theme.ScrollBarSize(), area.Size().Width)
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), area.Position())
+			assert.Equal(t, theme.ScrollBarSize(), bar.Size().Width)
+			assert.Equal(t, 0, bar.Position().X)
+
+			bar.MouseOut()
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+		case ScrollModeBoth:
+			rect.SetMinSize(fyne.NewSize(500, 500))
+			scroll.Resize(fyne.NewSize(100, 100))
+			areaHoriz := Renderer(scroll).(*scrollRenderer).horizArea
+			areaVert := Renderer(scroll).(*scrollRenderer).vertArea
+			barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
+			barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
+			require.True(t, barHoriz.Visible())
+			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+			require.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
+			require.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
+			require.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
+			require.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
+
+			barHoriz.MouseIn(&desktop.MouseEvent{})
+			assert.Equal(t, theme.ScrollBarSize(), areaHoriz.Size().Height)
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSize()), areaHoriz.Position())
+			assert.Equal(t, theme.ScrollBarSize(), barHoriz.Size().Height)
+			assert.Equal(t, 0, barHoriz.Position().Y)
+
+			barHoriz.MouseOut()
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
+			assert.Equal(t, fyne.NewPos(0, 100-theme.ScrollBarSmallSize()*2), areaHoriz.Position())
+			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Size().Height)
+			assert.Equal(t, theme.ScrollBarSmallSize(), barHoriz.Position().Y)
+
+			require.True(t, barVert.Visible())
+			require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
+			require.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
+			require.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
+			require.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
+			require.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
+
+			barVert.MouseIn(&desktop.MouseEvent{})
+			assert.Equal(t, theme.ScrollBarSize(), areaVert.Size().Width)
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), areaVert.Position())
+			assert.Equal(t, theme.ScrollBarSize(), barVert.Size().Width)
+			assert.Equal(t, 0, barVert.Position().X)
+
+			barVert.MouseOut()
+			assert.Equal(t, theme.ScrollBarSmallSize()*2, areaVert.Size().Width)
+			assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), areaVert.Position())
+			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Size().Width)
+			assert.Equal(t, theme.ScrollBarSmallSize(), barVert.Position().X)
+		}
+	}
+}
+
+func TestScrollContainer_ShowShadowOnLeftIfContentIsScrolled(t *testing.T) {
+	rect := canvas.NewRectangle(color.Black)
+	rect.SetMinSize(fyne.NewSize(500, 100))
+	scroll := NewScrollContainerWithMode(rect, ScrollModeHorizontal)
 	scroll.Resize(fyne.NewSize(100, 100))
-	area := Renderer(scroll).(*scrollRenderer).vertArea
-	bar := Renderer(area).(*scrollBarAreaRenderer).bar
-	require.True(t, bar.Visible())
-	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
-	require.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
-	require.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
-	require.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-	require.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+	r := Renderer(scroll).(*scrollRenderer)
+	assert.False(t, r.leftShadow.Visible())
+	assert.Equal(t, fyne.NewPos(0, 0), r.leftShadow.Position())
 
-	bar.MouseIn(&desktop.MouseEvent{})
-	assert.Equal(t, theme.ScrollBarSize(), area.Size().Width)
-	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSize(), 0), area.Position())
-	assert.Equal(t, theme.ScrollBarSize(), bar.Size().Width)
-	assert.Equal(t, 0, bar.Position().X)
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -1})
+	assert.True(t, r.leftShadow.Visible())
 
-	bar.MouseOut()
-	assert.Equal(t, theme.ScrollBarSmallSize()*2, area.Size().Width)
-	assert.Equal(t, fyne.NewPos(100-theme.ScrollBarSmallSize()*2, 0), area.Position())
-	assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
-	assert.Equal(t, theme.ScrollBarSmallSize(), bar.Position().X)
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 1})
+	assert.False(t, r.leftShadow.Visible())
+}
+
+func TestScrollContainer_ShowShadowOnRightIfContentCanScroll(t *testing.T) {
+	rect := canvas.NewRectangle(color.Black)
+	rect.SetMinSize(fyne.NewSize(500, 100))
+	scroll := NewScrollContainerWithMode(rect, ScrollModeHorizontal)
+	scroll.Resize(fyne.NewSize(100, 100))
+	r := Renderer(scroll).(*scrollRenderer)
+	assert.True(t, r.rightShadow.Visible())
+	assert.Equal(t, scroll.size.Width, r.rightShadow.Position().X+r.rightShadow.Size().Width)
+
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: -400})
+	assert.False(t, r.rightShadow.Visible())
+
+	scroll.Scrolled(&fyne.ScrollEvent{DeltaX: 100})
+	assert.True(t, r.rightShadow.Visible())
 }
 
 func TestScrollContainer_ShowShadowOnTopIfContentIsScrolled(t *testing.T) {
@@ -231,15 +584,18 @@ func TestScrollContainer_ShowShadowOnBottomIfContentCanScroll(t *testing.T) {
 func TestScrollBarRenderer_BarSize(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(100, 100))
-	scroll := NewScrollContainer(rect)
+	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
-	ar := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer)
+	areaHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer)
+	areaVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer)
 
-	assert.Equal(t, 100, ar.verticalBarHeight())
+	assert.Equal(t, 100, areaHoriz.horizontalBarWidth())
+	assert.Equal(t, 100, areaVert.verticalBarHeight())
 
 	// resize so content is twice our size. Bar should therefore be half again.
 	scroll.Resize(fyne.NewSize(50, 50))
-	assert.Equal(t, 25, ar.verticalBarHeight())
+	assert.Equal(t, 25, areaHoriz.horizontalBarWidth())
+	assert.Equal(t, 25, areaVert.verticalBarHeight())
 }
 
 func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
@@ -247,42 +603,56 @@ func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(120, 120))
-	ar := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer)
+	areaHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer)
+	areaVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer)
 
-	assert.Equal(t, 120, ar.verticalBarHeight())
+	assert.Equal(t, 120, areaHoriz.horizontalBarWidth())
+	assert.Equal(t, 120, areaVert.verticalBarHeight())
 }
 
 func TestScrollBar_Dragged_ClickedInside(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainer(rect)
+	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBar := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Create drag event with starting position inside scroll rectangle area
-	dragEvent := fyne.DragEvent{DraggedY: 20}
+	dragEvent := fyne.DragEvent{DraggedX: 20}
+	assert.Equal(t, 0, scroll.Offset.X)
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 200, scroll.Offset.X)
 
+	dragEvent = fyne.DragEvent{DraggedY: 20}
 	assert.Equal(t, 0, scroll.Offset.Y)
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 200, scroll.Offset.Y)
 }
 
 func TestScrollBar_DraggedBack_ClickedInside(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainer(rect)
+	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBar := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Drag forward
-	dragEvent := fyne.DragEvent{DraggedY: 20}
-	scrollBar.Dragged(&dragEvent)
+	dragEvent := fyne.DragEvent{DraggedX: 20}
+	scrollBarHoriz.Dragged(&dragEvent)
+	dragEvent = fyne.DragEvent{DraggedY: 20}
+	scrollBarVert.Dragged(&dragEvent)
 
 	// Drag back
-	dragEvent = fyne.DragEvent{DraggedY: -10}
+	dragEvent = fyne.DragEvent{DraggedX: -10}
+	assert.Equal(t, 200, scroll.Offset.X)
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 100, scroll.Offset.X)
 
+	dragEvent = fyne.DragEvent{DraggedY: -10}
 	assert.Equal(t, 200, scroll.Offset.Y)
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 100, scroll.Offset.Y)
 }
 
@@ -291,57 +661,89 @@ func TestScrollBar_Dragged_Limit(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBar := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Drag over limit
-	dragEvent := fyne.DragEvent{DraggedY: 2000}
+	dragEvent := fyne.DragEvent{DraggedX: 2000}
+	assert.Equal(t, 0, scroll.Offset.X)
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 900, scroll.Offset.X)
 
+	dragEvent = fyne.DragEvent{DraggedY: 2000}
 	assert.Equal(t, 0, scroll.Offset.Y)
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 900, scroll.Offset.Y)
 
 	// Drag again
-	dragEvent = fyne.DragEvent{DraggedY: 100}
+	dragEvent = fyne.DragEvent{DraggedX: 100}
+	// Offset doesn't go over limit
+	assert.Equal(t, 900, scroll.Offset.X)
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 900, scroll.Offset.X)
 
+	dragEvent = fyne.DragEvent{DraggedY: 100}
 	// Offset doesn't go over limit
 	assert.Equal(t, 900, scroll.Offset.Y)
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 900, scroll.Offset.Y)
 
 	// Drag back (still outside limit)
+	dragEvent = fyne.DragEvent{DraggedX: -1000}
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 900, scroll.Offset.X)
+
 	dragEvent = fyne.DragEvent{DraggedY: -1000}
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 900, scroll.Offset.Y)
 
 	// Drag back (inside limit)
+	dragEvent = fyne.DragEvent{DraggedX: -1040}
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 600, scroll.Offset.X)
+
 	dragEvent = fyne.DragEvent{DraggedY: -1040}
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 600, scroll.Offset.Y)
 }
 
 func TestScrollBar_Dragged_BackLimit(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
-	scroll := NewScrollContainer(rect)
+	scroll := NewScrollContainerWithMode(rect, ScrollModeBoth)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBar := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Drag over back limit
-	dragEvent := fyne.DragEvent{DraggedY: -1000}
+	dragEvent := fyne.DragEvent{DraggedX: -1000}
+	// Offset doesn't go over limit
+	assert.Equal(t, 0, scroll.Offset.X)
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 0, scroll.Offset.X)
 
+	dragEvent = fyne.DragEvent{DraggedY: -1000}
 	// Offset doesn't go over limit
 	assert.Equal(t, 0, scroll.Offset.Y)
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 0, scroll.Offset.Y)
 
 	// Drag (still outside limit)
+	dragEvent = fyne.DragEvent{DraggedX: 500}
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 0, scroll.Offset.X)
+
 	dragEvent = fyne.DragEvent{DraggedY: 500}
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 0, scroll.Offset.Y)
 
 	// Drag (inside limit)
+	dragEvent = fyne.DragEvent{DraggedX: 520}
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 200, scroll.Offset.X)
+
 	dragEvent = fyne.DragEvent{DraggedY: 520}
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 200, scroll.Offset.Y)
 }
 
@@ -350,16 +752,25 @@ func TestScrollBar_DraggedWithNonZeroStartPosition(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBar := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := Renderer(Renderer(scroll).(*scrollRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
-	dragEvent := fyne.DragEvent{DraggedY: 50}
+	dragEvent := fyne.DragEvent{DraggedX: 50}
+	assert.Equal(t, 0, scroll.Offset.X)
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 500, scroll.Offset.X)
 
+	dragEvent = fyne.DragEvent{DraggedY: 50}
 	assert.Equal(t, 0, scroll.Offset.Y)
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 500, scroll.Offset.Y)
 
 	// Drag again (after releasing mouse button)
+	dragEvent = fyne.DragEvent{DraggedX: 20}
+	scrollBarHoriz.Dragged(&dragEvent)
+	assert.Equal(t, 700, scroll.Offset.X)
+
 	dragEvent = fyne.DragEvent{DraggedY: 20}
-	scrollBar.Dragged(&dragEvent)
+	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, 700, scroll.Offset.Y)
 }

--- a/widget/shadow.go
+++ b/widget/shadow.go
@@ -12,6 +12,8 @@ type shadowType int
 
 const (
 	shadowAround shadowType = iota
+	shadowLeft
+	shadowRight
 	shadowBottom
 	shadowTop
 )
@@ -50,6 +52,12 @@ type shadowRenderer struct {
 
 func (r *shadowRenderer) createShadows() {
 	switch r.s.typ {
+	case shadowLeft:
+		r.l = canvas.NewHorizontalGradient(color.Transparent, theme.ShadowColor())
+		r.objects = []fyne.CanvasObject{r.l}
+	case shadowRight:
+		r.r = canvas.NewHorizontalGradient(theme.ShadowColor(), color.Transparent)
+		r.objects = []fyne.CanvasObject{r.r}
 	case shadowBottom:
 		r.b = canvas.NewVerticalGradient(theme.ShadowColor(), color.Transparent)
 		r.objects = []fyne.CanvasObject{r.b}


### PR DESCRIPTION
Fixes #465 and #132

Adds horizontal scrolling with three modes for scrollers:
SCROLLER_MODE_HORIZONTAL
SCROLLER_MODE_VERTICAL
SCROLLER_MODE_BOTH

Scroller defaults to vertical as that was the orientation on previous releases.  No APIs changed so all current scrollers will remain vertical.  New API added: NewScrollerWithMode that allows you to specify a mode for the scroller.

Run Fyne_Demo and the scroller test has been updated as well as a new scroller test added

Mobile scrolling now works - run fyne_demo with go run -tags mobile

