### PR TITLE
Don't lay out parent object more than required

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -252,6 +252,7 @@ func (c *glCanvas) ensureMinSize() bool {
 	if c.Content() == nil {
 		return false
 	}
+	var lastParent fyne.CanvasObject
 
 	windowNeedsMinSizeUpdate := false
 	ensureMinSize := func(node *renderCacheNode) {
@@ -280,13 +281,9 @@ func (c *glCanvas) ensureMinSize() bool {
 				}
 			}
 
-			switch cont := objToLayout.(type) {
-			case *fyne.Container:
-				if cont.Layout != nil {
-					cont.Layout.Layout(cont.Objects, cont.Size())
-				}
-			case fyne.Widget:
-				cache.Renderer(cont).Layout(cont.Size())
+			if objToLayout != lastParent {
+				updateLayout(lastParent)
+				lastParent = objToLayout
 			}
 		}
 	}
@@ -294,7 +291,22 @@ func (c *glCanvas) ensureMinSize() bool {
 	if windowNeedsMinSizeUpdate && (c.size.Width < c.MinSize().Width || c.size.Height < c.MinSize().Height) {
 		c.Resize(c.Size().Union(c.MinSize()))
 	}
+
+	if lastParent != nil {
+		updateLayout(lastParent)
+	}
 	return windowNeedsMinSizeUpdate
+}
+
+func updateLayout(objToLayout fyne.CanvasObject) {
+	switch cont := objToLayout.(type) {
+	case *fyne.Container:
+		if cont.Layout != nil {
+			cont.Layout.Layout(cont.Objects, cont.Size())
+		}
+	case fyne.Widget:
+		cache.Renderer(cont).Layout(cont.Size())
+	}
 }
 
 func (c *glCanvas) paint(size fyne.Size) {


### PR DESCRIPTION
### Description:
Work on textgrid revealed this issue - in ensureMinSize the parent is laid out for every child.
Instead let's try to only do it once per parent.

### Checklist:

- [ ] Tests included. - not sure how to test an optimisation like this, suggestions?
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

