### PR TITLE
Remove extra refresh

### DIFF
--- a/container.go
+++ b/container.go
@@ -28,6 +28,10 @@ func (c *Container) Size() Size {
 
 // Resize sets a new size for the Container.
 func (c *Container) Resize(size Size) {
+	if c.size == size {
+		return
+	}
+
 	c.size = size
 	c.layout()
 }

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -2,11 +2,23 @@ package app
 
 import (
 	"fyne.io/fyne"
+	"fyne.io/fyne/widget"
 )
 
 // ApplyThemeTo ensures that the specified canvasobject and all widgets and themeable objects will
 // be updated for the current theme.
-func ApplyThemeTo(content fyne.CanvasObject, _ fyne.Canvas) {
+func ApplyThemeTo(content fyne.CanvasObject, canv fyne.Canvas) {
+	if wid, ok := content.(fyne.Widget); ok {
+		for _, o := range widget.Renderer(wid).Objects() {
+			ApplyThemeTo(o, canv)
+		}
+	}
+	if c, ok := content.(*fyne.Container); ok {
+		for _, o := range c.Objects {
+			ApplyThemeTo(o, canv)
+		}
+	}
+
 	content.Refresh()
 }
 

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -50,12 +50,19 @@ func (a *testApp) UniqueID() string {
 	return "testApp" // TODO should this be randomised?
 }
 
-func (a *testApp) applyThemeTo(content fyne.CanvasObject, _ fyne.Canvas) {
-	if content == nil {
-		return
-	}
-
+func (a *testApp) applyThemeTo(content fyne.CanvasObject, canv fyne.Canvas) {
 	content.Refresh()
+
+	if wid, ok := content.(fyne.Widget); ok {
+		for _, o := range wid.CreateRenderer().Objects() {
+			a.applyThemeTo(o, canv)
+		}
+	}
+	if c, ok := content.(*fyne.Container); ok {
+		for _, o := range c.Objects {
+			a.applyThemeTo(o, canv)
+		}
+	}
 }
 
 func (a *testApp) applyTheme() {

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -51,6 +51,9 @@ func (a *testApp) UniqueID() string {
 }
 
 func (a *testApp) applyThemeTo(content fyne.CanvasObject, canv fyne.Canvas) {
+	if content == nil {
+		return
+	}
 	content.Refresh()
 
 	if wid, ok := content.(fyne.Widget); ok {

--- a/widget/button.go
+++ b/widget/button.go
@@ -120,16 +120,13 @@ func (b *buttonRenderer) Refresh() {
 				b.icon.Resource = b.button.Icon
 			}
 		}
-		b.icon.Hidden = false
+		b.icon.Show()
 	} else if b.icon != nil {
-		b.icon.Hidden = true
+		b.icon.Hide()
 	}
 
-	b.label.Refresh()
-	b.icon.Refresh()
-	b.shadow.Refresh()
-
 	b.Layout(b.button.Size())
+	canvas.Refresh(b.button)
 }
 
 func (b *buttonRenderer) Objects() []fyne.CanvasObject {

--- a/widget/button.go
+++ b/widget/button.go
@@ -125,8 +125,11 @@ func (b *buttonRenderer) Refresh() {
 		b.icon.Hidden = true
 	}
 
+	b.label.Refresh()
+	b.icon.Refresh()
+	b.shadow.Refresh()
+
 	b.Layout(b.button.Size())
-	canvas.Refresh(b.button)
 }
 
 func (b *buttonRenderer) Objects() []fyne.CanvasObject {

--- a/widget/group.go
+++ b/widget/group.go
@@ -114,7 +114,8 @@ func (g *groupRenderer) Refresh() {
 	g.label.SetText(g.group.Text)
 	g.Layout(g.group.Size())
 
-	canvas.Refresh(g.group)
+	g.line.Refresh()
+	g.labelBg.Refresh()
 }
 
 func (g *groupRenderer) Destroy() {

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -20,13 +20,11 @@ const (
 type scrollBarRenderer struct {
 	scrollBar *scrollBar
 
-	color   color.Color
 	minSize fyne.Size
-	objects []fyne.CanvasObject
 }
 
 func (r *scrollBarRenderer) BackgroundColor() color.Color {
-	return r.color
+	return theme.ScrollBarColor()
 }
 
 func (r *scrollBarRenderer) Destroy() {
@@ -40,11 +38,10 @@ func (r *scrollBarRenderer) MinSize() fyne.Size {
 }
 
 func (r *scrollBarRenderer) Objects() []fyne.CanvasObject {
-	return r.objects
+	return nil
 }
 
 func (r *scrollBarRenderer) Refresh() {
-	r.color = theme.ScrollBarColor()
 }
 
 var _ desktop.Hoverable = (*scrollBar)(nil)

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -500,8 +500,7 @@ func (r *tabButtonRenderer) Refresh() {
 	r.label.Color = theme.TextColor()
 	r.label.TextSize = theme.TextSize()
 
-	r.label.Refresh()
-	r.icon.Refresh()
+	canvas.Refresh(r.button)
 }
 
 func (r *tabButtonRenderer) padding() fyne.Size {

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -307,6 +307,7 @@ func (t *tabContainerRenderer) Objects() []fyne.CanvasObject {
 
 func (t *tabContainerRenderer) Refresh() {
 	t.line.FillColor = theme.ButtonColor()
+	t.line.Refresh()
 
 	t.Layout(t.container.Size().Union(t.container.MinSize()))
 
@@ -333,6 +334,8 @@ func (t *tabContainerRenderer) Refresh() {
 		} else {
 			button.(*tabButton).Style = DefaultButton
 		}
+
+		button.Refresh()
 	}
 }
 
@@ -496,6 +499,9 @@ func (r *tabButtonRenderer) Objects() []fyne.CanvasObject {
 func (r *tabButtonRenderer) Refresh() {
 	r.label.Color = theme.TextColor()
 	r.label.TextSize = theme.TextSize()
+
+	r.label.Refresh()
+	r.icon.Refresh()
 }
 
 func (r *tabButtonRenderer) padding() fyne.Size {

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -133,9 +133,6 @@ func (w *BaseWidget) Refresh() {
 func (w *BaseWidget) refresh(wid fyne.Widget) {
 	render := cache.Renderer(wid)
 	render.Refresh()
-	for _, child := range render.Objects() {
-		child.Refresh()
-	}
 	render.Layout(w.impl.Size())
 }
 

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -34,6 +34,9 @@ func (w *BaseWidget) Size() fyne.Size {
 // Resize sets a new size for a widget.
 // Note this should not be used if the widget is being managed by a Layout within a Container.
 func (w *BaseWidget) Resize(size fyne.Size) {
+	if w.size == size {
+		return
+	}
 	w.size = size
 
 	if w.impl == nil {


### PR DESCRIPTION
**Description**

Recent changes to refresh made scrolling really slow.
We should not propagate refresh up the whole tree. Leave it to widgets to determine like before

Fixes #516

**Checklist**

- [ ] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass
