### PR TITLE
Refactor/entry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -453,9 +453,9 @@ func (e *Entry) Tapped(ev *fyne.PointEvent) {
 }
 
 // copyToClipboard copies the current selection to a given clipboard and then removes the selected text.
-// This does nothing if it is a password entry.
+// This does nothing if it is a concealed entry.
 func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
-	if !e.selecting || e.password() {
+	if !e.selecting || e.concealed() {
 		return
 	}
 
@@ -464,9 +464,9 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 }
 
 // copyToClipboard copies the current selection to a given clipboard.
-// This does nothing if it is a password entry.
+// This does nothing if it is a concealed entry.
 func (e *Entry) copyToClipboard(clipboard fyne.Clipboard) {
-	if !e.selecting || e.password() {
+	if !e.selecting || e.concealed() {
 		return
 	}
 
@@ -543,13 +543,13 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	popUpPos := entryPos.Add(fyne.NewPos(pe.Position.X, pe.Position.Y))
 	c := fyne.CurrentApp().Driver().CanvasForObject(super)
 
-	if e.Disabled() && e.password() {
-		return // no popup options for a disabled password field
+	if e.Disabled() && e.concealed() {
+		return // no popup options for a disabled concealed field
 	}
 
 	if e.Disabled() {
 		e.popUp = NewPopUpMenuAtPosition(fyne.NewMenu("", copyItem, selectAllItem), c, popUpPos)
-	} else if e.password() {
+	} else if e.concealed() {
 		e.popUp = NewPopUpMenuAtPosition(fyne.NewMenu("", pasteItem, selectAllItem), c, popUpPos)
 	} else {
 		e.popUp = NewPopUpMenuAtPosition(fyne.NewMenu("", cutItem, copyItem, pasteItem, selectAllItem), c, popUpPos)
@@ -1006,8 +1006,8 @@ func (e *Entry) textColor() color.Color {
 	return theme.TextColor()
 }
 
-// password tells the rendering textProvider if we are a password field
-func (e *Entry) password() bool {
+// concealed tells the rendering textProvider if we are a concealed field
+func (e *Entry) concealed() bool {
 	return e.Password
 }
 
@@ -1035,9 +1035,9 @@ func (p *placeholderPresenter) textColor() color.Color {
 	return theme.PlaceHolderColor()
 }
 
-// password tells the rendering textProvider if we are a password field
+// concealed tells the rendering textProvider if we are a concealed field
 // placeholder text is not obfuscated, returning false
-func (p *placeholderPresenter) password() bool {
+func (p *placeholderPresenter) concealed() bool {
 	return false
 }
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -153,10 +153,10 @@ func (e *entryRenderer) Layout(size fyne.Size) {
 	e.line.Move(fyne.NewPos(0, size.Height-theme.Padding()))
 
 	actionIconSize := fyne.NewSize(0, 0)
-	if e.entry.actionItem != nil {
+	if e.entry.ActionItem != nil {
 		actionIconSize = fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
-		e.entry.actionItem.Resize(actionIconSize)
-		e.entry.actionItem.Move(fyne.NewPos(size.Width-actionIconSize.Width-theme.Padding(), theme.Padding()*2))
+		e.entry.ActionItem.Resize(actionIconSize)
+		e.entry.ActionItem.Move(fyne.NewPos(size.Width-actionIconSize.Width-theme.Padding(), theme.Padding()*2))
 	}
 
 	entrySize := size.Subtract(fyne.NewSize(theme.Padding()*2-actionIconSize.Width, theme.Padding()*2))
@@ -201,8 +201,8 @@ func (e *entryRenderer) Refresh() {
 	}
 
 	e.entry.text.Refresh()
-	if e.entry.actionItem != nil {
-		e.entry.actionItem.Refresh()
+	if e.entry.ActionItem != nil {
+		e.entry.ActionItem.Refresh()
 	}
 	canvas.Refresh(e.entry.super())
 }
@@ -262,8 +262,8 @@ type Entry struct {
 	popUp     *PopUp
 	// TODO: Add OnSelectChanged
 
-	// actionItem is a small item which is displayed at the outer right of the entry (like a password revealer)
-	actionItem fyne.CanvasObject
+	// ActionItem is a small item which is displayed at the outer right of the entry (like a password revealer)
+	ActionItem fyne.CanvasObject
 }
 
 // SetText manually sets the text of the Entry to the given text value.
@@ -1051,7 +1051,7 @@ func (e *Entry) MinSize() fyne.Size {
 	e.ExtendBaseWidget(e)
 
 	min := e.BaseWidget.MinSize()
-	if e.actionItem != nil {
+	if e.ActionItem != nil {
 		min = min.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0))
 	}
 
@@ -1068,14 +1068,14 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 
 	objects := []fyne.CanvasObject{line, e.placeholderProvider(), e.textProvider(), cursor}
 
-	if e.Password && e.actionItem == nil {
+	if e.Password && e.ActionItem == nil {
 		// An entry widget has been created via struct setting manually
 		// the Password field to true. Going to enable the password revealer.
-		e.actionItem = newPasswordRevealer(e)
+		e.ActionItem = newPasswordRevealer(e)
 	}
 
-	if e.actionItem != nil {
-		objects = append(objects, e.actionItem)
+	if e.ActionItem != nil {
+		objects = append(objects, e.ActionItem)
 	}
 	return &entryRenderer{line, cursor, []fyne.CanvasObject{}, objects, e}
 }
@@ -1126,7 +1126,7 @@ func NewMultiLineEntry() *Entry {
 func NewPasswordEntry() *Entry {
 	e := &Entry{Password: true}
 	e.ExtendBaseWidget(e)
-	e.actionItem = newPasswordRevealer(e)
+	e.ActionItem = newPasswordRevealer(e)
 	return e
 }
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -263,7 +263,7 @@ type Entry struct {
 	// TODO: Add OnSelectChanged
 
 	// passwordRevealer represents the passwordRevealer widget
-	passwordRevealer *passwordRevealer
+	passwordRevealer fyne.CanvasObject
 }
 
 // SetText manually sets the text of the Entry to the given text value.

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1071,13 +1071,7 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 	if e.Password && e.actionItem == nil {
 		// An entry widget has been created via struct setting manually
 		// the Password field to true. Going to enable the password revealer.
-		pr := &passwordRevealer{
-			icon:  canvas.NewImageFromResource(theme.VisibilityOffIcon()),
-			entry: e,
-		}
-		pr.ExtendBaseWidget(pr)
-
-		e.actionItem = pr
+		e.actionItem = newPasswordRevealer(e)
 	}
 
 	if e.actionItem != nil {
@@ -1132,14 +1126,7 @@ func NewMultiLineEntry() *Entry {
 func NewPasswordEntry() *Entry {
 	e := &Entry{Password: true}
 	e.ExtendBaseWidget(e)
-
-	pr := &passwordRevealer{
-		icon:  canvas.NewImageFromResource(theme.VisibilityOffIcon()),
-		entry: e,
-	}
-	pr.ExtendBaseWidget(pr)
-
-	e.actionItem = pr
+	e.actionItem = newPasswordRevealer(e)
 	return e
 }
 
@@ -1200,4 +1187,13 @@ func (pr *passwordRevealer) Tapped(*fyne.PointEvent) {
 }
 
 func (pr *passwordRevealer) TappedSecondary(*fyne.PointEvent) {
+}
+
+func newPasswordRevealer(e *Entry) *passwordRevealer {
+	pr := &passwordRevealer{
+		icon:  canvas.NewImageFromResource(theme.VisibilityOffIcon()),
+		entry: e,
+	}
+	pr.ExtendBaseWidget(pr)
+	return pr
 }

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -152,14 +152,14 @@ func (e *entryRenderer) Layout(size fyne.Size) {
 	e.line.Resize(fyne.NewSize(size.Width, theme.Padding()))
 	e.line.Move(fyne.NewPos(0, size.Height-theme.Padding()))
 
-	revealIconSize := fyne.NewSize(0, 0)
-	if e.entry.passwordRevealer != nil {
-		revealIconSize = fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
-		e.entry.passwordRevealer.Resize(revealIconSize)
-		e.entry.passwordRevealer.Move(fyne.NewPos(size.Width-revealIconSize.Width-theme.Padding(), theme.Padding()*2))
+	actionIconSize := fyne.NewSize(0, 0)
+	if e.entry.actionItem != nil {
+		actionIconSize = fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
+		e.entry.actionItem.Resize(actionIconSize)
+		e.entry.actionItem.Move(fyne.NewPos(size.Width-actionIconSize.Width-theme.Padding(), theme.Padding()*2))
 	}
 
-	entrySize := size.Subtract(fyne.NewSize(theme.Padding()*2-revealIconSize.Width, theme.Padding()*2))
+	entrySize := size.Subtract(fyne.NewSize(theme.Padding()*2-actionIconSize.Width, theme.Padding()*2))
 	e.entry.text.Resize(entrySize)
 	e.entry.text.Move(fyne.NewPos(theme.Padding(), theme.Padding()))
 
@@ -201,8 +201,8 @@ func (e *entryRenderer) Refresh() {
 	}
 
 	e.entry.text.Refresh()
-	if e.entry.passwordRevealer != nil {
-		e.entry.passwordRevealer.Refresh()
+	if e.entry.actionItem != nil {
+		e.entry.actionItem.Refresh()
 	}
 	canvas.Refresh(e.entry.super())
 }
@@ -262,8 +262,8 @@ type Entry struct {
 	popUp     *PopUp
 	// TODO: Add OnSelectChanged
 
-	// passwordRevealer represents the passwordRevealer widget
-	passwordRevealer fyne.CanvasObject
+	// actionItem is a small item which is displayed at the outer right of the entry (like a password revealer)
+	actionItem fyne.CanvasObject
 }
 
 // SetText manually sets the text of the Entry to the given text value.
@@ -1051,7 +1051,7 @@ func (e *Entry) MinSize() fyne.Size {
 	e.ExtendBaseWidget(e)
 
 	min := e.BaseWidget.MinSize()
-	if e.passwordRevealer != nil {
+	if e.actionItem != nil {
 		min = min.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0))
 	}
 
@@ -1068,7 +1068,7 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 
 	objects := []fyne.CanvasObject{line, e.placeholderProvider(), e.textProvider(), cursor}
 
-	if e.Password && e.passwordRevealer == nil {
+	if e.Password && e.actionItem == nil {
 		// An entry widget has been created via struct setting manually
 		// the Password field to true. Going to enable the password revealer.
 		pr := &passwordRevealer{
@@ -1077,11 +1077,11 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 		}
 		pr.ExtendBaseWidget(pr)
 
-		e.passwordRevealer = pr
+		e.actionItem = pr
 	}
 
-	if e.passwordRevealer != nil {
-		objects = append(objects, e.passwordRevealer)
+	if e.actionItem != nil {
+		objects = append(objects, e.actionItem)
 	}
 	return &entryRenderer{line, cursor, []fyne.CanvasObject{}, objects, e}
 }
@@ -1139,7 +1139,7 @@ func NewPasswordEntry() *Entry {
 	}
 	pr.ExtendBaseWidget(pr)
 
-	e.passwordRevealer = pr
+	e.actionItem = pr
 	return e
 }
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -455,7 +455,7 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	entry.Password = true
 	test.TapSecondaryAt(entry, tapPos)
 	over = fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
-	assert.Nil(t, over) // No popup for disabled concealed
+	assert.Nil(t, over) // No popup for disabled password
 
 	entry.Enable()
 	test.TapSecondaryAt(entry, tapPos)

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -455,7 +455,7 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	entry.Password = true
 	test.TapSecondaryAt(entry, tapPos)
 	over = fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
-	assert.Nil(t, over) // No popup for disabled password
+	assert.Nil(t, over) // No popup for disabled concealed
 
 	entry.Enable()
 	test.TapSecondaryAt(entry, tapPos)
@@ -946,7 +946,7 @@ func TestPasswordEntry_Placeholder(t *testing.T) {
 	entry.SetPlaceHolder("Password")
 
 	assert.Equal(t, "Password", entryRenderPlaceholderTexts(entry)[0].Text)
-	assert.False(t, entry.placeholderProvider().presenter.password())
+	assert.False(t, entry.placeholderProvider().presenter.concealed())
 }
 
 const (

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1338,7 +1338,7 @@ func TestEntry_EraseEmptySelection(t *testing.T) {
 func TestPasswordEntry_Reveal(t *testing.T) {
 	t.Run("NewPasswordEntry constructor", func(t *testing.T) {
 		entry := NewPasswordEntry()
-		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.passwordRevealer.(*passwordRevealer)
+		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.actionItem.(*passwordRevealer)
 
 		test.Type(entry, "Hié™שרה")
 		assert.Equal(t, "Hié™שרה", entry.Text)
@@ -1372,7 +1372,7 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 		entry.Refresh()
 
 		// action icon is not displayed
-		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.passwordRevealer
+		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.actionItem
 		assert.NotNil(t, actionIcon)
 
 		test.Type(entry, "Hié™שרה")

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1338,7 +1338,7 @@ func TestEntry_EraseEmptySelection(t *testing.T) {
 func TestPasswordEntry_Reveal(t *testing.T) {
 	t.Run("NewPasswordEntry constructor", func(t *testing.T) {
 		entry := NewPasswordEntry()
-		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.actionItem.(*passwordRevealer)
+		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.ActionItem.(*passwordRevealer)
 
 		test.Type(entry, "Hié™שרה")
 		assert.Equal(t, "Hié™שרה", entry.Text)
@@ -1372,7 +1372,7 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 		entry.Refresh()
 
 		// action icon is not displayed
-		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.actionItem
+		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.ActionItem
 		assert.NotNil(t, actionIcon)
 
 		test.Type(entry, "Hié™שרה")

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1338,7 +1338,7 @@ func TestEntry_EraseEmptySelection(t *testing.T) {
 func TestPasswordEntry_Reveal(t *testing.T) {
 	t.Run("NewPasswordEntry constructor", func(t *testing.T) {
 		entry := NewPasswordEntry()
-		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.passwordRevealer
+		actionIcon := test.WidgetRenderer(entry).(*entryRenderer).entry.passwordRevealer.(*passwordRevealer)
 
 		test.Type(entry, "Hié™שרה")
 		assert.Equal(t, "Hié™שרה", entry.Text)

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -71,8 +71,8 @@ func (hl *Hyperlink) textColor() color.Color {
 	return theme.HyperlinkColor()
 }
 
-// password tells the rendering textProvider if we are a password field
-func (hl *Hyperlink) password() bool {
+// concealed tells the rendering textProvider if we are a concealed field
+func (hl *Hyperlink) concealed() bool {
 	return false
 }
 

--- a/widget/label.go
+++ b/widget/label.go
@@ -52,8 +52,8 @@ func (l *Label) textColor() color.Color {
 	return theme.TextColor()
 }
 
-// password tells the rendering textProvider if we are a password field
-func (l *Label) password() bool {
+// concealed tells the rendering textProvider if we are a concealed field
+func (l *Label) concealed() bool {
 	return false
 }
 

--- a/widget/text.go
+++ b/widget/text.go
@@ -19,7 +19,7 @@ type textPresenter interface {
 	textStyle() fyne.TextStyle
 	textColor() color.Color
 
-	password() bool
+	concealed() bool
 
 	object() fyne.Widget
 }
@@ -180,7 +180,7 @@ func (t *textProvider) rowLength(row int) int {
 // CharMinSize returns the average char size to use for internal computation
 func (t *textProvider) charMinSize() fyne.Size {
 	defaultChar := "M"
-	if t.presenter.password() {
+	if t.presenter.concealed() {
 		defaultChar = passwordChar
 	}
 	return textMinSize(defaultChar, theme.TextSize(), t.presenter.textStyle())
@@ -198,7 +198,7 @@ func (t *textProvider) lineSizeToColumn(col, row int) (size fyne.Size) {
 	}
 
 	measureText := string(line[0:col])
-	if t.presenter.password() {
+	if t.presenter.concealed() {
 		measureText = strings.Repeat(passwordChar, col)
 	}
 
@@ -266,7 +266,7 @@ func (r *textRenderer) Refresh() {
 	for ; index < r.provider.rows(); index++ {
 		var line string
 		row := r.provider.row(index)
-		if r.provider.presenter.password() {
+		if r.provider.presenter.concealed() {
 			line = strings.Repeat(passwordChar, len(row))
 		} else {
 			line = string(row)

--- a/widget/text_test.go
+++ b/widget/text_test.go
@@ -33,7 +33,7 @@ func (t *testTextParent) textColor() color.Color {
 	return t.fg
 }
 
-func (t *testTextParent) password() bool {
+func (t *testTextParent) concealed() bool {
 	return false
 }
 


### PR DESCRIPTION
### Description:

Refactor `Entry` to know less about passwords.
The generalization of `Entry.passwordRevealer` to `Entry.ActionItem` allows Fyne users to add different action icons (like a drop-down).

### Checklist:

- ~~[ ] Tests included.~~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
