### PR TITLE
Bugfix #469: canvas stack

### DIFF
--- a/cmd/fyne_demo/screens/window.go
+++ b/cmd/fyne_demo/screens/window.go
@@ -60,11 +60,15 @@ func DialogScreen(win fyne.Window) fyne.CanvasObject {
 			prog.Show()
 		}),
 		widget.NewButton("Custom", func() {
-			content := widget.NewEntry()
-			content.SetPlaceHolder("Type something here")
-			content.OnChanged = func(text string) {
+			entry := widget.NewEntry()
+			entry.SetPlaceHolder("Type something here")
+			entry.OnChanged = func(text string) {
 				fmt.Println("Entered", text)
 			}
+			sel := widget.NewSelect([]string{"Option A", "Option B", "Option C"}, func(o string) {
+				fmt.Println("Selected", o)
+			})
+			content := widget.NewVBox(entry, sel)
 			dialog.ShowCustom("Custom dialog", "Done", content, win)
 		}),
 	)

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -69,6 +69,7 @@ type renderCacheNode struct {
 type overlayStack struct {
 	internal.OverlayStack
 
+	onChange     func()
 	renderCaches []*renderCacheTree
 }
 
@@ -78,11 +79,13 @@ func (o *overlayStack) Add(overlay fyne.CanvasObject) {
 	}
 	o.OverlayStack.Add(overlay)
 	o.renderCaches = append(o.renderCaches, &renderCacheTree{root: &renderCacheNode{obj: overlay}})
+	o.onChange()
 }
 
 func (o *overlayStack) Remove(overlay fyne.CanvasObject) {
 	o.OverlayStack.Remove(overlay)
 	o.renderCaches = o.renderCaches[:len(o.List())]
+	o.onChange()
 }
 
 func (c *glCanvas) Capture() image.Image {
@@ -544,7 +547,7 @@ func newCanvas() *glCanvas {
 	c.contentTree = &renderCacheTree{root: &renderCacheNode{obj: c.content}}
 	c.padded = true
 
-	c.overlays = &overlayStack{}
+	c.overlays = &overlayStack{onChange: func() { c.setDirty(true) }}
 
 	c.focusMgr = app.NewFocusManager(c)
 	c.refreshQueue = make(chan fyne.CanvasObject, 1024)

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -69,19 +69,20 @@ type renderCacheNode struct {
 type overlayStack struct {
 	internal.OverlayStack
 
-	renderCache *renderCacheTree
+	renderCaches []*renderCacheTree
 }
 
 func (o *overlayStack) Add(overlay fyne.CanvasObject) {
+	if overlay == nil {
+		return
+	}
 	o.OverlayStack.Add(overlay)
-	o.renderCache = &renderCacheTree{root: &renderCacheNode{obj: overlay}}
+	o.renderCaches = append(o.renderCaches, &renderCacheTree{root: &renderCacheNode{obj: overlay}})
 }
 
 func (o *overlayStack) Remove(overlay fyne.CanvasObject) {
 	o.OverlayStack.Remove(overlay)
-	if o.Top() == nil {
-		o.renderCache = nil
-	}
+	o.renderCaches = o.renderCaches[:len(o.List())]
 }
 
 func (c *glCanvas) Capture() image.Image {
@@ -379,13 +380,15 @@ func (c *glCanvas) walkTrees(
 	beforeChildren func(*renderCacheNode, fyne.Position),
 	afterChildren func(*renderCacheNode),
 ) {
+	c.RLock()
+	defer c.RUnlock()
 	c.walkTree(c.contentTree, beforeChildren, afterChildren)
 	if c.menu != nil {
 		c.walkTree(c.menuTree, beforeChildren, afterChildren)
 	}
-	for _, overlay := range c.overlays.List() {
-		if overlay != nil {
-			c.walkTree(c.overlays.renderCache, beforeChildren, afterChildren)
+	for _, tree := range c.overlays.renderCaches {
+		if tree != nil {
+			c.walkTree(tree, beforeChildren, afterChildren)
 		}
 	}
 }

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -42,6 +42,7 @@ func TestGlCanvas_Resize(t *testing.T) {
 	assert.Equal(t, size, content.Size())
 }
 
+// TODO: this can be removed when #707 is addressed
 func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
 	w := d.CreateWindow("Test")
 	w.SetPadded(false)
@@ -63,6 +64,7 @@ func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
 	assert.Equal(t, overContentSize, over.Content.Size(), "canvas overlay content is _not_ resized")
 }
 
+// TODO: this can be removed when #707 is addressed
 func TestGlCanvas_ResizeWithOtherOverlay(t *testing.T) {
 	w := d.CreateWindow("Test")
 	w.SetPadded(false)
@@ -81,6 +83,38 @@ func TestGlCanvas_ResizeWithOtherOverlay(t *testing.T) {
 	w.Resize(size)
 	assert.Equal(t, size, content.Size(), "canvas content is resized")
 	assert.Equal(t, size, over.Size(), "canvas overlay is resized")
+}
+
+func TestGlCanvas_ResizeWithOverlays(t *testing.T) {
+	w := d.CreateWindow("Test")
+	w.SetPadded(false)
+
+	content := widget.NewLabel("Content")
+	o1 := widget.NewLabel("o1")
+	o2 := widget.NewLabel("o2")
+	o3 := widget.NewLabel("o3")
+	w.SetContent(content)
+	w.Canvas().Overlays().Add(o1)
+	// TODO: address #707; overlays should always be canvas size
+	o1.Resize(w.Canvas().Size())
+	w.Canvas().Overlays().Add(o2)
+	// TODO: address #707; overlays should always be canvas size
+	o2.Resize(w.Canvas().Size())
+	w.Canvas().Overlays().Add(o3)
+	// TODO: address #707; overlays should always be canvas size
+	o3.Resize(w.Canvas().Size())
+
+	size := fyne.NewSize(100, 100)
+	assert.NotEqual(t, size, content.Size())
+	assert.NotEqual(t, size, o1.Size())
+	assert.NotEqual(t, size, o2.Size())
+	assert.NotEqual(t, size, o3.Size())
+
+	w.Resize(size)
+	assert.Equal(t, size, content.Size(), "canvas content is resized")
+	assert.Equal(t, size, o1.Size(), "canvas overlay 1 is resized")
+	assert.Equal(t, size, o2.Size(), "canvas overlay 2 is resized")
+	assert.Equal(t, size, o3.Size(), "canvas overlay 3 is resized")
 }
 
 func TestGlCanvas_Scale(t *testing.T) {

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -4,7 +4,7 @@ import "fyne.io/fyne"
 
 // OverlayStack implements fyne.OverlayStack
 type OverlayStack struct {
-	overlay fyne.CanvasObject
+	overlays []fyne.CanvasObject
 }
 
 var _ fyne.OverlayStack = (*OverlayStack)(nil)
@@ -14,26 +14,28 @@ func (s *OverlayStack) Add(overlay fyne.CanvasObject) {
 	if overlay == nil {
 		return
 	}
-	s.overlay = overlay
+	s.overlays = append(s.overlays, overlay)
 }
 
 // List satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) List() []fyne.CanvasObject {
-	if s.overlay == nil {
-		return nil
-	}
-	return []fyne.CanvasObject{s.overlay}
+	return s.overlays
 }
 
 // Remove satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Remove(overlay fyne.CanvasObject) {
-	if s.overlay != overlay {
-		return
+	for i, o := range s.overlays {
+		if o == overlay {
+			s.overlays = s.overlays[:i]
+			break
+		}
 	}
-	s.overlay = nil
 }
 
 // Top satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Top() fyne.CanvasObject {
-	return s.overlay
+	if len(s.overlays) == 0 {
+		return nil
+	}
+	return s.overlays[len(s.overlays)-1]
 }

--- a/internal/overlay_stack_test.go
+++ b/internal/overlay_stack_test.go
@@ -1,0 +1,56 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/internal"
+	"fyne.io/fyne/widget"
+)
+
+func TestOverlayStack(t *testing.T) {
+	s := &internal.OverlayStack{}
+	o1 := widget.NewLabel("A")
+	o2 := widget.NewLabel("B")
+	o3 := widget.NewLabel("C")
+	o4 := widget.NewLabel("D")
+	o5 := widget.NewLabel("E")
+
+	// initial empty
+	assert.Empty(t, s.List())
+	assert.Nil(t, s.Top())
+
+	// add one & remove
+	s.Add(o1)
+	assert.Equal(t, []fyne.CanvasObject{o1}, s.List())
+	assert.Equal(t, o1, s.Top())
+	// remove other does nothing
+	s.Remove(o2)
+	assert.Equal(t, []fyne.CanvasObject{o1}, s.List())
+	assert.Equal(t, o1, s.Top())
+	// remove the correct one
+	s.Remove(o1)
+	assert.Empty(t, s.List())
+	assert.Nil(t, s.Top())
+
+	// add multiple & remove
+	s.Add(o1)
+	s.Add(o2)
+	s.Add(o3)
+	s.Add(o4)
+	s.Add(o5)
+	assert.Equal(t, []fyne.CanvasObject{o1, o2, o3, o4, o5}, s.List())
+	assert.Equal(t, o5, s.Top())
+	s.Remove(o5)
+	assert.Equal(t, []fyne.CanvasObject{o1, o2, o3, o4}, s.List())
+	assert.Equal(t, o4, s.Top())
+	// remove cuts the stack
+	s.Remove(o2)
+	assert.Equal(t, []fyne.CanvasObject{o1}, s.List())
+	assert.Equal(t, o1, s.Top())
+	s.Remove(o1)
+	assert.Empty(t, s.List())
+	assert.Nil(t, s.Top())
+}

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -18,15 +18,19 @@ type PopUp struct {
 	Content fyne.CanvasObject
 	Canvas  fyne.Canvas
 
-	innerPos  fyne.Position
-	innerSize fyne.Size
-	modal     bool
+	innerPos     fyne.Position
+	innerSize    fyne.Size
+	modal        bool
+	overlayShown bool
 }
 
 // Hide this widget, if it was previously visible
 func (p *PopUp) Hide() {
+	if p.overlayShown {
+		p.Canvas.Overlays().Remove(p)
+		p.overlayShown = false
+	}
 	p.BaseWidget.Hide()
-	p.Canvas.Overlays().Remove(p)
 }
 
 // Move the widget to a new position. A PopUp position is absolute to the top, left of its canvas.
@@ -52,8 +56,11 @@ func (p *PopUp) Resize(size fyne.Size) {
 
 // Show this widget, if it was previously hidden
 func (p *PopUp) Show() {
+	if !p.overlayShown {
+		p.Canvas.Overlays().Add(p)
+		p.overlayShown = true
+	}
 	p.BaseWidget.Show()
-	p.Canvas.Overlays().Add(p)
 }
 
 // Tapped is called when the user taps the popUp background - if not modal then dismiss this widget

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -13,6 +13,7 @@ import (
 func TestNewPopUp(t *testing.T) {
 	label := NewLabel("Hi")
 	pop := NewPopUp(label, test.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	assert.True(t, pop.Visible())
 	assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
@@ -32,6 +33,7 @@ func TestPopUp_Hide(t *testing.T) {
 func TestPopUp_MinSize(t *testing.T) {
 	label := NewLabel("Hi")
 	pop := NewPopUp(label, test.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	inner := pop.Content.MinSize()
 	assert.Equal(t, label.MinSize().Width, inner.Width)
@@ -47,6 +49,7 @@ func TestPopUp_Move(t *testing.T) {
 	win := test.NewWindow(NewLabel("OK"))
 	win.Resize(fyne.NewSize(50, 50))
 	pop := NewPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	pos := fyne.NewPos(10, 10)
 	pop.Move(pos)
@@ -65,6 +68,7 @@ func TestPopUp_Move_Constrained(t *testing.T) {
 	win := test.NewWindow(NewLabel("OK"))
 	win.Resize(fyne.NewSize(60, 40))
 	pop := NewPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	pos := fyne.NewPos(30, 20)
 	pop.Move(pos)
@@ -85,6 +89,7 @@ func TestPopUp_Move_ConstrainedWindowToSmall(t *testing.T) {
 	win := test.NewWindow(NewLabel("OK"))
 	win.Resize(fyne.NewSize(10, 5))
 	pop := NewPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	pos := fyne.NewPos(20, 10)
 	pop.Move(pos)
@@ -99,6 +104,7 @@ func TestPopUp_Resize(t *testing.T) {
 	win := test.NewWindow(NewLabel("OK"))
 	win.Resize(fyne.NewSize(80, 80))
 	pop := NewPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	size := fyne.NewSize(50, 40)
 	pop.Resize(size)
@@ -132,9 +138,46 @@ func TestPopUp_TappedSecondary(t *testing.T) {
 	assert.Equal(t, 0, len(test.Canvas().Overlays().List()))
 }
 
+func TestPopUp_Stacked(t *testing.T) {
+	assert.Nil(t, test.Canvas().Overlays().Top())
+	assert.Empty(t, test.Canvas().Overlays().List())
+
+	pop1 := NewPopUp(NewLabel("Hi"), test.Canvas())
+	assert.True(t, pop1.Visible())
+	assert.Equal(t, pop1, test.Canvas().Overlays().Top())
+	assert.Equal(t, []fyne.CanvasObject{pop1}, test.Canvas().Overlays().List())
+
+	pop2 := NewPopUp(NewLabel("Hi"), test.Canvas())
+	assert.True(t, pop1.Visible())
+	assert.True(t, pop2.Visible())
+	assert.Equal(t, pop2, test.Canvas().Overlays().Top())
+	assert.Equal(t, []fyne.CanvasObject{pop1, pop2}, test.Canvas().Overlays().List())
+
+	pop3 := NewPopUp(NewLabel("Hi"), test.Canvas())
+	assert.True(t, pop1.Visible())
+	assert.True(t, pop2.Visible())
+	assert.True(t, pop3.Visible())
+	assert.Equal(t, pop3, test.Canvas().Overlays().Top())
+	assert.Equal(t, []fyne.CanvasObject{pop1, pop2, pop3}, test.Canvas().Overlays().List())
+
+	pop3.Hide()
+	assert.True(t, pop1.Visible())
+	assert.True(t, pop2.Visible())
+	assert.False(t, pop3.Visible())
+	assert.Equal(t, pop2, test.Canvas().Overlays().Top())
+	assert.Equal(t, []fyne.CanvasObject{pop1, pop2}, test.Canvas().Overlays().List())
+
+	// hiding a pop-up cuts stack
+	pop1.Hide()
+	assert.False(t, pop1.Visible())
+	assert.Nil(t, test.Canvas().Overlays().Top())
+	assert.Empty(t, test.Canvas().Overlays().List())
+}
+
 func TestModalPopUp_Tapped(t *testing.T) {
 	label := NewLabel("Hi")
 	pop := NewModalPopUp(label, test.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	assert.True(t, pop.Visible())
 	test.Tap(pop)
@@ -146,6 +189,7 @@ func TestModalPopUp_Tapped(t *testing.T) {
 func TestModalPopUp_TappedSecondary(t *testing.T) {
 	label := NewLabel("Hi")
 	pop := NewModalPopUp(label, test.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
 
 	assert.True(t, pop.Visible())
 	test.TapSecondary(pop)


### PR DESCRIPTION
### Description:

This PR changes `OverlayStack` to be a real stack. Thus it allows for pop-ups in overlays.

Fixes #469 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
