### PR TITLE
Support resetting a Select widget's current selection

### DIFF
--- a/widget/select.go
+++ b/widget/select.go
@@ -199,19 +199,19 @@ func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 // clearing the current option, the Select widget's PlaceHolder will
 // be displayed.
 func (s *Select) ClearSelected() {
-	s.updateSelect("")
+	s.updateSelected("")
 }
 
 // SetSelected sets the current option of the select widget
 func (s *Select) SetSelected(text string) {
 	for _, option := range s.Options {
 		if text == option {
-			s.updateSelect(text)
+			s.updateSelected(text)
 		}
 	}
 }
 
-func (s *Select) updateSelect(text string) {
+func (s *Select) updateSelected(text string) {
 	s.Selected = text
 
 	if s.OnChanged != nil {

--- a/widget/select.go
+++ b/widget/select.go
@@ -196,7 +196,7 @@ func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 }
 
 // ClearSelected clears the current option of the select widget.  After
-// clearing the current option, the Select widgets PlaceHolder will
+// clearing the current option, the Select widget's PlaceHolder will
 // be displayed.
 func (s *Select) ClearSelected() {
 	s.Selected = ""

--- a/widget/select.go
+++ b/widget/select.go
@@ -195,6 +195,19 @@ func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 	return &selectRenderer{icon, text, shadow, objects, s}
 }
 
+// ClearSelected clears the current option of the select widget.  After
+// clearing the current option, the Select widgets PlaceHolder will
+// be displayed.
+func (s *Select) ClearSelected() {
+	s.Selected = ""
+
+	if s.OnChanged != nil {
+		s.OnChanged("")
+	}
+
+	s.Refresh()
+}
+
 // SetSelected sets the current option of the select widget
 func (s *Select) SetSelected(text string) {
 	for _, option := range s.Options {

--- a/widget/select.go
+++ b/widget/select.go
@@ -199,25 +199,23 @@ func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 // clearing the current option, the Select widget's PlaceHolder will
 // be displayed.
 func (s *Select) ClearSelected() {
-	s.Selected = ""
-
-	if s.OnChanged != nil {
-		s.OnChanged("")
-	}
-
-	s.Refresh()
+	s.updateSelect("")
 }
 
 // SetSelected sets the current option of the select widget
 func (s *Select) SetSelected(text string) {
 	for _, option := range s.Options {
 		if text == option {
-			s.Selected = text
+			s.updateSelect(text)
 		}
 	}
+}
+
+func (s *Select) updateSelect(text string) {
+	s.Selected = text
 
 	if s.OnChanged != nil {
-		s.OnChanged(text)
+		s.OnChanged(s.Selected)
 	}
 
 	s.Refresh()

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -47,7 +47,6 @@ func TestSelect_ClearSelected(t *testing.T) {
 	assert.Equal(t, optClear, combo.Selected)
 	assert.True(t, triggered)
 	assert.Equal(t, optClear, triggeredValue)
-
 }
 
 func TestSelect_SetSelected(t *testing.T) {

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -97,6 +97,50 @@ func TestSelect_SetSelected_Callback(t *testing.T) {
 	assert.Equal(t, "2", selected)
 }
 
+func TestSelect_SetSelected_InvalidNoCallback(t *testing.T) {
+	var triggered bool
+	combo := NewSelect([]string{"1", "2"}, func(string) {
+		triggered = true
+	})
+	combo.SetSelected("")
+
+	assert.False(t, triggered)
+}
+
+func TestSelect_updateSelected(t *testing.T) {
+	const (
+		opt1 = "1"
+		opt2 = "2"
+	)
+
+	combo := NewSelect([]string{opt1, opt2}, func(string) {})
+
+	combo.updateSelected(opt2)
+
+	assert.Equal(t, opt2, combo.Selected)
+}
+
+func TestSelect_updateSelected_Callback(t *testing.T) {
+	const (
+		opt1 = "1"
+		opt2 = "2"
+	)
+	var (
+		triggered      bool
+		triggeredValue string
+	)
+
+	combo := NewSelect([]string{opt1, opt2}, func(s string) {
+		triggered = true
+		triggeredValue = s
+	})
+
+	combo.updateSelected(opt2)
+
+	assert.True(t, triggered)
+	assert.Equal(t, opt2, triggeredValue)
+}
+
 func TestSelect_Tapped(t *testing.T) {
 	combo := NewSelect([]string{"1", "2"}, func(s string) {})
 	test.Tap(combo)

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -37,15 +37,39 @@ func TestSelect_ClearSelected(t *testing.T) {
 	combo.SetSelected(opt1)
 	assert.Equal(t, opt1, combo.Selected)
 
+	var triggered bool
+	var triggeredValue string
+	combo.OnChanged = func(s string) {
+		triggered = true
+		triggeredValue = s
+	}
 	combo.ClearSelected()
 	assert.Equal(t, optClear, combo.Selected)
+	assert.True(t, triggered)
+	assert.Equal(t, optClear, triggeredValue)
+
 }
 
 func TestSelect_SetSelected(t *testing.T) {
-	combo := NewSelect([]string{"1", "2"}, func(string) {})
+	var triggered bool
+	var triggeredValue string
+	combo := NewSelect([]string{"1", "2"}, func(s string) {
+		triggered = true
+		triggeredValue = s
+	})
 	combo.SetSelected("2")
 
 	assert.Equal(t, "2", combo.Selected)
+	assert.True(t, triggered)
+	assert.Equal(t, "2", triggeredValue)
+}
+
+func TestSelect_SetSelected_NoChangeOnEmpty(t *testing.T) {
+	var triggered bool
+	combo := NewSelect([]string{"1", "2"}, func(string) { triggered = true })
+	combo.SetSelected("")
+
+	assert.False(t, triggered)
 }
 
 func TestSelect_SetSelected_Invalid(t *testing.T) {

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -25,6 +25,22 @@ func TestSelect_PlaceHolder(t *testing.T) {
 	assert.Equal(t, "changed!", combo.PlaceHolder)
 }
 
+func TestSelect_ClearSelected(t *testing.T) {
+	const (
+		opt1     = "1"
+		opt2     = "2"
+		optClear = ""
+	)
+	combo := NewSelect([]string{opt1, opt2}, func(string) {})
+	assert.NotEmpty(t, combo.PlaceHolder)
+
+	combo.SetSelected(opt1)
+	assert.Equal(t, opt1, combo.Selected)
+
+	combo.ClearSelected()
+	assert.Equal(t, optClear, combo.Selected)
+}
+
 func TestSelect_SetSelected(t *testing.T) {
 	combo := NewSelect([]string{"1", "2"}, func(string) {})
 	combo.SetSelected("2")


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Adding the ability to reset the current selection on a Select widget causing it to use the PlaceHolder text.  This feature came out while having cascading Select widgets where one Select's selection determined what should be in the other Select.  When changing the first selection, the text being shown would stay the last chosen value.  The only way around this was to set the current selection to a value that is in the Select's option slice.  What is desired is that you could easily reset the current selection.  The other option would be to keep separate Selects around for each sub list and swap them out, but this is a cumbersome approach.

Fixes #(issue)
https://github.com/fyne-io/fyne/issues/723

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
