### PR TITLE
Add Progress infinite dialog

### DIFF
--- a/cmd/fyne_demo/screens/window.go
+++ b/cmd/fyne_demo/screens/window.go
@@ -49,6 +49,16 @@ func DialogScreen(win fyne.Window) fyne.CanvasObject {
 
 			prog.Show()
 		}),
+		widget.NewButton("ProgressInfinite", func() {
+			prog := dialog.NewProgressInfinite("MyProgress", "Closes after 5 seconds...", win)
+
+			go func() {
+				time.Sleep(time.Second * 5)
+				prog.Hide()
+			}()
+
+			prog.Show()
+		}),
 		widget.NewButton("Custom", func() {
 			content := widget.NewEntry()
 			content.SetPlaceHolder("Type something here")

--- a/dialog/progressinfinite.go
+++ b/dialog/progressinfinite.go
@@ -1,0 +1,31 @@
+package dialog
+
+import (
+	"fyne.io/fyne"
+	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
+)
+
+// ProgressInfiniteDialog is a simple dialog window that displays text and a infinite progress bar.
+type ProgressInfiniteDialog struct {
+	*dialog
+
+	bar *widget.ProgressBarInfinite
+}
+
+// NewProgressInfinite creates a infinite progress dialog and returns the handle.
+// Using the returned type you should call Show().
+func NewProgressInfinite(title, message string, parent fyne.Window) *ProgressInfiniteDialog {
+	d := newDialog(title, message, theme.InfoIcon(), nil /*cancel?*/, parent)
+	bar := widget.NewProgressBarInfinite()
+	bar.Resize(fyne.NewSize(200, bar.MinSize().Height))
+
+	d.setButtons(bar)
+	return &ProgressInfiniteDialog{d, bar}
+}
+
+// Hide this dialog and stop the infinite progress goroutine
+func (d *ProgressInfiniteDialog) Hide() {
+	d.bar.Hide()
+	d.dialog.Hide()
+}

--- a/dialog/progressinfinite_test.go
+++ b/dialog/progressinfinite_test.go
@@ -1,0 +1,42 @@
+package dialog
+
+import (
+	"testing"
+
+	"fyne.io/fyne/test"
+	"fyne.io/fyne/widget"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressInfiniteDialog_MinSize(t *testing.T) {
+	d := NewProgressInfinite("title", "message", test.NewWindow(nil))
+
+	dialogContent := d.win.Content.MinSize()
+	progressBar := d.bar.MinSize()
+
+	assert.Less(t, progressBar.Width, dialogContent.Width)
+}
+
+func TestProgressInfiniteDialog_Content(t *testing.T) {
+	title := "title"
+	message := "message"
+
+	d := NewProgressInfinite(title, message, test.NewWindow(nil))
+
+	assert.Equal(t, d.title, title)
+	assert.Equal(t, d.content.(*widget.Label).Text, message)
+}
+
+func TestProgressInfiniteDialog_Show(t *testing.T) {
+	d := NewProgressInfinite("title", "message", test.NewWindow(nil))
+
+	d.Show()
+
+	assert.False(t, d.win.Hidden)
+	assert.True(t, d.bar.Running())
+
+	d.Hide()
+
+	assert.True(t, d.win.Hidden)
+	assert.False(t, d.bar.Running())
+}


### PR DESCRIPTION
### Description:

Add ProgressInfiniteDialog that used instead of ProgressDialog when progress is unknown.
This dialog has no SetValue method unlike ProgressDialog.

![image](https://user-images.githubusercontent.com/31386431/73604618-e70e1880-45d6-11ea-8d48-1ab5c8cca4a7.png)

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
