### PR TITLE
Add virtual keyboard APIs to mobile specific device extension

### DIFF
--- a/driver/mobile/device.go
+++ b/driver/mobile/device.go
@@ -1,0 +1,7 @@
+package mobile
+
+// Device describes functionality only available on mobile
+type Device interface {
+	ShowVirtualKeyboard() // Request that the mobile device show the touch screen keyboard (standard layout)
+	HideVirtualKeyboard() // Request that the mobile device dismiss the touch screen keyboard
+}

--- a/internal/driver/gomobile/device.go
+++ b/internal/driver/gomobile/device.go
@@ -30,3 +30,11 @@ func (*device) IsMobile() bool {
 func (*device) HasKeyboard() bool {
 	return false
 }
+
+func (*device) ShowVirtualKeyboard() {
+	showVirtualKeyboard()
+}
+
+func (*device) HideVirtualKeyboard() {
+	hideVirtualKeyboard()
+}


### PR DESCRIPTION
### Description:
Applications that wish to handle input without using the Entry widget cannot currently work on mobile.
This allows the app to request a keyboard show or hide programatically.

### Checklist:

- [ ] Tests included. <- I could not find a way to test this, it is a thin layer on top of existing functionality
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.

The following code has been used to run it. The time.Sleep is not required normally but this app wants the keyboard to appear on load, which must be slightly delayed.

```go
	if mobDev, ok := fyne.CurrentDevice().(mobile.Device); ok {
		go func() {
			time.Sleep(time.Second/10)
			mobDev.ShowVirtualKeyboard()
		}()
	}
```

resulting in:

![IMG_0220](https://user-images.githubusercontent.com/294436/72386548-78e1de80-3719-11ea-85ea-5e6b588f9084.PNG)
