### PR TITLE
Relative scale settings

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -19,7 +19,7 @@ type Canvas interface {
 	Scale() float32
 	// SetScale sets ths scale for this canvas only, overriding system and user settings.
 	//
-	// Deprecated: SetScale will be replaced by system wide settings in the future
+	// Deprecated: Settings are now calculated solely on the user configuration and system setup.
 	SetScale(float32)
 
 	Overlay() CanvasObject

--- a/device.go
+++ b/device.go
@@ -29,6 +29,7 @@ type Device interface {
 	Orientation() DeviceOrientation
 	IsMobile() bool
 	HasKeyboard() bool
+	SystemScale() float32
 }
 
 // CurrentDevice returns the device information for the current hardware (via the driver)

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -180,9 +180,9 @@ func (c *glCanvas) Scale() float32 {
 
 // SetScale sets the render scale for this specific canvas
 //
-// Deprecated: SetScale will be replaced by system wide settings in the future
-func (c *glCanvas) SetScale(scale float32) {
-	c.scale = c.context.(*window).selectScale()
+// Deprecated: Settings are now calculated solely on the user configuration and system setup.
+func (c *glCanvas) SetScale(_ float32) {
+	c.scale = c.context.(*window).calculatedScale()
 	c.setDirty(true)
 
 	c.context.RescaleContext()

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -182,20 +182,10 @@ func (c *glCanvas) Scale() float32 {
 //
 // Deprecated: SetScale will be replaced by system wide settings in the future
 func (c *glCanvas) SetScale(scale float32) {
-	c.setScaleValue(scale)
+	c.scale = c.context.(*window).selectScale()
+	c.setDirty(true)
 
 	c.context.RescaleContext()
-}
-
-func (c *glCanvas) setScaleValue(scale float32) {
-	if scale == fyne.SettingsScaleAuto {
-		c.scale = c.detectedScale
-	} else if scale == 0 {
-		return
-	} else {
-		c.scale = scale
-	}
-	c.setDirty(true)
 }
 
 func (c *glCanvas) OnTypedRune() func(rune) {

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -65,7 +65,6 @@ func Test_glCanvas_SetContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := d.CreateWindow("Test").(*window)
-			w.Canvas().SetScale(1)
 			w.SetPadded(tt.padding)
 			if tt.menu {
 				w.SetMainMenu(fyne.NewMainMenu(fyne.NewMenu("Test", fyne.NewMenuItem("Test", func() {}))))
@@ -118,7 +117,6 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToRoot(t *testing.T) {
 func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToScroll(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
 	c := w.Canvas().(*glCanvas)
-	c.SetScale(1)
 	leftObj1 := canvas.NewRectangle(color.Black)
 	leftObj1.SetMinSize(fyne.NewSize(50, 50))
 	leftObj2 := canvas.NewRectangle(color.Black)
@@ -156,7 +154,6 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToScroll(t *testing.T) {
 func Test_glCanvas_ChildMinSizeChangesInDifferentScrollAffectAncestorsUpToScroll(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
 	c := w.Canvas().(*glCanvas)
-	c.SetScale(1)
 	leftObj1 := canvas.NewRectangle(color.Black)
 	leftObj1.SetMinSize(fyne.NewSize(50, 50))
 	leftObj2 := canvas.NewRectangle(color.Black)

--- a/internal/driver/glfw/device.go
+++ b/internal/driver/glfw/device.go
@@ -1,6 +1,10 @@
 package glfw
 
-import "fyne.io/fyne"
+import (
+	"runtime"
+
+	"fyne.io/fyne"
+)
 
 type glDevice struct {
 }
@@ -18,4 +22,12 @@ func (*glDevice) IsMobile() bool {
 
 func (*glDevice) HasKeyboard() bool {
 	return true // TODO actually check - we could be in tablet mode
+}
+
+func (*glDevice) SystemScale() float32 {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return 1.0
+	}
+
+	return fyne.SettingsScaleAuto
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -301,18 +301,19 @@ func (w *window) userScale() float32 {
 	return 1.0 // user preference for auto is now passed as 1 so the system auto is picked up
 }
 
-func (w *window) selectScale() float32 {
-	user := w.userScale()
+func calculateScale(user, system, detected float32) float32 {
 	if user == fyne.SettingsScaleAuto {
 		user = 1.0
 	}
 
-	system := fyne.CurrentDevice().SystemScale()
 	if system == fyne.SettingsScaleAuto {
-		system = w.detectScale()
+		system = detected
 	}
 
 	return system * user
+}
+func (w *window) calculatedScale() float32 {
+	return calculateScale(w.userScale(), fyne.CurrentDevice().SystemScale(), w.detectScale())
 }
 
 func (w *window) detectScale() float32 {
@@ -443,7 +444,7 @@ func (w *window) moved(viewport *glfw.Window, x, y int) {
 	}
 
 	w.canvas.detectedScale = w.detectScale()
-	w.canvas.SetScale(w.selectScale())
+	w.canvas.SetScale(fyne.SettingsScaleAuto) // scale is ignored
 	w.rescaleOnMain()
 }
 
@@ -1107,7 +1108,7 @@ func (d *gLDriver) CreateWindow(title string) fyne.Window {
 		ret.canvas.painter.Init()
 		ret.canvas.context = ret
 		ret.canvas.detectedScale = ret.detectScale()
-		ret.canvas.scale = ret.selectScale()
+		ret.canvas.scale = ret.calculatedScale()
 		ret.SetIcon(ret.icon)
 		d.windows = append(d.windows, ret)
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -280,7 +280,7 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 	return monitor
 }
 
-func (w *window) selectScale() float32 {
+func (w *window) userScale() float32 {
 	env := os.Getenv("FYNE_SCALE")
 
 	if env != "" && env != "auto" {
@@ -293,20 +293,26 @@ func (w *window) selectScale() float32 {
 
 	if env != "auto" {
 		setting := fyne.CurrentApp().Settings().Scale()
-		switch setting {
-		case fyne.SettingsScaleAuto:
-			// fall through
-		case 0.0:
-			if env == "" {
-				return 1.0
-			}
-			// fall through
-		default:
+		if setting != fyne.SettingsScaleAuto && setting != 0.0 {
 			return setting
 		}
 	}
 
-	return w.detectScale()
+	return 1.0 // user preference for auto is now passed as 1 so the system auto is picked up
+}
+
+func (w *window) selectScale() float32 {
+	user := w.userScale()
+	if user == fyne.SettingsScaleAuto {
+		user = 1.0
+	}
+
+	system := fyne.CurrentDevice().SystemScale()
+	if system == fyne.SettingsScaleAuto {
+		system = w.detectScale()
+	}
+
+	return system * user
 }
 
 func (w *window) detectScale() float32 {
@@ -318,7 +324,7 @@ func (w *window) detectScale() float32 {
 	if dpi > 1000 || dpi < 10 {
 		dpi = 96
 	}
-	return float32(math.Round(float64(dpi)/144.0*10.0)) / 10.0
+	return float32(math.Round(float64(dpi)/96.0*10.0)) / 10.0
 }
 
 func (w *window) Show() {
@@ -429,21 +435,15 @@ func (w *window) destroy(d *gLDriver) {
 }
 
 func (w *window) moved(viewport *glfw.Window, x, y int) {
-	if w.canvas.scale != w.canvas.detectedScale {
-		return
-	}
-
 	// save coordinates
 	w.xpos, w.ypos = x, y
-	scale := w.canvas.scale
-	newScale := w.detectScale()
-	if scale == newScale {
-		forceWindowRefresh(w)
+
+	if w.canvas.detectedScale == w.detectScale() {
 		return
 	}
 
-	w.canvas.detectedScale = newScale
-	w.canvas.setScaleValue(newScale)
+	w.canvas.detectedScale = w.detectScale()
+	w.canvas.SetScale(w.selectScale())
 	w.rescaleOnMain()
 }
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -568,6 +568,32 @@ func TestWindow_PixelSize(t *testing.T) {
 	assert.Equal(t, internal.ScaleInt(w.Canvas(), 100), winH)
 }
 
+var scaleTests = []struct {
+	user, system, detected, expected float32
+	name                             string
+}{
+	{1.0, 1.0, 1.0, 1.0, "Windows with user setting 1.0"},
+	{fyne.SettingsScaleAuto, 1.0, 1.0, 1.0, "Windows with user legacy setting auto"},
+	{1.5, 1.0, 1.0, 1.5, "Windows with user setting 1.5"},
+
+	{1.0, fyne.SettingsScaleAuto, 1.0, 1.0, "Linux lowDPI with user setting 1.0"},
+	{fyne.SettingsScaleAuto, fyne.SettingsScaleAuto, 1.0, 1.0, "Linux lowDPI with user legacy setting auto"},
+	{1.5, fyne.SettingsScaleAuto, 1.0, 1.5, "Linux lowDPI with user setting 1.5"},
+
+	{1.0, fyne.SettingsScaleAuto, 2.0, 2.0, "Linux highDPI with user setting 1.0"},
+	{fyne.SettingsScaleAuto, fyne.SettingsScaleAuto, 2.0, 2.0, "Linux highDPI with user legacy setting auto"},
+	{1.5, fyne.SettingsScaleAuto, 2.0, 3.0, "Linux highDPI with user setting 1.5"},
+}
+
+func TestWindow_calculateScale(t *testing.T) {
+	for _, tt := range scaleTests {
+		t.Run(tt.name, func(t *testing.T) {
+			calculated := calculateScale(tt.user, tt.system, tt.detected)
+			assert.Equal(t, tt.expected, calculated)
+		})
+	}
+}
+
 func TestWindow_Padded(t *testing.T) {
 	w := d.CreateWindow("Test")
 	content := canvas.NewRectangle(color.White)

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -39,7 +39,6 @@ func TestMain(m *testing.M) {
 
 func TestWindow_HandleHoverable(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	h1 := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
 	h1.SetMinSize(fyne.NewSize(10, 10))
 	h2 := &hoverableObject{Rectangle: canvas.NewRectangle(color.Black)}
@@ -81,7 +80,6 @@ func TestWindow_HandleHoverable(t *testing.T) {
 
 func TestWindow_HandleDragging(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	d1 := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
 	d1.SetMinSize(fyne.NewSize(10, 10))
 	d2 := &draggableObject{Rectangle: canvas.NewRectangle(color.Black)}
@@ -180,7 +178,6 @@ func TestWindow_HandleDragging(t *testing.T) {
 
 func TestWindow_DragObjectThatMoves(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	d1 := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
 	d1.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(widget.NewHBox(d1))
@@ -221,7 +218,6 @@ func TestWindow_DragObjectThatMoves(t *testing.T) {
 
 func TestWindow_DragIntoNewObjectKeepingFocus(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	d1 := &draggableMouseableObject{Rectangle: canvas.NewRectangle(color.White)}
 	d1.SetMinSize(fyne.NewSize(10, 10))
 	d2 := &draggableMouseableObject{Rectangle: canvas.NewRectangle(color.White)}
@@ -261,7 +257,6 @@ func TestWindow_DragIntoNewObjectKeepingFocus(t *testing.T) {
 
 func TestWindow_NoDragEndWithoutDraggedEvent(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	do := &draggableMouseableObject{Rectangle: canvas.NewRectangle(color.White)}
 	do.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(do)
@@ -282,7 +277,6 @@ func TestWindow_NoDragEndWithoutDraggedEvent(t *testing.T) {
 
 func TestWindow_HoverableOnDragging(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
 	dh.SetMinSize(fyne.NewSize(10, 10))
 	w.SetContent(dh)
@@ -372,7 +366,6 @@ func TestWindow_Tapped(t *testing.T) {
 
 func TestWindow_TappedIgnoresScrollerClip(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
 	rect := canvas.NewRectangle(color.White)
 	rect.SetMinSize(fyne.NewSize(100, 100))
@@ -406,7 +399,6 @@ func TestWindow_TappedIgnoresScrollerClip(t *testing.T) {
 
 func TestWindow_TappedIgnoredWhenMovedOffOfTappable(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
-	w.Canvas().SetScale(1.0)
 	tapped := 0
 	b1 := widget.NewButton("Tap", func() { tapped = 1 })
 	b2 := widget.NewButton("Tap", func() { tapped = 2 })
@@ -628,7 +620,6 @@ func TestWindow_SetPadded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := d.CreateWindow("Test").(*window)
-			w.Canvas().SetScale(1)
 			w.SetPadded(tt.padding)
 			if tt.menu {
 				w.SetMainMenu(fyne.NewMainMenu(fyne.NewMenu("Test", fyne.NewMenuItem("Test", func() {}))))

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -127,14 +127,9 @@ func (c *mobileCanvas) Scale() float32 {
 	return c.scale
 }
 
-func (c *mobileCanvas) SetScale(scale float32) {
-	if scale == fyne.SettingsScaleAuto {
-		c.scale = fyne.CurrentDevice().SystemScale()
-	} else if scale == 0 { // not set in the config
-		return
-	} else {
-		c.scale = fyne.CurrentDevice().SystemScale() * scale
-	}
+// Deprecated: Settings are now calculated solely on the user configuration and system setup.
+func (c *mobileCanvas) SetScale(_ float32) {
+	c.scale = fyne.CurrentDevice().SystemScale()
 }
 
 func (c *mobileCanvas) Overlay() fyne.CanvasObject {

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -129,11 +129,11 @@ func (c *mobileCanvas) Scale() float32 {
 
 func (c *mobileCanvas) SetScale(scale float32) {
 	if scale == fyne.SettingsScaleAuto {
-		c.scale = deviceScale()
+		c.scale = fyne.CurrentDevice().SystemScale()
 	} else if scale == 0 { // not set in the config
 		return
 	} else {
-		c.scale = scale
+		c.scale = fyne.CurrentDevice().SystemScale() * scale
 	}
 }
 
@@ -352,7 +352,7 @@ func (c *mobileCanvas) setupThemeListener() {
 // NewCanvas creates a new gomobile mobileCanvas. This is a mobileCanvas that will render on a mobile device using OpenGL.
 func NewCanvas() fyne.Canvas {
 	ret := &mobileCanvas{padded: true}
-	ret.scale = deviceScale()
+	ret.scale = fyne.CurrentDevice().SystemScale()
 	ret.refreshQueue = make(chan fyne.CanvasObject, 1024)
 	ret.touched = make(map[int]mobile.Touchable)
 	ret.lastTapDownPos = make(map[int]fyne.Position)

--- a/internal/driver/gomobile/canvas_android.go
+++ b/internal/driver/gomobile/canvas_android.go
@@ -8,6 +8,6 @@ func devicePadding() (topLeft, bottomRight fyne.Size) {
 	return fyne.NewSize(0, 48), fyne.NewSize(0, 0)
 }
 
-func deviceScale() float32 {
+func (*device) SystemScale() float32 {
 	return 3 // TODO detect device DPI and pick from 1, 1.5, 2, 3 and 4
 }

--- a/internal/driver/gomobile/canvas_desktop.go
+++ b/internal/driver/gomobile/canvas_desktop.go
@@ -3,9 +3,6 @@
 package gomobile
 
 import (
-	"os"
-	"strconv"
-
 	"fyne.io/fyne"
 )
 
@@ -13,15 +10,6 @@ func devicePadding() (topLeft, bottomRight fyne.Size) {
 	return fyne.NewSize(0, 0), fyne.NewSize(0, 0)
 }
 
-func deviceScale() float32 {
-	env := os.Getenv("FYNE_SCALE")
-	if env != "" && env != "auto" {
-		scale, err := strconv.ParseFloat(env, 32)
-		if err == nil && scale != 0 {
-			return float32(scale)
-		}
-		fyne.LogError("Error reading scale", err)
-	}
-
-	return 1
+func (*device) SystemScale() float32 {
+	return 2
 }

--- a/internal/driver/gomobile/canvas_ios.go
+++ b/internal/driver/gomobile/canvas_ios.go
@@ -14,6 +14,6 @@ func devicePadding() (topLeft, bottomRight fyne.Size) {
 	}
 }
 
-func deviceScale() float32 {
+func (*device) SystemScale() float32 {
 	return 3 // TODO return 2 for < iPhone X, Xs but 3 for Plus/Max size
 }

--- a/internal/driver/gomobile/device.go
+++ b/internal/driver/gomobile/device.go
@@ -14,7 +14,7 @@ var currentOrientation size.Orientation
 // Declare conformity with Device
 var _ fyne.Device = (*device)(nil)
 
-func (device) Orientation() fyne.DeviceOrientation {
+func (*device) Orientation() fyne.DeviceOrientation {
 	switch currentOrientation {
 	case size.OrientationLandscape:
 		return fyne.OrientationHorizontalLeft
@@ -23,10 +23,10 @@ func (device) Orientation() fyne.DeviceOrientation {
 	}
 }
 
-func (device) IsMobile() bool {
+func (*device) IsMobile() bool {
 	return true
 }
 
-func (device) HasKeyboard() bool {
+func (*device) HasKeyboard() bool {
 	return false
 }

--- a/test/device.go
+++ b/test/device.go
@@ -19,3 +19,7 @@ func (d *device) IsMobile() bool {
 func (d *device) HasKeyboard() bool {
 	return false
 }
+
+func (d *device) SystemScale() float32 {
+	return 1
+}


### PR DESCRIPTION
**Description**

Updating scale to be relative to system setting.
On macOS and Windows this is “1.0” as they scale at the system level.
In Linux this is detected per-monitor.
On mobile we remove code that may have scaled if apps asked as this has been deprecated.

This wraps up the deprecation as well so SetScale can be removed from the public api in the future.

Fixes #595

**Checklist**

- [x] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

(where applicable)

- [x] Public APIs match existing style
- [x] Any breaking changes have a deprecation path or have been discussed

This follows documentation reviewed on the wiki https://github.com/fyne-io/fyne/wiki/Scaling-Revisited