### PR TITLE
Refactoring: reduce widget dependencies to internal/cache

### DIFF
--- a/canvasobject.go
+++ b/canvasobject.go
@@ -17,7 +17,9 @@ type CanvasObject interface {
 
 	// visibility
 	Visible() bool
+	// Show shows this object.
 	Show()
+	// Hide hides this object.
 	Hide()
 
 	Refresh()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -10,7 +10,6 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
-	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/theme"
 )
 
@@ -216,17 +215,12 @@ func (e *entryRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (e *entryRenderer) Destroy() {
-	if e.entry.popUp != nil {
-		c := fyne.CurrentApp().Driver().CanvasForObject(e.entry.super())
-		c.SetOverlay(nil)
-		cache.Renderer(e.entry.popUp).Destroy()
-		e.entry.popUp = nil
-	}
 }
 
 // Declare conformity with interfaces
 var _ fyne.Draggable = (*Entry)(nil)
 var _ fyne.Tappable = (*Entry)(nil)
+var _ fyne.Widget = (*Entry)(nil)
 var _ desktop.Mouseable = (*Entry)(nil)
 var _ desktop.Keyable = (*Entry)(nil)
 
@@ -317,6 +311,22 @@ func (e *Entry) Disable() { // TODO remove this override after ReadOnly is remov
 	e.ReadOnly = true
 
 	e.DisableableWidget.Disable()
+}
+
+// Hide satisfies the fyne.CanvasObject interface.
+func (e *Entry) Hide() {
+	if e.popUp != nil {
+		e.popUp.Hide()
+	}
+	e.DisableableWidget.Hide()
+}
+
+// Show satisfies the fyne.CanvasObject interface.
+func (e *Entry) Show() {
+	if e.popUp != nil {
+		e.popUp.Show()
+	}
+	e.DisableableWidget.Show()
 }
 
 // updateText updates the internal text to the given value

--- a/widget/select.go
+++ b/widget/select.go
@@ -6,7 +6,6 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
-	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/theme"
 )
 
@@ -87,12 +86,6 @@ func (s *selectRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (s *selectRenderer) Destroy() {
-	if s.combo.popUp != nil {
-		c := fyne.CurrentApp().Driver().CanvasForObject(s.combo)
-		c.SetOverlay(nil)
-		cache.Renderer(s.combo.popUp).Destroy()
-		s.combo.popUp = nil
-	}
 }
 
 // Select widget has a list of options, with the current one shown, and triggers an event func when clicked
@@ -106,6 +99,24 @@ type Select struct {
 
 	hovered bool
 	popUp   *PopUp
+}
+
+var _ fyne.Widget = (*Select)(nil)
+
+// Hide satisfies the fyne.CanvasObject interface.
+func (s *Select) Hide() {
+	if s.popUp != nil {
+		s.popUp.Hide()
+	}
+	s.BaseWidget.Hide()
+}
+
+// Show satisfies the fyne.CanvasObject interface.
+func (s *Select) Show() {
+	if s.popUp != nil {
+		s.popUp.Show()
+	}
+	s.BaseWidget.Show()
 }
 
 // Resize sets a new size for a widget.


### PR DESCRIPTION
### Description:

Some widget renderers implemented `Destroy` and used the internal cache in there.
These implementations were replaced by a proper implementation of `Show` and `Hide`.

### Checklist:

- ~~[ ] Tests included.~~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
