### PR TITLE
Fix dialog width calculation with long title

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -105,8 +105,10 @@ func (d *dialog) MinSize(obj []fyne.CanvasObject) fyne.Size {
 	textMin := obj[2].MinSize()
 	btnMin := obj[3].MinSize().Union(obj[3].Size())
 
-	return fyne.NewSize(fyne.Max(textMin.Width, btnMin.Width)+padWidth*2,
-		textMin.Height+btnMin.Height+d.label.MinSize().Height+theme.Padding()+padHeight*2)
+	width := fyne.Max(fyne.Max(textMin.Width, btnMin.Width), obj[4].MinSize().Width) + padWidth*2
+	height := textMin.Height + btnMin.Height + d.label.MinSize().Height + theme.Padding() + padHeight*2
+
+	return fyne.NewSize(width, height)
 }
 
 func (d *dialog) applyTheme() {

--- a/dialog/information_test.go
+++ b/dialog/information_test.go
@@ -1,9 +1,10 @@
 package dialog
 
 import (
+	"testing"
+
 	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDialog_MinSize(t *testing.T) {

--- a/dialog/information_test.go
+++ b/dialog/information_test.go
@@ -1,0 +1,17 @@
+package dialog
+
+import (
+	"fyne.io/fyne/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDialog_MinSize(t *testing.T) {
+	d := NewInformation("Looooooooooooooong title", "message...", test.NewWindow(nil))
+	information := d.(*dialog)
+
+	dialogContent := information.win.Content.MinSize()
+	label := information.label.MinSize()
+
+	assert.Less(t, label.Width, dialogContent.Width)
+}


### PR DESCRIPTION
### Description:

For example, [before](https://i.imgur.com/kqlpMRz.png), [after](https://i.imgur.com/v1qwXaz.png)

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
