### PR TITLE
Bugfix: absolute position computation + Select.Move()

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -277,6 +277,16 @@ func (c *glCanvas) AddShortcut(shortcut fyne.Shortcut, handler func(shortcut fyn
 	c.shortcut.AddShortcut(shortcut, handler)
 }
 
+func (c *glCanvas) objectTrees() []fyne.CanvasObject {
+	trees := make([]fyne.CanvasObject, 0, len(c.Overlays().List())+2)
+	trees = append(trees, c.content)
+	if c.menu != nil {
+		trees = append(trees, c.menu)
+	}
+	trees = append(trees, c.Overlays().List()...)
+	return trees
+}
+
 func (c *glCanvas) ensureMinSize() bool {
 	if c.Content() == nil {
 		return false

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -33,37 +33,13 @@ func (d *gLDriver) CanvasForObject(obj fyne.CanvasObject) fyne.Canvas {
 }
 
 func (d *gLDriver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position {
-	var pos fyne.Position
-	found := false
 	c := d.CanvasForObject(co)
 	if c == nil {
-		return pos
+		return fyne.NewPos(0, 0)
 	}
 
 	glc := c.(*glCanvas)
-	findPos := func(o fyne.CanvasObject, p fyne.Position, _ fyne.Position, _ fyne.Size) bool {
-		if o == co {
-			pos = p
-			found = true
-			return true
-		}
-		return false
-	}
-
-	driver.WalkVisibleObjectTree(glc.content, findPos, nil)
-	if !found && glc.menu != nil {
-		driver.WalkVisibleObjectTree(glc.menu, findPos, nil)
-	}
-	if !found {
-		for _, overlay := range glc.Overlays().List() {
-			driver.WalkVisibleObjectTree(overlay, findPos, nil)
-			if found {
-				break
-			}
-		}
-	}
-
-	return pos
+	return driver.AbsolutePositionForObject(co, glc.objectTrees())
 }
 
 func (d *gLDriver) Device() fyne.Device {

--- a/internal/driver/glfw/driver_test.go
+++ b/internal/driver/glfw/driver_test.go
@@ -1,0 +1,100 @@
+// +build !ci
+
+package glfw
+
+import (
+	"testing"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/internal/cache"
+	"fyne.io/fyne/widget"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_gLDriver_AbsolutePositionForObject(t *testing.T) {
+	w := d.CreateWindow("Test")
+
+	cr1c1 := widget.NewLabel("row 1 col 1")
+	cr1c2 := widget.NewLabel("row 1 col 2")
+	cr1c3 := widget.NewLabel("row 1 col 3")
+	cr2c1 := widget.NewLabel("row 2 col 1")
+	cr2c2 := widget.NewLabel("row 2 col 2")
+	cr2c3 := widget.NewLabel("row 2 col 3")
+	cr3c1 := widget.NewLabel("row 3 col 1")
+	cr3c2 := widget.NewLabel("row 3 col 2")
+	cr3c3 := widget.NewLabel("row 3 col 3")
+	cr1 := widget.NewHBox(cr1c1, cr1c2, cr1c3)
+	cr2 := widget.NewHBox(cr2c1, cr2c2, cr2c3)
+	cr3 := widget.NewHBox(cr3c1, cr3c2, cr3c3)
+	content := widget.NewVBox(cr1, cr2, cr3)
+
+	cr2c2.Hide()
+	w.SetContent(content)
+	w.Resize(fyne.NewSize(200, 200))
+
+	mm := fyne.NewMainMenu(
+		fyne.NewMenu("Menu 1", fyne.NewMenuItem("Menu 1 Item", nil)),
+		fyne.NewMenu("Menu 2", fyne.NewMenuItem("Menu 2 Item", nil)),
+	)
+	// We want to test the handling of the canvas' Fyne menu here.
+	// We work around w.SetMainMenu because on MacOS the main menu is a native menu.
+	c := w.Canvas().(*glCanvas)
+	mbar := buildMenuBar(mm, c)
+	c.setMenuBar(mbar)
+
+	ovli1 := widget.NewLabel("Overlay Item 1")
+	ovli2 := widget.NewLabel("Overlay Item 2")
+	ovli3 := widget.NewLabel("Overlay Item 3")
+	ovlContent := widget.NewVBox(ovli1, ovli2, ovli3)
+	ovl := widget.NewModalPopUp(ovlContent, c)
+
+	repaintWindow(w.(*window))
+	// accessing the menu bar's actual CanvasObjects isn't straight forward
+	m2 := cache.Renderer(mbar).Objects()[1]
+
+	tests := map[string]struct {
+		object fyne.CanvasObject
+		want   fyne.Position
+	}{
+		"a cell": {
+			object: cr1c3,
+			want:   fyne.NewPos(182, 33),
+		},
+		"a row": {
+			object: cr2,
+			want:   fyne.NewPos(4, 66),
+		},
+		"the window content": {
+			object: content,
+			want:   fyne.NewPos(4, 33),
+		},
+		"a hidden element": {
+			object: cr2c2,
+			want:   fyne.NewPos(0, 0),
+		},
+
+		"a menu": {
+			object: m2,
+			want:   fyne.NewPos(74, 0),
+		},
+
+		"an overlay item": {
+			object: ovli2,
+			want:   fyne.NewPos(79, 85),
+		},
+		"the overlay content": {
+			object: ovlContent,
+			want:   fyne.NewPos(79, 52),
+		},
+		"the overlay": {
+			object: ovl,
+			want:   fyne.NewPos(0, 0),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, d.AbsolutePositionForObject(tt.object))
+		})
+	}
+}

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -179,6 +179,16 @@ func (c *mobileCanvas) Capture() image.Image {
 	return c.painter.Capture(c)
 }
 
+func (c *mobileCanvas) objectTrees() []fyne.CanvasObject {
+	trees := make([]fyne.CanvasObject, 0, len(c.Overlays().List())+2)
+	trees = append(trees, c.content)
+	if c.menu != nil {
+		trees = append(trees, c.menu)
+	}
+	trees = append(trees, c.Overlays().List()...)
+	return trees
+}
+
 func (c *mobileCanvas) walkTree(
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
 	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -76,18 +76,13 @@ func (d *mobileDriver) CanvasForObject(fyne.CanvasObject) fyne.Canvas {
 }
 
 func (d *mobileDriver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position {
-	var pos fyne.Position
-	c := fyne.CurrentApp().Driver().CanvasForObject(co).(*mobileCanvas)
+	c := d.CanvasForObject(co)
+	if c == nil {
+		return fyne.NewPos(0, 0)
+	}
 
-	c.walkTree(func(o fyne.CanvasObject, p fyne.Position, _ fyne.Position, _ fyne.Size) bool {
-		if o == co {
-			pos = p
-			return true
-		}
-		return false
-	}, nil)
-
-	return pos
+	mc := c.(*mobileCanvas)
+	return driver.AbsolutePositionForObject(co, mc.objectTrees())
 }
 
 func (d *mobileDriver) Quit() {

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -5,7 +5,6 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/internal/cache"
-	"fyne.io/fyne/widget"
 )
 
 // WalkVisibleObjectTree will walk an object tree for all visible objects executing the passed functions following
@@ -65,9 +64,9 @@ func walkObjectTree(
 	case fyne.Widget:
 		children = cache.Renderer(co).Objects()
 
-		if scroll, ok := obj.(*widget.ScrollContainer); ok {
+		if _, ok := obj.(fyne.Scrollable); ok {
 			clipPos = pos
-			clipSize = scroll.Size()
+			clipSize = obj.Size()
 		}
 	}
 
@@ -142,4 +141,23 @@ func FindObjectAtPositionMatching(mouse fyne.Position, matches func(object fyne.
 	}
 
 	return found, foundPos
+}
+
+// AbsolutePositionForObject returns the absolute position of an object in a set of object trees.
+// If the object is not part of any of the trees, the position (0,0) is returned.
+func AbsolutePositionForObject(object fyne.CanvasObject, trees []fyne.CanvasObject) fyne.Position {
+	var pos fyne.Position
+	findPos := func(o fyne.CanvasObject, p fyne.Position, _ fyne.Position, _ fyne.Size) bool {
+		if o == object {
+			pos = p
+			return true
+		}
+		return false
+	}
+	for _, tree := range trees {
+		if WalkVisibleObjectTree(tree, findPos, nil) {
+			break
+		}
+	}
+	return pos
 }

--- a/internal/driver/util_test.go
+++ b/internal/driver/util_test.go
@@ -1,4 +1,4 @@
-package driver
+package driver_test
 
 import (
 	"image/color"
@@ -8,6 +8,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/internal/driver"
 	"fyne.io/fyne/layout"
 	_ "fyne.io/fyne/test"
 	"fyne.io/fyne/widget"
@@ -21,7 +22,7 @@ func TestWalkVisibleObjectTree(t *testing.T) {
 	base := widget.NewHBox(rect, child)
 
 	walked := 0
-	WalkVisibleObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
+	driver.WalkVisibleObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
 		walked++
 		return false
 	}, nil)
@@ -37,7 +38,7 @@ func TestWalkWholeObjectTree(t *testing.T) {
 	base := widget.NewHBox(rect, child)
 
 	walked := 0
-	WalkCompleteObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
+	driver.WalkCompleteObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
 		walked++
 		return false
 	}, nil)
@@ -54,7 +55,7 @@ func TestWalkVisibleObjectTree_Clip(t *testing.T) {
 	clipPos := fyne.NewPos(0, 0)
 	clipSize := rect.MinSize()
 
-	WalkVisibleObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
+	driver.WalkVisibleObjectTree(base, func(object fyne.CanvasObject, position fyne.Position, clippingPos fyne.Position, clippingSize fyne.Size) bool {
 		if _, ok := object.(*widget.ScrollContainer); ok {
 			clipPos = clippingPos
 			clipSize = clippingSize
@@ -64,4 +65,102 @@ func TestWalkVisibleObjectTree_Clip(t *testing.T) {
 
 	assert.Equal(t, fyne.NewPos(0, 104), clipPos)
 	assert.Equal(t, fyne.NewSize(100, 100), clipSize)
+}
+
+func TestAbsolutePositionForObject(t *testing.T) {
+	t1r1c1 := widget.NewLabel("row 1 col 1")
+	t1r1c2 := widget.NewLabel("row 1 col 2")
+	t1r2c1 := widget.NewLabel("row 2 col 1")
+	t1r2c2 := widget.NewLabel("row 2 col 2")
+	t1r2c2.Hide()
+	t1r1 := fyne.NewContainer(t1r1c1, t1r1c2)
+	t1r2 := fyne.NewContainer(t1r2c1, t1r2c2)
+	tree1 := fyne.NewContainer(t1r1, t1r2)
+
+	t1r1c1.Move(fyne.NewPos(111, 111))
+	t1r1c2.Move(fyne.NewPos(112, 112))
+	t1r2c1.Move(fyne.NewPos(121, 121))
+	t1r2c2.Move(fyne.NewPos(122, 122))
+	t1r1.Move(fyne.NewPos(11, 11))
+	t1r2.Move(fyne.NewPos(12, 12))
+	tree1.Move(fyne.NewPos(1, 1))
+
+	t2r1c1 := widget.NewLabel("row 1 col 1")
+	t2r1c2 := widget.NewLabel("row 1 col 2")
+	t2r2c1 := widget.NewLabel("row 2 col 1")
+	t2r2c2 := widget.NewLabel("row 2 col 2")
+	t2r1 := fyne.NewContainer(t2r1c1, t2r1c2)
+	t2r2 := fyne.NewContainer(t2r2c1, t2r2c2)
+	tree2 := fyne.NewContainer(t2r1, t2r2)
+
+	t2r1c1.Move(fyne.NewPos(211, 211))
+	t2r1c2.Move(fyne.NewPos(212, 212))
+	t2r2c1.Move(fyne.NewPos(221, 221))
+	t2r2c2.Move(fyne.NewPos(222, 222))
+	t2r1.Move(fyne.NewPos(21, 21))
+	t2r2.Move(fyne.NewPos(22, 22))
+	tree2.Move(fyne.NewPos(2, 2))
+
+	t3r1 := widget.NewLabel("row 1")
+	t3r2 := widget.NewLabel("row 2")
+	tree3 := fyne.NewContainer(t3r1, t3r2)
+
+	t3r1.Move(fyne.NewPos(31, 31))
+	t3r2.Move(fyne.NewPos(32, 32))
+	tree3.Move(fyne.NewPos(3, 3))
+
+	trees := []fyne.CanvasObject{tree1, tree2, tree3}
+
+	outsideTrees := widget.NewLabel("outside trees")
+	outsideTrees.Move(fyne.NewPos(10, 10))
+
+	tests := map[string]struct {
+		object fyne.CanvasObject
+		want   fyne.Position
+	}{
+		"tree 1: a cell": {
+			object: t1r1c2,
+			want:   fyne.NewPos(124, 124), // 1 (root) + 11 (row 1) + 112 (cell 2)
+		},
+		"tree 1: a row": {
+			object: t1r2,
+			want:   fyne.NewPos(13, 13), // 1 (root) + 12 (row 2)
+		},
+		"tree 1: root": {
+			object: tree1,
+			want:   fyne.NewPos(1, 1),
+		},
+		"tree 1: a hidden element": {
+			object: t1r2c2,
+			want:   fyne.NewPos(0, 0),
+		},
+
+		"tree 2: a row": {
+			object: t2r2,
+			want:   fyne.NewPos(24, 24), // 2 (root) + 22 (row 2)
+		},
+		"tree 2: root": {
+			object: tree2,
+			want:   fyne.NewPos(2, 2),
+		},
+
+		"tree 3: a row": {
+			object: t3r2,
+			want:   fyne.NewPos(35, 35), // 3 (root) + 32 (row 2)
+		},
+		"tree 3: root": {
+			object: tree3,
+			want:   fyne.NewPos(3, 3),
+		},
+
+		"an object not inside any tree": {
+			object: outsideTrees,
+			want:   fyne.NewPos(0, 0),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, driver.AbsolutePositionForObject(tt.object, trees))
+		})
+	}
 }

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -167,6 +167,15 @@ func (c *testCanvas) Capture() image.Image {
 	return img
 }
 
+func (c *testCanvas) objectTrees() []fyne.CanvasObject {
+	trees := make([]fyne.CanvasObject, 0, len(c.Overlays().List())+1)
+	if c.content != nil {
+		trees = append(trees, c.content)
+	}
+	trees = append(trees, c.Overlays().List()...)
+	return trees
+}
+
 // NewCanvas returns a single use in-memory canvas used for testing
 func NewCanvas() WindowlessCanvas {
 	padding := fyne.NewSize(10, 10)

--- a/test/testdriver.go
+++ b/test/testdriver.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/internal/driver"
+
 	"github.com/goki/freetype/truetype"
 	"golang.org/x/image/font"
 )
@@ -32,7 +34,13 @@ func (d *testDriver) CanvasForObject(fyne.CanvasObject) fyne.Canvas {
 }
 
 func (d *testDriver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position {
-	return co.Position() // TODO get the real answer
+	c := d.CanvasForObject(co)
+	if c == nil {
+		return fyne.NewPos(0, 0)
+	}
+
+	tc := c.(*testCanvas)
+	return driver.AbsolutePositionForObject(co, tc.objectTrees())
 }
 
 func (d *testDriver) CreateWindow(string) fyne.Window {

--- a/widget/select.go
+++ b/widget/select.go
@@ -112,6 +112,15 @@ func (s *Select) Hide() {
 	s.BaseWidget.Hide()
 }
 
+// Move satisfies the fyne.CanvasObject interface.
+func (s *Select) Move(pos fyne.Position) {
+	s.BaseWidget.Move(pos)
+
+	if s.popUp != nil {
+		s.popUp.Move(s.popUpPos())
+	}
+}
+
 // Resize sets a new size for a widget.
 // Note this should not be used if the widget is being managed by a Layout within a Container.
 func (s *Select) Resize(size fyne.Size) {
@@ -140,11 +149,13 @@ func (s *Select) Tapped(*fyne.PointEvent) {
 		items = append(items, item)
 	}
 
-	buttonPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(s.super())
-	popUpPos := buttonPos.Add(fyne.NewPos(0, s.Size().Height))
-
-	s.popUp = NewPopUpMenuAtPosition(fyne.NewMenu("", items...), c, popUpPos)
+	s.popUp = NewPopUpMenuAtPosition(fyne.NewMenu("", items...), c, s.popUpPos())
 	s.popUp.Resize(fyne.NewSize(s.Size().Width, s.popUp.MinSize().Height))
+}
+
+func (s *Select) popUpPos() fyne.Position {
+	buttonPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(s.super())
+	return buttonPos.Add(fyne.NewPos(0, s.Size().Height))
 }
 
 // TappedSecondary is called when a secondary pointer tapped event is captured

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -83,6 +83,7 @@ func TestSelect_Tapped_Constrained(t *testing.T) {
 	combo := NewSelect([]string{"1", "2"}, func(s string) {})
 	canvas := fyne.CurrentApp().Driver().CanvasForObject(combo)
 	canvas.(test.WindowlessCanvas).Resize(fyne.NewSize(100, 100))
+	canvas.SetContent(combo)
 
 	combo.Resize(combo.MinSize())
 	combo.Move(fyne.NewPos(canvas.Size().Width-10, canvas.Size().Height-10))

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne/theme"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSelect(t *testing.T) {
@@ -108,4 +109,26 @@ func TestSelectRenderer_ApplyTheme(t *testing.T) {
 	})
 
 	assert.NotEqual(t, textSize, customTextSize)
+}
+
+func TestSelect_Move(t *testing.T) {
+	// fresh app for this test
+	app := test.NewApp()
+	// don't let our app hang around for too long
+	defer test.NewApp()
+
+	combo := NewSelect([]string{"1", "2"}, nil)
+	canvas := app.Driver().CanvasForObject(combo)
+	canvas.(test.WindowlessCanvas).Resize(fyne.NewSize(100, 100))
+	canvas.SetContent(combo)
+
+	combo.Resize(combo.MinSize())
+	combo.Move(fyne.NewPos(10, 10))
+	require.Equal(t, fyne.NewPos(10, 10), combo.Position())
+
+	combo.Tapped(&fyne.PointEvent{})
+	require.Equal(t, fyne.NewPos(10, 39), combo.popUp.innerPos)
+
+	combo.Move(fyne.NewPos(20, 20))
+	assert.Equal(t, fyne.NewPos(20, 49), combo.popUp.innerPos)
 }


### PR DESCRIPTION
### Description:

Moving a `Select` with an open pop-up now moves the pop-up, too.
This implies a fix to `driver.AbsolutePositionForObject`.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
