### PR TITLE
Password reveal/conceal support in PasswordEntry widget

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -74,14 +74,8 @@ func makeFormTab() fyne.Widget {
 	name.SetPlaceHolder("John Smith")
 	email := widget.NewEntry()
 	email.SetPlaceHolder("test@example.com")
-	password := widget.NewPasswordEntry()
+	password := widget.NewPasswordRevealEntry()
 	password.SetPlaceHolder("Password")
-	showPassword := widget.NewCheck("Show Password", func(on bool) {
-		password.Lock()
-		password.Password = !on
-		password.Unlock()
-		widget.Refresh(password)
-	})
 	largeText := widget.NewMultiLineEntry()
 
 	form := &widget.Form{
@@ -99,7 +93,6 @@ func makeFormTab() fyne.Widget {
 	form.Append("Name", name)
 	form.Append("Email", email)
 	form.Append("Password", password)
-	form.Append("", showPassword)
 	form.Append("Message", largeText)
 
 	return form

--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -74,7 +74,7 @@ func makeFormTab() fyne.Widget {
 	name.SetPlaceHolder("John Smith")
 	email := widget.NewEntry()
 	email.SetPlaceHolder("test@example.com")
-	password := widget.NewPasswordRevealEntry()
+	password := widget.NewPasswordEntry()
 	password.SetPlaceHolder("Password")
 	largeText := widget.NewMultiLineEntry()
 

--- a/cmd/hello/main.go
+++ b/cmd/hello/main.go
@@ -11,7 +11,7 @@ func main() {
 
 	w := a.NewWindow("Hello")
 	w.SetContent(widget.NewVBox(
-		widget.NewPasswordRevealEntry(),
+		widget.NewLabel("Hello Fyne!"),
 		widget.NewButton("Quit", func() {
 			a.Quit()
 		}),

--- a/cmd/hello/main.go
+++ b/cmd/hello/main.go
@@ -11,7 +11,7 @@ func main() {
 
 	w := a.NewWindow("Hello")
 	w.SetContent(widget.NewVBox(
-		widget.NewLabel("Hello Fyne!"),
+		widget.NewPasswordRevealEntry(),
 		widget.NewButton("Quit", func() {
 			a.Quit()
 		}),

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1110,15 +1110,6 @@ func NewMultiLineEntry() *Entry {
 
 // NewPasswordEntry creates a new entry password widget
 func NewPasswordEntry() *Entry {
-	e := &Entry{Password: true}
-	e.registerShortcut()
-	e.ExtendBaseWidget(e)
-	return e
-}
-
-// NewPasswordRevealEntry creates a new entry password widget
-// with an additionally button allows to reveal/conceal the password value
-func NewPasswordRevealEntry() *Entry {
 	e := &Entry{Password: true, allowPasswordReveal: true}
 	e.registerShortcut()
 	e.ExtendBaseWidget(e)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1164,7 +1164,7 @@ func (pr *passwordRevealer) Tapped(*fyne.PointEvent) {
 	} else {
 		pr.icon.Resource = theme.VisibilityIcon()
 	}
-	pr.entry.Refresh()
+	fyne.CurrentApp().Driver().CanvasForObject(pr).Focus(pr.entry)
 }
 
 func (pr *passwordRevealer) TappedSecondary(*fyne.PointEvent) {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1336,7 +1336,7 @@ func TestEntry_EraseEmptySelection(t *testing.T) {
 func TestPasswordEntry_Reveal(t *testing.T) {
 	t.Run("NewPasswordEntry constructor", func(t *testing.T) {
 		entry := NewPasswordEntry()
-		actionIcon := Renderer(entry).(*entryRenderer).rph
+		actionIcon := Renderer(entry).(*entryRenderer).entry.passwordRevealer
 
 		test.Type(entry, "Hié™שרה")
 		assert.Equal(t, "Hié™שרה", entry.Text)
@@ -1370,7 +1370,7 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 		entry.Refresh()
 
 		// action icon is not displayed
-		actionIcon := Renderer(entry).(*entryRenderer).rph
+		actionIcon := Renderer(entry).(*entryRenderer).entry.passwordRevealer
 		assert.Nil(t, actionIcon)
 
 		test.Type(entry, "Hié™שרה")

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1340,12 +1340,20 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 	assert.Equal(t, "Hié™שרה", entry.Text)
 	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
 
-	// Reveal password that should be obfuscated until it is refreshed
+	// The Password field is ignored when using the PasswordEntry constructor
 	entry.Password = false
 	Refresh(entry)
 
 	assert.Equal(t, "Hié™שרה", entry.Text)
+	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+
+	actionIcon := Renderer(entry).(*entryRenderer).rph
+
+	test.Tap(actionIcon)
+
+	assert.Equal(t, "Hié™שרה", entry.Text)
 	assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
+	assert.True(t, entry.Focused())
 }
 
 func TestEntry_PageUpDown(t *testing.T) {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1334,26 +1334,58 @@ func TestEntry_EraseEmptySelection(t *testing.T) {
 }
 
 func TestPasswordEntry_Reveal(t *testing.T) {
-	entry := NewPasswordEntry()
+	t.Run("NewPasswordEntry constructor", func(t *testing.T) {
+		entry := NewPasswordEntry()
+		actionIcon := Renderer(entry).(*entryRenderer).rph
 
-	test.Type(entry, "Hié™שרה")
-	assert.Equal(t, "Hié™שרה", entry.Text)
-	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+		test.Type(entry, "Hié™שרה")
+		assert.Equal(t, "Hié™שרה", entry.Text)
+		assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+		assert.Equal(t, theme.VisibilityOffIcon(), actionIcon.icon.Resource)
 
-	// The Password field is ignored when using the PasswordEntry constructor
-	entry.Password = false
-	Refresh(entry)
+		// update the Password field
+		entry.Password = false
+		Refresh(entry)
 
-	assert.Equal(t, "Hié™שרה", entry.Text)
-	assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+		assert.Equal(t, "Hié™שרה", entry.Text)
+		assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
+		assert.True(t, entry.Focused())
+		assert.Equal(t, theme.VisibilityIcon(), actionIcon.icon.Resource)
 
-	actionIcon := Renderer(entry).(*entryRenderer).rph
+		// tap on action icon
+		test.Tap(actionIcon)
 
-	test.Tap(actionIcon)
+		assert.Equal(t, "Hié™שרה", entry.Text)
+		assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+		assert.True(t, entry.Focused())
+		assert.Equal(t, theme.VisibilityOffIcon(), actionIcon.icon.Resource)
+	})
 
-	assert.Equal(t, "Hié™שרה", entry.Text)
-	assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
-	assert.True(t, entry.Focused())
+	// This test cover backward compatibility use case when on an Entry widget
+	// the Password field is set to true.
+	// In this case the action item should not be diplayed
+	t.Run("Entry with Password field", func(t *testing.T) {
+		entry := NewEntry()
+		entry.Password = true
+		entry.Refresh()
+
+		// action icon is not displayed
+		actionIcon := Renderer(entry).(*entryRenderer).rph
+		assert.Nil(t, actionIcon)
+
+		test.Type(entry, "Hié™שרה")
+		assert.Equal(t, "Hié™שרה", entry.Text)
+		assert.Equal(t, "*******", entryRenderTexts(entry)[0].Text)
+
+		// update the Password field
+		entry.Password = false
+		Refresh(entry)
+
+		assert.Equal(t, "Hié™שרה", entry.Text)
+		assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
+		assert.True(t, entry.Focused())
+		assert.Nil(t, actionIcon)
+	})
 }
 
 func TestEntry_PageUpDown(t *testing.T) {


### PR DESCRIPTION
**Description**

Password reveal/conceal support in PasswordEntry widget

Fixes #452

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

