### PR TITLE
Add support to customize form buttons text

### DIFF
--- a/widget/form.go
+++ b/widget/form.go
@@ -24,11 +24,11 @@ func NewFormItem(text string, widget fyne.CanvasObject) *FormItem {
 type Form struct {
 	BaseWidget
 
-	Items        []*FormItem
-	SubmitButton *Button
-	CancelButton *Button
-	OnSubmit     func()
-	OnCancel     func()
+	Items      []*FormItem
+	OnSubmit   func()
+	OnCancel   func()
+	SubmitText string
+	CancelText string
 
 	itemGrid *fyne.Container
 }
@@ -84,18 +84,20 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 
 	buttons := NewHBox(layout.NewSpacer())
 	if f.OnCancel != nil {
-		if f.CancelButton == nil {
-			f.CancelButton = NewButtonWithIcon("Cancel", theme.CancelIcon(), f.OnCancel)
-		}
-		buttons.Append(f.CancelButton)
-	}
-	if f.OnSubmit != nil {
-		if f.CancelButton == nil {
-			f.SubmitButton = NewButtonWithIcon("Submit", theme.ConfirmIcon(), f.OnSubmit)
-			f.SubmitButton.Style = PrimaryButton
+		if f.CancelText == "" {
+			f.CancelText = "Cancel"
 		}
 
-		buttons.Append(f.SubmitButton)
+		buttons.Append(NewButtonWithIcon(f.CancelText, theme.CancelIcon(), f.OnCancel))
+	}
+	if f.OnSubmit != nil {
+		if f.SubmitText == "" {
+			f.SubmitText = "Submit"
+		}
+
+		submitButton := NewButtonWithIcon(f.SubmitText, theme.ConfirmIcon(), f.OnSubmit)
+		submitButton.Style = PrimaryButton
+		buttons.Append(submitButton)
 	}
 	return Renderer(NewVBox(f.itemGrid, buttons))
 }

--- a/widget/form.go
+++ b/widget/form.go
@@ -28,7 +28,9 @@ type Form struct {
 	OnSubmit func()
 	OnCancel func()
 
-	itemGrid *fyne.Container
+	itemGrid     *fyne.Container
+	submitButton *Button
+	cancelButton *Button
 }
 
 func (f *Form) createLabel(text string) *Label {
@@ -82,15 +84,55 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 
 	buttons := NewHBox(layout.NewSpacer())
 	if f.OnCancel != nil {
-		buttons.Append(NewButtonWithIcon("Cancel", theme.CancelIcon(), f.OnCancel))
+		if f.cancelButton == nil {
+			f.cancelButton = NewButtonWithIcon("Cancel", theme.CancelIcon(), f.OnCancel)
+		}
+		buttons.Append(f.cancelButton)
 	}
 	if f.OnSubmit != nil {
-		submit := NewButtonWithIcon("Submit", theme.ConfirmIcon(), f.OnSubmit)
-		submit.Style = PrimaryButton
+		if f.cancelButton == nil {
+			f.submitButton = NewButtonWithIcon("Submit", theme.ConfirmIcon(), f.OnSubmit)
+			f.submitButton.Style = PrimaryButton
+		}
 
-		buttons.Append(submit)
+		buttons.Append(f.submitButton)
 	}
 	return Renderer(NewVBox(f.itemGrid, buttons))
+}
+
+//SetSubmitText is set text for Submit button
+func (f *Form) SetSubmitText(text string) {
+	if f.submitButton != nil {
+		f.submitButton.SetText(text)
+	} else {
+		f.submitButton = NewButtonWithIcon(text, theme.ConfirmIcon(), f.OnSubmit)
+		f.submitButton.Style = PrimaryButton
+	}
+}
+
+//GetSubmitText returns text of Submit button
+func (f *Form) GetSubmitText() string {
+	if f.submitButton != nil {
+		return f.submitButton.Text
+	}
+	return "Submit"
+}
+
+//SetCancelText is set text for Cancel button
+func (f *Form) SetCancelText(text string) {
+	if f.cancelButton != nil {
+		f.cancelButton.SetText(text)
+	} else {
+		f.cancelButton = NewButtonWithIcon(text, theme.CancelIcon(), f.OnCancel)
+	}
+}
+
+//GetCancelText returns text of Cancel button
+func (f *Form) GetCancelText() string {
+	if f.cancelButton != nil {
+		return f.cancelButton.Text
+	}
+	return "Cancel"
 }
 
 // NewForm creates a new form widget with the specified rows of form items

--- a/widget/form.go
+++ b/widget/form.go
@@ -24,13 +24,13 @@ func NewFormItem(text string, widget fyne.CanvasObject) *FormItem {
 type Form struct {
 	BaseWidget
 
-	Items    []*FormItem
-	OnSubmit func()
-	OnCancel func()
+	Items        []*FormItem
+	SubmitButton *Button
+	CancelButton *Button
+	OnSubmit     func()
+	OnCancel     func()
 
-	itemGrid     *fyne.Container
-	submitButton *Button
-	cancelButton *Button
+	itemGrid *fyne.Container
 }
 
 func (f *Form) createLabel(text string) *Label {
@@ -84,55 +84,20 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 
 	buttons := NewHBox(layout.NewSpacer())
 	if f.OnCancel != nil {
-		if f.cancelButton == nil {
-			f.cancelButton = NewButtonWithIcon("Cancel", theme.CancelIcon(), f.OnCancel)
+		if f.CancelButton == nil {
+			f.CancelButton = NewButtonWithIcon("Cancel", theme.CancelIcon(), f.OnCancel)
 		}
-		buttons.Append(f.cancelButton)
+		buttons.Append(f.CancelButton)
 	}
 	if f.OnSubmit != nil {
-		if f.cancelButton == nil {
-			f.submitButton = NewButtonWithIcon("Submit", theme.ConfirmIcon(), f.OnSubmit)
-			f.submitButton.Style = PrimaryButton
+		if f.CancelButton == nil {
+			f.SubmitButton = NewButtonWithIcon("Submit", theme.ConfirmIcon(), f.OnSubmit)
+			f.SubmitButton.Style = PrimaryButton
 		}
 
-		buttons.Append(f.submitButton)
+		buttons.Append(f.SubmitButton)
 	}
 	return Renderer(NewVBox(f.itemGrid, buttons))
-}
-
-//SetSubmitText is set text for Submit button
-func (f *Form) SetSubmitText(text string) {
-	if f.submitButton != nil {
-		f.submitButton.SetText(text)
-	} else {
-		f.submitButton = NewButtonWithIcon(text, theme.ConfirmIcon(), f.OnSubmit)
-		f.submitButton.Style = PrimaryButton
-	}
-}
-
-//GetSubmitText returns text of Submit button
-func (f *Form) GetSubmitText() string {
-	if f.submitButton != nil {
-		return f.submitButton.Text
-	}
-	return "Submit"
-}
-
-//SetCancelText is set text for Cancel button
-func (f *Form) SetCancelText(text string) {
-	if f.cancelButton != nil {
-		f.cancelButton.SetText(text)
-	} else {
-		f.cancelButton = NewButtonWithIcon(text, theme.CancelIcon(), f.OnCancel)
-	}
-}
-
-//GetCancelText returns text of Cancel button
-func (f *Form) GetCancelText() string {
-	if f.cancelButton != nil {
-		return f.cancelButton.Text
-	}
-	return "Cancel"
 }
 
 // NewForm creates a new form widget with the specified rows of form items

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"testing"
 
+	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +18,7 @@ func TestFormSize(t *testing.T) {
 
 func TestForm_CreateRenderer(t *testing.T) {
 	form := &Form{Items: []*FormItem{{Text: "test1", Widget: NewEntry()}}}
-	assert.NotNil(t, Renderer(form))
+	assert.NotNil(t, test.WidgetRenderer(form))
 	assert.Equal(t, 2, len(form.itemGrid.Objects))
 
 	form.Append("test2", NewEntry())

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"testing"
 
+	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,13 +38,11 @@ func TestForm_Append(t *testing.T) {
 	assert.Equal(t, item, form.Items[2])
 }
 
-func TestForm_ButtonsText(t *testing.T) {
+func TestForm_CustomButtonsText(t *testing.T) {
 	form := &Form{}
-	assert.Equal(t, "Submit", form.GetSubmitText())
-	assert.Equal(t, "Cancel", form.GetCancelText())
-
-	form.SetCancelText("Close")
-	form.SetSubmitText("Apply")
-	assert.Equal(t, "Apply", form.GetSubmitText())
-	assert.Equal(t, "Close", form.GetCancelText())
+	form.SubmitButton = NewButtonWithIcon("Apply", theme.ConfirmIcon(), form.OnSubmit)
+	form.SubmitButton.Style = PrimaryButton
+	form.CancelButton = NewButtonWithIcon("Close", theme.CancelIcon(), form.OnCancel)
+	assert.Equal(t, "Apply", form.SubmitButton.Text)
+	assert.Equal(t, "Close", form.CancelButton.Text)
 }

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -3,7 +3,6 @@ package widget
 import (
 	"testing"
 
-	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +17,7 @@ func TestFormSize(t *testing.T) {
 
 func TestForm_CreateRenderer(t *testing.T) {
 	form := &Form{Items: []*FormItem{{Text: "test1", Widget: NewEntry()}}}
-	assert.NotNil(t, test.WidgetRenderer(form))
+	assert.NotNil(t, Renderer(form))
 	assert.Equal(t, 2, len(form.itemGrid.Objects))
 
 	form.Append("test2", NewEntry())
@@ -36,4 +35,15 @@ func TestForm_Append(t *testing.T) {
 	form.AppendItem(item)
 	assert.True(t, len(form.Items) == 3)
 	assert.Equal(t, item, form.Items[2])
+}
+
+func TestForm_ButtonsText(t *testing.T) {
+	form := &Form{}
+	assert.Equal(t, "Submit", form.GetSubmitText())
+	assert.Equal(t, "Cancel", form.GetCancelText())
+
+	form.SetCancelText("Close")
+	form.SetSubmitText("Apply")
+	assert.Equal(t, "Apply", form.GetSubmitText())
+	assert.Equal(t, "Close", form.GetCancelText())
 }

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -3,7 +3,6 @@ package widget
 import (
 	"testing"
 
-	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,10 +38,13 @@ func TestForm_Append(t *testing.T) {
 }
 
 func TestForm_CustomButtonsText(t *testing.T) {
-	form := &Form{}
-	form.SubmitButton = NewButtonWithIcon("Apply", theme.ConfirmIcon(), form.OnSubmit)
-	form.SubmitButton.Style = PrimaryButton
-	form.CancelButton = NewButtonWithIcon("Close", theme.CancelIcon(), form.OnCancel)
-	assert.Equal(t, "Apply", form.SubmitButton.Text)
-	assert.Equal(t, "Close", form.CancelButton.Text)
+	form := &Form{OnSubmit: func() {}, OnCancel: func() {}}
+	form.Append("test", NewEntry())
+	assert.Equal(t, "Submit", form.SubmitText)
+	assert.Equal(t, "Cancel", form.CancelText)
+
+	form = &Form{OnSubmit: func() {}, SubmitText: "Apply",
+		OnCancel: func() {}, CancelText: "Close"}
+	assert.Equal(t, "Apply", form.SubmitText)
+	assert.Equal(t, "Close", form.CancelText)
 }


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Form is very convenient widget but sometimes there is need to change button labels so I propose to add such feature. 

### Checklist:

- [X] Tests included.
- [ ] Lint and formatter run with no errors.
- [X] Tests all pass.

#### Where applicable:

- [] Public APIs match existing style.
- [X] Any breaking changes have a deprecation path or have been discussed.
