### PR TITLE
Use auto-detected scaling on Windows

### DIFF
--- a/internal/driver/glfw/device.go
+++ b/internal/driver/glfw/device.go
@@ -25,7 +25,7 @@ func (*glDevice) HasKeyboard() bool {
 }
 
 func (*glDevice) SystemScale() float32 {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+	if  runtime.GOOS == "darwin" {
 		return 1.0
 	}
 


### PR DESCRIPTION


### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Use auto-detected scaling on Windows.
There are two possible situation with incorrect scaling according to Windows display settings:
1. Everything displayed very small with original scaling.
2. Windows force scale it that display in correct size but blurry.

The detectScale() method detected correct scaling so use it when user do not explicitly specify the scaling.
Tested ok on my Windows10, 3840x2160  200% scaling display.
Fixes #(issue)
#520 
### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
