### PR TITLE
Remove Focus func from Focused interface

### DIFF
--- a/canvasobject.go
+++ b/canvasobject.go
@@ -65,6 +65,7 @@ type Draggable interface {
 type Focusable interface {
 	FocusGained()
 	FocusLost()
+	Focused() bool // Deprecated: this is an internal detail, canvas tracks current focused object
 
 	TypedRune(rune)
 	TypedKey(*KeyEvent)

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -65,7 +65,6 @@ type Draggable interface {
 type Focusable interface {
 	FocusGained()
 	FocusLost()
-	Focused() bool
 
 	TypedRune(rune)
 	TypedKey(*KeyEvent)

--- a/widget/check.go
+++ b/widget/check.go
@@ -212,6 +212,15 @@ func (c *Check) FocusLost() {
 	c.Refresh()
 }
 
+// Focused returns whether or not this Check has focus.
+// Deprecated: this method will be removed as it is no longer required, widgets do not expose their focus state.
+func (c *Check) Focused() bool {
+	if c.Disabled() {
+		return false
+	}
+	return c.focused
+}
+
 // TypedRune receives text input events when the Check is focused.
 func (c *Check) TypedRune(r rune) {
 	if c.Disabled() {

--- a/widget/check.go
+++ b/widget/check.go
@@ -74,7 +74,7 @@ func (c *checkRenderer) Refresh() {
 
 	if c.check.Disabled() {
 		c.focusIndicator.FillColor = theme.BackgroundColor()
-	} else if c.check.Focused() {
+	} else if c.check.focused {
 		c.focusIndicator.FillColor = theme.FocusColor()
 	} else if c.check.hovered {
 		c.focusIndicator.FillColor = theme.HoverColor()
@@ -121,7 +121,7 @@ func (c *Check) SetChecked(checked bool) {
 
 // Hide this widget, if it was previously visible
 func (c *Check) Hide() {
-	if c.Focused() {
+	if c.focused {
 		c.FocusLost()
 		fyne.CurrentApp().Driver().CanvasForObject(c).Focus(nil)
 	}
@@ -150,7 +150,7 @@ func (c *Check) MouseMoved(*desktop.MouseEvent) {
 
 // Tapped is called when a pointer tapped event is captured and triggers any change handler
 func (c *Check) Tapped(*fyne.PointEvent) {
-	if !c.Focused() {
+	if !c.focused {
 		c.FocusGained()
 	}
 	if !c.Disabled() {
@@ -210,14 +210,6 @@ func (c *Check) FocusLost() {
 	c.focused = false
 
 	c.Refresh()
-}
-
-// Focused returns whether or not this Check has focus.
-func (c *Check) Focused() bool {
-	if c.Disabled() {
-		return false
-	}
-	return c.focused
 }
 
 // TypedRune receives text input events when the Check is focused.

--- a/widget/check_test.go
+++ b/widget/check_test.go
@@ -133,29 +133,29 @@ func TestCheck_Focused(t *testing.T) {
 	check := NewCheck("Test", func(on bool) {})
 	render := test.WidgetRenderer(check).(*checkRenderer)
 
-	assert.False(t, check.Focused())
+	assert.False(t, check.focused)
 	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
 
 	check.SetChecked(true)
-	assert.False(t, check.Focused())
+	assert.False(t, check.focused)
 	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
 
 	test.Tap(check)
-	assert.True(t, check.Focused())
+	assert.True(t, check.focused)
 	assert.Equal(t, theme.FocusColor(), render.focusIndicator.FillColor)
 
 	check.Disable()
-	assert.False(t, check.Focused())
+	assert.True(t, check.disabled)
 	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
 
 	check.Enable()
-	assert.True(t, check.Focused())
+	assert.True(t, check.focused)
 
 	check.Hide()
-	assert.False(t, check.Focused())
+	assert.False(t, check.focused)
 
 	check.Show()
-	assert.False(t, check.Focused())
+	assert.False(t, check.focused)
 }
 
 func TestCheck_Hovered(t *testing.T) {
@@ -175,7 +175,7 @@ func TestCheck_Hovered(t *testing.T) {
 	assert.Equal(t, theme.FocusColor(), render.focusIndicator.FillColor)
 
 	check.Disable()
-	assert.False(t, check.Focused())
+	assert.True(t, check.disabled)
 	assert.True(t, check.hovered)
 	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
 
@@ -197,7 +197,7 @@ func TestCheck_TypedRune(t *testing.T) {
 	assert.False(t, check.Checked)
 
 	test.Tap(check)
-	assert.True(t, check.Focused())
+	assert.True(t, check.focused)
 	assert.True(t, check.Checked)
 
 	test.Type(check, " ")

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -434,11 +434,6 @@ func (e *Entry) FocusLost() {
 	e.Refresh()
 }
 
-// Focused returns whether or not this Entry has focus.
-func (e *Entry) Focused() bool {
-	return e.focused
-}
-
 func (e *Entry) cursorColAt(text []rune, pos fyne.Position) int {
 	for i := 0; i < len(text); i++ {
 		str := string(text[0 : i+1])

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -434,6 +434,12 @@ func (e *Entry) FocusLost() {
 	e.Refresh()
 }
 
+// Focused returns whether or not this Entry has focus.
+// Deprecated: this method will be removed as it is no longer required, widgets do not expose their focus state.
+func (e *Entry) Focused() bool {
+	return e.focused
+}
+
 func (e *Entry) cursorColAt(text []rune, pos fyne.Position) int {
 	for i := 0; i < len(text); i++ {
 		str := string(text[0 : i+1])

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -155,11 +155,11 @@ func TestEntry_SetReadOnly_OnFocus(t *testing.T) {
 	entry.SetReadOnly(true)
 
 	entry.FocusGained()
-	assert.False(t, entry.Focused())
+	assert.False(t, entry.focused)
 
 	entry.SetReadOnly(false)
 	entry.FocusGained()
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 }
 
 func TestEntry_OnKeyDown_Insert(t *testing.T) {
@@ -332,17 +332,17 @@ func TestEntryFocus(t *testing.T) {
 	entry := NewEntry()
 
 	entry.FocusGained()
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 
 	entry.FocusLost()
-	assert.False(t, entry.Focused())
+	assert.False(t, entry.focused)
 }
 
 func TestEntryWindowFocus(t *testing.T) {
 	entry := NewEntry()
 
 	test.Canvas().Focus(entry)
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 }
 
 func TestEntry_Tapped(t *testing.T) {
@@ -350,7 +350,7 @@ func TestEntry_Tapped(t *testing.T) {
 	entry.SetText("MMM")
 
 	test.Tap(entry)
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(int(float32(testCharSize)*1.5), testCharSize/2) // tap in the middle of the 2nd "M"
@@ -373,7 +373,7 @@ func TestEntry_Tapped_AfterCol(t *testing.T) {
 	entry.SetText("M")
 
 	test.Tap(entry)
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(testCharSize*2, testCharSize/2) // tap after text
@@ -389,7 +389,7 @@ func TestEntry_Tapped_AfterRow(t *testing.T) {
 	entry.SetText("M\nM\n")
 
 	test.Tap(entry)
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(testCharSize, testCharSize*4) // tap below rows
@@ -477,7 +477,7 @@ func TestEntry_FocusWithPopUp(t *testing.T) {
 	assert.NotNil(t, entry.popUp)
 
 	test.Tap(entry.popUp)
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 }
 
 func TestEntry_HidePopUpOnEntry(t *testing.T) {
@@ -650,7 +650,7 @@ func TestEntry_DoubleTapped_AfterCol(t *testing.T) {
 	entry.SetText("A\nB\n")
 
 	test.Tap(entry)
-	assert.True(t, entry.Focused())
+	assert.True(t, entry.focused)
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(testCharSize, testCharSize*4) // tap below rows
@@ -1375,7 +1375,7 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 
 		assert.Equal(t, "Hié™שרה", entry.Text)
 		assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
-		assert.True(t, entry.Focused())
+		assert.True(t, entry.focused)
 		assert.Equal(t, theme.VisibilityIcon(), actionIcon.icon.Resource)
 
 		// tap on action icon
@@ -1383,13 +1383,13 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 
 		assert.Equal(t, "Hié™שרה", entry.Text)
 		assert.Equal(t, "•••••••", entryRenderTexts(entry)[0].Text)
-		assert.True(t, entry.Focused())
+		assert.True(t, entry.focused)
 		assert.Equal(t, theme.VisibilityOffIcon(), actionIcon.icon.Resource)
 	})
 
 	// This test cover backward compatibility use case when on an Entry widget
 	// the Password field is set to true.
-	// In this case the action item should not be diplayed
+	// In this case the action item should not be displayed
 	t.Run("Entry with Password field", func(t *testing.T) {
 		entry := NewEntry()
 		entry.Password = true
@@ -1409,7 +1409,7 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 
 		assert.Equal(t, "Hié™שרה", entry.Text)
 		assert.Equal(t, "Hié™שרה", entryRenderTexts(entry)[0].Text)
-		assert.True(t, entry.Focused())
+		assert.True(t, entry.focused)
 		assert.NotNil(t, actionIcon)
 	})
 }


### PR DESCRIPTION
### Description:
I saw that Focused() is never used, so let's get rid of it!?

### Checklist:

- [ ] Tests included. - no new tests
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

- [x] Any breaking changes have a deprecation path or have been discussed. - this could be considered breaking.

It removes Entry and CheckBox Focus() funcs as they are not actually needed.
Should I re-add them as deprecated in case anyone was calling them, despite their lack of use internally?
