### PR TITLE
Add a visible disabled state to Entry and deprecate ReadOnly in favour of this.

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -27,8 +27,8 @@ func makeInputTab() fyne.Widget {
 	entry := widget.NewEntry()
 	entry.SetPlaceHolder("Entry")
 	entryReadOnly := widget.NewEntry()
-	entryReadOnly.SetPlaceHolder("Entry (read only)")
-	entryReadOnly.ReadOnly = true
+	entryReadOnly.SetText("Entry (disabled)")
+	entryReadOnly.Disable()
 
 	disabledCheck := widget.NewCheck("Disabled check", func(bool) {})
 	disabledCheck.Disable()

--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -19,8 +19,8 @@ func (f *FocusManager) nextInChain(current fyne.Focusable) fyne.Focusable {
 			// disabled widget cannot receive focus
 			return false
 		}
-		if e, ok := obj.(*widget.Entry); ok && e.ReadOnly {
-			return false // TODO can we handle this in a more generic way? Focusable.ReadOnly() perhaps?
+		if e, ok := obj.(*widget.Entry); ok && e.ReadOnly { // TODO remove once ReadOnly is gone
+			return false
 		}
 
 		focus, ok := obj.(fyne.Focusable)

--- a/internal/cache/widget.go
+++ b/internal/cache/widget.go
@@ -30,6 +30,9 @@ func Renderer(wid fyne.Widget) fyne.WidgetRenderer {
 		renderers.Store(wid, renderer)
 	}
 
+	if renderer == nil {
+		return nil
+	}
 	return renderer.(fyne.WidgetRenderer)
 }
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -492,7 +492,7 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 	cursor := defaultCursor
 	obj, pos := w.findObjectAtPositionMatching(w.canvas, w.mousePos, func(object fyne.CanvasObject) bool {
 		if wid, ok := object.(*widget.Entry); ok {
-			if !wid.ReadOnly {
+			if !wid.Disabled() {
 				cursor = entryCursor
 			}
 		} else if _, ok := object.(*widget.Hyperlink); ok {

--- a/widget/button.go
+++ b/widget/button.go
@@ -88,7 +88,7 @@ func (b *buttonRenderer) applyTheme() {
 
 func (b *buttonRenderer) BackgroundColor() color.Color {
 	switch {
-	case b.button.disabled:
+	case b.button.Disabled():
 		return theme.DisabledButtonColor()
 	case b.button.Style == PrimaryButton:
 		return theme.PrimaryColor()
@@ -138,7 +138,7 @@ func (b *buttonRenderer) Destroy() {
 
 // Button widget has a text label and triggers an event func when clicked
 type Button struct {
-	BaseWidget
+	DisableableWidget
 	Text         string
 	Style        ButtonStyle
 	Icon         fyne.Resource
@@ -158,23 +158,6 @@ const (
 	// PrimaryButton that should be more prominent to the user
 	PrimaryButton
 )
-
-// Enable this widget, if it was previously disabled
-func (b *Button) Enable() {
-	b.enable(b)
-	b.refresh(b)
-}
-
-// Disable this widget, if it was previously enabled
-func (b *Button) Disable() {
-	b.disable(b)
-	b.refresh(b)
-}
-
-// Disabled returns true if the widget is disabled
-func (b *Button) Disabled() bool {
-	return b.disabled
-}
 
 // Tapped is called when a pointer tapped event is captured and triggers any tap handler
 func (b *Button) Tapped(*fyne.PointEvent) {
@@ -257,18 +240,18 @@ func (b *Button) SetIcon(icon fyne.Resource) {
 
 // NewButton creates a new button widget with the set label and tap handler
 func NewButton(label string, tapped func()) *Button {
-	button := &Button{BaseWidget{}, label, DefaultButton, nil, nil,
+	button := &Button{DisableableWidget{}, label, DefaultButton, nil, nil,
 		tapped, false, false}
 
-	Renderer(button).Layout(button.MinSize())
+	button.ExtendBaseWidget(button)
 	return button
 }
 
 // NewButtonWithIcon creates a new button widget with the specified label, themed icon and tap handler
 func NewButtonWithIcon(label string, icon fyne.Resource, tapped func()) *Button {
-	button := &Button{BaseWidget{}, label, DefaultButton, icon, theme.NewDisabledResource(icon),
+	button := &Button{DisableableWidget{}, label, DefaultButton, icon, theme.NewDisabledResource(icon),
 		tapped, false, false}
 
-	Renderer(button).Layout(button.MinSize())
+	button.ExtendBaseWidget(button)
 	return button
 }

--- a/widget/button_test.go
+++ b/widget/button_test.go
@@ -132,6 +132,7 @@ func TestButton_Tapped(t *testing.T) {
 func TestButtonRenderer_Layout(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
 	render := Renderer(button).(*buttonRenderer)
+	render.Layout(render.MinSize())
 
 	assert.True(t, render.icon.Position().X < render.label.Position().X)
 	assert.Equal(t, theme.Padding()*2, render.icon.Position().X)

--- a/widget/check.go
+++ b/widget/check.go
@@ -94,7 +94,7 @@ func (c *checkRenderer) Destroy() {
 
 // Check widget has a text label and a checked (or unchecked) icon and triggers an event func when toggled
 type Check struct {
-	BaseWidget
+	DisableableWidget
 	Text    string
 	Checked bool
 
@@ -127,23 +127,6 @@ func (c *Check) Hide() {
 	}
 
 	c.BaseWidget.Hide()
-}
-
-// Enable this widget, if it was previously disabled
-func (c *Check) Enable() {
-	c.enable(c)
-	c.refresh(c)
-}
-
-// Disable this widget, if it was previously enabled
-func (c *Check) Disable() {
-	c.disable(c)
-	c.refresh(c)
-}
-
-// Disabled returns true if the widget is disabled
-func (c *Check) Disabled() bool {
-	return c.disabled
 }
 
 // MouseIn is called when a desktop pointer enters the widget
@@ -200,7 +183,7 @@ func (c *Check) CreateRenderer() fyne.WidgetRenderer {
 // NewCheck creates a new check widget with the set label and change handler
 func NewCheck(label string, changed func(bool)) *Check {
 	c := &Check{
-		BaseWidget{},
+		DisableableWidget{},
 		label,
 		false,
 		changed,
@@ -208,7 +191,7 @@ func NewCheck(label string, changed func(bool)) *Check {
 		false,
 	}
 
-	Renderer(c).Layout(c.MinSize())
+	c.ExtendBaseWidget(c)
 	return c
 }
 

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -163,7 +163,7 @@ func (r *radioRenderer) Destroy() {
 // Radio widget has a list of text labels and radio check icons next to each.
 // Changing the selection (only one can be selected) will trigger the changed func.
 type Radio struct {
-	BaseWidget
+	DisableableWidget
 	Options  []string
 	Selected string
 
@@ -171,23 +171,6 @@ type Radio struct {
 	Horizontal bool
 
 	hoveredItemIndex int
-}
-
-// Enable this widget, if it was previously disabled
-func (r *Radio) Enable() {
-	r.enable(r)
-	r.refresh(r)
-}
-
-// Disable this widget, if it was previously enabled
-func (r *Radio) Disable() {
-	r.disable(r)
-	r.refresh(r)
-}
-
-// Disabled returns true if the widget is disabled
-func (r *Radio) Disabled() bool {
-	return r.disabled
 }
 
 // indexByPosition returns the item index for a specified position or noRadioItemIndex if any
@@ -327,7 +310,7 @@ func (r *Radio) removeDuplicateOptions() {
 // NewRadio creates a new radio widget with the set options and change handler
 func NewRadio(options []string, changed func(string)) *Radio {
 	r := &Radio{
-		BaseWidget{},
+		DisableableWidget{},
 		options,
 		"",
 		changed,
@@ -336,7 +319,6 @@ func NewRadio(options []string, changed func(string)) *Radio {
 	}
 
 	r.removeDuplicateOptions()
-
-	Renderer(r).Layout(r.MinSize())
+	r.ExtendBaseWidget(r)
 	return r
 }

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -12,7 +12,6 @@ type BaseWidget struct {
 	size     fyne.Size
 	position fyne.Position
 	Hidden   bool
-	disabled bool
 
 	impl fyne.Widget
 }
@@ -103,24 +102,6 @@ func (w *BaseWidget) Hide() {
 	w.impl.Refresh()
 }
 
-func (w *BaseWidget) enable(parent fyne.Widget) {
-	if !w.disabled {
-		return
-	}
-
-	w.disabled = false
-	parent.Refresh()
-}
-
-func (w *BaseWidget) disable(parent fyne.Widget) {
-	if w.disabled {
-		return
-	}
-
-	w.disabled = true
-	parent.Refresh()
-}
-
 // Refresh causes this widget to be redrawn in it's current state
 func (w *BaseWidget) Refresh() {
 	if w.impl == nil {
@@ -141,6 +122,34 @@ func (w *BaseWidget) refresh(wid fyne.Widget) {
 
 func (w *BaseWidget) super() fyne.Widget {
 	return w.impl
+}
+
+type DisableableWidget struct {
+	BaseWidget
+
+	disabled bool
+}
+
+func (w *DisableableWidget) Enable() {
+	if !w.disabled {
+		return
+	}
+
+	w.disabled = false
+	w.Refresh()
+}
+
+func (w *DisableableWidget) Disable() {
+	if w.disabled {
+		return
+	}
+
+	w.disabled = true
+	w.Refresh()
+}
+
+func (w *DisableableWidget) Disabled() bool {
+	return w.disabled
 }
 
 // Renderer looks up the render implementation for a widget

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -130,6 +130,7 @@ type DisableableWidget struct {
 	disabled bool
 }
 
+// Enable this widget, updating any style or features appropriately.
 func (w *DisableableWidget) Enable() {
 	if !w.disabled {
 		return
@@ -139,6 +140,7 @@ func (w *DisableableWidget) Enable() {
 	w.Refresh()
 }
 
+// Disable this widget so that it cannot be interacted with, updating any style appropriately.
 func (w *DisableableWidget) Disable() {
 	if w.disabled {
 		return
@@ -148,6 +150,7 @@ func (w *DisableableWidget) Disable() {
 	w.Refresh()
 }
 
+// Disabled returns true if this widget is currently disabled or false if it can currently be interacted with.
 func (w *DisableableWidget) Disabled() bool {
 	return w.disabled
 }

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -124,6 +124,8 @@ func (w *BaseWidget) super() fyne.Widget {
 	return w.impl
 }
 
+// DisableableWidget describes an extension to BaseWidget which can be disabled.
+// Disabled widgets should have a visually distinct style when disabled, normally using theme.DisabledButtonColor.
 type DisableableWidget struct {
 	BaseWidget
 

--- a/widget/widget_test.go
+++ b/widget/widget_test.go
@@ -12,21 +12,9 @@ import (
 )
 
 type myWidget struct {
-	BaseWidget
+	DisableableWidget
 
 	refreshed chan bool
-}
-
-func (m *myWidget) Enable() {
-	m.enable(m)
-}
-
-func (m *myWidget) Disable() {
-	m.disable(m)
-}
-
-func (m *myWidget) Disabled() bool {
-	return m.disabled
 }
 
 func (m *myWidget) Refresh() {


### PR DESCRIPTION
Entry.Disabled now looks disabled unlike ReadOnly

Add a public DisableableWidget that extends the BaseWidget for anyone to make use of this :)

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [x] Public APIs match existing style

