### PR TITLE
Fix goutine leak in dialog's Show()/Hide()

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -189,9 +189,7 @@ func ShowCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Wi
 	d := &dialog{content: content, title: title, icon: nil, parent: parent}
 
 	d.dismiss = &widget.Button{Text: dismiss,
-		OnTapped: func() {
-			d.response <- false
-		},
+		OnTapped: d.Hide,
 	}
 	d.setButtons(widget.NewHBox(layout.NewSpacer(), d.dismiss, layout.NewSpacer()))
 
@@ -208,14 +206,10 @@ func ShowCustomConfirm(title, confirm, dismiss string, content fyne.CanvasObject
 	d.callback = callback
 
 	d.dismiss = &widget.Button{Text: dismiss, Icon: theme.CancelIcon(),
-		OnTapped: func() {
-			d.response <- false
-		},
+		OnTapped: d.Hide,
 	}
 	ok := &widget.Button{Text: confirm, Icon: theme.ConfirmIcon(), Style: widget.PrimaryButton,
-		OnTapped: func() {
-			d.response <- true
-		},
+		OnTapped: d.Hide,
 	}
 	d.setButtons(widget.NewHBox(layout.NewSpacer(), d.dismiss, ok, layout.NewSpacer()))
 

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -209,7 +209,9 @@ func ShowCustomConfirm(title, confirm, dismiss string, content fyne.CanvasObject
 		OnTapped: d.Hide,
 	}
 	ok := &widget.Button{Text: confirm, Icon: theme.ConfirmIcon(), Style: widget.PrimaryButton,
-		OnTapped: d.Hide,
+		OnTapped: func() {
+			d.hideWithResponse(true)
+		},
 	}
 	d.setButtons(widget.NewHBox(layout.NewSpacer(), d.dismiss, ok, layout.NewSpacer()))
 

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -165,7 +165,7 @@ func (d *dialog) Show() {
 }
 
 func (d *dialog) Hide() {
-	d.hideWithResp(false)
+	d.hideWithResponse(false)
 }
 
 // SetDismissText allows custom text to be set in the confirmation button
@@ -174,7 +174,7 @@ func (d *dialog) SetDismissText(label string) {
 	widget.Refresh(d.win)
 }
 
-func (d *dialog) hideWithResp(resp bool) {
+func (d *dialog) hideWithResponse(resp bool) {
 	if d.response == nil {
 		// Already hidden
 		return

--- a/dialog/confirm.go
+++ b/dialog/confirm.go
@@ -26,13 +26,11 @@ func NewConfirm(title, message string, callback func(bool), parent fyne.Window) 
 	d := newDialog(title, message, theme.QuestionIcon(), callback, parent)
 
 	d.dismiss = &widget.Button{Text: "No", Icon: theme.CancelIcon(),
-		OnTapped: func() {
-			d.response <- false
-		},
+		OnTapped: d.Hide,
 	}
 	confirm := &widget.Button{Text: "Yes", Icon: theme.ConfirmIcon(), Style: widget.PrimaryButton,
 		OnTapped: func() {
-			d.response <- true
+			d.hideWithResp(true)
 		},
 	}
 	d.setButtons(newButtonList(d.dismiss, confirm))

--- a/dialog/confirm.go
+++ b/dialog/confirm.go
@@ -30,7 +30,7 @@ func NewConfirm(title, message string, callback func(bool), parent fyne.Window) 
 	}
 	confirm := &widget.Button{Text: "Yes", Icon: theme.ConfirmIcon(), Style: widget.PrimaryButton,
 		OnTapped: func() {
-			d.hideWithResp(true)
+			d.hideWithResponse(true)
 		},
 	}
 	d.setButtons(newButtonList(d.dismiss, confirm))

--- a/dialog/information.go
+++ b/dialog/information.go
@@ -10,9 +10,7 @@ func createTextDialog(title, message string, icon fyne.Resource, parent fyne.Win
 	d := newDialog(title, message, icon, nil, parent)
 
 	d.dismiss = &widget.Button{Text: "OK",
-		OnTapped: func() {
-			d.response <- false
-		},
+		OnTapped: d.Hide,
 	}
 	d.setButtons(newButtonList(d.dismiss))
 


### PR DESCRIPTION
### Description:

Instead of spawning a blocked goroutine in Show(), just hide the popup and call the callback directly from Hide().

Make all dialog button callbacks use Hide() or hideWithResp(), to encapsulate the
logic better.

### Checklist:

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
