### PR TITLE
Only trigger DoubleTapped if the tap before occured on the same canvas object

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -67,6 +67,7 @@ type window struct {
 	mouseButton        desktop.MouseButton
 	mouseOver          desktop.Hoverable
 	mouseClickTime     time.Time
+	mouseLastClick     fyne.CanvasObject
 	mousePressed       fyne.Tappable
 	onClosed           func()
 
@@ -636,13 +637,14 @@ func (w *window) mouseClicked(viewport *glfw.Window, btn glfw.MouseButton, actio
 	if action == glfw.Release && button == desktop.LeftMouseButton {
 		now := time.Now()
 		// we can safely subtract the first "zero" time as it'll be much larger than doubleClickDelay
-		if now.Sub(w.mouseClickTime).Nanoseconds()/1e6 <= doubleClickDelay {
+		if now.Sub(w.mouseClickTime).Nanoseconds()/1e6 <= doubleClickDelay && w.mouseLastClick == co {
 			if wid, ok := co.(fyne.DoubleTappable); ok {
 				doubleTapped = true
 				w.queueEvent(func() { wid.DoubleTapped(ev) })
 			}
 		}
 		w.mouseClickTime = now
+		w.mouseLastClick = co
 	}
 
 	// Prevent Tapped from triggering if DoubleTapped has been sent


### PR DESCRIPTION
### Description:
Only trigger the DoubleTapped event if the double click happens on the same object. 

Currently, click anywhere on the window, then click on an object and it will trigger DoubleTapped on that object, while the object wasn't technically double tapped.

### Checklist:

- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.


