### PR TITLE
Update modal popup to respect innerSize as well

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -19,11 +19,25 @@ func (s1 Size) Subtract(s2 Size) Size {
 }
 
 // Union returns a new Size that is the maximum of the current Size and s2.
+// Deprecated: use Max() instead
 func (s1 Size) Union(s2 Size) Size {
+	return s1.Max(s2)
+}
+
+// Max returns a new Size that is the maximum of the current Size and s2.
+func (s1 Size) Max(s2 Size) Size {
 	maxW := Max(s1.Width, s2.Width)
 	maxH := Max(s1.Height, s2.Height)
 
 	return NewSize(maxW, maxH)
+}
+
+// Min returns a new Size that is the minimum of the current Size and s2.
+func (s1 Size) Min(s2 Size) Size {
+	minW := Min(s1.Width, s2.Width)
+	minH := Min(s1.Height, s2.Height)
+
+	return NewSize(minW, minH)
 }
 
 // NewSize returns a newly allocated Size of the specified dimensions.

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -39,6 +39,32 @@ func TestSizeUnion(t *testing.T) {
 	assert.Equal(t, size3.Height, maxH)
 }
 
+func TestSizeMax(t *testing.T) {
+	size1 := NewSize(10, 100)
+	size2 := NewSize(100, 10)
+
+	size3 := size1.Max(size2)
+
+	maxW := Max(size1.Width, size2.Width)
+	maxH := Max(size1.Height, size2.Height)
+
+	assert.Equal(t, size3.Width, maxW)
+	assert.Equal(t, size3.Height, maxH)
+}
+
+func TestSizeMin(t *testing.T) {
+	size1 := NewSize(10, 100)
+	size2 := NewSize(100, 10)
+
+	size3 := size1.Min(size2)
+
+	minW := Min(size1.Width, size2.Width)
+	minH := Min(size1.Height, size2.Height)
+
+	assert.Equal(t, size3.Width, minW)
+	assert.Equal(t, size3.Height, minH)
+}
+
 func TestPosition_Add(t *testing.T) {
 	pos1 := NewPos(10, 10)
 	pos2 := NewPos(25, 25)

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -5,7 +5,6 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
-	"fyne.io/fyne/layout"
 	"fyne.io/fyne/theme"
 )
 
@@ -88,8 +87,7 @@ func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
 	p.ExtendBaseWidget(p)
 	if p.modal {
 		bg := canvas.NewRectangle(theme.BackgroundColor())
-		return &modalPopUpRenderer{center: layout.NewCenterLayout(), popUp: p, bg: bg,
-			objects: []fyne.CanvasObject{bg, p.Content}}
+		return &modalPopUpRenderer{popUp: p, bg: bg, objects: []fyne.CanvasObject{bg, p.Content}}
 	}
 
 	shadow := newShadow(shadowAround, theme.Padding()*2)
@@ -181,17 +179,20 @@ func (r *popUpRenderer) Destroy() {
 }
 
 type modalPopUpRenderer struct {
-	center  fyne.Layout
 	popUp   *PopUp
 	bg      *canvas.Rectangle
 	objects []fyne.CanvasObject
 }
 
-func (r *modalPopUpRenderer) Layout(size fyne.Size) {
-	r.center.Layout(r.objects, size)
+func (r *modalPopUpRenderer) Layout(canvasSize fyne.Size) {
+	size := r.popUp.innerSize.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2))
+	size = size.Min(canvasSize).Max(r.popUp.MinSize())
+	pos := fyne.NewPos((canvasSize.Width-size.Width)/2, (canvasSize.Height-size.Height)/2)
+	r.popUp.Content.Move(pos)
+	r.popUp.Content.Resize(size)
 
-	r.bg.Move(r.popUp.Content.Position().Subtract(fyne.NewPos(theme.Padding(), theme.Padding())))
-	r.bg.Resize(r.MinSize())
+	r.bg.Move(pos.Subtract(fyne.NewPos(theme.Padding(), theme.Padding())))
+	r.bg.Resize(size.Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
 }
 
 func (r *modalPopUpRenderer) MinSize() fyne.Size {

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -118,7 +118,7 @@ func TestPopUp_Resize(t *testing.T) {
 	assert.Equal(t, size.Height-theme.Padding()*2, innerSize.Height)
 
 	popSize := pop.Size()
-	assert.Equal(t, 80, popSize.Width) // these are 50 as the popUp must fill our overlay
+	assert.Equal(t, 80, popSize.Width) // these are 80 as the popUp must fill our overlay
 	assert.Equal(t, 80, popSize.Height)
 }
 
@@ -200,4 +200,23 @@ func TestModalPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
 	assert.Equal(t, pop, test.Canvas().Overlays().List()[0])
+}
+
+func TestModalPopUp_Resize(t *testing.T) {
+	label := NewLabel("Hi")
+	win := test.NewWindow(NewLabel("OK"))
+	win.Resize(fyne.NewSize(80, 80))
+	pop := NewModalPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
+
+	size := fyne.NewSize(70, 50)
+	pop.Resize(size)
+
+	innerSize := pop.Content.Size()
+	assert.Equal(t, size.Width-theme.Padding()*2, innerSize.Width)
+	assert.Equal(t, size.Height-theme.Padding()*2, innerSize.Height)
+
+	popSize := pop.Size()
+	assert.Equal(t, 80, popSize.Width) // these are 80 as the popUp must fill our overlay
+	assert.Equal(t, 80, popSize.Height)
 }


### PR DESCRIPTION
### Description:
Update the modal layout to respect the popup innerSize changes.
(as it is centred it will ignore innerPosition).

Added Size.Min and Max, deprecated confusingly named Size.Union

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.