### PR TITLE
Split Tappable interface

### DIFF
--- a/canvasobject.go
+++ b/canvasobject.go
@@ -29,6 +29,9 @@ type CanvasObject interface {
 // This should be implemented by buttons etc that wish to handle pointer interactions.
 type Tappable interface {
 	Tapped(*PointEvent)
+}
+
+type SecondaryTappable interface {
 	TappedSecondary(*PointEvent)
 }
 

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -31,6 +31,7 @@ type Tappable interface {
 	Tapped(*PointEvent)
 }
 
+// SecondaryTappable describes a CanvasObject that can be right-clicked or long-tapped.
 type SecondaryTappable interface {
 	TappedSecondary(*PointEvent)
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -579,7 +579,7 @@ func (w *window) mouseOut() {
 	})
 }
 
-func (w *window) mouseClicked(viewport *glfw.Window, btn glfw.MouseButton, action glfw.Action, mods glfw.ModifierKey) {
+func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.Action, mods glfw.ModifierKey) {
 	co, pos := w.findObjectAtPositionMatching(w.canvas, w.mousePos, func(object fyne.CanvasObject) bool {
 		if _, ok := object.(fyne.Tappable); ok {
 			return true
@@ -668,10 +668,9 @@ func (w *window) mouseClicked(viewport *glfw.Window, btn glfw.MouseButton, actio
 			w.mousePressed = co
 		} else if action == glfw.Release {
 			if co == w.mousePressed {
-				switch button {
-				case desktop.RightMouseButton:
+				if button == desktop.RightMouseButton && altTap {
 					w.queueEvent(func() { co.(fyne.SecondaryTappable).TappedSecondary(ev) })
-				default:
+				} else if button == desktop.LeftMouseButton && tap {
 					w.queueEvent(func() { co.(fyne.Tappable).Tapped(ev) })
 				}
 			}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -386,6 +386,44 @@ func TestWindow_Tapped(t *testing.T) {
 	}
 }
 
+func TestWindow_TappedSecondary(t *testing.T) {
+	w := d.CreateWindow("Test").(*window)
+	o := &tappableObject{Rectangle: canvas.NewRectangle(color.White)}
+	o.SetMinSize(fyne.NewSize(100, 100))
+	w.SetContent(o)
+
+	w.mousePos = fyne.NewPos(50, 60)
+	w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Press, 0)
+	w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Release, 0)
+	w.waitForEvents()
+
+	assert.Nil(t, o.popTapEvent(), "no primary tap")
+	if e, _ := o.popSecondaryTapEvent().(*fyne.PointEvent); assert.NotNil(t, e, "tapped secondary") {
+		assert.Equal(t, fyne.NewPos(50, 60), e.AbsolutePosition)
+		assert.Equal(t, fyne.NewPos(46, 56), e.Position)
+	}
+}
+
+func TestWindow_TappedSecondary_OnPrimaryOnlyTarget(t *testing.T) {
+	w := d.CreateWindow("Test").(*window)
+	tapped := false
+	o := widget.NewButton("Test", func() {
+		tapped = true
+	})
+	w.SetContent(o)
+
+	w.mousePos = fyne.NewPos(10, 25)
+	w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Press, 0)
+	w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Release, 0)
+	w.waitForEvents()
+	assert.False(t, tapped)
+
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.waitForEvents()
+	assert.True(t, tapped)
+}
+
 func TestWindow_TappedIgnoresScrollerClip(t *testing.T) {
 	w := d.CreateWindow("Test").(*window)
 	fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -305,7 +305,7 @@ func (c *mobileCanvas) tapMove(pos fyne.Position, tapID int,
 
 func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 	tapCallback func(fyne.Tappable, *fyne.PointEvent),
-	tapAltCallback func(fyne.Tappable, *fyne.PointEvent),
+	tapAltCallback func(fyne.SecondaryTappable, *fyne.PointEvent),
 	dragCallback func(fyne.Draggable, *fyne.DragEvent)) {
 	if c.dragging != nil {
 		c.dragging.DragEnd()
@@ -323,6 +323,8 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 
 	co, objPos := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
 		if _, ok := object.(fyne.Tappable); ok {
+			return true
+		} else if _, ok := object.(fyne.SecondaryTappable); ok {
 			return true
 		} else if _, ok := object.(mobile.Touchable); ok {
 			return true
@@ -345,11 +347,13 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 	ev.Position = objPos
 	ev.AbsolutePosition = pos
 
-	if wid, ok := co.(fyne.Tappable); ok {
-		// TODO move event queue to common code w.queueEvent(func() { wid.Tapped(ev) })
-		if duration < tapSecondaryDelay {
+	// TODO move event queue to common code w.queueEvent(func() { wid.Tapped(ev) })
+	if duration < tapSecondaryDelay {
+		if wid, ok := co.(fyne.Tappable); ok {
 			tapCallback(wid, ev)
-		} else {
+		}
+	} else {
+		if wid, ok := co.(fyne.SecondaryTappable); ok {
 			tapAltCallback(wid, ev)
 		}
 	}

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -43,7 +43,7 @@ func TestCanvas_Tapped(t *testing.T) {
 		tappedObj = wid
 		pointEvent = ev
 		wid.Tapped(ev)
-	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
+	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 		altTapped = true
 		wid.TappedSecondary(ev)
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
@@ -73,7 +73,7 @@ func TestCanvas_Tapped_Multi(t *testing.T) {
 	c.tapDown(tapPos, 0)
 	c.tapUp(tapPos, 1, func(wid fyne.Tappable, ev *fyne.PointEvent) { // different tapID
 		wid.Tapped(ev)
-	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
+	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
 
@@ -85,7 +85,7 @@ func TestCanvas_TappedSecondary(t *testing.T) {
 	altTapped := false
 	buttonTap := false
 	var pointEvent *fyne.PointEvent
-	var altTappedObj fyne.Tappable
+	var altTappedObj fyne.SecondaryTappable
 	button := widget.NewButton("Test", func() {
 		buttonTap = false
 	})
@@ -100,7 +100,7 @@ func TestCanvas_TappedSecondary(t *testing.T) {
 	c.tapUp(tapPos, 0, func(wid fyne.Tappable, ev *fyne.PointEvent) {
 		tapped = true
 		wid.Tapped(ev)
-	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
+	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 		altTapped = true
 		altTappedObj = wid
 		pointEvent = ev
@@ -156,7 +156,7 @@ func TestCanvas_Tappable(t *testing.T) {
 	assert.True(t, content.down)
 
 	c.tapUp(fyne.NewPos(15, 15), 0, func(wid fyne.Tappable, ev *fyne.PointEvent) {
-	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
+	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
 	assert.True(t, content.up)

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -81,37 +81,32 @@ func TestCanvas_Tapped_Multi(t *testing.T) {
 }
 
 func TestCanvas_TappedSecondary(t *testing.T) {
-	tapped := false
-	altTapped := false
-	buttonTap := false
 	var pointEvent *fyne.PointEvent
 	var altTappedObj fyne.SecondaryTappable
-	button := widget.NewButton("Test", func() {
-		buttonTap = false
-	})
+	obj := &tappableLabel{}
+	obj.ExtendBaseWidget(obj)
 	c := NewCanvas().(*mobileCanvas)
-	c.SetContent(button)
+	c.SetContent(obj)
 	c.resize(fyne.NewSize(36, 24))
-	button.Move(fyne.NewPos(3, 3))
+	obj.Move(fyne.NewPos(3, 3))
 
 	tapPos := fyne.NewPos(6, 6)
 	c.tapDown(tapPos, 0)
 	time.Sleep(310 * time.Millisecond)
 	c.tapUp(tapPos, 0, func(wid fyne.Tappable, ev *fyne.PointEvent) {
-		tapped = true
+		obj.tap = true
 		wid.Tapped(ev)
 	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
-		altTapped = true
+		obj.altTap = true
 		altTappedObj = wid
 		pointEvent = ev
 		wid.TappedSecondary(ev)
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
 
-	assert.False(t, tapped, "don't tap primary")
-	assert.True(t, altTapped, "tap secondary")
-	assert.False(t, buttonTap, "button should not be tapped (primary)")
-	assert.Equal(t, button, altTappedObj)
+	assert.False(t, obj.tap, "don't tap primary")
+	assert.True(t, obj.altTap, "tap secondary")
+	assert.Equal(t, obj, altTappedObj)
 	if assert.NotNil(t, pointEvent) {
 		assert.Equal(t, fyne.NewPos(6, 6), pointEvent.AbsolutePosition)
 		assert.Equal(t, fyne.NewPos(3, 3), pointEvent.Position)
@@ -183,4 +178,17 @@ func (t *touchableLabel) TouchUp(event *mobile.TouchEvent) {
 
 func (t *touchableLabel) TouchCancel(event *mobile.TouchEvent) {
 	t.cancel = true
+}
+
+type tappableLabel struct {
+	widget.Label
+	tap, altTap bool
+}
+
+func (t *tappableLabel) Tapped(_ *fyne.PointEvent) {
+	t.tap = true
+}
+
+func (t *tappableLabel) TappedSecondary(_ *fyne.PointEvent) {
+	t.altTap = true
 }

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -229,7 +229,7 @@ func (d *mobileDriver) tapUpCanvas(canvas *mobileCanvas, x, y float32, tapID tou
 
 	canvas.tapUp(pos, int(tapID), func(wid fyne.Tappable, ev *fyne.PointEvent) {
 		go wid.Tapped(ev)
-	}, func(wid fyne.Tappable, ev *fyne.PointEvent) {
+	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 		go wid.TappedSecondary(ev)
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 		go wid.DragEnd()

--- a/internal/driver/gomobile/menu.go
+++ b/internal/driver/gomobile/menu.go
@@ -23,9 +23,6 @@ func (m *menuLabel) Tapped(*fyne.PointEvent) {
 	widget.NewPopUpMenuAtPosition(m.menu, m.canvas, fyne.NewPos(pos.X+m.Size().Width, pos.Y))
 }
 
-func (m *menuLabel) TappedSecondary(*fyne.PointEvent) {
-}
-
 func (m *menuLabel) CreateRenderer() fyne.WidgetRenderer {
 	return widget.Renderer(m.Box)
 }

--- a/test/util.go
+++ b/test/util.go
@@ -23,12 +23,12 @@ func TapAt(obj fyne.Tappable, pos fyne.Position) {
 }
 
 // TapSecondary simulates a right mouse click on the specified object.
-func TapSecondary(obj fyne.Tappable) {
+func TapSecondary(obj fyne.SecondaryTappable) {
 	TapSecondaryAt(obj, fyne.NewPos(1, 1))
 }
 
 // TapSecondaryAt simulates a right mouse click on the passed object at a specified place within it.
-func TapSecondaryAt(obj fyne.Tappable, pos fyne.Position) {
+func TapSecondaryAt(obj fyne.SecondaryTappable, pos fyne.Position) {
 	if focus, ok := obj.(fyne.Focusable); ok {
 		if focus != Canvas().Focused() {
 			Canvas().Focus(focus)

--- a/widget/button.go
+++ b/widget/button.go
@@ -170,10 +170,6 @@ func (b *Button) Tapped(*fyne.PointEvent) {
 	}
 }
 
-// TappedSecondary is called when a secondary pointer tapped event is captured
-func (b *Button) TappedSecondary(*fyne.PointEvent) {
-}
-
 // MouseIn is called when a desktop pointer enters the widget
 func (b *Button) MouseIn(*desktop.MouseEvent) {
 	b.hovered = true

--- a/widget/check.go
+++ b/widget/check.go
@@ -158,10 +158,6 @@ func (c *Check) Tapped(*fyne.PointEvent) {
 	}
 }
 
-// TappedSecondary is called when a secondary pointer tapped event is captured
-func (c *Check) TappedSecondary(*fyne.PointEvent) {
-}
-
 // MinSize returns the size that this widget should not shrink below
 func (c *Check) MinSize() fyne.Size {
 	c.ExtendBaseWidget(c)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1194,9 +1194,6 @@ func (pr *passwordRevealer) Tapped(*fyne.PointEvent) {
 	fyne.CurrentApp().Driver().CanvasForObject(pr).Focus(pr.entry)
 }
 
-func (pr *passwordRevealer) TappedSecondary(*fyne.PointEvent) {
-}
-
 func newPasswordRevealer(e *Entry) *passwordRevealer {
 	pr := &passwordRevealer{
 		icon:  canvas.NewImageFromResource(theme.VisibilityOffIcon()),

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -88,10 +88,6 @@ func (hl *Hyperlink) Tapped(*fyne.PointEvent) {
 	}
 }
 
-// TappedSecondary is called when a secondary pointer tapped event is captured
-func (hl *Hyperlink) TappedSecondary(*fyne.PointEvent) {
-}
-
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (hl *Hyperlink) CreateRenderer() fyne.WidgetRenderer {
 	hl.textProvider = newTextProvider(hl.Text, hl)

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -49,9 +49,6 @@ func (t *menuItemWidget) Tapped(*fyne.PointEvent) {
 	t.OnTapped()
 }
 
-func (t *menuItemWidget) TappedSecondary(*fyne.PointEvent) {
-}
-
 func (t *menuItemWidget) CreateRenderer() fyne.WidgetRenderer {
 	return &hoverLabelRenderer{t.Label.CreateRenderer().(*textRenderer), t}
 }

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -249,10 +249,6 @@ func (r *Radio) Tapped(event *fyne.PointEvent) {
 	r.Refresh()
 }
 
-// TappedSecondary is called when a secondary pointer tapped event is captured
-func (r *Radio) TappedSecondary(*fyne.PointEvent) {
-}
-
 // MinSize returns the size that this widget should not shrink below
 func (r *Radio) MinSize() fyne.Size {
 	r.ExtendBaseWidget(r)

--- a/widget/select.go
+++ b/widget/select.go
@@ -158,10 +158,6 @@ func (s *Select) popUpPos() fyne.Position {
 	return buttonPos.Add(fyne.NewPos(0, s.Size().Height))
 }
 
-// TappedSecondary is called when a secondary pointer tapped event is captured
-func (s *Select) TappedSecondary(*fyne.PointEvent) {
-}
-
 // MouseIn is called when a desktop pointer enters the widget
 func (s *Select) MouseIn(*desktop.MouseEvent) {
 	s.hovered = true

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -418,9 +418,6 @@ func (b *tabButton) Tapped(e *fyne.PointEvent) {
 	b.OnTap()
 }
 
-func (b *tabButton) TappedSecondary(e *fyne.PointEvent) {
-}
-
 type tabButtonRenderer struct {
 	button  *tabButton
 	icon    *canvas.Image


### PR DESCRIPTION
### Description:
Remove the requirement for people to implement TappedSecondary() when they only want Tapped().

### Checklist:

- [ ] Tests included. - no new tests
- [x] Lint and formatter run with no errors.
- [x] Tests all pass

- [ ] Any breaking changes have a deprecation path or have been discussed. - it removes empty methods, is this breaking or not? :)