### PR TITLE
fix a bug in overlay size handling by canvas

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -152,9 +152,13 @@ func (c *glCanvas) Resize(size fyne.Size) {
 	c.size = size
 
 	if c.overlay != nil {
-		// “Notifies” the overlay of the canvas size change.
-		// Overlays which take the whole canvas size (like widget.PopUp) will adjust their size.
-		c.overlay.Resize(c.overlay.Size())
+		if p, ok := c.overlay.(*widget.PopUp); ok {
+			// TODO: remove this when #707 is being addressed.
+			// “Notifies” the PopUp of the canvas size change.
+			c.overlay.Resize(p.Content.Size().Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
+		} else {
+			c.overlay.Resize(size)
+		}
 	}
 
 	c.content.Resize(c.contentSize(size))

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,14 +33,54 @@ func TestGlCanvas_Resize(t *testing.T) {
 	w.SetPadded(false)
 
 	content := widget.NewLabel("Content")
+	w.SetContent(content)
+
+	size := fyne.NewSize(100, 100)
+	assert.NotEqual(t, size, content.Size())
+
+	w.Resize(size)
+	assert.Equal(t, size, content.Size())
+}
+
+func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
+	w := d.CreateWindow("Test")
+	w.SetPadded(false)
+
+	content := widget.NewLabel("Content")
 	over := widget.NewPopUp(widget.NewLabel("Over"), w.Canvas())
 	w.SetContent(content)
 	w.Canvas().SetOverlay(over)
 
 	size := fyne.NewSize(100, 100)
+	overContentSize := over.Content.Size()
+	assert.NotEqual(t, size, content.Size())
+	assert.NotEqual(t, size, over.Size())
+	assert.NotEqual(t, size, overContentSize)
+
 	w.Resize(size)
-	assert.Equal(t, size, content.Size())
-	assert.Equal(t, size, over.Size())
+	assert.Equal(t, size, content.Size(), "canvas content is resized")
+	assert.Equal(t, size, over.Size(), "canvas overlay is resized")
+	assert.Equal(t, overContentSize, over.Content.Size(), "canvas overlay content is _not_ resized")
+}
+
+func TestGlCanvas_ResizeWithOtherOverlay(t *testing.T) {
+	w := d.CreateWindow("Test")
+	w.SetPadded(false)
+
+	content := widget.NewLabel("Content")
+	over := widget.NewLabel("Over")
+	w.SetContent(content)
+	w.Canvas().SetOverlay(over)
+	// TODO: address #707; overlays should always be canvas size
+	over.Resize(w.Canvas().Size())
+
+	size := fyne.NewSize(100, 100)
+	assert.NotEqual(t, size, content.Size())
+	assert.NotEqual(t, size, over.Size())
+
+	w.Resize(size)
+	assert.Equal(t, size, content.Size(), "canvas content is resized")
+	assert.Equal(t, size, over.Size(), "canvas overlay is resized")
 }
 
 func TestGlCanvas_Scale(t *testing.T) {


### PR DESCRIPTION
### Description:

With the refactoring of the `PopUp` size and position handling a bug was introduced regarding overlay size handling on canvas resize. The fix brings back the dependency from the canvas to `widget` but this will vanish as soon as #707 is addressed.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
