### PR TITLE
Fix slice bounds out of range when pasting unicode chars from clipboard

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -490,8 +490,13 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 		e.CursorColumn += len(runes)
 	} else {
 		e.CursorRow += newlines
-		lastNewline := strings.LastIndex(text, "\n")
-		e.CursorColumn = len(runes) - lastNewline - 1
+		lastNewlineIndex := 0
+		for i, r := range runes {
+			if r == '\n' {
+				lastNewlineIndex = i
+			}
+		}
+		e.CursorColumn = len(runes) - lastNewlineIndex - 1
 	}
 	e.updateText(provider.String())
 	Renderer(e).(*entryRenderer).moveCursor()

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1441,3 +1441,21 @@ func TestEntry_PageUpDown(t *testing.T) {
 		assert.Equal(t, 7, e.CursorColumn)
 	})
 }
+
+func TestEntry_PasteUnicode(t *testing.T) {
+	e := NewMultiLineEntry()
+	e.SetText("line")
+	e.CursorColumn = 4
+
+	clipboard := test.NewClipboard()
+	clipboard.SetContent("thing {\n\titem: 'val测试'\n}")
+	shortcut := &fyne.ShortcutPaste{Clipboard: clipboard}
+	handled := e.TypedShortcut(shortcut)
+
+	assert.True(t, handled)
+	assert.Equal(t, "thing {\n\titem: 'val测试'\n}", clipboard.Content())
+	assert.Equal(t, "linething {\n\titem: 'val测试'\n}", e.Text)
+
+	assert.Equal(t, 2, e.CursorRow)
+	assert.Equal(t, 1, e.CursorColumn)
+}


### PR DESCRIPTION
Fixes  #597

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [ ] Public APIs match existing style
- [ ] Any breaking changes have a deprecation path or have been discussed

