### PR TITLE
Password reveal/conceal and copy support in PasswordEntry widget

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -76,12 +76,6 @@ func makeFormTab() fyne.Widget {
 	email.SetPlaceHolder("test@example.com")
 	password := widget.NewPasswordEntry()
 	password.SetPlaceHolder("Password")
-	showPassword := widget.NewCheck("Show Password", func(on bool) {
-		password.Lock()
-		password.Password = !on
-		password.Unlock()
-		widget.Refresh(password)
-	})
 	largeText := widget.NewMultiLineEntry()
 
 	form := &widget.Form{
@@ -99,7 +93,6 @@ func makeFormTab() fyne.Widget {
 	form.Append("Name", name)
 	form.Append("Email", email)
 	form.Append("Password", password)
-	form.Append("", showPassword)
 	form.Append("Message", largeText)
 
 	return form

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1119,13 +1119,8 @@ func (p *PasswordEntry) CreateRenderer() fyne.WidgetRenderer {
 		}
 		p.Entry.Refresh()
 	})
-	copyButton := NewButtonWithIcon("", theme.ContentCopyIcon(), func() {
-		clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
-		clipboard.SetContent(p.Entry.Text)
-	})
 
-	b := NewHBox(revealButton, copyButton)
-	borderLayout := layout.NewBorderLayout(nil, nil, nil, b)
-	c := fyne.NewContainerWithLayout(borderLayout, b, p.Entry)
+	borderLayout := layout.NewBorderLayout(nil, nil, nil, revealButton)
+	c := fyne.NewContainerWithLayout(borderLayout, revealButton, p.Entry)
 	return NewVBox(c).CreateRenderer()
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -775,7 +775,7 @@ func TestPasswordEntry_NewlineIgnored(t *testing.T) {
 	entry := NewPasswordEntry()
 	entry.SetText("test")
 
-	checkNewlineIgnored(t, entry)
+	checkNewlineIgnored(t, entry.Entry)
 }
 
 func TestPasswordEntry_Obfuscation(t *testing.T) {
@@ -783,7 +783,7 @@ func TestPasswordEntry_Obfuscation(t *testing.T) {
 
 	test.Type(entry, "Hié™שרה")
 	assert.Equal(t, "Hié™שרה", entry.Text)
-	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+	assert.Equal(t, "*******", entryRenderTexts(entry.Entry)[0].Text)
 }
 
 func TestEntry_OnCut(t *testing.T) {
@@ -803,7 +803,7 @@ func TestEntry_OnCut(t *testing.T) {
 func TestEntry_OnCut_Password(t *testing.T) {
 	e := NewPasswordEntry()
 	e.SetText("Testing")
-	typeKeys(e, keyShiftLeftDown, fyne.KeyRight, fyne.KeyRight, fyne.KeyRight)
+	typeKeys(e.Entry, keyShiftLeftDown, fyne.KeyRight, fyne.KeyRight, fyne.KeyRight)
 
 	clipboard := test.NewClipboard()
 	shortcut := &fyne.ShortcutCut{Clipboard: clipboard}
@@ -831,7 +831,7 @@ func TestEntry_OnCopy(t *testing.T) {
 func TestEntry_OnCopy_Password(t *testing.T) {
 	e := NewPasswordEntry()
 	e.SetText("Testing")
-	typeKeys(e, keyShiftLeftDown, fyne.KeyRight, fyne.KeyRight, fyne.KeyRight)
+	typeKeys(e.Entry, keyShiftLeftDown, fyne.KeyRight, fyne.KeyRight, fyne.KeyRight)
 
 	clipboard := test.NewClipboard()
 	shortcut := &fyne.ShortcutCopy{Clipboard: clipboard}
@@ -894,7 +894,7 @@ func TestEntry_OnPaste(t *testing.T) {
 		},
 		{
 			name:             "password: with new line",
-			entry:            NewPasswordEntry(),
+			entry:            NewPasswordEntry().Entry,
 			clipboardContent: "3SB=y+)z\nkHGK(hx6 -e_\"1TZu q^bF3^$u H[:e\"1O.",
 			wantText:         `3SB=y+)z kHGK(hx6 -e_"1TZu q^bF3^$u H[:e"1O.`,
 			wantRow:          0,
@@ -941,7 +941,7 @@ func TestPasswordEntry_Placeholder(t *testing.T) {
 	entry := NewPasswordEntry()
 	entry.SetPlaceHolder("Password")
 
-	assert.Equal(t, "Password", entryRenderPlaceholderTexts(entry)[0].Text)
+	assert.Equal(t, "Password", entryRenderPlaceholderTexts(entry.Entry)[0].Text)
 	assert.False(t, entry.placeholderProvider().presenter.password())
 }
 
@@ -1338,14 +1338,14 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 
 	test.Type(entry, "Hié™שרה")
 	assert.Equal(t, "Hié™שרה", entry.Text)
-	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+	assert.Equal(t, "*******", entryRenderTexts(entry.Entry)[0].Text)
 
 	// Reveal password that should be obfuscated until it is refreshed
 	entry.Password = false
 	Refresh(entry)
 
 	assert.Equal(t, "Hié™שרה", entry.Text)
-	assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
+	assert.Equal(t, "Hié™שרה", entryRenderTexts(entry.Entry)[0].Text)
 }
 
 func TestEntry_PageUpDown(t *testing.T) {


### PR DESCRIPTION
**Description**

This PR updates the entry password widget allowing to copy and reveal the password value using buttons.

Fixes #452

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

