### PR TITLE
Fix wrong rendering and even crash on appending tabs

### DIFF
--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -119,7 +119,6 @@ func (t *TabContainer) CreateRenderer() fyne.WidgetRenderer {
 	}
 	tabBar := t.buildTabBar(buttons)
 	line := canvas.NewRectangle(theme.ButtonColor())
-	objects = append(objects, line, tabBar)
 	return &tabContainerRenderer{tabBar: tabBar, line: line, objects: objects, container: t}
 }
 
@@ -150,6 +149,7 @@ func (t *TabContainer) buildTabBar(buttons []fyne.CanvasObject) *fyne.Container 
 func (t *TabContainer) Append(item *TabItem) {
 	r := cache.Renderer(t).(*tabContainerRenderer)
 	t.Items = append(t.Items, item)
+	r.objects = append(r.objects, item.Content)
 	r.tabBar.Objects = append(r.tabBar.Objects, t.makeButton(item))
 
 	t.Refresh()
@@ -169,6 +169,7 @@ func (t *TabContainer) Remove(item *TabItem) {
 func (t *TabContainer) RemoveIndex(index int) {
 	r := cache.Renderer(t).(*tabContainerRenderer)
 	t.Items = append(t.Items[:index], t.Items[index+1:]...)
+	r.objects = append(r.objects[:index], r.objects[index+1:]...)
 	r.tabBar.Objects = append(r.tabBar.Objects[:index], r.tabBar.Objects[index+1:]...)
 
 	t.Refresh()
@@ -188,9 +189,7 @@ func (t *TabContainer) SetTabLocation(l TabLocation) {
 			b.(*tabButton).IconPosition = buttonIconInline
 		}
 	}
-	r.tabBar.Objects = nil
 	r.tabBar = t.buildTabBar(buttons)
-	r.objects[len(r.objects)-1] = r.tabBar
 
 	r.Layout(t.size)
 }
@@ -229,6 +228,7 @@ type tabContainerRenderer struct {
 	tabBar *fyne.Container
 	line   *canvas.Rectangle
 
+	// objects holds only the CanvasObject of the tabs' content
 	objects   []fyne.CanvasObject
 	container *TabContainer
 }
@@ -314,7 +314,7 @@ func (t *tabContainerRenderer) BackgroundColor() color.Color {
 }
 
 func (t *tabContainerRenderer) Objects() []fyne.CanvasObject {
-	return t.objects
+	return append(t.objects, t.tabBar, t.line)
 }
 
 func (t *tabContainerRenderer) Refresh() {

--- a/widget/tabcontainer_test.go
+++ b/widget/tabcontainer_test.go
@@ -388,6 +388,18 @@ func TestTabContainer_DynamicTabs(t *testing.T) {
 	assert.Equal(t, len(tabs.Items), 1)
 	assert.Equal(t, len(r.tabBar.Objects), 1)
 	assert.Equal(t, tabs.Items[0].Text, appendedItem.Text)
+
+	appendedItem3 := NewTabItem("Text3", canvas.NewCircle(theme.BackgroundColor()))
+	appendedItem4 := NewTabItem("Text4", canvas.NewCircle(theme.BackgroundColor()))
+	appendedItem5 := NewTabItem("Text5", canvas.NewCircle(theme.BackgroundColor()))
+	tabs.Append(appendedItem3)
+	tabs.Append(appendedItem4)
+	tabs.Append(appendedItem5)
+	assert.Equal(t, 4, len(tabs.Items))
+	assert.Equal(t, 4, len(r.tabBar.Objects))
+	assert.Equal(t, "Text3", tabs.Items[1].Text)
+	assert.Equal(t, "Text4", tabs.Items[2].Text)
+	assert.Equal(t, "Text5", tabs.Items[3].Text)
 }
 
 func Test_tabButton_Hovered(t *testing.T) {


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The divider (`line`) and tab bar (`tabBar`) are appended to `tabContainerRenderer.objects`, but it doesn't get updated properly when tabs are added via `Append`. When appending tabs the divider and the tab bar are overwritten. When appending 3 or more tabs, it crashes.

This bugfix removes divider and tab bar from that `objects` field, and populate it correctly on appending and removing.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
