### PR TITLE
Fix incorrect wording for Slider struct

### DIFF
--- a/widget/slider.go
+++ b/widget/slider.go
@@ -20,7 +20,7 @@ const (
 
 var _ fyne.Draggable = (*Slider)(nil)
 
-// Slider if a widget that can slide between two fixed values.
+// Slider is a widget that can slide between two fixed values.
 type Slider struct {
 	BaseWidget
 


### PR DESCRIPTION
### Description:
Changes `if` to `is`, not much more to it :)