### PR TITLE
lib-version implementation

### DIFF
--- a/cmd/fyne/main.go
+++ b/cmd/fyne/main.go
@@ -52,6 +52,7 @@ func loadCommands() {
 	commands["get"] = &getter{}
 	commands["package"] = &packager{}
 	commands["install"] = &installer{}
+	commands["lib-version"] = &versioner{}
 }
 
 func main() {

--- a/cmd/fyne/version.go
+++ b/cmd/fyne/version.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const pkg = "fyne.io/fyne"
+
+// Declare conformity to command interface
+var _ command = (*versioner)(nil)
+
+type versioner struct {
+	context build.Context
+}
+
+func (v *versioner) run(_ []string) {
+	err := v.validate()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	err = v.doVersion()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+func (v *versioner) validate() error {
+	return nil
+}
+
+func (v *versioner) doVersion() error {
+	c := build.Default
+	p, e := c.Import(pkg, ".", build.FindOnly)
+	if e != nil {
+		return e
+	}
+	// p.PkgObj =~ /home/ser/go/pkg/mod/fyne.io/fyne@v1.2.2/pkg/li
+	ps := strings.Split(p.PkgObj, "@")
+	if len(ps) < 2 {
+		return errors.New(fmt.Sprintf("Malformed package info %s; not using modules?", p.PkgObj))
+	}
+	vs := strings.Split(ps[1], "/")
+	if len(vs) < 2 {
+		return errors.New(fmt.Sprintf("Missing version information %s; not using modules?", p.PkgObj))
+	}
+	fmt.Println(vs[0])
+	return nil
+}
+
+func (v *versioner) printHelp(indent string) {
+	fmt.Println(indent, "Print the version of the Fyne library that would be used to build the package.")
+}
+
+func (v *versioner) addFlags() {
+}

--- a/cmd/fyne/version.go
+++ b/cmd/fyne/version.go
@@ -42,17 +42,28 @@ func (v *versioner) doVersion() error {
 	if e != nil {
 		return e
 	}
-	// p.PkgObj =~ /home/ser/go/pkg/mod/fyne.io/fyne@v1.2.2/pkg/li
-	ps := strings.Split(p.PkgObj, "@")
-	if len(ps) < 2 {
-		return errors.New(fmt.Sprintf("Malformed package info %s; not using modules?", p.PkgObj))
+	ve, e := parsePkgString(p.PkgObj)
+	if e != nil {
+		return e
 	}
-	vs := strings.Split(ps[1], "/")
-	if len(vs) < 2 {
-		return errors.New(fmt.Sprintf("Missing version information %s; not using modules?", p.PkgObj))
-	}
-	fmt.Println(vs[0])
+	fmt.Println(ve)
 	return nil
+}
+
+func parsePkgString(s string) (string, error) {
+	// @ separates the package path from the version
+	ps := strings.Split(s, "@")
+	if len(ps) < 2 {
+		return "", errors.New(fmt.Sprintf("No version information in %s; not using modules?", s))
+	}
+	// PkgObj contains some junk after the version -- "junk," in this case,
+	// meaning some internal information I don't understand. It's not part of
+	// the version, in any case.
+	vs := strings.Split(ps[1], "/")
+	if len(vs) < 1 {
+		return "", errors.New(fmt.Sprintf("Missing version information %s; not using modules?", s))
+	}
+	return vs[0], nil
 }
 
 func (v *versioner) printHelp(indent string) {

--- a/cmd/fyne/version_test.go
+++ b/cmd/fyne/version_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePkgString(t *testing.T) {
+	type test struct {
+		in string // Test input
+		es string // Expected output
+		ee bool   // Expecting error?
+	}
+
+	ts := []test{
+		{in: "/home/user/go/pkg/mod/fyne.io/fyne@v1.2.2/pkg/li", es: "v1.2.2", ee: false},
+		{in: "fyne.io/fyne@v1.1", es: "v1.1", ee: false},
+		{in: "/home/user/fyne/pkg/linux_amd64/fyne.io/fyne.a", es: "", ee: true},
+		{in: "v1.2.2", es: "", ee: true},
+		{in: "/home/user/go/pkg/mod/github.com/peterbourgon/diskv@v2.0.1+incompatible/pkg/linux_amd64/github.com/peterbourgon/diskv.a", es: "v2.0.1+incompatible", ee: false},
+		{in: "/home/ser/go/pkg/mod/github.com/peterbourgon/diskv/v3@v3.0.0/pkg/linux_amd64/github.com/peterbourgon/diskv/v3.a", es: "v3.0.0", ee: false},
+	}
+
+	for _, tc := range ts {
+		gs, ge := parsePkgString(tc.in)
+		assert.Equal(t, tc.es, gs)
+		if tc.ee {
+			assert.Error(t, ge)
+		}
+	}
+}


### PR DESCRIPTION
### Description:
Adds a `lib-version` command to print out the version of fyne that would be used to compile the project.

Fixes #656 

### Checklist:

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style. **N/A**
- [ ] Any breaking changes have a deprecation path or have been discussed. **N/A**
