### PR TITLE
Add helper PixelCoordinateForPosition function in Canvas

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -32,4 +32,8 @@ type Canvas interface {
 	AddShortcut(shortcut Shortcut, handler func(shortcut Shortcut))
 
 	Capture() image.Image
+
+	// PixelCoordinateForPosition returns the x and y pixel coordinate for a given position on this canvas.
+	// This can be used to find absolute pixel positions or pixel offsets relative to an object top left.
+	PixelCoordinateForPosition(Position) (int, int)
 }

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -2,6 +2,7 @@ package glfw
 
 import (
 	"image"
+	"math"
 	"sync"
 
 	"fyne.io/fyne"
@@ -32,8 +33,8 @@ type glCanvas struct {
 	onKeyUp     func(*fyne.KeyEvent)
 	shortcut    fyne.ShortcutHandler
 
-	scale, detectedScale float32
-	painter              gl.Painter
+	scale, detectedScale, texScale float32
+	painter                        gl.Painter
 
 	dirty                              bool
 	dirtyMutex                         *sync.Mutex
@@ -190,6 +191,21 @@ func (c *glCanvas) SetScale(_ float32) {
 	c.setDirty(true)
 
 	c.context.RescaleContext()
+}
+
+func (c *glCanvas) setTextureScale(scale float32) {
+	c.texScale = scale
+	c.painter.SetFrameBufferScale(scale)
+}
+
+func (c *glCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
+	texScale := c.texScale
+	multiple := float64(c.Scale() * texScale)
+	scaleInt := func(x int) int {
+		return int(math.Round(float64(x) * multiple))
+	}
+
+	return scaleInt(pos.X), scaleInt(pos.Y)
 }
 
 func (c *glCanvas) OnTypedRune() func(rune) {
@@ -463,7 +479,7 @@ func (c *glCanvas) contentPos() fyne.Position {
 }
 
 func newCanvas() *glCanvas {
-	c := &glCanvas{scale: 1.0}
+	c := &glCanvas{scale: 1.0, texScale: 1.0}
 	c.content = &canvas.Rectangle{FillColor: theme.BackgroundColor()}
 	c.contentTree = &renderCacheTree{root: &renderCacheNode{obj: c.content}}
 	c.padded = true

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -42,6 +42,30 @@ func TestGlCanvas_Resize(t *testing.T) {
 	assert.Equal(t, size, over.Size())
 }
 
+func TestGlCanvas_Scale(t *testing.T) {
+	w := d.CreateWindow("Test").(*window)
+	c := w.Canvas().(*glCanvas)
+
+	c.scale = 2.5
+	assert.Equal(t, 5, int(2*c.Scale()))
+}
+
+func TestGlCanvas_PixelCoordinateAtPosition(t *testing.T) {
+	w := d.CreateWindow("Test").(*window)
+	c := w.Canvas().(*glCanvas)
+
+	pos := fyne.NewPos(4, 4)
+	c.scale = 2.5
+	x, y := c.PixelCoordinateForPosition(pos)
+	assert.Equal(t, 10, x)
+	assert.Equal(t, 10, y)
+
+	c.texScale = 2.0
+	x, y = c.PixelCoordinateForPosition(pos)
+	assert.Equal(t, 20, x)
+	assert.Equal(t, 20, y)
+}
+
 func Test_glCanvas_SetContent(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
 	var menuHeight int

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -469,7 +469,7 @@ func (w *window) frameSized(viewport *glfw.Window, width, height int) {
 
 	winWidth, _ := w.viewport.GetSize()
 	texScale := float32(width) / float32(winWidth) // This will be > 1.0 on a HiDPI screen
-	w.canvas.painter.SetFrameBufferScale(texScale)
+	w.canvas.setTextureScale(texScale)
 	w.canvas.painter.SetOutputSize(width, height)
 }
 

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -132,6 +132,10 @@ func (c *mobileCanvas) SetScale(_ float32) {
 	c.scale = fyne.CurrentDevice().SystemScale()
 }
 
+func (c *mobileCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
+	return int(float32(pos.X) * c.scale), int(float32(pos.Y) * c.scale)
+}
+
 func (c *mobileCanvas) Overlay() fyne.CanvasObject {
 	return c.overlay
 }

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCanvas_PixelCoordinateAtPosition(t *testing.T) {
+	c := NewCanvas().(*mobileCanvas)
+
+	pos := fyne.NewPos(4, 4)
+	c.scale = 2.5
+	x, y := c.PixelCoordinateForPosition(pos)
+	assert.Equal(t, 10, x)
+	assert.Equal(t, 10, y)
+}
+
 func TestCanvas_Tapped(t *testing.T) {
 	tapped := false
 	altTapped := false

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -118,6 +118,10 @@ func (c *testCanvas) SetScale(scale float32) {
 	c.scale = scale
 }
 
+func (c *testCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
+	return int(float32(pos.X) * c.scale), int(float32(pos.Y) * c.scale)
+}
+
 func (c *testCanvas) OnTypedRune() func(rune) {
 	return c.onTypedRune
 }

--- a/test/testcanvas_test.go
+++ b/test/testcanvas_test.go
@@ -24,3 +24,13 @@ func TestTestCanvas_Capture(t *testing.T) {
 	assert.Equal(t, b1, b2)
 	assert.Equal(t, a1, a2)
 }
+
+func TestGlCanvas_PixelCoordinateAtPosition(t *testing.T) {
+	c := NewCanvas().(*testCanvas)
+
+	pos := fyne.NewPos(4, 4)
+	c.scale = 2.5
+	x, y := c.PixelCoordinateForPosition(pos)
+	assert.Equal(t, 10, x)
+	assert.Equal(t, 10, y)
+}


### PR DESCRIPTION
A converting helper from position to pixels is required for certain use-cases to know where in a render output a position is.
Cannot be done with current API due to Gl texture scale in glPainter on macOS

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.

I considered putting this in the driver but as it requires the canvas context that didn't make sense.
The API is not hugely visible as most apps don't interact with canvas directly.