### PR TITLE
Fix some problems of `fyne help` command

### DIFF
--- a/cmd/fyne/main.go
+++ b/cmd/fyne/main.go
@@ -85,8 +85,9 @@ func main() {
 
 	if command == "help" {
 		if len(args) >= 2 {
-			provider = getCommand(args[1])
-			provider.addFlags()
+			if provider = getCommand(args[1]); provider != nil {
+				provider.addFlags()
+			}
 		}
 		help()
 	} else {

--- a/cmd/fyne/main.go
+++ b/cmd/fyne/main.go
@@ -7,16 +7,21 @@ import (
 	"os"
 )
 
-var commands map[string]command
+var commands []idCommandPair
 var provider command
+
+type idCommandPair struct {
+	id       string
+	provider command
+}
 
 func printUsage() {
 	fmt.Println("Usage: fyne [command] [parameters], where command is one of:")
 	fmt.Print("  ")
 
 	i := 0
-	for id := range commands {
-		fmt.Print(id)
+	for _, c := range commands {
+		fmt.Print(c.id)
 
 		if i < len(commands)-1 {
 			fmt.Print(", ")
@@ -30,10 +35,10 @@ func printUsage() {
 	if provider != nil {
 		provider.printHelp(" ")
 	} else {
-		for id, provider := range commands {
-			fmt.Printf("  %s\n", id)
-			provider.printHelp("   ")
-			fmt.Printf("    For more information run \"fyne help %s\"\n", id)
+		for _, c := range commands {
+			fmt.Printf("  %s\n", c.id)
+			c.provider.printHelp("   ")
+			fmt.Printf("    For more information run \"fyne help %s\"\n", c.id)
 			fmt.Println("")
 		}
 	}
@@ -46,13 +51,22 @@ func help() {
 }
 
 func loadCommands() {
-	commands = make(map[string]command)
+	commands = []idCommandPair{
+		{"bundle", &bundler{}},
+		{"get", &getter{}},
+		{"package", &packager{}},
+		{"install", &installer{}},
+		{"vendor", &vendor{}},
+	}
+}
 
-	commands["bundle"] = &bundler{}
-	commands["get"] = &getter{}
-	commands["package"] = &packager{}
-	commands["install"] = &installer{}
-	commands["vendor"] = &vendor{}
+func getCommand(id string) command {
+	for _, c := range commands {
+		if c.id == id {
+			return c.provider
+		}
+	}
+	return nil
 }
 
 func main() {
@@ -71,12 +85,12 @@ func main() {
 
 	if command == "help" {
 		if len(args) >= 2 {
-			provider = commands[args[1]]
+			provider = getCommand(args[1])
 			provider.addFlags()
 		}
 		help()
 	} else {
-		provider = commands[command]
+		provider = getCommand(command)
 		if provider == nil {
 			fmt.Fprintln(os.Stderr, "Unsupported command", command)
 			return


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

- The order of displaying sub-commands when executing `fyne help` command is undefined, so fixed it to fix the display order.
- Error occurred because of nil pointer dereference when invalid command name is specified in `fyne help [command]`, and so fixed to show default help message in that case.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
