### PR TITLE
Stabilize gofmt in goreportcard

### DIFF
--- a/theme/bundled-icons.go
+++ b/theme/bundled-icons.go
@@ -1,3 +1,4 @@
+// auto-generated
 // **** THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT IT **** //
 
 package theme

--- a/theme/gen.go
+++ b/theme/gen.go
@@ -14,6 +14,9 @@ import (
 
 const fontFace = "NotoSans"
 
+const fileHeader = "// auto-generated\n" + // to exclude this file in goreportcard
+	"// **** THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT IT **** //"
+
 func formatVariable(name string) string {
 	str := strings.Replace(name, "-", "", -1)
 	return strings.Replace(str, "_", "", -1)
@@ -64,7 +67,7 @@ func openFile(filename string) *os.File {
 		return nil
 	}
 
-	_, err = f.WriteString("// **** THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT IT **** //\n\npackage theme\n\nimport \"fyne.io/fyne\"\n\n")
+	_, err = f.WriteString(fileHeader + "\n\npackage theme\n\nimport \"fyne.io/fyne\"\n\n")
 	if err != nil {
 		fyne.LogError("Unable to write file "+filename, err)
 		return nil


### PR DESCRIPTION
**Description**

In order to make gofmt work with goreportcard stably, exclude automatically generated files(bundled-*.go) from goreportcard.

In goreportcard, gofmt failed with OOM, so I tried to exclude automatically generated files.

I checked the forked repository and it looked stable:

https://github.com/lusingander/fyne/commit/e5770d38d1639be5f61fa778e11bafd2c414f15f
https://goreportcard.com/report/github.com/lusingander/fyne

I think that it is not necessary to do gofmt or lint so much for automatically generated files.

I don't think this is the best way, but I think it's better than failing gofmt.

**Checklist**

- [ ] Tests included
- [x] Lint and formatter run with no errors
- [x] Tests all pass

