### PR TITLE
provide default window title

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -31,6 +31,7 @@ const (
 var (
 	defaultCursor, entryCursor, hyperlinkCursor *glfw.Cursor
 	initOnce                                    = &sync.Once{}
+	defaultTitle                                = "Fyne Application"
 )
 
 func initCursors() {
@@ -1031,6 +1032,9 @@ func (d *gLDriver) CreateWindow(title string) fyne.Window {
 
 func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 	var ret *window
+	if title == "" {
+		title = defaultTitle
+	}
 	runOnMain(func() {
 		initOnce.Do(d.initGLFW)
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -39,7 +39,9 @@ func TestMain(m *testing.M) {
 
 func TestGLDriver_CreateWindow(t *testing.T) {
 	w := NewGLDriver().CreateWindow("Test").(*window)
+	wt := NewGLDriver().CreateWindow("").(*window)
 
+	assert.Equal(t, wt.Title(), "Fyne Application")
 	assert.Equal(t, 1, w.viewport.GetAttrib(glfw.Decorated))
 	assert.True(t, w.Padded())
 	assert.False(t, w.centered)

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -39,12 +39,15 @@ func TestMain(m *testing.M) {
 
 func TestGLDriver_CreateWindow(t *testing.T) {
 	w := NewGLDriver().CreateWindow("Test").(*window)
-	wt := NewGLDriver().CreateWindow("").(*window)
 
-	assert.Equal(t, wt.Title(), "Fyne Application")
 	assert.Equal(t, 1, w.viewport.GetAttrib(glfw.Decorated))
 	assert.True(t, w.Padded())
 	assert.False(t, w.centered)
+}
+
+func TestGLDriver_CreateWindow_EmptyTitle(t *testing.T) {
+	w := NewGLDriver().CreateWindow("").(*window)
+	assert.Equal(t, w.Title(), "Fyne Application")
 }
 
 func TestGLDriver_CreateSplashWindow(t *testing.T) {


### PR DESCRIPTION
### Description:
Provide default window title. This replaces the default title GLFW-Application from glfw driver.

Fixes #(issue)

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
