### PR TITLE
fix select popup size adjustment

### DIFF
--- a/widget/select.go
+++ b/widget/select.go
@@ -114,7 +114,7 @@ func (s *Select) Resize(size fyne.Size) {
 	s.BaseWidget.Resize(size)
 
 	if s.popUp != nil {
-		s.popUp.Content.Resize(fyne.NewSize(size.Width, s.popUp.MinSize().Height))
+		s.popUp.Content.Resize(fyne.NewSize(size.Width-theme.Padding()*2, s.popUp.Content.MinSize().Height))
 	}
 }
 


### PR DESCRIPTION
### Description:
I expected that `s.popUp.Resize` would work but it doesn't.
The content is smaller than the popup that's why the size adjustment has
to handle this.

### Checklist:

- ~~[ ] Tests included.~~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
