### PR TITLE
Move shortcuts to the event queue

### DIFF
--- a/canvasobject.go
+++ b/canvasobject.go
@@ -71,5 +71,5 @@ type Focusable interface {
 
 // Shortcutable describes any CanvasObject that can respond to shortcut commands (quit, cut, copy, and paste).
 type Shortcutable interface {
-	TypedShortcut(shortcut Shortcut) bool
+	TypedShortcut(Shortcut)
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -970,13 +970,13 @@ func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, a
 	}
 
 	if shortcut != nil {
-		if shortcutable, ok := w.canvas.Focused().(fyne.Shortcutable); ok {
-			if shortcutable.TypedShortcut(shortcut) {
-				return
-			}
-		} else if w.canvas.shortcut.TypedShortcut(shortcut) {
+		if focused, ok := w.canvas.Focused().(fyne.Shortcutable); ok {
+			w.queueEvent(func() { focused.TypedShortcut(shortcut) })
 			return
 		}
+
+		w.queueEvent(func() { w.canvas.shortcut.TypedShortcut(shortcut) })
+		return
 	}
 
 	// No shortcut detected, pass down to TypedKey

--- a/shortcut.go
+++ b/shortcut.go
@@ -12,15 +12,12 @@ type ShortcutHandler struct {
 }
 
 // TypedShortcut handle the registered shortcut
-func (sh *ShortcutHandler) TypedShortcut(shortcut Shortcut) bool {
-	if shortcut == nil {
-		return false
+func (sh *ShortcutHandler) TypedShortcut(shortcut Shortcut) {
+	if _, ok := sh.entry[shortcut.ShortcutName()]; !ok {
+		return
 	}
-	if sc, ok := sh.entry[shortcut.ShortcutName()]; ok {
-		sc(shortcut)
-		return true
-	}
-	return false
+
+	sh.entry[shortcut.ShortcutName()](shortcut)
 }
 
 // AddShortcut register an handler to be executed when the shortcut action is triggered

--- a/shortcut_test.go
+++ b/shortcut_test.go
@@ -29,19 +29,10 @@ func TestShortcutHandler_HandleShortcut(t *testing.T) {
 		pasteCalled = true
 	})
 
-	assert.True(t, handle.TypedShortcut(&ShortcutCut{}))
+	handle.TypedShortcut(&ShortcutCut{})
 	assert.True(t, cutCalled)
-	assert.True(t, handle.TypedShortcut(&ShortcutCopy{}))
+	handle.TypedShortcut(&ShortcutCopy{})
 	assert.True(t, copyCalled)
-	assert.True(t, handle.TypedShortcut(&ShortcutPaste{}))
+	handle.TypedShortcut(&ShortcutPaste{})
 	assert.True(t, pasteCalled)
-}
-
-func TestShortcutHandler_HandleShortcut_Failures(t *testing.T) {
-	handle := &ShortcutHandler{}
-	handle.AddShortcut(&ShortcutPaste{}, func(shortcut Shortcut) {})
-
-	assert.False(t, handle.TypedShortcut(nil))
-	assert.False(t, handle.TypedShortcut(&ShortcutCut{}))
-
 }

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -963,8 +963,8 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 }
 
 // TypedShortcut implements the Shortcutable interface
-func (e *Entry) TypedShortcut(shortcut fyne.Shortcut) bool {
-	return e.shortcut.TypedShortcut(shortcut)
+func (e *Entry) TypedShortcut(shortcut fyne.Shortcut) {
+	e.shortcut.TypedShortcut(shortcut)
 }
 
 // textProvider returns the text handler for this entry

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -793,9 +793,8 @@ func TestEntry_OnCut(t *testing.T) {
 
 	clipboard := test.NewClipboard()
 	shortcut := &fyne.ShortcutCut{Clipboard: clipboard}
-	handled := e.TypedShortcut(shortcut)
+	e.TypedShortcut(shortcut)
 
-	assert.True(t, handled)
 	assert.Equal(t, "sti", clipboard.Content())
 	assert.Equal(t, "Teng", e.Text)
 }
@@ -807,9 +806,8 @@ func TestEntry_OnCut_Password(t *testing.T) {
 
 	clipboard := test.NewClipboard()
 	shortcut := &fyne.ShortcutCut{Clipboard: clipboard}
-	handled := e.TypedShortcut(shortcut)
+	e.TypedShortcut(shortcut)
 
-	assert.True(t, handled)
 	assert.Equal(t, "", clipboard.Content())
 	assert.Equal(t, "Testing", e.Text)
 }
@@ -821,9 +819,8 @@ func TestEntry_OnCopy(t *testing.T) {
 
 	clipboard := test.NewClipboard()
 	shortcut := &fyne.ShortcutCopy{Clipboard: clipboard}
-	handled := e.TypedShortcut(shortcut)
+	e.TypedShortcut(shortcut)
 
-	assert.True(t, handled)
 	assert.Equal(t, "sti", clipboard.Content())
 	assert.Equal(t, "Testing", e.Text)
 }
@@ -835,9 +832,8 @@ func TestEntry_OnCopy_Password(t *testing.T) {
 
 	clipboard := test.NewClipboard()
 	shortcut := &fyne.ShortcutCopy{Clipboard: clipboard}
-	handled := e.TypedShortcut(shortcut)
+	e.TypedShortcut(shortcut)
 
-	assert.True(t, handled)
 	assert.Equal(t, "", clipboard.Content())
 	assert.Equal(t, "Testing", e.Text)
 }
@@ -913,8 +909,7 @@ func TestEntry_OnPaste(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clipboard.SetContent(tt.clipboardContent)
-			handled := tt.entry.TypedShortcut(shortcut)
-			assert.True(t, handled)
+			tt.entry.TypedShortcut(shortcut)
 			assert.Equal(t, tt.wantText, tt.entry.Text)
 			assert.Equal(t, tt.wantRow, tt.entry.CursorRow)
 			assert.Equal(t, tt.wantCol, tt.entry.CursorColumn)
@@ -930,9 +925,8 @@ func TestEntry_PasteOverSelection(t *testing.T) {
 	clipboard := test.NewClipboard()
 	clipboard.SetContent("Insert")
 	shortcut := &fyne.ShortcutPaste{Clipboard: clipboard}
-	handled := e.TypedShortcut(shortcut)
+	e.TypedShortcut(shortcut)
 
-	assert.True(t, handled)
 	assert.Equal(t, "Insert", clipboard.Content())
 	assert.Equal(t, "TeInsertng", e.Text)
 }
@@ -1450,9 +1444,8 @@ func TestEntry_PasteUnicode(t *testing.T) {
 	clipboard := test.NewClipboard()
 	clipboard.SetContent("thing {\n\titem: 'val测试'\n}")
 	shortcut := &fyne.ShortcutPaste{Clipboard: clipboard}
-	handled := e.TypedShortcut(shortcut)
+	e.TypedShortcut(shortcut)
 
-	assert.True(t, handled)
 	assert.Equal(t, "thing {\n\titem: 'val测试'\n}", clipboard.Content())
 	assert.Equal(t, "linething {\n\titem: 'val测试'\n}", e.Text)
 


### PR DESCRIPTION
This does break the definition of shortcuttable, and removes
the functionality to check if it will apply.
But nonetheless seems complete.

Fixes #611

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed. <- discussing now
