### PR TITLE
Adds a command to print the version of the Fyne library that would be…

### DIFF
--- a/cmd/fyne/main.go
+++ b/cmd/fyne/main.go
@@ -52,6 +52,7 @@ func loadCommands() {
 	commands["get"] = &getter{}
 	commands["package"] = &packager{}
 	commands["install"] = &installer{}
+	commands["lib-version"] = &versioner{}
 }
 
 func main() {

--- a/cmd/fyne/version.go
+++ b/cmd/fyne/version.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const PKG = "fyne.io/fyne"
+
+// Declare conformity to command interface
+var _ command = (*versioner)(nil)
+
+type versioner struct {
+	context build.Context
+}
+
+func (v *versioner) run(_ []string) {
+	err := v.validate()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	err = v.doVersion()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+func (v *versioner) validate() error {
+	return nil
+}
+
+func (v *versioner) doVersion() error {
+	c := build.Default
+	p, e := c.Import(PKG, ".", build.FindOnly)
+	if e != nil {
+		return e
+	}
+	// p.PkgObj =~ /home/ser/go/pkg/mod/fyne.io/fyne@v1.2.2/pkg/li
+	ps := strings.Split(p.PkgObj, "@")
+	if len(ps) < 2 {
+		return errors.New(fmt.Sprintf("Malformed package info %s; not using modules?", p.PkgObj))
+	}
+	vs := strings.Split(ps[1], "/")
+	if len(vs) < 2 {
+		return errors.New(fmt.Sprintf("Missing version information %s; not using modules?", p.PkgObj))
+	}
+	fmt.Println(vs[0])
+	return nil
+}
+
+func (v *versioner) printHelp(indent string) {
+	fmt.Println(indent, "Print the version of the Fyne library that would be used to build the package.")
+}
+
+func (v *versioner) addFlags() {
+}


### PR DESCRIPTION
… used to compile packages, if go modules are used.

### Description:
Adds a `lib-version` command that uses the `go/build` library to introspect on the `fyne.io/fyne` package being used in the current environment, and prints out the version number (if any).  As version information is only available for Go modules, this will only produce useful information if modules are disabled, or if Fyne is being somehow otherwise referenced.  E.g., it doesn't work well within the Fyne project itself.

If modules are not being used, it merely reports that it can't get version information when none exists.

E.g.:
```
$ cd ~/workspace/fyne
$ fyne lib-version
Malformed package info /home/ser/workspace/fyne/pkg/linux_amd64/fyne.io/fyne.a; not using modules?
$ cd ~/workspace/healthdiary
$ fyne lib-version
v1.2.2
```

Fixes #656

### Checklist:

- [ ] Tests included.  **Nope.  I didn't see any test patterns for other commands, so I didn't provide one for this.**
- [X] Lint and formatter run with no errors.
- [X] Tests all pass. **Yes, but see above.**

#### Where applicable:

- [X] Public APIs match existing style. **I guess?**
- [X] Any breaking changes have a deprecation path or have been discussed. **N/A**
