### PR TITLE
Bugfix/469 overlay stack interface

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -22,8 +22,28 @@ type Canvas interface {
 	// Deprecated: Settings are now calculated solely on the user configuration and system setup.
 	SetScale(float32)
 
+	// Overlay returns the current overlay.
+	//
+	// Deprecated: Overlays are stacked now.
+	// This method returns the top of the overlay stack.
+	// Use Overlays() instead.
 	Overlay() CanvasObject
+	// Overlays returns the overlays currently on the overlay stack.
+	Overlays() []CanvasObject
+	// PopOverlay removes the top-most object of the overlay stack and returns it.
+	PopOverlay() CanvasObject
+	// PushOverlay pushes an overlay on the top of the overlay stack.
+	PushOverlay(CanvasObject)
+	// RemoveOverlay removes the given object and all objects above it from the overlay stack.
+	RemoveOverlay(CanvasObject)
+	// SetOverlay sets the overlay for the canvas.
+	//
+	// Deprecated: Overlays are stacked now.
+	// This method replaces the whole stack by the given overlay.
+	// Use PushOverlay() instead.
 	SetOverlay(CanvasObject)
+	// TopOverlay returns the top-most object of the overlay stack.
+	TopOverlay() CanvasObject
 
 	OnTypedRune() func(rune)
 	SetOnTypedRune(func(rune))

--- a/canvas.go
+++ b/canvas.go
@@ -28,22 +28,14 @@ type Canvas interface {
 	// This method returns the top of the overlay stack.
 	// Use Overlays() instead.
 	Overlay() CanvasObject
-	// Overlays returns the overlays currently on the overlay stack.
-	Overlays() []CanvasObject
-	// PopOverlay removes the top-most object of the overlay stack and returns it.
-	PopOverlay() CanvasObject
-	// PushOverlay pushes an overlay on the top of the overlay stack.
-	PushOverlay(CanvasObject)
-	// RemoveOverlay removes the given object and all objects above it from the overlay stack.
-	RemoveOverlay(CanvasObject)
+	// Overlays returns the overlay stack.
+	Overlays() OverlayStack
 	// SetOverlay sets the overlay for the canvas.
 	//
 	// Deprecated: Overlays are stacked now.
 	// This method replaces the whole stack by the given overlay.
-	// Use PushOverlay() instead.
+	// Use Overlays() instead.
 	SetOverlay(CanvasObject)
-	// TopOverlay returns the top-most object of the overlay stack.
-	TopOverlay() CanvasObject
 
 	OnTypedRune() func(rune)
 	SetOnTypedRune(func(rune))

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -33,7 +33,7 @@ func ApplySettings(set fyne.Settings, app fyne.App) {
 		ApplyThemeTo(window.Content(), window.Canvas())
 		window.Canvas().SetScale(set.Scale())
 
-		for _, overlay := range window.Canvas().Overlays().All() {
+		for _, overlay := range window.Canvas().Overlays().List() {
 			ApplyThemeTo(overlay, window.Canvas())
 		}
 	}

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -33,7 +33,7 @@ func ApplySettings(set fyne.Settings, app fyne.App) {
 		ApplyThemeTo(window.Content(), window.Canvas())
 		window.Canvas().SetScale(set.Scale())
 
-		for _, overlay := range window.Canvas().Overlays().Overlays() {
+		for _, overlay := range window.Canvas().Overlays().All() {
 			ApplyThemeTo(overlay, window.Canvas())
 		}
 	}

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -33,7 +33,7 @@ func ApplySettings(set fyne.Settings, app fyne.App) {
 		ApplyThemeTo(window.Content(), window.Canvas())
 		window.Canvas().SetScale(set.Scale())
 
-		for _, overlay := range window.Canvas().Overlays() {
+		for _, overlay := range window.Canvas().Overlays().Overlays() {
 			ApplyThemeTo(overlay, window.Canvas())
 		}
 	}

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -33,8 +33,8 @@ func ApplySettings(set fyne.Settings, app fyne.App) {
 		ApplyThemeTo(window.Content(), window.Canvas())
 		window.Canvas().SetScale(set.Scale())
 
-		if window.Canvas().Overlay() != nil {
-			ApplyThemeTo(window.Canvas().Overlay(), window.Canvas())
+		for _, overlay := range window.Canvas().Overlays() {
+			ApplyThemeTo(overlay, window.Canvas())
 		}
 	}
 }

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -72,14 +72,14 @@ type overlayStack struct {
 	renderCache *renderCacheTree
 }
 
-func (o *overlayStack) AddOverlay(overlay fyne.CanvasObject) {
-	o.OverlayStack.AddOverlay(overlay)
+func (o *overlayStack) Add(overlay fyne.CanvasObject) {
+	o.OverlayStack.Add(overlay)
 	o.renderCache = &renderCacheTree{root: &renderCacheNode{obj: overlay}}
 }
 
-func (o *overlayStack) RemoveOverlay(overlay fyne.CanvasObject) {
-	o.OverlayStack.RemoveOverlay(overlay)
-	if o.TopOverlay() == nil {
+func (o *overlayStack) Remove(overlay fyne.CanvasObject) {
+	o.OverlayStack.Remove(overlay)
+	if o.Top() == nil {
 		o.renderCache = nil
 	}
 }
@@ -115,7 +115,7 @@ func (c *glCanvas) SetContent(content fyne.CanvasObject) {
 func (c *glCanvas) Overlay() fyne.CanvasObject {
 	c.RLock()
 	defer c.RUnlock()
-	return c.overlays.TopOverlay()
+	return c.overlays.Top()
 }
 
 func (c *glCanvas) Overlays() fyne.OverlayStack {
@@ -128,10 +128,10 @@ func (c *glCanvas) Overlays() fyne.OverlayStack {
 func (c *glCanvas) SetOverlay(overlay fyne.CanvasObject) {
 	c.Lock()
 	defer c.Unlock()
-	if len(c.overlays.Overlays()) > 0 {
-		c.overlays.RemoveOverlay(c.overlays.Overlays()[0])
+	if len(c.overlays.All()) > 0 {
+		c.overlays.Remove(c.overlays.All()[0])
 	}
-	c.overlays.AddOverlay(overlay)
+	c.overlays.Add(overlay)
 	c.setDirty(true)
 }
 
@@ -180,7 +180,7 @@ func (c *glCanvas) Focused() fyne.Focusable {
 func (c *glCanvas) Resize(size fyne.Size) {
 	c.size = size
 
-	for _, overlay := range c.overlays.Overlays() {
+	for _, overlay := range c.overlays.All() {
 		if p, ok := overlay.(*widget.PopUp); ok {
 			// TODO: remove this when #707 is being addressed.
 			// “Notifies” the PopUp of the canvas size change.
@@ -361,7 +361,7 @@ func (c *glCanvas) walkTrees(
 	if c.menu != nil {
 		c.walkTree(c.menuTree, beforeChildren, afterChildren)
 	}
-	for _, overlay := range c.overlays.Overlays() {
+	for _, overlay := range c.overlays.All() {
 		if overlay != nil {
 			c.walkTree(c.overlays.renderCache, beforeChildren, afterChildren)
 		}

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -72,13 +72,8 @@ type overlayStack struct {
 	renderCache *renderCacheTree
 }
 
-func (o *overlayStack) PopOverlay() fyne.CanvasObject {
-	o.renderCache = nil
-	return o.OverlayStack.PopOverlay()
-}
-
-func (o *overlayStack) PushOverlay(overlay fyne.CanvasObject) {
-	o.OverlayStack.PushOverlay(overlay)
+func (o *overlayStack) AddOverlay(overlay fyne.CanvasObject) {
+	o.OverlayStack.AddOverlay(overlay)
 	o.renderCache = &renderCacheTree{root: &renderCacheNode{obj: overlay}}
 }
 
@@ -136,7 +131,7 @@ func (c *glCanvas) SetOverlay(overlay fyne.CanvasObject) {
 	if len(c.overlays.Overlays()) > 0 {
 		c.overlays.RemoveOverlay(c.overlays.Overlays()[0])
 	}
-	c.overlays.PushOverlay(overlay)
+	c.overlays.AddOverlay(overlay)
 	c.setDirty(true)
 }
 

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -128,8 +128,8 @@ func (c *glCanvas) Overlays() fyne.OverlayStack {
 func (c *glCanvas) SetOverlay(overlay fyne.CanvasObject) {
 	c.Lock()
 	defer c.Unlock()
-	if len(c.overlays.All()) > 0 {
-		c.overlays.Remove(c.overlays.All()[0])
+	if len(c.overlays.List()) > 0 {
+		c.overlays.Remove(c.overlays.List()[0])
 	}
 	c.overlays.Add(overlay)
 	c.setDirty(true)
@@ -180,7 +180,7 @@ func (c *glCanvas) Focused() fyne.Focusable {
 func (c *glCanvas) Resize(size fyne.Size) {
 	c.size = size
 
-	for _, overlay := range c.overlays.All() {
+	for _, overlay := range c.overlays.List() {
 		if p, ok := overlay.(*widget.PopUp); ok {
 			// TODO: remove this when #707 is being addressed.
 			// “Notifies” the PopUp of the canvas size change.
@@ -361,7 +361,7 @@ func (c *glCanvas) walkTrees(
 	if c.menu != nil {
 		c.walkTree(c.menuTree, beforeChildren, afterChildren)
 	}
-	for _, overlay := range c.overlays.All() {
+	for _, overlay := range c.overlays.List() {
 		if overlay != nil {
 			c.walkTree(c.overlays.renderCache, beforeChildren, afterChildren)
 		}

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -49,7 +49,7 @@ func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
 	content := widget.NewLabel("Content")
 	over := widget.NewPopUp(widget.NewLabel("Over"), w.Canvas())
 	w.SetContent(content)
-	w.Canvas().SetOverlay(over)
+	w.Canvas().PushOverlay(over)
 
 	size := fyne.NewSize(100, 100)
 	overContentSize := over.Content.Size()

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -49,7 +49,7 @@ func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
 	content := widget.NewLabel("Content")
 	over := widget.NewPopUp(widget.NewLabel("Over"), w.Canvas())
 	w.SetContent(content)
-	w.Canvas().PushOverlay(over)
+	w.Canvas().Overlays().PushOverlay(over)
 
 	size := fyne.NewSize(100, 100)
 	overContentSize := over.Content.Size()

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -49,7 +49,7 @@ func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
 	content := widget.NewLabel("Content")
 	over := widget.NewPopUp(widget.NewLabel("Over"), w.Canvas())
 	w.SetContent(content)
-	w.Canvas().Overlays().PushOverlay(over)
+	w.Canvas().Overlays().AddOverlay(over)
 
 	size := fyne.NewSize(100, 100)
 	overContentSize := over.Content.Size()

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -49,7 +49,7 @@ func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
 	content := widget.NewLabel("Content")
 	over := widget.NewPopUp(widget.NewLabel("Over"), w.Canvas())
 	w.SetContent(content)
-	w.Canvas().Overlays().AddOverlay(over)
+	w.Canvas().Overlays().Add(over)
 
 	size := fyne.NewSize(100, 100)
 	overContentSize := over.Content.Size()

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -488,7 +488,7 @@ func (w *window) findObjectAtPositionMatching(canvas *glCanvas, mouse fyne.Posit
 		roots = []fyne.CanvasObject{canvas.menu, canvas.content}
 	}
 
-	return driver.FindObjectAtPositionMatching(mouse, matches, canvas.TopOverlay(), roots...)
+	return driver.FindObjectAtPositionMatching(mouse, matches, canvas.Overlays().TopOverlay(), roots...)
 }
 
 func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -488,7 +488,7 @@ func (w *window) findObjectAtPositionMatching(canvas *glCanvas, mouse fyne.Posit
 		roots = []fyne.CanvasObject{canvas.menu, canvas.content}
 	}
 
-	return driver.FindObjectAtPositionMatching(mouse, matches, canvas.Overlays().TopOverlay(), roots...)
+	return driver.FindObjectAtPositionMatching(mouse, matches, canvas.Overlays().Top(), roots...)
 }
 
 func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -488,7 +488,7 @@ func (w *window) findObjectAtPositionMatching(canvas *glCanvas, mouse fyne.Posit
 		roots = []fyne.CanvasObject{canvas.menu, canvas.content}
 	}
 
-	return driver.FindObjectAtPositionMatching(mouse, matches, canvas.overlay, roots...)
+	return driver.FindObjectAtPositionMatching(mouse, matches, canvas.TopOverlay(), roots...)
 }
 
 func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -59,8 +59,8 @@ func (c *mobileCanvas) Overlays() fyne.OverlayStack {
 
 // Deprecated: Use Overlays() instead.
 func (c *mobileCanvas) SetOverlay(overlay fyne.CanvasObject) {
-	if len(c.overlays.All()) > 0 {
-		c.overlays.Remove(c.overlays.All()[0])
+	if len(c.overlays.List()) > 0 {
+		c.overlays.Remove(c.overlays.List()[0])
 	}
 	c.overlays.Add(overlay)
 }
@@ -190,7 +190,7 @@ func (c *mobileCanvas) walkTree(
 	if c.menu != nil {
 		driver.WalkVisibleObjectTree(c.menu, beforeChildren, afterChildren)
 	}
-	for _, overlay := range c.overlays.All() {
+	for _, overlay := range c.overlays.List() {
 		if overlay != nil {
 			driver.WalkVisibleObjectTree(overlay, beforeChildren, afterChildren)
 		}

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -62,7 +62,7 @@ func (c *mobileCanvas) SetOverlay(overlay fyne.CanvasObject) {
 	if len(c.overlays.Overlays()) > 0 {
 		c.overlays.RemoveOverlay(c.overlays.Overlays()[0])
 	}
-	c.overlays.PushOverlay(overlay)
+	c.overlays.AddOverlay(overlay)
 }
 
 func (c *mobileCanvas) Refresh(obj fyne.CanvasObject) {

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -50,7 +50,7 @@ func (c *mobileCanvas) SetContent(content fyne.CanvasObject) {
 
 // Deprecated: Use Overlays() instead.
 func (c *mobileCanvas) Overlay() fyne.CanvasObject {
-	return c.overlays.TopOverlay()
+	return c.overlays.Top()
 }
 
 func (c *mobileCanvas) Overlays() fyne.OverlayStack {
@@ -59,10 +59,10 @@ func (c *mobileCanvas) Overlays() fyne.OverlayStack {
 
 // Deprecated: Use Overlays() instead.
 func (c *mobileCanvas) SetOverlay(overlay fyne.CanvasObject) {
-	if len(c.overlays.Overlays()) > 0 {
-		c.overlays.RemoveOverlay(c.overlays.Overlays()[0])
+	if len(c.overlays.All()) > 0 {
+		c.overlays.Remove(c.overlays.All()[0])
 	}
-	c.overlays.AddOverlay(overlay)
+	c.overlays.Add(overlay)
 }
 
 func (c *mobileCanvas) Refresh(obj fyne.CanvasObject) {
@@ -190,7 +190,7 @@ func (c *mobileCanvas) walkTree(
 	if c.menu != nil {
 		driver.WalkVisibleObjectTree(c.menu, beforeChildren, afterChildren)
 	}
-	for _, overlay := range c.overlays.Overlays() {
+	for _, overlay := range c.overlays.All() {
 		if overlay != nil {
 			driver.WalkVisibleObjectTree(overlay, beforeChildren, afterChildren)
 		}
@@ -198,11 +198,11 @@ func (c *mobileCanvas) walkTree(
 }
 
 func (c *mobileCanvas) findObjectAtPositionMatching(pos fyne.Position, test func(object fyne.CanvasObject) bool) (fyne.CanvasObject, fyne.Position) {
-	if c.menu != nil && c.overlays.TopOverlay() == nil {
+	if c.menu != nil && c.overlays.Top() == nil {
 		return driver.FindObjectAtPositionMatching(pos, test, c.menu)
 	}
 
-	return driver.FindObjectAtPositionMatching(pos, test, c.overlays.TopOverlay(), c.windowHead, c.content)
+	return driver.FindObjectAtPositionMatching(pos, test, c.overlays.Top(), c.windowHead, c.content)
 }
 
 func (c *mobileCanvas) tapDown(pos fyne.Position, tapID int) {
@@ -305,7 +305,7 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 
 	duration := time.Since(c.lastTapDown[tapID])
 
-	if c.menu != nil && c.overlays.TopOverlay() == nil && pos.X > c.menu.Size().Width {
+	if c.menu != nil && c.overlays.Top() == nil && pos.X > c.menu.Size().Width {
 		c.menu.Hide()
 		c.menu = nil
 		return

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -136,12 +136,45 @@ func (c *mobileCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) 
 	return int(float32(pos.X) * c.scale), int(float32(pos.Y) * c.scale)
 }
 
+// Deprecated: Use Overlays() instead.
 func (c *mobileCanvas) Overlay() fyne.CanvasObject {
 	return c.overlay
 }
 
+func (c *mobileCanvas) Overlays() []fyne.CanvasObject {
+	if c.overlay == nil {
+		return nil
+	}
+	return []fyne.CanvasObject{c.overlay}
+}
+
+func (c *mobileCanvas) PopOverlay() fyne.CanvasObject {
+	overlay := c.overlay
+	c.overlay = nil
+	return overlay
+}
+
+func (c *mobileCanvas) PushOverlay(overlay fyne.CanvasObject) {
+	if overlay == nil {
+		return
+	}
+	c.overlay = overlay
+}
+
+func (c *mobileCanvas) RemoveOverlay(overlay fyne.CanvasObject) {
+	if c.overlay != overlay {
+		return
+	}
+	c.overlay = nil
+}
+
+// Deprecated: Use PushOverlay() instead.
 func (c *mobileCanvas) SetOverlay(overlay fyne.CanvasObject) {
 	c.overlay = overlay
+}
+
+func (c *mobileCanvas) TopOverlay() fyne.CanvasObject {
+	return c.overlay
 }
 
 func (c *mobileCanvas) OnTypedRune() func(rune) {
@@ -179,17 +212,19 @@ func (c *mobileCanvas) walkTree(
 	if c.menu != nil {
 		driver.WalkVisibleObjectTree(c.menu, beforeChildren, afterChildren)
 	}
-	if c.overlay != nil {
-		driver.WalkVisibleObjectTree(c.overlay, beforeChildren, afterChildren)
+	for _, overlay := range c.Overlays() {
+		if overlay != nil {
+			driver.WalkVisibleObjectTree(overlay, beforeChildren, afterChildren)
+		}
 	}
 }
 
 func (c *mobileCanvas) findObjectAtPositionMatching(pos fyne.Position, test func(object fyne.CanvasObject) bool) (fyne.CanvasObject, fyne.Position) {
-	if c.menu != nil && c.overlay == nil {
+	if c.menu != nil && len(c.Overlays()) == 0 {
 		return driver.FindObjectAtPositionMatching(pos, test, c.menu)
 	}
 
-	return driver.FindObjectAtPositionMatching(pos, test, c.overlay, c.windowHead, c.content)
+	return driver.FindObjectAtPositionMatching(pos, test, c.TopOverlay(), c.windowHead, c.content)
 }
 
 func (c *mobileCanvas) tapDown(pos fyne.Position, tapID int) {
@@ -292,7 +327,7 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 
 	duration := time.Since(c.lastTapDown[tapID])
 
-	if c.menu != nil && c.overlay == nil && pos.X > c.menu.Size().Width {
+	if c.menu != nil && len(c.Overlays()) == 0 && pos.X > c.menu.Size().Width {
 		c.menu.Hide()
 		c.menu = nil
 		return

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -7,6 +7,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/driver/mobile"
+	"fyne.io/fyne/internal"
 	"fyne.io/fyne/internal/app"
 	"fyne.io/fyne/internal/driver"
 	"fyne.io/fyne/internal/painter/gl"
@@ -15,7 +16,9 @@ import (
 )
 
 type mobileCanvas struct {
-	content, overlay fyne.CanvasObject
+	internal.OverlayStack
+
+	content          fyne.CanvasObject
 	windowHead, menu fyne.CanvasObject
 	painter          gl.Painter
 	scale            float32
@@ -134,47 +137,6 @@ func (c *mobileCanvas) SetScale(_ float32) {
 
 func (c *mobileCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
 	return int(float32(pos.X) * c.scale), int(float32(pos.Y) * c.scale)
-}
-
-// Deprecated: Use Overlays() instead.
-func (c *mobileCanvas) Overlay() fyne.CanvasObject {
-	return c.overlay
-}
-
-func (c *mobileCanvas) Overlays() []fyne.CanvasObject {
-	if c.overlay == nil {
-		return nil
-	}
-	return []fyne.CanvasObject{c.overlay}
-}
-
-func (c *mobileCanvas) PopOverlay() fyne.CanvasObject {
-	overlay := c.overlay
-	c.overlay = nil
-	return overlay
-}
-
-func (c *mobileCanvas) PushOverlay(overlay fyne.CanvasObject) {
-	if overlay == nil {
-		return
-	}
-	c.overlay = overlay
-}
-
-func (c *mobileCanvas) RemoveOverlay(overlay fyne.CanvasObject) {
-	if c.overlay != overlay {
-		return
-	}
-	c.overlay = nil
-}
-
-// Deprecated: Use PushOverlay() instead.
-func (c *mobileCanvas) SetOverlay(overlay fyne.CanvasObject) {
-	c.overlay = overlay
-}
-
-func (c *mobileCanvas) TopOverlay() fyne.CanvasObject {
-	return c.overlay
 }
 
 func (c *mobileCanvas) OnTypedRune() func(rune) {

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -17,8 +17,8 @@ func (s *OverlayStack) Add(overlay fyne.CanvasObject) {
 	s.overlay = overlay
 }
 
-// All satisfies the fyne.OverlayStack interface.
-func (s *OverlayStack) All() []fyne.CanvasObject {
+// List satisfies the fyne.OverlayStack interface.
+func (s *OverlayStack) List() []fyne.CanvasObject {
 	if s.overlay == nil {
 		return nil
 	}

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -9,31 +9,31 @@ type OverlayStack struct {
 
 var _ fyne.OverlayStack = (*OverlayStack)(nil)
 
-// AddOverlay satisfies the fyne.OverlayStack interface.
-func (s *OverlayStack) AddOverlay(overlay fyne.CanvasObject) {
+// Add satisfies the fyne.OverlayStack interface.
+func (s *OverlayStack) Add(overlay fyne.CanvasObject) {
 	if overlay == nil {
 		return
 	}
 	s.overlay = overlay
 }
 
-// Overlays satisfies the fyne.OverlayStack interface.
-func (s *OverlayStack) Overlays() []fyne.CanvasObject {
+// All satisfies the fyne.OverlayStack interface.
+func (s *OverlayStack) All() []fyne.CanvasObject {
 	if s.overlay == nil {
 		return nil
 	}
 	return []fyne.CanvasObject{s.overlay}
 }
 
-// RemoveOverlay satisfies the fyne.OverlayStack interface.
-func (s *OverlayStack) RemoveOverlay(overlay fyne.CanvasObject) {
+// Remove satisfies the fyne.OverlayStack interface.
+func (s *OverlayStack) Remove(overlay fyne.CanvasObject) {
 	if s.overlay != overlay {
 		return
 	}
 	s.overlay = nil
 }
 
-// TopOverlay satisfies the fyne.OverlayStack interface.
-func (s *OverlayStack) TopOverlay() fyne.CanvasObject {
+// Top satisfies the fyne.OverlayStack interface.
+func (s *OverlayStack) Top() fyne.CanvasObject {
 	return s.overlay
 }

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -7,13 +7,15 @@ type OverlayStack struct {
 	overlay fyne.CanvasObject
 }
 
+var _ fyne.OverlayStack = (*OverlayStack)(nil)
+
 // Overlay satisfies the fyne.Canvas interface.
 // Deprecated: Use Overlays() instead.
 func (s *OverlayStack) Overlay() fyne.CanvasObject {
 	return s.overlay
 }
 
-// Overlays satisfies the fyne.Canvas interface.
+// Overlays satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Overlays() []fyne.CanvasObject {
 	if s.overlay == nil {
 		return nil
@@ -21,14 +23,14 @@ func (s *OverlayStack) Overlays() []fyne.CanvasObject {
 	return []fyne.CanvasObject{s.overlay}
 }
 
-// PopOverlay satisfies the fyne.Canvas interface.
+// PopOverlay satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) PopOverlay() fyne.CanvasObject {
 	overlay := s.overlay
 	s.overlay = nil
 	return overlay
 }
 
-// PushOverlay satisfies the fyne.Canvas interface.
+// PushOverlay satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) PushOverlay(overlay fyne.CanvasObject) {
 	if overlay == nil {
 		return
@@ -36,7 +38,7 @@ func (s *OverlayStack) PushOverlay(overlay fyne.CanvasObject) {
 	s.overlay = overlay
 }
 
-// RemoveOverlay satisfies the fyne.Canvas interface.
+// RemoveOverlay satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) RemoveOverlay(overlay fyne.CanvasObject) {
 	if s.overlay != overlay {
 		return
@@ -50,7 +52,7 @@ func (s *OverlayStack) SetOverlay(overlay fyne.CanvasObject) {
 	s.overlay = overlay
 }
 
-// TopOverlay satisfies the fyne.Canvas interface.
+// TopOverlay satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) TopOverlay() fyne.CanvasObject {
 	return s.overlay
 }

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -2,18 +2,12 @@ package internal
 
 import "fyne.io/fyne"
 
-// OverlayStack is a mix-in for providing an overlay stack to canvases.
+// OverlayStack implements fyne.OverlayStack
 type OverlayStack struct {
 	overlay fyne.CanvasObject
 }
 
 var _ fyne.OverlayStack = (*OverlayStack)(nil)
-
-// Overlay satisfies the fyne.Canvas interface.
-// Deprecated: Use Overlays() instead.
-func (s *OverlayStack) Overlay() fyne.CanvasObject {
-	return s.overlay
-}
 
 // Overlays satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Overlays() []fyne.CanvasObject {
@@ -44,12 +38,6 @@ func (s *OverlayStack) RemoveOverlay(overlay fyne.CanvasObject) {
 		return
 	}
 	s.overlay = nil
-}
-
-// SetOverlay satisfies the fyne.Canvas interface.
-// Deprecated: Use PushOverlay() instead.
-func (s *OverlayStack) SetOverlay(overlay fyne.CanvasObject) {
-	s.overlay = overlay
 }
 
 // TopOverlay satisfies the fyne.OverlayStack interface.

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -9,27 +9,20 @@ type OverlayStack struct {
 
 var _ fyne.OverlayStack = (*OverlayStack)(nil)
 
+// AddOverlay satisfies the fyne.OverlayStack interface.
+func (s *OverlayStack) AddOverlay(overlay fyne.CanvasObject) {
+	if overlay == nil {
+		return
+	}
+	s.overlay = overlay
+}
+
 // Overlays satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Overlays() []fyne.CanvasObject {
 	if s.overlay == nil {
 		return nil
 	}
 	return []fyne.CanvasObject{s.overlay}
-}
-
-// PopOverlay satisfies the fyne.OverlayStack interface.
-func (s *OverlayStack) PopOverlay() fyne.CanvasObject {
-	overlay := s.overlay
-	s.overlay = nil
-	return overlay
-}
-
-// PushOverlay satisfies the fyne.OverlayStack interface.
-func (s *OverlayStack) PushOverlay(overlay fyne.CanvasObject) {
-	if overlay == nil {
-		return
-	}
-	s.overlay = overlay
 }
 
 // RemoveOverlay satisfies the fyne.OverlayStack interface.

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -1,0 +1,56 @@
+package internal
+
+import "fyne.io/fyne"
+
+// OverlayStack is a mix-in for providing an overlay stack to canvases.
+type OverlayStack struct {
+	overlay fyne.CanvasObject
+}
+
+// Overlay satisfies the fyne.Canvas interface.
+// Deprecated: Use Overlays() instead.
+func (s *OverlayStack) Overlay() fyne.CanvasObject {
+	return s.overlay
+}
+
+// Overlays satisfies the fyne.Canvas interface.
+func (s *OverlayStack) Overlays() []fyne.CanvasObject {
+	if s.overlay == nil {
+		return nil
+	}
+	return []fyne.CanvasObject{s.overlay}
+}
+
+// PopOverlay satisfies the fyne.Canvas interface.
+func (s *OverlayStack) PopOverlay() fyne.CanvasObject {
+	overlay := s.overlay
+	s.overlay = nil
+	return overlay
+}
+
+// PushOverlay satisfies the fyne.Canvas interface.
+func (s *OverlayStack) PushOverlay(overlay fyne.CanvasObject) {
+	if overlay == nil {
+		return
+	}
+	s.overlay = overlay
+}
+
+// RemoveOverlay satisfies the fyne.Canvas interface.
+func (s *OverlayStack) RemoveOverlay(overlay fyne.CanvasObject) {
+	if s.overlay != overlay {
+		return
+	}
+	s.overlay = nil
+}
+
+// SetOverlay satisfies the fyne.Canvas interface.
+// Deprecated: Use PushOverlay() instead.
+func (s *OverlayStack) SetOverlay(overlay fyne.CanvasObject) {
+	s.overlay = overlay
+}
+
+// TopOverlay satisfies the fyne.Canvas interface.
+func (s *OverlayStack) TopOverlay() fyne.CanvasObject {
+	return s.overlay
+}

--- a/overlay_stack.go
+++ b/overlay_stack.go
@@ -2,12 +2,10 @@ package fyne
 
 // OverlayStack is a stack of CanvasObjects intended to be used as overlays of a Canvas.
 type OverlayStack interface {
+	// AddOverlay adds an overlay on the top of the overlay stack.
+	AddOverlay(overlay CanvasObject)
 	// Overlays returns the overlays currently on the overlay stack.
 	Overlays() []CanvasObject
-	// PopOverlay removes and returns the top-most object of the overlay stack.
-	PopOverlay() CanvasObject
-	// PushOverlay pushes an overlay on the top of the overlay stack.
-	PushOverlay(overlay CanvasObject)
 	// RemoveOverlay removes the given object and all objects above it from the overlay stack.
 	RemoveOverlay(overlay CanvasObject)
 	// TopOverlay returns the top-most object of the overlay stack.

--- a/overlay_stack.go
+++ b/overlay_stack.go
@@ -2,12 +2,12 @@ package fyne
 
 // OverlayStack is a stack of CanvasObjects intended to be used as overlays of a Canvas.
 type OverlayStack interface {
-	// AddOverlay adds an overlay on the top of the overlay stack.
-	AddOverlay(overlay CanvasObject)
-	// Overlays returns the overlays currently on the overlay stack.
-	Overlays() []CanvasObject
-	// RemoveOverlay removes the given object and all objects above it from the overlay stack.
-	RemoveOverlay(overlay CanvasObject)
-	// TopOverlay returns the top-most object of the overlay stack.
-	TopOverlay() CanvasObject
+	// Add adds an overlay on the top of the overlay stack.
+	Add(overlay CanvasObject)
+	// All returns the overlays currently on the overlay stack.
+	All() []CanvasObject
+	// Remove removes the given object and all objects above it from the overlay stack.
+	Remove(overlay CanvasObject)
+	// Top returns the top-most object of the overlay stack.
+	Top() CanvasObject
 }

--- a/overlay_stack.go
+++ b/overlay_stack.go
@@ -4,8 +4,8 @@ package fyne
 type OverlayStack interface {
 	// Add adds an overlay on the top of the overlay stack.
 	Add(overlay CanvasObject)
-	// All returns the overlays currently on the overlay stack.
-	All() []CanvasObject
+	// List returns the overlays currently on the overlay stack.
+	List() []CanvasObject
 	// Remove removes the given object and all objects above it from the overlay stack.
 	Remove(overlay CanvasObject)
 	// Top returns the top-most object of the overlay stack.

--- a/overlay_stack.go
+++ b/overlay_stack.go
@@ -1,0 +1,15 @@
+package fyne
+
+// OverlayStack is a stack of CanvasObjects intended to be used as overlays of a Canvas.
+type OverlayStack interface {
+	// Overlays returns the overlays currently on the overlay stack.
+	Overlays() []CanvasObject
+	// PopOverlay removes and returns the top-most object of the overlay stack.
+	PopOverlay() CanvasObject
+	// PushOverlay pushes an overlay on the top of the overlay stack.
+	PushOverlay(overlay CanvasObject)
+	// RemoveOverlay removes the given object and all objects above it from the overlay stack.
+	RemoveOverlay(overlay CanvasObject)
+	// TopOverlay returns the top-most object of the overlay stack.
+	TopOverlay() CanvasObject
+}

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -53,12 +53,45 @@ func (c *testCanvas) SetContent(content fyne.CanvasObject) {
 	c.Resize(content.MinSize().Add(padding))
 }
 
+// Deprecated
 func (c *testCanvas) Overlay() fyne.CanvasObject {
-	return c.overlay
+	panic("deprecated method should not be used")
 }
 
-func (c *testCanvas) SetOverlay(overlay fyne.CanvasObject) {
+func (c *testCanvas) Overlays() []fyne.CanvasObject {
+	if c.overlay == nil {
+		return nil
+	}
+	return []fyne.CanvasObject{c.overlay}
+}
+
+func (c *testCanvas) PopOverlay() fyne.CanvasObject {
+	overlay := c.overlay
+	c.overlay = nil
+	return overlay
+}
+
+func (c *testCanvas) PushOverlay(overlay fyne.CanvasObject) {
+	if overlay == nil {
+		return
+	}
 	c.overlay = overlay
+}
+
+func (c *testCanvas) RemoveOverlay(overlay fyne.CanvasObject) {
+	if c.overlay != overlay {
+		return
+	}
+	c.overlay = nil
+}
+
+// Deprecated
+func (c *testCanvas) SetOverlay(_ fyne.CanvasObject) {
+	panic("deprecated method should not be used")
+}
+
+func (c *testCanvas) TopOverlay() fyne.CanvasObject {
+	return c.overlay
 }
 
 func (c *testCanvas) Refresh(fyne.CanvasObject) {

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -23,12 +23,14 @@ type WindowlessCanvas interface {
 }
 
 type testCanvas struct {
+	internal.OverlayStack
+
 	size  fyne.Size
 	scale float32
 
-	content, overlay fyne.CanvasObject
-	focused          fyne.Focusable
-	padded           bool
+	content fyne.CanvasObject
+	focused fyne.Focusable
+	padded  bool
 
 	onTypedRune func(rune)
 	onTypedKey  func(*fyne.KeyEvent)
@@ -58,40 +60,9 @@ func (c *testCanvas) Overlay() fyne.CanvasObject {
 	panic("deprecated method should not be used")
 }
 
-func (c *testCanvas) Overlays() []fyne.CanvasObject {
-	if c.overlay == nil {
-		return nil
-	}
-	return []fyne.CanvasObject{c.overlay}
-}
-
-func (c *testCanvas) PopOverlay() fyne.CanvasObject {
-	overlay := c.overlay
-	c.overlay = nil
-	return overlay
-}
-
-func (c *testCanvas) PushOverlay(overlay fyne.CanvasObject) {
-	if overlay == nil {
-		return
-	}
-	c.overlay = overlay
-}
-
-func (c *testCanvas) RemoveOverlay(overlay fyne.CanvasObject) {
-	if c.overlay != overlay {
-		return
-	}
-	c.overlay = nil
-}
-
 // Deprecated
 func (c *testCanvas) SetOverlay(_ fyne.CanvasObject) {
 	panic("deprecated method should not be used")
-}
-
-func (c *testCanvas) TopOverlay() fyne.CanvasObject {
-	return c.overlay
 }
 
 func (c *testCanvas) Refresh(fyne.CanvasObject) {

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -23,14 +23,13 @@ type WindowlessCanvas interface {
 }
 
 type testCanvas struct {
-	internal.OverlayStack
-
 	size  fyne.Size
 	scale float32
 
-	content fyne.CanvasObject
-	focused fyne.Focusable
-	padded  bool
+	content  fyne.CanvasObject
+	overlays *internal.OverlayStack
+	focused  fyne.Focusable
+	padded   bool
 
 	onTypedRune func(rune)
 	onTypedKey  func(*fyne.KeyEvent)
@@ -58,6 +57,10 @@ func (c *testCanvas) SetContent(content fyne.CanvasObject) {
 // Deprecated
 func (c *testCanvas) Overlay() fyne.CanvasObject {
 	panic("deprecated method should not be used")
+}
+
+func (c *testCanvas) Overlays() fyne.OverlayStack {
+	return c.overlays
 }
 
 // Deprecated
@@ -167,7 +170,7 @@ func (c *testCanvas) Capture() image.Image {
 // NewCanvas returns a single use in-memory canvas used for testing
 func NewCanvas() WindowlessCanvas {
 	padding := fyne.NewSize(10, 10)
-	return &testCanvas{size: padding, padded: true, scale: 1.0}
+	return &testCanvas{size: padding, padded: true, scale: 1.0, overlays: &internal.OverlayStack{}}
 }
 
 // NewCanvasWithPainter allows creation of an in-memory canvas with a specific painter.

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -429,8 +429,8 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	tapPos := fyne.NewPos(1, 1)
 	test.TapSecondaryAt(entry, tapPos)
 
-	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
-	over := canvas.Overlays().TopOverlay()
+	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	over := canvas.Overlays().Top()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
 	cont := over.(*PopUp).Content
@@ -444,8 +444,8 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	entry.Disable()
 
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
-	over = canvas.Overlays().TopOverlay()
+	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	over = canvas.Overlays().Top()
 
 	cont = over.(*PopUp).Content
 	items = cont.(*Box).Children
@@ -455,12 +455,12 @@ func TestEntry_TappedSecondary(t *testing.T) {
 
 	entry.Password = true
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Nil(t, canvas.Overlays().TopOverlay()) // No popup for disabled password
+	assert.Nil(t, canvas.Overlays().Top()) // No popup for disabled password
 
 	entry.Enable()
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
-	over = canvas.Overlays().TopOverlay()
+	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	over = canvas.Overlays().Top()
 	assert.NotNil(t, over)
 
 	cont = over.(*PopUp).Content

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -423,14 +423,15 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	defer test.NewApp()
 
 	entry := NewEntry()
-	fyne.CurrentApp().Driver().CanvasForObject(entry).(test.WindowlessCanvas).Resize(fyne.NewSize(100, 150))
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(entry)
+	canvas.(test.WindowlessCanvas).Resize(fyne.NewSize(100, 150))
 
 	tapPos := fyne.NewPos(1, 1)
 	test.TapSecondaryAt(entry, tapPos)
 
-	over := fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
+	assert.Equal(t, 1, len(canvas.Overlays()))
+	over := canvas.Overlays()[0]
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
-	assert.NotNil(t, over)
 
 	cont := over.(*PopUp).Content
 	assert.Equal(t, pos.X+theme.Padding()+tapPos.X, cont.Position().X)
@@ -443,8 +444,8 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	entry.Disable()
 
 	test.TapSecondaryAt(entry, tapPos)
-	over = fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
-	assert.NotNil(t, over)
+	assert.Equal(t, 1, len(canvas.Overlays()))
+	over = canvas.Overlays()[0]
 
 	cont = over.(*PopUp).Content
 	items = cont.(*Box).Children
@@ -454,12 +455,12 @@ func TestEntry_TappedSecondary(t *testing.T) {
 
 	entry.Password = true
 	test.TapSecondaryAt(entry, tapPos)
-	over = fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
-	assert.Nil(t, over) // No popup for disabled password
+	assert.Equal(t, 0, len(canvas.Overlays())) // No popup for disabled password
 
 	entry.Enable()
 	test.TapSecondaryAt(entry, tapPos)
-	over = fyne.CurrentApp().Driver().CanvasForObject(entry).Overlay()
+	assert.Equal(t, 1, len(canvas.Overlays()))
+	over = canvas.Overlays()[0]
 	assert.NotNil(t, over)
 
 	cont = over.(*PopUp).Content

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -429,7 +429,7 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	tapPos := fyne.NewPos(1, 1)
 	test.TapSecondaryAt(entry, tapPos)
 
-	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	assert.Equal(t, 1, len(canvas.Overlays().List()))
 	over := canvas.Overlays().Top()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
@@ -444,7 +444,7 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	entry.Disable()
 
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	assert.Equal(t, 1, len(canvas.Overlays().List()))
 	over = canvas.Overlays().Top()
 
 	cont = over.(*PopUp).Content
@@ -459,7 +459,7 @@ func TestEntry_TappedSecondary(t *testing.T) {
 
 	entry.Enable()
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	assert.Equal(t, 1, len(canvas.Overlays().List()))
 	over = canvas.Overlays().Top()
 	assert.NotNil(t, over)
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -429,8 +429,8 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	tapPos := fyne.NewPos(1, 1)
 	test.TapSecondaryAt(entry, tapPos)
 
-	assert.Equal(t, 1, len(canvas.Overlays()))
-	over := canvas.Overlays()[0]
+	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
+	over := canvas.Overlays().TopOverlay()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
 	cont := over.(*PopUp).Content
@@ -444,8 +444,8 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	entry.Disable()
 
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Equal(t, 1, len(canvas.Overlays()))
-	over = canvas.Overlays()[0]
+	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
+	over = canvas.Overlays().TopOverlay()
 
 	cont = over.(*PopUp).Content
 	items = cont.(*Box).Children
@@ -455,12 +455,12 @@ func TestEntry_TappedSecondary(t *testing.T) {
 
 	entry.Password = true
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Equal(t, 0, len(canvas.Overlays())) // No popup for disabled password
+	assert.Nil(t, canvas.Overlays().TopOverlay()) // No popup for disabled password
 
 	entry.Enable()
 	test.TapSecondaryAt(entry, tapPos)
-	assert.Equal(t, 1, len(canvas.Overlays()))
-	over = canvas.Overlays()[0]
+	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
+	over = canvas.Overlays().TopOverlay()
 	assert.NotNil(t, over)
 
 	cont = over.(*PopUp).Content

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -21,7 +21,7 @@ func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *
 			if c.Focused() == nil {
 				c.Focus(focused)
 			}
-			c.PopOverlay()
+			c.Overlays().PopOverlay()
 
 			opt.Action()
 		}))

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -12,22 +12,24 @@ import (
 // NewPopUpMenuAtPosition creates a PopUp widget populated with menu items from the passed menu structure.
 // It will automatically be positioned at the provided location and shown as an overlay on the specified canvas.
 func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *PopUp {
-	var pop *PopUp
 	options := NewVBox()
-	focused := c.Focused()
 	for _, option := range menu.Items {
 		opt := option // capture value
-		options.Append(newTappableLabel(opt.Label, func() {
+		options.Append(newTappableLabel(opt.Label))
+	}
+	pop := NewPopUpAtPosition(options, c, pos)
+	focused := c.Focused()
+	for i, o := range options.Children {
+		label := o.(*menuItemWidget)
+		item := menu.Items[i]
+		label.OnTapped = func() {
 			if c.Focused() == nil {
 				c.Focus(focused)
 			}
-			c.Overlays().PopOverlay()
-
-			opt.Action()
-		}))
+			pop.Hide()
+			item.Action()
+		}
 	}
-
-	pop = NewPopUpAtPosition(options, c, pos)
 	return pop
 }
 
@@ -72,8 +74,8 @@ func (t *menuItemWidget) MouseOut() {
 func (t *menuItemWidget) MouseMoved(*desktop.MouseEvent) {
 }
 
-func newTappableLabel(label string, tapped func()) *menuItemWidget {
-	ret := &menuItemWidget{NewLabel(label), tapped, false}
+func newTappableLabel(label string) *menuItemWidget {
+	ret := &menuItemWidget{Label: NewLabel(label)}
 	ret.ExtendBaseWidget(ret)
 	return ret
 }

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -21,8 +21,7 @@ func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *
 			if c.Focused() == nil {
 				c.Focus(focused)
 			}
-			c.SetOverlay(nil)
-			Renderer(pop).Destroy()
+			c.PopOverlay()
 
 			opt.Action()
 		}))

--- a/widget/menu_test.go
+++ b/widget/menu_test.go
@@ -13,9 +13,9 @@ func TestNewPopUpMenu(t *testing.T) {
 	menu := fyne.NewMenu("Foo", fyne.NewMenuItem("Bar", func() {}))
 
 	pop := NewPopUpMenu(menu, c)
-	assert.Equal(t, 1, len(c.Overlays().All()))
-	assert.Equal(t, pop, c.Overlays().All()[0])
+	assert.Equal(t, 1, len(c.Overlays().List()))
+	assert.Equal(t, pop, c.Overlays().List()[0])
 
 	pop.Hide()
-	assert.Equal(t, 0, len(c.Overlays().All()))
+	assert.Equal(t, 0, len(c.Overlays().List()))
 }

--- a/widget/menu_test.go
+++ b/widget/menu_test.go
@@ -13,9 +13,9 @@ func TestNewPopUpMenu(t *testing.T) {
 	menu := fyne.NewMenu("Foo", fyne.NewMenuItem("Bar", func() {}))
 
 	pop := NewPopUpMenu(menu, c)
-	assert.Equal(t, 1, len(c.Overlays()))
-	assert.Equal(t, pop, c.Overlays()[0])
+	assert.Equal(t, 1, len(c.Overlays().Overlays()))
+	assert.Equal(t, pop, c.Overlays().Overlays()[0])
 
 	pop.Hide()
-	assert.Equal(t, 0, len(c.Overlays()))
+	assert.Equal(t, 0, len(c.Overlays().Overlays()))
 }

--- a/widget/menu_test.go
+++ b/widget/menu_test.go
@@ -13,9 +13,9 @@ func TestNewPopUpMenu(t *testing.T) {
 	menu := fyne.NewMenu("Foo", fyne.NewMenuItem("Bar", func() {}))
 
 	pop := NewPopUpMenu(menu, c)
-	assert.Equal(t, 1, len(c.Overlays().Overlays()))
-	assert.Equal(t, pop, c.Overlays().Overlays()[0])
+	assert.Equal(t, 1, len(c.Overlays().All()))
+	assert.Equal(t, pop, c.Overlays().All()[0])
 
 	pop.Hide()
-	assert.Equal(t, 0, len(c.Overlays().Overlays()))
+	assert.Equal(t, 0, len(c.Overlays().All()))
 }

--- a/widget/menu_test.go
+++ b/widget/menu_test.go
@@ -13,8 +13,9 @@ func TestNewPopUpMenu(t *testing.T) {
 	menu := fyne.NewMenu("Foo", fyne.NewMenuItem("Bar", func() {}))
 
 	pop := NewPopUpMenu(menu, c)
-	assert.Equal(t, pop, c.Overlay())
+	assert.Equal(t, 1, len(c.Overlays()))
+	assert.Equal(t, pop, c.Overlays()[0])
 
 	pop.Hide()
-	assert.Nil(t, c.Overlay())
+	assert.Equal(t, 0, len(c.Overlays()))
 }

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -26,7 +26,7 @@ type PopUp struct {
 // Hide this widget, if it was previously visible
 func (p *PopUp) Hide() {
 	p.BaseWidget.Hide()
-	p.Canvas.Overlays().RemoveOverlay(p)
+	p.Canvas.Overlays().Remove(p)
 }
 
 // Move the widget to a new position. A PopUp position is absolute to the top, left of its canvas.
@@ -53,7 +53,7 @@ func (p *PopUp) Resize(size fyne.Size) {
 // Show this widget, if it was previously hidden
 func (p *PopUp) Show() {
 	p.BaseWidget.Show()
-	p.Canvas.Overlays().AddOverlay(p)
+	p.Canvas.Overlays().Add(p)
 }
 
 // Tapped is called when the user taps the popUp background - if not modal then dismiss this widget

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -53,7 +53,7 @@ func (p *PopUp) Resize(size fyne.Size) {
 // Show this widget, if it was previously hidden
 func (p *PopUp) Show() {
 	p.BaseWidget.Show()
-	p.Canvas.Overlays().PushOverlay(p)
+	p.Canvas.Overlays().AddOverlay(p)
 }
 
 // Tapped is called when the user taps the popUp background - if not modal then dismiss this widget

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -26,7 +26,7 @@ type PopUp struct {
 // Hide this widget, if it was previously visible
 func (p *PopUp) Hide() {
 	p.BaseWidget.Hide()
-	p.Canvas.RemoveOverlay(p)
+	p.Canvas.Overlays().RemoveOverlay(p)
 }
 
 // Move the widget to a new position. A PopUp position is absolute to the top, left of its canvas.
@@ -53,7 +53,7 @@ func (p *PopUp) Resize(size fyne.Size) {
 // Show this widget, if it was previously hidden
 func (p *PopUp) Show() {
 	p.BaseWidget.Show()
-	p.Canvas.PushOverlay(p)
+	p.Canvas.Overlays().PushOverlay(p)
 }
 
 // Tapped is called when the user taps the popUp background - if not modal then dismiss this widget
@@ -92,7 +92,7 @@ func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
 }
 
 // NewPopUpAtPosition creates a new popUp for the specified content at the specified absolute position.
-// It will then display the popup it on the passed canvas.
+// It will then display the popup on the passed canvas.
 func NewPopUpAtPosition(content fyne.CanvasObject, canvas fyne.Canvas, pos fyne.Position) *PopUp {
 	ret := &PopUp{Content: content, Canvas: canvas, modal: false}
 	ret.ExtendBaseWidget(ret)

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -26,7 +26,7 @@ type PopUp struct {
 // Hide this widget, if it was previously visible
 func (p *PopUp) Hide() {
 	p.BaseWidget.Hide()
-	p.Canvas.SetOverlay(nil)
+	p.Canvas.RemoveOverlay(p)
 }
 
 // Move the widget to a new position. A PopUp position is absolute to the top, left of its canvas.
@@ -53,7 +53,7 @@ func (p *PopUp) Resize(size fyne.Size) {
 // Show this widget, if it was previously hidden
 func (p *PopUp) Show() {
 	p.BaseWidget.Show()
-	p.Canvas.SetOverlay(p)
+	p.Canvas.PushOverlay(p)
 }
 
 // Tapped is called when the user taps the popUp background - if not modal then dismiss this widget

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -15,8 +15,8 @@ func TestNewPopUp(t *testing.T) {
 	pop := NewPopUp(label, test.Canvas())
 
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays().Overlays()))
-	assert.Equal(t, pop, test.Canvas().Overlays().Overlays()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().All()))
+	assert.Equal(t, pop, test.Canvas().Overlays().All()[0])
 }
 
 func TestPopUp_Hide(t *testing.T) {
@@ -26,7 +26,7 @@ func TestPopUp_Hide(t *testing.T) {
 	assert.True(t, pop.Visible())
 	pop.Hide()
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays().Overlays()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().All()))
 }
 
 func TestPopUp_MinSize(t *testing.T) {
@@ -119,7 +119,7 @@ func TestPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays().Overlays()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().All()))
 }
 
 func TestPopUp_TappedSecondary(t *testing.T) {
@@ -129,7 +129,7 @@ func TestPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays().Overlays()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().All()))
 }
 
 func TestModalPopUp_Tapped(t *testing.T) {
@@ -139,8 +139,8 @@ func TestModalPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays().Overlays()))
-	assert.Equal(t, pop, test.Canvas().Overlays().Overlays()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().All()))
+	assert.Equal(t, pop, test.Canvas().Overlays().All()[0])
 }
 
 func TestModalPopUp_TappedSecondary(t *testing.T) {
@@ -150,6 +150,6 @@ func TestModalPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays().Overlays()))
-	assert.Equal(t, pop, test.Canvas().Overlays().Overlays()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().All()))
+	assert.Equal(t, pop, test.Canvas().Overlays().All()[0])
 }

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -15,8 +15,8 @@ func TestNewPopUp(t *testing.T) {
 	pop := NewPopUp(label, test.Canvas())
 
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays()))
-	assert.Equal(t, pop, test.Canvas().Overlays()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().Overlays()))
+	assert.Equal(t, pop, test.Canvas().Overlays().Overlays()[0])
 }
 
 func TestPopUp_Hide(t *testing.T) {
@@ -26,7 +26,7 @@ func TestPopUp_Hide(t *testing.T) {
 	assert.True(t, pop.Visible())
 	pop.Hide()
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().Overlays()))
 }
 
 func TestPopUp_MinSize(t *testing.T) {
@@ -119,7 +119,7 @@ func TestPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().Overlays()))
 }
 
 func TestPopUp_TappedSecondary(t *testing.T) {
@@ -129,7 +129,7 @@ func TestPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().Overlays()))
 }
 
 func TestModalPopUp_Tapped(t *testing.T) {
@@ -139,8 +139,8 @@ func TestModalPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays()))
-	assert.Equal(t, pop, test.Canvas().Overlays()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().Overlays()))
+	assert.Equal(t, pop, test.Canvas().Overlays().Overlays()[0])
 }
 
 func TestModalPopUp_TappedSecondary(t *testing.T) {
@@ -150,6 +150,6 @@ func TestModalPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays()))
-	assert.Equal(t, pop, test.Canvas().Overlays()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().Overlays()))
+	assert.Equal(t, pop, test.Canvas().Overlays().Overlays()[0])
 }

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -15,8 +15,8 @@ func TestNewPopUp(t *testing.T) {
 	pop := NewPopUp(label, test.Canvas())
 
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays().All()))
-	assert.Equal(t, pop, test.Canvas().Overlays().All()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
+	assert.Equal(t, pop, test.Canvas().Overlays().List()[0])
 }
 
 func TestPopUp_Hide(t *testing.T) {
@@ -26,7 +26,7 @@ func TestPopUp_Hide(t *testing.T) {
 	assert.True(t, pop.Visible())
 	pop.Hide()
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays().All()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().List()))
 }
 
 func TestPopUp_MinSize(t *testing.T) {
@@ -119,7 +119,7 @@ func TestPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays().All()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().List()))
 }
 
 func TestPopUp_TappedSecondary(t *testing.T) {
@@ -129,7 +129,7 @@ func TestPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.False(t, pop.Visible())
-	assert.Equal(t, 0, len(test.Canvas().Overlays().All()))
+	assert.Equal(t, 0, len(test.Canvas().Overlays().List()))
 }
 
 func TestModalPopUp_Tapped(t *testing.T) {
@@ -139,8 +139,8 @@ func TestModalPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays().All()))
-	assert.Equal(t, pop, test.Canvas().Overlays().All()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
+	assert.Equal(t, pop, test.Canvas().Overlays().List()[0])
 }
 
 func TestModalPopUp_TappedSecondary(t *testing.T) {
@@ -150,6 +150,6 @@ func TestModalPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, 1, len(test.Canvas().Overlays().All()))
-	assert.Equal(t, pop, test.Canvas().Overlays().All()[0])
+	assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
+	assert.Equal(t, pop, test.Canvas().Overlays().List()[0])
 }

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -15,7 +15,8 @@ func TestNewPopUp(t *testing.T) {
 	pop := NewPopUp(label, test.Canvas())
 
 	assert.True(t, pop.Visible())
-	assert.Equal(t, pop, test.Canvas().Overlay())
+	assert.Equal(t, 1, len(test.Canvas().Overlays()))
+	assert.Equal(t, pop, test.Canvas().Overlays()[0])
 }
 
 func TestPopUp_Hide(t *testing.T) {
@@ -25,7 +26,7 @@ func TestPopUp_Hide(t *testing.T) {
 	assert.True(t, pop.Visible())
 	pop.Hide()
 	assert.False(t, pop.Visible())
-	assert.Nil(t, test.Canvas().Overlay())
+	assert.Equal(t, 0, len(test.Canvas().Overlays()))
 }
 
 func TestPopUp_MinSize(t *testing.T) {
@@ -118,7 +119,7 @@ func TestPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.False(t, pop.Visible())
-	assert.Nil(t, test.Canvas().Overlay())
+	assert.Equal(t, 0, len(test.Canvas().Overlays()))
 }
 
 func TestPopUp_TappedSecondary(t *testing.T) {
@@ -128,7 +129,7 @@ func TestPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.False(t, pop.Visible())
-	assert.Nil(t, test.Canvas().Overlay())
+	assert.Equal(t, 0, len(test.Canvas().Overlays()))
 }
 
 func TestModalPopUp_Tapped(t *testing.T) {
@@ -138,7 +139,8 @@ func TestModalPopUp_Tapped(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, pop, test.Canvas().Overlay())
+	assert.Equal(t, 1, len(test.Canvas().Overlays()))
+	assert.Equal(t, pop, test.Canvas().Overlays()[0])
 }
 
 func TestModalPopUp_TappedSecondary(t *testing.T) {
@@ -148,5 +150,6 @@ func TestModalPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)
 	assert.True(t, pop.Visible())
-	assert.Equal(t, pop, test.Canvas().Overlay())
+	assert.Equal(t, 1, len(test.Canvas().Overlays()))
+	assert.Equal(t, pop, test.Canvas().Overlays()[0])
 }

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -62,8 +62,8 @@ func TestSelect_Tapped(t *testing.T) {
 	test.Tap(combo)
 
 	canvas := fyne.CurrentApp().Driver().CanvasForObject(combo)
-	assert.Equal(t, 1, len(canvas.Overlays()))
-	over := canvas.Overlays()[0]
+	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
+	over := canvas.Overlays().TopOverlay()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
 	cont := over.(*PopUp).Content
@@ -89,8 +89,8 @@ func TestSelect_Tapped_Constrained(t *testing.T) {
 	test.Tap(combo)
 
 	comboPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(combo)
-	assert.Equal(t, 1, len(canvas.Overlays()))
-	cont := canvas.Overlays()[0].(*PopUp).Content
+	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
+	cont := canvas.Overlays().TopOverlay().(*PopUp).Content
 	assert.Less(t, cont.Position().Y, comboPos.Y, "window too small so we render higher up")
 	assert.Less(t, cont.Position().X, comboPos.X, "window too small so we render to the left")
 }

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -62,7 +62,7 @@ func TestSelect_Tapped(t *testing.T) {
 	test.Tap(combo)
 
 	canvas := fyne.CurrentApp().Driver().CanvasForObject(combo)
-	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	assert.Equal(t, 1, len(canvas.Overlays().List()))
 	over := canvas.Overlays().Top()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
@@ -89,7 +89,7 @@ func TestSelect_Tapped_Constrained(t *testing.T) {
 	test.Tap(combo)
 
 	comboPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(combo)
-	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	assert.Equal(t, 1, len(canvas.Overlays().List()))
 	cont := canvas.Overlays().Top().(*PopUp).Content
 	assert.Less(t, cont.Position().Y, comboPos.Y, "window too small so we render higher up")
 	assert.Less(t, cont.Position().X, comboPos.X, "window too small so we render to the left")

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -61,9 +61,10 @@ func TestSelect_Tapped(t *testing.T) {
 	combo := NewSelect([]string{"1", "2"}, func(s string) {})
 	test.Tap(combo)
 
-	over := fyne.CurrentApp().Driver().CanvasForObject(combo).Overlay()
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(combo)
+	assert.Equal(t, 1, len(canvas.Overlays()))
+	over := canvas.Overlays()[0]
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
-	assert.NotNil(t, over)
 
 	cont := over.(*PopUp).Content
 	assert.Equal(t, cont.Position().X, pos.X+theme.Padding())
@@ -88,7 +89,8 @@ func TestSelect_Tapped_Constrained(t *testing.T) {
 	test.Tap(combo)
 
 	comboPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(combo)
-	cont := canvas.Overlay().(*PopUp).Content
+	assert.Equal(t, 1, len(canvas.Overlays()))
+	cont := canvas.Overlays()[0].(*PopUp).Content
 	assert.Less(t, cont.Position().Y, comboPos.Y, "window too small so we render higher up")
 	assert.Less(t, cont.Position().X, comboPos.X, "window too small so we render to the left")
 }

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -62,8 +62,8 @@ func TestSelect_Tapped(t *testing.T) {
 	test.Tap(combo)
 
 	canvas := fyne.CurrentApp().Driver().CanvasForObject(combo)
-	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
-	over := canvas.Overlays().TopOverlay()
+	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	over := canvas.Overlays().Top()
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
 	cont := over.(*PopUp).Content
@@ -89,8 +89,8 @@ func TestSelect_Tapped_Constrained(t *testing.T) {
 	test.Tap(combo)
 
 	comboPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(combo)
-	assert.Equal(t, 1, len(canvas.Overlays().Overlays()))
-	cont := canvas.Overlays().TopOverlay().(*PopUp).Content
+	assert.Equal(t, 1, len(canvas.Overlays().All()))
+	cont := canvas.Overlays().Top().(*PopUp).Content
 	assert.Less(t, cont.Position().Y, comboPos.Y, "window too small so we render higher up")
 	assert.Less(t, cont.Position().X, comboPos.X, "window too small so we render to the left")
 }


### PR DESCRIPTION
### Description:

In preparation for a fix of #469 this PR introduces a new overlay interface to `fyne.Canvas`. The old methods (`Overlay`, `SetOverlay`) are deprecated.

### Checklist:

- ~~[ ] Tests included.~~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
