### PR TITLE
Add borderless window support on desktop 

### DIFF
--- a/cmd/fyne_demo/screens/window.go
+++ b/cmd/fyne_demo/screens/window.go
@@ -7,6 +7,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/dialog"
+	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/widget"
 )
@@ -58,7 +59,7 @@ func DialogScreen(win fyne.Window) fyne.CanvasObject {
 		}),
 	)
 
-	windows := widget.NewVBox(dialogs, widget.NewGroup("Windows",
+	windowGroup := widget.NewGroup("Windows",
 		widget.NewButton("New window", func() {
 			w := fyne.CurrentApp().NewWindow("Hello")
 			w.SetContent(widget.NewLabel("Hello World!"))
@@ -78,7 +79,24 @@ func DialogScreen(win fyne.Window) fyne.CanvasObject {
 
 			w.CenterOnScreen()
 			w.Show()
-		})))
+		}))
+
+	drv := fyne.CurrentApp().Driver()
+	if drv, ok := drv.(desktop.Driver); ok {
+		windowGroup.Append(
+			widget.NewButton("Splash Window (only use on start)", func() {
+				w := drv.CreateSplashWindow()
+				w.SetContent(widget.NewLabelWithStyle("Hello World!\n\nMake a splash!",
+					fyne.TextAlignCenter, fyne.TextStyle{Bold: true}))
+				w.Show()
+
+				go func() {
+					time.Sleep(time.Second * 3)
+					w.Close()
+				}()
+			}))
+	}
+	windows := widget.NewVBox(dialogs, windowGroup)
 
 	return fyne.NewContainerWithLayout(layout.NewAdaptiveGridLayout(2), windows, LayoutPanel())
 }

--- a/driver/desktop/driver.go
+++ b/driver/desktop/driver.go
@@ -1,0 +1,9 @@
+package desktop
+
+import "fyne.io/fyne"
+
+// Driver represents the extended capabilities of a desktop driver
+type Driver interface {
+	// Create a new borderless window that is centered on screen
+	CreateSplashWindow() fyne.Window
+}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1082,12 +1082,21 @@ func (w *window) waitForEvents() {
 }
 
 func (d *gLDriver) CreateWindow(title string) fyne.Window {
+	return d.createWindow(title, true)
+}
+
+func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 	var ret *window
 	runOnMain(func() {
 		initOnce.Do(d.initGLFW)
 
 		// make the window hidden, we will set it up and then show it later
 		glfw.WindowHint(glfw.Visible, 0)
+		if decorate {
+			glfw.WindowHint(glfw.Decorated, 1)
+		} else {
+			glfw.WindowHint(glfw.Decorated, 0)
+		}
 		initWindowHints()
 
 		win, err := glfw.CreateWindow(10, 10, title, nil, nil)
@@ -1126,6 +1135,12 @@ func (d *gLDriver) CreateWindow(title string) fyne.Window {
 		glfw.DetachCurrentContext()
 	})
 	return ret
+}
+
+func (d *gLDriver) CreateSplashWindow() fyne.Window {
+	win := d.createWindow("", false)
+	win.CenterOnScreen()
+	return win
 }
 
 func (d *gLDriver) AllWindows() []fyne.Window {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1139,6 +1139,7 @@ func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 
 func (d *gLDriver) CreateSplashWindow() fyne.Window {
 	win := d.createWindow("", false)
+	win.SetPadded(false)
 	win.CenterOnScreen()
 	return win
 }

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -604,7 +604,6 @@ func TestWindow_calculateScale(t *testing.T) {
 func TestWindow_Padded(t *testing.T) {
 	w := d.CreateWindow("Test")
 	content := canvas.NewRectangle(color.White)
-	w.Canvas().SetScale(1.0)
 	w.SetContent(content)
 
 	width, _ := w.(*window).minSizeOnScreen()

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -37,6 +37,21 @@ func TestMain(m *testing.M) {
 	d.Run()
 }
 
+func TestGLDriver_CreateWindow(t *testing.T) {
+	w := NewGLDriver().CreateWindow("Test").(*window)
+
+	assert.Equal(t, 1, w.viewport.GetAttrib(glfw.Decorated))
+	assert.False(t, w.centered)
+}
+
+func TestGLDriver_CreateSplashWindow(t *testing.T) {
+	d := NewGLDriver().(desktop.Driver)
+	w := d.CreateSplashWindow().(*window)
+
+	assert.Equal(t, 0, w.viewport.GetAttrib(glfw.Decorated))
+	assert.True(t, w.centered)
+}
+
 func TestWindow_HandleHoverable(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
 	h1 := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -41,6 +41,7 @@ func TestGLDriver_CreateWindow(t *testing.T) {
 	w := NewGLDriver().CreateWindow("Test").(*window)
 
 	assert.Equal(t, 1, w.viewport.GetAttrib(glfw.Decorated))
+	assert.True(t, w.Padded())
 	assert.False(t, w.centered)
 }
 
@@ -49,6 +50,7 @@ func TestGLDriver_CreateSplashWindow(t *testing.T) {
 	w := d.CreateSplashWindow().(*window)
 
 	assert.Equal(t, 0, w.viewport.GetAttrib(glfw.Decorated))
+	assert.False(t, w.Padded())
 	assert.True(t, w.centered)
 }
 


### PR DESCRIPTION
### Description:
Support borderless window requests on desktop.
This does not expose through the main app API on purpose as it’s platform specific.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

- [x] Public APIs match existing style.
