### PR TITLE
Add support for -appVersion and -buildNumber in fyne package

### DIFF
--- a/cmd/fyne/package_test.go
+++ b/cmd/fyne/package_test.go
@@ -16,3 +16,58 @@ func Test_calculateExeName(t *testing.T) {
 	nonModulesApp := calculateExeName("testdata", "linux")
 	assert.Equal(t, "testdata", nonModulesApp)
 }
+
+type numericVersionTest struct {
+	Version string
+	Min     int
+	Max     int
+	Expect  string
+}
+
+type numericVersionErrorTest struct {
+	Version string
+	Min     int
+	Max     int
+}
+
+func TestNumericVersion(t *testing.T) {
+	versionTests := []numericVersionTest{
+		{"2", 1, 1, "2"},
+		{"2", 2, 3, "2.0"},
+		{"2", 3, 3, "2.0.0"},
+		{"2", 4, 4, "2.0.0.0"},
+		{"2", 4, 100, "2.0.0.0"},
+		{"1.2.3", 1, 3, "1.2.3"},
+		{"1.2", 3, 3, "1.2.0"},
+		{"1.2", 0, 100, "1.2"},
+		{"1.2.3", 0, 100, "1.2.3"},
+	}
+	for _, v := range versionTests {
+		res, err := buildNumericVersion(v.Version, v.Min, v.Max)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if res != v.Expect {
+			t.Errorf("error building version: expected %q but got %q", v.Expect, res)
+		}
+	}
+}
+
+func TestNumericVersionErrors(t *testing.T) {
+	versionTests := []numericVersionErrorTest{
+		{"", 0, 0},
+		{"", 1, 1},
+		{"", 0, 1},
+		{"2.3.4", 2, 2},
+		{"2.3.0-alpha", 2, 3},
+		{"beta", 1, 1},
+		{"1.2.x", 1, 1},
+	}
+	for _, v := range versionTests {
+		res, err := buildNumericVersion(v.Version, v.Min, v.Max)
+		if err == nil {
+			t.Errorf("expecting an error when parsing (%q, [%d, %d]), but got %q instead", v.Version, v.Min, v.Max, res)
+		}
+	}
+}


### PR DESCRIPTION
Add support for -appVersion and -buildNumber in fyne package
    
For macOS, -appVersion is mapped to CFBundleVersionShort while
-buildNumer is used for CFBundleVersion. If no CFBundleVersion
is provided, it's set to the same value as CFBundleVersionShort.
   
For Windows, -appVersion is expanded to 3 components, then
-buildNumber (which must have 1 component at most) is appended
to it to form the 4 component assembly version that Windows
expects. If no -buildNumber is provided, we append a zero to
get to 4 components.
    
No other platforms use these 2 new flags for now.

### Description:

These changes allow specifying the app version in macOS and Windows. This is important on macOS where users expect an "About" dialog that shows the app version. It also makes automatic updates a bit easier.

At some point, this should probably be extended to support iOS and Android too, since at least the App Store does enforce increasing version numbers on the bundle version (not sure about Android, it's been a long time since I've written software for it).

### Checklist:

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

#### Where applicable:

- [X] Public APIs match existing style.
