### PR TITLE
Add a supported way to get access to widget renderers in tests

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -1,6 +1,9 @@
 package test
 
-import "fyne.io/fyne"
+import (
+	"fyne.io/fyne"
+	"fyne.io/fyne/internal/cache"
+)
 
 // Tap simulates a left mouse click on the specified object.
 func Tap(obj fyne.Tappable) {
@@ -55,4 +58,10 @@ func Type(obj fyne.Focusable, chars string) {
 // rather than a focusable widget.
 func TypeOnCanvas(c fyne.Canvas, chars string) {
 	typeChars([]rune(chars), c.OnTypedRune())
+}
+
+// WidgetRenderer allows test scripts to gain access to the current renderer for a widget.
+// This can be used for verifying correctness of rendered components for a widget in unit tests.
+func WidgetRenderer(wid fyne.Widget) fyne.WidgetRenderer {
+	return cache.Renderer(wid)
 }

--- a/widget/button_test.go
+++ b/widget/button_test.go
@@ -43,26 +43,26 @@ func TestButton_MinSize_Icon(t *testing.T) {
 
 func TestButton_Style(t *testing.T) {
 	button := NewButton("Test", nil)
-	bg := Renderer(button).BackgroundColor()
+	bg := test.WidgetRenderer(button).BackgroundColor()
 
 	button.Style = PrimaryButton
-	assert.NotEqual(t, bg, Renderer(button).BackgroundColor())
+	assert.NotEqual(t, bg, test.WidgetRenderer(button).BackgroundColor())
 }
 
 func TestButton_DisabledColor(t *testing.T) {
 	button := NewButton("Test", nil)
-	bg := Renderer(button).BackgroundColor()
+	bg := test.WidgetRenderer(button).BackgroundColor()
 	button.Style = DefaultButton
 	assert.Equal(t, bg, theme.ButtonColor())
 
 	button.Disable()
-	bg = Renderer(button).BackgroundColor()
+	bg = test.WidgetRenderer(button).BackgroundColor()
 	assert.Equal(t, bg, theme.DisabledButtonColor())
 }
 
 func TestButton_DisabledIcon(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := Renderer(button).(*buttonRenderer)
+	render := test.WidgetRenderer(button).(*buttonRenderer)
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
 
 	button.Disable()
@@ -74,7 +74,7 @@ func TestButton_DisabledIcon(t *testing.T) {
 
 func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := Renderer(button).(*buttonRenderer)
+	render := test.WidgetRenderer(button).(*buttonRenderer)
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
 
 	// assert we are using the disabled original icon
@@ -94,7 +94,7 @@ func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 
 func TestButton_DisabledIconChangedDirectly(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := Renderer(button).(*buttonRenderer)
+	render := test.WidgetRenderer(button).(*buttonRenderer)
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
 
 	// assert we are using the disabled original icon
@@ -131,7 +131,7 @@ func TestButton_Tapped(t *testing.T) {
 
 func TestButtonRenderer_Layout(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := Renderer(button).(*buttonRenderer)
+	render := test.WidgetRenderer(button).(*buttonRenderer)
 	render.Layout(render.MinSize())
 
 	assert.True(t, render.icon.Position().X < render.label.Position().X)
@@ -142,7 +142,7 @@ func TestButtonRenderer_Layout(t *testing.T) {
 func TestButtonRenderer_Layout_Stretch(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
 	button.Resize(button.MinSize().Add(fyne.NewSize(100, 100)))
-	render := Renderer(button).(*buttonRenderer)
+	render := test.WidgetRenderer(button).(*buttonRenderer)
 
 	iconYOffset, labelYOffset := 0, 0
 	textHeight := render.label.MinSize().Height
@@ -159,7 +159,7 @@ func TestButtonRenderer_Layout_Stretch(t *testing.T) {
 
 func TestButtonRenderer_Layout_NoText(t *testing.T) {
 	button := NewButtonWithIcon("", theme.CancelIcon(), nil)
-	render := Renderer(button).(*buttonRenderer)
+	render := test.WidgetRenderer(button).(*buttonRenderer)
 
 	button.Resize(fyne.NewSize(100, 100))
 
@@ -222,7 +222,7 @@ func TestButton_Disabled(t *testing.T) {
 
 func TestButtonRenderer_ApplyTheme(t *testing.T) {
 	button := &Button{}
-	render := Renderer(button).(*buttonRenderer)
+	render := test.WidgetRenderer(button).(*buttonRenderer)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize

--- a/widget/check_test.go
+++ b/widget/check_test.go
@@ -20,7 +20,7 @@ func TestCheckSize(t *testing.T) {
 
 func TestCheck_BackgroundStyle(t *testing.T) {
 	check := NewCheck("Hi", nil)
-	bg := Renderer(check).BackgroundColor()
+	bg := test.WidgetRenderer(check).BackgroundColor()
 
 	assert.Equal(t, bg, theme.BackgroundColor())
 }
@@ -49,7 +49,7 @@ func TestCheckUnChecked(t *testing.T) {
 func TestCheck_DisabledWhenChecked(t *testing.T) {
 	check := NewCheck("Hi", nil)
 	check.SetChecked(true)
-	render := Renderer(check).(*checkRenderer)
+	render := test.WidgetRenderer(check).(*checkRenderer)
 
 	assert.Equal(t, render.icon.Resource.Name(), theme.CheckButtonCheckedIcon().Name())
 
@@ -59,7 +59,7 @@ func TestCheck_DisabledWhenChecked(t *testing.T) {
 
 func TestCheck_DisabledWhenUnchecked(t *testing.T) {
 	check := NewCheck("Hi", nil)
-	render := Renderer(check).(*checkRenderer)
+	render := test.WidgetRenderer(check).(*checkRenderer)
 	assert.Equal(t, render.icon.Resource.Name(), theme.CheckButtonIcon().Name())
 
 	check.Disable()
@@ -131,7 +131,7 @@ func TestCheck_Enable(t *testing.T) {
 
 func TestCheck_Focused(t *testing.T) {
 	check := NewCheck("Test", func(on bool) {})
-	render := Renderer(check).(*checkRenderer)
+	render := test.WidgetRenderer(check).(*checkRenderer)
 
 	assert.False(t, check.Focused())
 	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
@@ -160,7 +160,7 @@ func TestCheck_Focused(t *testing.T) {
 
 func TestCheck_Hovered(t *testing.T) {
 	check := NewCheck("Test", func(on bool) {})
-	render := Renderer(check).(*checkRenderer)
+	render := test.WidgetRenderer(check).(*checkRenderer)
 
 	check.SetChecked(true)
 	assert.False(t, check.hovered)
@@ -219,7 +219,7 @@ func TestCheck_Disabled(t *testing.T) {
 
 func TestCheckRenderer_ApplyTheme(t *testing.T) {
 	check := &Check{}
-	render := Renderer(check).(*checkRenderer)
+	render := test.WidgetRenderer(check).(*checkRenderer)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -173,6 +173,9 @@ func (e *entryRenderer) BackgroundColor() color.Color {
 }
 
 func (e *entryRenderer) Refresh() {
+	if e.entry.Text != string(e.entry.textProvider().buffer) {
+		e.entry.textProvider().SetText(e.entry.Text)
+	}
 	if e.entry.textProvider().len() == 0 && e.entry.Visible() {
 		e.entry.placeholderProvider().Show()
 	} else if e.entry.placeholderProvider().Visible() {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -173,9 +173,6 @@ func (e *entryRenderer) BackgroundColor() color.Color {
 }
 
 func (e *entryRenderer) Refresh() {
-	if e.entry.Text != string(e.entry.textProvider().buffer) {
-		e.entry.textProvider().SetText(e.entry.Text)
-	}
 	if e.entry.textProvider().len() == 0 && e.entry.Visible() {
 		e.entry.placeholderProvider().Show()
 	} else if e.entry.placeholderProvider().Visible() {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -14,12 +14,12 @@ import (
 
 func entryRenderTexts(e *Entry) []*canvas.Text {
 	textWid := e.text
-	return Renderer(textWid).(*textRenderer).texts
+	return test.WidgetRenderer(textWid).(*textRenderer).texts
 }
 
 func entryRenderPlaceholderTexts(e *Entry) []*canvas.Text {
 	textWid := e.placeholder
-	return Renderer(textWid).(*textRenderer).texts
+	return test.WidgetRenderer(textWid).(*textRenderer).texts
 }
 
 func TestEntry_MinSize(t *testing.T) {
@@ -1059,7 +1059,7 @@ var setupReverse = func() *Entry {
 
 func TestEntry_SelectionHides(t *testing.T) {
 	e := setup()
-	selection := Renderer(e).(*entryRenderer).selection[0]
+	selection := test.WidgetRenderer(e).(*entryRenderer).selection[0]
 
 	e.FocusGained()
 	assert.True(t, selection.Visible())
@@ -1336,7 +1336,7 @@ func TestEntry_EraseEmptySelection(t *testing.T) {
 func TestPasswordEntry_Reveal(t *testing.T) {
 	t.Run("NewPasswordEntry constructor", func(t *testing.T) {
 		entry := NewPasswordEntry()
-		actionIcon := Renderer(entry).(*entryRenderer).entry.passwordRevealer
+		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.passwordRevealer
 
 		test.Type(entry, "Hié™שרה")
 		assert.Equal(t, "Hié™שרה", entry.Text)
@@ -1370,7 +1370,7 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 		entry.Refresh()
 
 		// action icon is not displayed
-		actionIcon := Renderer(entry).(*entryRenderer).entry.passwordRevealer
+		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.passwordRevealer
 		assert.NotNil(t, actionIcon)
 
 		test.Type(entry, "Hié™שרה")

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"testing"
 
+	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +18,7 @@ func TestFormSize(t *testing.T) {
 
 func TestForm_CreateRenderer(t *testing.T) {
 	form := &Form{Items: []*FormItem{{Text: "test1", Widget: NewEntry()}}}
-	assert.NotNil(t, Renderer(form))
+	assert.NotNil(t, test.WidgetRenderer(form))
 	assert.Equal(t, 2, len(form.itemGrid.Objects))
 
 	form.Append("test2", NewEntry())

--- a/widget/group_test.go
+++ b/widget/group_test.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"testing"
 
+	"fyne.io/fyne/test"
 	_ "fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,10 +35,10 @@ func TestGroupAppend(t *testing.T) {
 
 func TestGroup_Text(t *testing.T) {
 	group := NewGroup("Test")
-	Renderer(group).Refresh()
+	group.Refresh()
 
 	group.Text = "World"
-	Renderer(group).Refresh()
+	group.Refresh()
 
-	assert.Equal(t, "World", Renderer(group).(*groupRenderer).label.Text)
+	assert.Equal(t, "World", test.WidgetRenderer(group).(*groupRenderer).label.Text)
 }

--- a/widget/icon_test.go
+++ b/widget/icon_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewIcon(t *testing.T) {
 	icon := NewIcon(theme.ConfirmIcon())
-	render := Renderer(icon)
+	render := test.WidgetRenderer(icon)
 
 	assert.Equal(t, 1, len(render.Objects()))
 	obj := render.Objects()[0]
@@ -23,7 +24,7 @@ func TestNewIcon(t *testing.T) {
 
 func TestIcon_Nil(t *testing.T) {
 	icon := NewIcon(nil)
-	render := Renderer(icon)
+	render := test.WidgetRenderer(icon)
 
 	assert.Equal(t, 0, len(render.Objects()))
 }
@@ -38,7 +39,7 @@ func TestIcon_MinSize(t *testing.T) {
 
 func TestIconRenderer_ApplyTheme(t *testing.T) {
 	icon := NewIcon(theme.CancelIcon())
-	render := Renderer(icon).(*iconRenderer)
+	render := test.WidgetRenderer(icon).(*iconRenderer)
 	visible := render.objects[0].Visible()
 
 	render.Refresh()

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/test"
 	_ "fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func TestText_MinSize_MultiLine(t *testing.T) {
 	assert.True(t, min2.Height > min.Height)
 
 	yPos := -1
-	for _, text := range Renderer(text).(*textRenderer).texts {
+	for _, text := range test.WidgetRenderer(text).(*textRenderer).texts {
 		assert.True(t, text.Size().Height < min2.Height)
 		assert.True(t, text.Position().Y > yPos)
 		yPos = text.Position().Y
@@ -88,7 +89,7 @@ func TestLabel_ApplyTheme(t *testing.T) {
 	text := NewLabel("Line 1")
 	text.Hide()
 
-	render := Renderer(text).(*textRenderer)
+	render := test.WidgetRenderer(text).(*textRenderer)
 	assert.Equal(t, theme.TextColor(), render.texts[0].Color)
 	text.Show()
 	assert.Equal(t, theme.TextColor(), render.texts[0].Color)

--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +23,7 @@ func TestProgressRenderer_Layout(t *testing.T) {
 	bar := NewProgressBar()
 	bar.Resize(fyne.NewSize(100, 10))
 
-	render := Renderer(bar).(*progressRenderer)
+	render := test.WidgetRenderer(bar).(*progressRenderer)
 	assert.Equal(t, 0, render.bar.Size().Width)
 
 	bar.SetValue(.5)
@@ -36,7 +37,7 @@ func TestProgressRenderer_Layout_Overflow(t *testing.T) {
 	bar := NewProgressBar()
 	bar.Resize(fyne.NewSize(100, 10))
 
-	render := Renderer(bar).(*progressRenderer)
+	render := test.WidgetRenderer(bar).(*progressRenderer)
 	bar.SetValue(1)
 	assert.Equal(t, bar.Size().Width, render.bar.Size().Width)
 
@@ -46,7 +47,7 @@ func TestProgressRenderer_Layout_Overflow(t *testing.T) {
 
 func TestProgressRenderer_ApplyTheme(t *testing.T) {
 	bar := NewProgressBar()
-	render := Renderer(bar).(*progressRenderer)
+	render := test.WidgetRenderer(bar).(*progressRenderer)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/internal/cache"
+	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,7 +50,7 @@ func TestInfiniteProgressRenderer_Layout(t *testing.T) {
 	width := 100.0
 	bar.Resize(fyne.NewSize(int(width), 10))
 
-	render := Renderer(bar).(*infProgressRenderer)
+	render := test.WidgetRenderer(bar).(*infProgressRenderer)
 
 	// width of bar is one step size because updateBar() will have run once
 	assert.Equal(t, int(width*progressBarInfiniteStepSizeRatio), render.bar.Size().Width)

--- a/widget/radio_test.go
+++ b/widget/radio_test.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/driver/desktop"
+	"fyne.io/fyne/test"
 	_ "fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ func TestRadio_MinSize(t *testing.T) {
 
 func TestRadio_BackgroundStyle(t *testing.T) {
 	radio := NewRadio([]string{"Hi"}, nil)
-	bg := Renderer(radio).BackgroundColor()
+	bg := test.WidgetRenderer(radio).BackgroundColor()
 
 	assert.Equal(t, bg, theme.BackgroundColor())
 }
@@ -68,7 +69,7 @@ func TestRadio_Unselected(t *testing.T) {
 func TestRadio_DisableWhenSelected(t *testing.T) {
 	radio := NewRadio([]string{"Hi"}, nil)
 	radio.SetSelected("Hi")
-	render := Renderer(radio).(*radioRenderer)
+	render := test.WidgetRenderer(radio).(*radioRenderer)
 	resName := render.items[0].icon.Resource.Name()
 
 	assert.Equal(t, resName, theme.RadioButtonCheckedIcon().Name())
@@ -80,7 +81,7 @@ func TestRadio_DisableWhenSelected(t *testing.T) {
 
 func TestRadio_DisableWhenNotSelected(t *testing.T) {
 	radio := NewRadio([]string{"Hi"}, nil)
-	render := Renderer(radio).(*radioRenderer)
+	render := test.WidgetRenderer(radio).(*radioRenderer)
 	resName := render.items[0].icon.Resource.Name()
 
 	assert.Equal(t, resName, theme.RadioButtonIcon().Name())
@@ -128,26 +129,26 @@ func TestRadio_Append(t *testing.T) {
 	radio := NewRadio([]string{"Hi"}, nil)
 
 	assert.Equal(t, 1, len(radio.Options))
-	assert.Equal(t, 1, len(Renderer(radio).(*radioRenderer).items))
+	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 
 	radio.Options = append(radio.Options, "Another")
 	Refresh(radio)
 
 	assert.Equal(t, 2, len(radio.Options))
-	assert.Equal(t, 2, len(Renderer(radio).(*radioRenderer).items))
+	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 }
 
 func TestRadio_Remove(t *testing.T) {
 	radio := NewRadio([]string{"Hi", "Another"}, nil)
 
 	assert.Equal(t, 2, len(radio.Options))
-	assert.Equal(t, 2, len(Renderer(radio).(*radioRenderer).items))
+	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 
 	radio.Options = radio.Options[:1]
 	Refresh(radio)
 
 	assert.Equal(t, 1, len(radio.Options))
-	assert.Equal(t, 1, len(Renderer(radio).(*radioRenderer).items))
+	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 }
 
 func TestRadio_SetSelected(t *testing.T) {
@@ -184,7 +185,7 @@ func TestRadio_DuplicatedOptions(t *testing.T) {
 	radio := NewRadio([]string{"Hi", "Hi", "Hi", "Another", "Another"}, nil)
 
 	assert.Equal(t, 2, len(radio.Options))
-	assert.Equal(t, 2, len(Renderer(radio).(*radioRenderer).items))
+	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 }
 
 func TestRadio_AppendDuplicate(t *testing.T) {
@@ -193,7 +194,7 @@ func TestRadio_AppendDuplicate(t *testing.T) {
 	radio.Append("Hi")
 
 	assert.Equal(t, 1, len(radio.Options))
-	assert.Equal(t, 1, len(Renderer(radio).(*radioRenderer).items))
+	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 }
 
 func TestRadio_Disable(t *testing.T) {
@@ -255,7 +256,7 @@ func TestRadio_Hovered(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			radio := NewRadio(tt.options, nil)
 			radio.Horizontal = tt.isHorizontal
-			render := Renderer(radio).(*radioRenderer)
+			render := test.WidgetRenderer(radio).(*radioRenderer)
 
 			assert.Equal(t, noRadioItemIndex, radio.hoveredItemIndex)
 			assert.Equal(t, theme.BackgroundColor(), render.items[0].focusIndicator.FillColor)
@@ -321,7 +322,7 @@ func TestRadio_FocusIndicator_Centered_Vertically(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			radio := NewRadio(tt.options, nil)
 			radio.Horizontal = tt.isHorizontal
-			render := Renderer(radio).(*radioRenderer)
+			render := test.WidgetRenderer(radio).(*radioRenderer)
 			render.Layout(radio.MinSize())
 
 			heightCenterOffset := (radio.itemHeight() - focusIndicatorSize) / 2
@@ -343,7 +344,7 @@ func TestRadio_FocusIndicator_Centered_Vertically(t *testing.T) {
 
 func TestRadioRenderer_ApplyTheme(t *testing.T) {
 	radio := NewRadio([]string{"Test"}, func(string) {})
-	render := Renderer(radio).(*radioRenderer)
+	render := test.WidgetRenderer(radio).(*radioRenderer)
 
 	item := render.items[0]
 	textSize := item.label.TextSize

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
+	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,8 +18,8 @@ func TestNewScrollContainer(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(10, 10))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	barArea := Renderer(scroll).(*scrollContainerRenderer).vertArea
-	bar := Renderer(barArea).(*scrollBarAreaRenderer).bar
+	barArea := test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea
+	bar := test.WidgetRenderer(barArea).(*scrollBarAreaRenderer).bar
 	assert.Equal(t, 0, scroll.Offset.Y)
 	assert.Equal(t, theme.ScrollBarSmallSize()*2, barArea.Size().Width)
 	assert.Equal(t, theme.ScrollBarSmallSize(), bar.Size().Width)
@@ -126,7 +127,7 @@ func TestScrollContainer_ScrollBarForSmallContentIsHidden(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 200))
-	r := Renderer(scroll).(*scrollContainerRenderer)
+	r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 	assert.False(t, r.vertArea.Visible())
 	assert.False(t, r.horizArea.Visible())
 }
@@ -134,7 +135,7 @@ func TestScrollContainer_ScrollBarForSmallContentIsHidden(t *testing.T) {
 func TestScrollContainer_ShowHiddenScrollBarIfContentGrows(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	scroll := NewScrollContainer(rect)
-	r := Renderer(scroll).(*scrollContainerRenderer)
+	r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	scroll.Resize(fyne.NewSize(200, 200))
 	require.False(t, r.horizArea.Visible())
@@ -148,7 +149,7 @@ func TestScrollContainer_ShowHiddenScrollBarIfContentGrows(t *testing.T) {
 func TestScrollContainer_HideScrollBarIfContentShrinks(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	scroll := NewScrollContainer(rect)
-	r := Renderer(scroll).(*scrollContainerRenderer)
+	r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 	rect.SetMinSize(fyne.NewSize(300, 300))
 	scroll.Resize(fyne.NewSize(200, 200))
 	require.True(t, r.horizArea.Visible())
@@ -164,10 +165,10 @@ func TestScrollContainer_ScrollBarIsSmall(t *testing.T) {
 	scroll := NewScrollContainer(rect)
 	rect.SetMinSize(fyne.NewSize(500, 500))
 	scroll.Resize(fyne.NewSize(100, 100))
-	areaHoriz := Renderer(scroll).(*scrollContainerRenderer).horizArea
-	areaVert := Renderer(scroll).(*scrollContainerRenderer).vertArea
-	barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
-	barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
+	areaHoriz := test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea
+	areaVert := test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea
+	barHoriz := test.WidgetRenderer(areaHoriz).(*scrollBarAreaRenderer).bar
+	barVert := test.WidgetRenderer(areaVert).(*scrollBarAreaRenderer).bar
 	require.True(t, areaHoriz.Visible())
 	require.True(t, areaVert.Visible())
 	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
@@ -188,10 +189,10 @@ func TestScrollContainer_ScrollBarGrowsAndShrinksOnMouseInAndMouseOut(t *testing
 	scroll := NewScrollContainer(rect)
 	rect.SetMinSize(fyne.NewSize(500, 500))
 	scroll.Resize(fyne.NewSize(100, 100))
-	areaHoriz := Renderer(scroll).(*scrollContainerRenderer).horizArea
-	areaVert := Renderer(scroll).(*scrollContainerRenderer).vertArea
-	barHoriz := Renderer(areaHoriz).(*scrollBarAreaRenderer).bar
-	barVert := Renderer(areaVert).(*scrollBarAreaRenderer).bar
+	areaHoriz := test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea
+	areaVert := test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea
+	barHoriz := test.WidgetRenderer(areaHoriz).(*scrollBarAreaRenderer).bar
+	barVert := test.WidgetRenderer(areaVert).(*scrollBarAreaRenderer).bar
 	require.True(t, barHoriz.Visible())
 	require.Less(t, theme.ScrollBarSmallSize(), theme.ScrollBarSize())
 	require.Equal(t, theme.ScrollBarSmallSize()*2, areaHoriz.Size().Height)
@@ -231,7 +232,7 @@ func TestScrollContainer_ShowShadowOnLeftIfContentIsScrolled(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(500, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	r := Renderer(scroll).(*scrollContainerRenderer)
+	r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 	assert.False(t, r.leftShadow.Visible())
 	assert.Equal(t, fyne.NewPos(0, 0), r.leftShadow.Position())
 
@@ -247,7 +248,7 @@ func TestScrollContainer_ShowShadowOnRightIfContentCanScroll(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(500, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	r := Renderer(scroll).(*scrollContainerRenderer)
+	r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 	assert.True(t, r.rightShadow.Visible())
 	assert.Equal(t, scroll.size.Width, r.rightShadow.Position().X+r.rightShadow.Size().Width)
 
@@ -263,7 +264,7 @@ func TestScrollContainer_ShowShadowOnTopIfContentIsScrolled(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 500))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	r := Renderer(scroll).(*scrollContainerRenderer)
+	r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 	assert.False(t, r.topShadow.Visible())
 	assert.Equal(t, fyne.NewPos(0, 0), r.topShadow.Position())
 
@@ -279,7 +280,7 @@ func TestScrollContainer_ShowShadowOnBottomIfContentCanScroll(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 500))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	r := Renderer(scroll).(*scrollContainerRenderer)
+	r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 	assert.True(t, r.bottomShadow.Visible())
 	assert.Equal(t, scroll.size.Height, r.bottomShadow.Position().Y+r.bottomShadow.Size().Height)
 
@@ -331,8 +332,8 @@ func TestScrollBarRenderer_BarSize(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	areaHoriz := Renderer(Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer)
-	areaVert := Renderer(Renderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer)
+	areaHoriz := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer)
+	areaVert := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer)
 
 	assert.Equal(t, 100, areaHoriz.bar.Size().Width)
 	assert.Equal(t, 100, areaVert.bar.Size().Height)
@@ -348,8 +349,8 @@ func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(120, 120))
-	areaHoriz := Renderer(Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer)
-	areaVert := Renderer(Renderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer)
+	areaHoriz := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer)
+	areaVert := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer)
 
 	assert.Equal(t, 120, areaHoriz.bar.Size().Width)
 	assert.Equal(t, 120, areaVert.bar.Size().Height)
@@ -360,8 +361,8 @@ func TestScrollBar_Dragged_ClickedInside(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
-	scrollBarVert := Renderer(Renderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Create drag event with starting position inside scroll rectangle area
 	dragEvent := fyne.DragEvent{DraggedX: 20}
@@ -380,8 +381,8 @@ func TestScrollBar_DraggedBack_ClickedInside(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
-	scrollBarVert := Renderer(Renderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Drag forward
 	dragEvent := fyne.DragEvent{DraggedX: 20}
@@ -406,8 +407,8 @@ func TestScrollBar_Dragged_Limit(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
-	scrollBarVert := Renderer(Renderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Drag over limit
 	dragEvent := fyne.DragEvent{DraggedX: 2000}
@@ -457,8 +458,8 @@ func TestScrollBar_Dragged_BackLimit(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
-	scrollBarVert := Renderer(Renderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	// Drag over back limit
 	dragEvent := fyne.DragEvent{DraggedX: -1000}
@@ -497,8 +498,8 @@ func TestScrollBar_DraggedWithNonZeroStartPosition(t *testing.T) {
 	rect.SetMinSize(fyne.NewSize(1000, 1000))
 	scroll := NewScrollContainer(rect)
 	scroll.Resize(fyne.NewSize(100, 100))
-	scrollBarHoriz := Renderer(Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
-	scrollBarVert := Renderer(Renderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
+	scrollBarHoriz := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
+	scrollBarVert := test.WidgetRenderer(test.WidgetRenderer(scroll).(*scrollContainerRenderer).vertArea).(*scrollBarAreaRenderer).bar
 
 	dragEvent := fyne.DragEvent{DraggedX: 50}
 	assert.Equal(t, 0, scroll.Offset.X)

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -94,7 +94,7 @@ func TestSelect_Tapped_Constrained(t *testing.T) {
 
 func TestSelectRenderer_ApplyTheme(t *testing.T) {
 	sel := &Select{}
-	render := Renderer(sel).(*selectRenderer)
+	render := test.WidgetRenderer(sel).(*selectRenderer)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize

--- a/widget/shadow_test.go
+++ b/widget/shadow_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne"
-	"fyne.io/fyne/internal/cache"
+	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,7 +14,7 @@ var shadowWidth = 5
 
 func TestShadow_TopShadow(t *testing.T) {
 	s := newShadow(shadowTop, shadowWidth)
-	r := Renderer(s).(*shadowRenderer)
+	r := test.WidgetRenderer(s).(*shadowRenderer)
 	r.Layout(fyne.NewSize(100, 100))
 
 	assert.Equal(t, []fyne.CanvasObject{r.t}, r.Objects())
@@ -27,7 +27,7 @@ func TestShadow_TopShadow(t *testing.T) {
 
 func TestShadow_BottomShadow(t *testing.T) {
 	s := newShadow(shadowBottom, shadowWidth)
-	r := Renderer(s).(*shadowRenderer)
+	r := test.WidgetRenderer(s).(*shadowRenderer)
 	r.Layout(fyne.NewSize(100, 100))
 
 	assert.Equal(t, []fyne.CanvasObject{r.b}, r.Objects())
@@ -40,7 +40,7 @@ func TestShadow_BottomShadow(t *testing.T) {
 
 func TestShadow_AroundShadow(t *testing.T) {
 	s := newShadow(shadowAround, shadowWidth)
-	r := Renderer(s).(*shadowRenderer)
+	r := test.WidgetRenderer(s).(*shadowRenderer)
 	r.Layout(fyne.NewSize(100, 100))
 
 	assert.Equal(t, []fyne.CanvasObject{r.tl, r.t, r.tr, r.r, r.br, r.b, r.bl, r.l}, r.Objects())
@@ -105,7 +105,7 @@ func TestShadow_AroundShadow(t *testing.T) {
 func TestShadow_ApplyTheme(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
 	s := newShadow(shadowAround, shadowWidth)
-	r := Renderer(s).(*shadowRenderer)
+	r := test.WidgetRenderer(s).(*shadowRenderer)
 	assert.Equal(t, theme.ShadowColor(), r.b.StartColor)
 
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
@@ -114,7 +114,7 @@ func TestShadow_ApplyTheme(t *testing.T) {
 }
 
 func TestShadow_BackgroundColor(t *testing.T) {
-	assert.Equal(t, color.Transparent, Renderer(newShadow(shadowAround, theme.Padding())).BackgroundColor())
+	assert.Equal(t, color.Transparent, test.WidgetRenderer(newShadow(shadowAround, theme.Padding())).BackgroundColor())
 }
 
 func TestShadow_MinSize(t *testing.T) {
@@ -126,14 +126,14 @@ func TestShadow_Theme(t *testing.T) {
 	light := theme.LightTheme()
 	fyne.CurrentApp().Settings().SetTheme(light)
 	shadow.Refresh()
-	assert.Equal(t, light.ShadowColor(), cache.Renderer(shadow).(*shadowRenderer).l.EndColor)
-	assert.Equal(t, light.ShadowColor(), cache.Renderer(shadow).(*shadowRenderer).r.StartColor)
-	assert.Equal(t, light.ShadowColor(), cache.Renderer(shadow).(*shadowRenderer).tr.StartColor)
+	assert.Equal(t, light.ShadowColor(), test.WidgetRenderer(shadow).(*shadowRenderer).l.EndColor)
+	assert.Equal(t, light.ShadowColor(), test.WidgetRenderer(shadow).(*shadowRenderer).r.StartColor)
+	assert.Equal(t, light.ShadowColor(), test.WidgetRenderer(shadow).(*shadowRenderer).tr.StartColor)
 
 	dark := theme.DarkTheme()
 	fyne.CurrentApp().Settings().SetTheme(dark)
 	shadow.Refresh()
-	assert.Equal(t, dark.ShadowColor(), cache.Renderer(shadow).(*shadowRenderer).r.StartColor)
-	assert.Equal(t, dark.ShadowColor(), cache.Renderer(shadow).(*shadowRenderer).r.StartColor)
-	assert.Equal(t, dark.ShadowColor(), cache.Renderer(shadow).(*shadowRenderer).tr.StartColor)
+	assert.Equal(t, dark.ShadowColor(), test.WidgetRenderer(shadow).(*shadowRenderer).r.StartColor)
+	assert.Equal(t, dark.ShadowColor(), test.WidgetRenderer(shadow).(*shadowRenderer).r.StartColor)
+	assert.Equal(t, dark.ShadowColor(), test.WidgetRenderer(shadow).(*shadowRenderer).tr.StartColor)
 }

--- a/widget/slider_test.go
+++ b/widget/slider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +13,7 @@ func TestSlider_HorizontalLayout(t *testing.T) {
 	slider := NewSlider(0, 1)
 	slider.Resize(fyne.NewSize(100, 10))
 
-	render := Renderer(slider).(*sliderRenderer)
+	render := test.WidgetRenderer(slider).(*sliderRenderer)
 	diameter := slider.buttonDiameter()
 	wSize := render.slider.Size()
 	tSize := render.track.Size()
@@ -32,7 +33,7 @@ func TestSlider_VerticalLayout(t *testing.T) {
 	slider.Orientation = Vertical
 	slider.Resize(fyne.NewSize(10, 100))
 
-	render := Renderer(slider).(*sliderRenderer)
+	render := test.WidgetRenderer(slider).(*sliderRenderer)
 	diameter := slider.buttonDiameter()
 	wSize := render.slider.Size()
 	tSize := render.track.Size()

--- a/widget/tabcontainer_test.go
+++ b/widget/tabcontainer_test.go
@@ -6,7 +6,7 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
-	"fyne.io/fyne/internal/cache"
+	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,7 +55,7 @@ func TestTabItem_Content(t *testing.T) {
 	item1 := &TabItem{Text: "Test1", Content: NewLabel("Test1")}
 	item2 := &TabItem{Text: "Test2", Content: NewLabel("Test2")}
 	tabs := NewTabContainer(item1, item2)
-	r := Renderer(tabs).(*tabContainerRenderer)
+	r := test.WidgetRenderer(tabs).(*tabContainerRenderer)
 
 	assert.Equal(t, 2, len(tabs.Items))
 	assert.Equal(t, item1.Content, r.objects[0])
@@ -80,7 +80,7 @@ func TestTabContainer_SetTabLocation(t *testing.T) {
 	tab2 := NewTabItem("Test2", NewLabel("Test2"))
 	tab3 := NewTabItem("Test3", NewLabel("Test3"))
 	tabs := NewTabContainer(tab1, tab2, tab3)
-	r := cache.Renderer(tabs).(*tabContainerRenderer)
+	r := test.WidgetRenderer(tabs).(*tabContainerRenderer)
 
 	buttons := r.tabBar.Objects
 	require.Len(t, buttons, 3)
@@ -145,37 +145,37 @@ func Test_tabContainer_Tapped(t *testing.T) {
 		NewTabItem("Test2", NewLabel("Test2")),
 		NewTabItem("Test3", NewLabel("Test3")),
 	)
-	r := Renderer(tabs).(*tabContainerRenderer)
+	r := test.WidgetRenderer(tabs).(*tabContainerRenderer)
 
 	tab1 := r.tabBar.Objects[0].(*tabButton)
 	tab2 := r.tabBar.Objects[1].(*tabButton)
 	tab3 := r.tabBar.Objects[2].(*tabButton)
 	require.Equal(t, 0, tabs.CurrentTabIndex())
-	require.Equal(t, theme.PrimaryColor(), Renderer(tab1).BackgroundColor())
+	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab1).BackgroundColor())
 
 	tab2.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 1, tabs.CurrentTabIndex())
-	require.Equal(t, theme.BackgroundColor(), Renderer(tab1).BackgroundColor())
-	require.Equal(t, theme.PrimaryColor(), Renderer(tab2).BackgroundColor())
-	require.Equal(t, theme.BackgroundColor(), Renderer(tab3).BackgroundColor())
+	require.Equal(t, theme.BackgroundColor(), test.WidgetRenderer(tab1).BackgroundColor())
+	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab2).BackgroundColor())
+	require.Equal(t, theme.BackgroundColor(), test.WidgetRenderer(tab3).BackgroundColor())
 	assert.False(t, tabs.Items[0].Content.Visible())
 	assert.True(t, tabs.Items[1].Content.Visible())
 	assert.False(t, tabs.Items[2].Content.Visible())
 
 	tab3.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 2, tabs.CurrentTabIndex())
-	require.Equal(t, theme.BackgroundColor(), Renderer(tab1).BackgroundColor())
-	require.Equal(t, theme.BackgroundColor(), Renderer(tab2).BackgroundColor())
-	require.Equal(t, theme.PrimaryColor(), Renderer(tab3).BackgroundColor())
+	require.Equal(t, theme.BackgroundColor(), test.WidgetRenderer(tab1).BackgroundColor())
+	require.Equal(t, theme.BackgroundColor(), test.WidgetRenderer(tab2).BackgroundColor())
+	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab3).BackgroundColor())
 	assert.False(t, tabs.Items[0].Content.Visible())
 	assert.False(t, tabs.Items[1].Content.Visible())
 	assert.True(t, tabs.Items[2].Content.Visible())
 
 	tab1.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 0, tabs.CurrentTabIndex())
-	require.Equal(t, theme.PrimaryColor(), Renderer(tab1).BackgroundColor())
-	require.Equal(t, theme.BackgroundColor(), Renderer(tab2).BackgroundColor())
-	require.Equal(t, theme.BackgroundColor(), Renderer(tab3).BackgroundColor())
+	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab1).BackgroundColor())
+	require.Equal(t, theme.BackgroundColor(), test.WidgetRenderer(tab2).BackgroundColor())
+	require.Equal(t, theme.BackgroundColor(), test.WidgetRenderer(tab3).BackgroundColor())
 	assert.True(t, tabs.Items[0].Content.Visible())
 	assert.False(t, tabs.Items[1].Content.Visible())
 	assert.False(t, tabs.Items[2].Content.Visible())
@@ -187,7 +187,7 @@ func TestTabContainer_Hidden_AsChild(t *testing.T) {
 	ti1 := NewTabItem("Tab 1", c1)
 	ti2 := NewTabItem("Tab 2", c2)
 	tabs := NewTabContainer(ti1, ti2)
-	Renderer(tabs)
+	tabs.Refresh()
 
 	assert.True(t, c1.Visible())
 	assert.False(t, c2.Visible())
@@ -200,11 +200,11 @@ func TestTabContainer_Hidden_AsChild(t *testing.T) {
 func TestTabContainerRenderer_ApplyTheme(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
 	tabs := NewTabContainer(&TabItem{Text: "Test1", Content: NewLabel("Test1")})
-	underline := Renderer(tabs).(*tabContainerRenderer).line
+	underline := test.WidgetRenderer(tabs).(*tabContainerRenderer).line
 	barColor := underline.FillColor
 
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
-	Renderer(tabs).Refresh()
+	tabs.Refresh()
 	assert.NotEqual(t, barColor, underline.FillColor)
 }
 
@@ -344,14 +344,14 @@ func TestTabContainerRenderer_Layout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tabs := NewTabContainer(tt.item)
-			r := Renderer(tabs).(*tabContainerRenderer)
+			r := test.WidgetRenderer(tabs).(*tabContainerRenderer)
 			require.Len(t, r.tabBar.Objects, 1)
 			tabs.SetTabLocation(tt.location)
 			r.Layout(r.MinSize())
 
 			b := r.tabBar.Objects[0].(*tabButton)
 			assert.Equal(t, tt.wantButtonSize, b.Size())
-			br := Renderer(b).(*tabButtonRenderer)
+			br := test.WidgetRenderer(b).(*tabButtonRenderer)
 			if tt.item.Icon != nil {
 				assert.Equal(t, tt.item.Icon, br.icon.Resource)
 				assert.Equal(t, tt.wantIconSize, br.icon.Size(), "icon size")
@@ -369,7 +369,7 @@ func TestTabContainerRenderer_Layout(t *testing.T) {
 func TestTabContainer_DynamicTabs(t *testing.T) {
 	item := NewTabItem("Text1", canvas.NewCircle(theme.BackgroundColor()))
 	tabs := NewTabContainer(item)
-	r := Renderer(tabs).(*tabContainerRenderer)
+	r := test.WidgetRenderer(tabs).(*tabContainerRenderer)
 
 	appendedItem := NewTabItem("Text2", canvas.NewCircle(theme.BackgroundColor()))
 
@@ -392,7 +392,7 @@ func TestTabContainer_DynamicTabs(t *testing.T) {
 
 func Test_tabButton_Hovered(t *testing.T) {
 	b := &tabButton{}
-	r := Renderer(b)
+	r := test.WidgetRenderer(b)
 	require.Equal(t, theme.BackgroundColor(), r.BackgroundColor())
 
 	b.MouseIn(&desktop.MouseEvent{})
@@ -402,7 +402,7 @@ func Test_tabButton_Hovered(t *testing.T) {
 }
 
 func Test_tabButtonRenderer_BackgroundColor(t *testing.T) {
-	r := Renderer(&tabButton{})
+	r := test.WidgetRenderer(&tabButton{})
 	assert.Equal(t, theme.BackgroundColor(), r.BackgroundColor())
 }
 
@@ -410,7 +410,7 @@ func TestTabButtonRenderer_ApplyTheme(t *testing.T) {
 	item := &TabItem{Text: "Test", Content: NewLabel("Content")}
 	tabs := NewTabContainer(item)
 	tabButton := tabs.makeButton(item)
-	render := Renderer(tabButton).(*tabButtonRenderer)
+	render := test.WidgetRenderer(tabButton).(*tabButtonRenderer)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize

--- a/widget/text_test.go
+++ b/widget/text_test.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +61,7 @@ func newTrailingBoldWhiteTextPresenter() textPresenter {
 func TestText_Alignment(t *testing.T) {
 	text := &textProvider{presenter: newTrailingBoldWhiteTextPresenter()}
 	text.SetText("Test")
-	assert.Equal(t, fyne.TextAlignTrailing, Renderer(text).(*textRenderer).texts[0].Alignment)
+	assert.Equal(t, fyne.TextAlignTrailing, test.WidgetRenderer(text).(*textRenderer).texts[0].Alignment)
 }
 
 func TestText_Row(t *testing.T) {
@@ -237,7 +238,7 @@ func TestText_Color(t *testing.T) {
 
 func TestTextRenderer_ApplyTheme(t *testing.T) {
 	label := NewLabel("Test\nLine2")
-	render := Renderer(label).(*textRenderer)
+	render := test.WidgetRenderer(label).(*textRenderer)
 
 	text1 := render.objects[0].(*canvas.Text)
 	text2 := render.objects[0].(*canvas.Text)


### PR DESCRIPTION
### Description:
Provide a supported way to gain access to WidgetRenderer for unit tests.

### Checklist:

- [ ] Tests included. <- didn't seem needed as it's refactoring existing code in tests
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
