### PR TITLE
fix #706: don't try to adjust insufficient size if it's already at max

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -270,7 +270,7 @@ func (c *glCanvas) ensureMinSize() bool {
 				windowNeedsMinSizeUpdate = true
 				size := obj.Size()
 				expectedSize := minSize.Union(size)
-				if expectedSize != size {
+				if expectedSize != size && size != c.size {
 					objToLayout = nil
 					obj.Resize(expectedSize)
 				}

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -297,6 +297,29 @@ func Test_glCanvas_ContentChangeWithoutMinSizeChangeDoesNotLayout(t *testing.T) 
 	w.ignoreResize = false
 }
 
+func Test_glCanvas_InsufficientSizeDoesntTriggerResizeIfSizeIsAlreadyMaxedOut(t *testing.T) {
+	w := d.CreateWindow("Test").(*window)
+	w.ignoreResize = true
+	c := w.Canvas().(*glCanvas)
+	c.Resize(fyne.NewSize(100, 100))
+	popUpContent := canvas.NewRectangle(color.Black)
+	popUpContent.SetMinSize(fyne.NewSize(1000, 10))
+	popUp := widget.NewPopUp(popUpContent, c)
+
+	// This is because of a bug in PopUp size handling that will be fixed later.
+	// This line will vanish then.
+	popUp.Resize(popUpContent.MinSize().Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
+
+	assert.Equal(t, fyne.NewSize(1000, 10), popUpContent.Size())
+	assert.Equal(t, fyne.NewSize(1000, 10).Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)), popUp.MinSize())
+	assert.Equal(t, fyne.NewSize(100, 100), popUp.Size())
+
+	repaintWindow(w)
+
+	assert.Equal(t, fyne.NewSize(1000, 10), popUpContent.Size())
+	assert.Equal(t, fyne.NewSize(100, 100), popUp.Size())
+}
+
 func Test_glCanvas_walkTree(t *testing.T) {
 	leftObj1 := canvas.NewRectangle(color.Gray16{Y: 1})
 	leftObj2 := canvas.NewRectangle(color.Gray16{Y: 2})


### PR DESCRIPTION
### Description:

This patch is for a very specific case. When an object's size is smaller than its minSize the minSize correction should not resize if the object is already at the maximum (canvas') size.
This case appears with `PopUp` where the content is larger than the canvas. It would be hidden by making the `PopUp` content scrollable (fixing #675) and would be avoided by addressing #707.

Fixes #706 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.