### PR TITLE
Update modal popup to respect innerSize

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -19,11 +19,25 @@ func (s1 Size) Subtract(s2 Size) Size {
 }
 
 // Union returns a new Size that is the maximum of the current Size and s2.
+// Deprecated: use Max() instead
 func (s1 Size) Union(s2 Size) Size {
+	return s1.Max(s2)
+}
+
+// Max returns a new Size that is the maximum of the current Size and s2.
+func (s1 Size) Max(s2 Size) Size {
 	maxW := Max(s1.Width, s2.Width)
 	maxH := Max(s1.Height, s2.Height)
 
 	return NewSize(maxW, maxH)
+}
+
+// Min returns a new Size that is the minimum of the current Size and s2.
+func (s1 Size) Min(s2 Size) Size {
+	minW := Min(s1.Width, s2.Width)
+	minH := Min(s1.Height, s2.Height)
+
+	return NewSize(minW, minH)
 }
 
 // NewSize returns a newly allocated Size of the specified dimensions.

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -12,8 +12,8 @@ func TestSizeAdd(t *testing.T) {
 
 	size3 := size1.Add(size2)
 
-	assert.Equal(t, size3.Width, size1.Width+size2.Width)
-	assert.Equal(t, size3.Height, size1.Height+size2.Height)
+	assert.Equal(t, 35, size3.Width)
+	assert.Equal(t, 35, size3.Height)
 }
 
 func TestSizeSubtract(t *testing.T) {
@@ -22,8 +22,8 @@ func TestSizeSubtract(t *testing.T) {
 
 	size3 := size1.Subtract(size2)
 
-	assert.Equal(t, size3.Width, size1.Width-size2.Width)
-	assert.Equal(t, size3.Height, size1.Height-size2.Height)
+	assert.Equal(t, 15, size3.Width)
+	assert.Equal(t, 15, size3.Height)
 }
 
 func TestSizeUnion(t *testing.T) {
@@ -32,8 +32,8 @@ func TestSizeUnion(t *testing.T) {
 
 	size3 := size1.Union(size2)
 
-	maxW := Max(size1.Width, size2.Width)
-	maxH := Max(size1.Height, size2.Height)
+	assert.Equal(t, 100, size3.Width)
+	assert.Equal(t, 100, size3.Height)
 }
 
 func TestSizeMax(t *testing.T) {
@@ -62,8 +62,8 @@ func TestPosition_Add(t *testing.T) {
 
 	pos3 := pos1.Add(pos2)
 
-	assert.Equal(t, pos3.X, pos1.X+pos2.X)
-	assert.Equal(t, pos3.Y, pos1.Y+pos2.Y)
+	assert.Equal(t, 35, pos3.X)
+	assert.Equal(t, 35, pos3.Y)
 }
 
 func TestPosition_Subtract(t *testing.T) {
@@ -72,6 +72,6 @@ func TestPosition_Subtract(t *testing.T) {
 
 	pos3 := pos1.Subtract(pos2)
 
-	assert.Equal(t, pos3.X, pos1.X-pos2.X)
-	assert.Equal(t, pos3.Y, pos1.Y-pos2.Y)
+	assert.Equal(t, 15, pos3.X)
+	assert.Equal(t, 15, pos3.Y)
 }

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -34,9 +34,26 @@ func TestSizeUnion(t *testing.T) {
 
 	maxW := Max(size1.Width, size2.Width)
 	maxH := Max(size1.Height, size2.Height)
+}
 
-	assert.Equal(t, size3.Width, maxW)
-	assert.Equal(t, size3.Height, maxH)
+func TestSizeMax(t *testing.T) {
+	size1 := NewSize(10, 100)
+	size2 := NewSize(100, 10)
+
+	size3 := size1.Max(size2)
+
+	assert.Equal(t, 100, size3.Width)
+	assert.Equal(t, 100, size3.Height)
+}
+
+func TestSizeMin(t *testing.T) {
+	size1 := NewSize(10, 100)
+	size2 := NewSize(100, 10)
+
+	size3 := size1.Min(size2)
+
+	assert.Equal(t, 10, size3.Width)
+	assert.Equal(t, 10, size3.Height)
 }
 
 func TestPosition_Add(t *testing.T) {

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -108,6 +108,10 @@ func (c *testCanvas) Resize(size fyne.Size) {
 		return
 	}
 
+	for _, overlay := range c.overlays.List() {
+		overlay.Resize(size)
+	}
+
 	if c.padded {
 		theme := fyne.CurrentApp().Settings().Theme()
 		c.content.Resize(size.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -5,7 +5,6 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
-	"fyne.io/fyne/layout"
 	"fyne.io/fyne/theme"
 )
 
@@ -88,8 +87,7 @@ func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
 	p.ExtendBaseWidget(p)
 	if p.modal {
 		bg := canvas.NewRectangle(theme.BackgroundColor())
-		return &modalPopUpRenderer{center: layout.NewCenterLayout(), popUp: p, bg: bg,
-			objects: []fyne.CanvasObject{bg, p.Content}}
+		return &modalPopUpRenderer{popUp: p, bg: bg, objects: []fyne.CanvasObject{bg, p.Content}}
 	}
 
 	shadow := newShadow(shadowAround, theme.Padding()*2)
@@ -181,17 +179,21 @@ func (r *popUpRenderer) Destroy() {
 }
 
 type modalPopUpRenderer struct {
-	center  fyne.Layout
 	popUp   *PopUp
 	bg      *canvas.Rectangle
 	objects []fyne.CanvasObject
 }
 
-func (r *modalPopUpRenderer) Layout(size fyne.Size) {
-	r.center.Layout(r.objects, size)
+func (r *modalPopUpRenderer) Layout(canvasSize fyne.Size) {
+	requestedSize := r.popUp.innerSize.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2))
+	size := r.popUp.MinSize().Max(requestedSize)
+	size = size.Min(canvasSize)
+	pos := fyne.NewPos((canvasSize.Width-size.Width)/2, (canvasSize.Height-size.Height)/2)
+	r.popUp.Content.Move(pos)
+	r.popUp.Content.Resize(size)
 
-	r.bg.Move(r.popUp.Content.Position().Subtract(fyne.NewPos(theme.Padding(), theme.Padding())))
-	r.bg.Resize(r.MinSize())
+	r.bg.Move(pos.Subtract(fyne.NewPos(theme.Padding(), theme.Padding())))
+	r.bg.Resize(size.Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
 }
 
 func (r *modalPopUpRenderer) MinSize() fyne.Size {

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -186,8 +186,8 @@ type modalPopUpRenderer struct {
 
 func (r *modalPopUpRenderer) Layout(canvasSize fyne.Size) {
 	requestedSize := r.popUp.innerSize.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2))
-	size := r.popUp.MinSize().Max(requestedSize)
-	size = size.Min(canvasSize)
+	size := r.popUp.Content.MinSize().Max(requestedSize)
+	size = size.Min(canvasSize.Subtract(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
 	pos := fyne.NewPos((canvasSize.Width-size.Width)/2, (canvasSize.Height-size.Height)/2)
 	r.popUp.Content.Move(pos)
 	r.popUp.Content.Resize(size)

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -209,8 +209,8 @@ func TestModalPopUp_Resize(t *testing.T) {
 	pop := NewModalPopUp(label, win.Canvas())
 	defer win.Canvas().Overlays().Remove(pop)
 
-	assert.Less(t, pop.Content.Size().Width, 70)
-	assert.Less(t, pop.Content.Size().Height, 50)
+	assert.Less(t, pop.Content.Size().Width, 70-theme.Padding()*2)
+	assert.Less(t, pop.Content.Size().Height, 50-theme.Padding()*2)
 
 	pop.Resize(fyne.NewSize(70, 50))
 	assert.Equal(t, 70-theme.Padding()*2, pop.Content.Size().Width)

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -227,22 +227,8 @@ func TestModalPopUp_Resize_Constrained(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(pop)
 
 	pop.Resize(fyne.NewSize(90, 100))
-	assert.Equal(t, 80, pop.Content.Size().Width)
-	assert.Equal(t, 80, pop.Content.Size().Height)
+	assert.Equal(t, 80-theme.Padding()*2, pop.Content.Size().Width)
+	assert.Equal(t, 80-theme.Padding()*2, pop.Content.Size().Height)
 	assert.Equal(t, 80, pop.Size().Width)
 	assert.Equal(t, 80, pop.Size().Height)
-}
-
-func TestModalPopUp_Resize_ConstrainedMin(t *testing.T) {
-	label := NewLabel("Hi")
-	win := test.NewWindow(NewLabel("OK"))
-	win.Resize(fyne.NewSize(80, 80))
-	pop := NewModalPopUp(label, win.Canvas())
-	defer win.Canvas().Overlays().Remove(pop)
-
-	win.Resize(fyne.NewSize(30, 20))
-	assert.Greater(t, pop.Content.Size().Width, 30)
-	assert.Greater(t, pop.Content.Size().Height, 20)
-	assert.Greater(t, pop.Size().Width, 30)
-	assert.Greater(t, pop.Size().Height, 20)
 }

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -207,7 +207,7 @@ func TestModalPopUp_Resize(t *testing.T) {
 	win := test.NewWindow(NewLabel("OK"))
 	win.Resize(fyne.NewSize(80, 80))
 	pop := NewModalPopUp(label, win.Canvas())
-	defer test.Canvas().Overlays().Remove(pop)
+	defer win.Canvas().Overlays().Remove(pop)
 
 	assert.Less(t, pop.Content.Size().Width, 70)
 	assert.Less(t, pop.Content.Size().Height, 50)
@@ -224,7 +224,7 @@ func TestModalPopUp_Resize_Constrained(t *testing.T) {
 	win := test.NewWindow(NewLabel("OK"))
 	win.Resize(fyne.NewSize(80, 80))
 	pop := NewModalPopUp(label, win.Canvas())
-	defer test.Canvas().Overlays().Remove(pop)
+	defer win.Canvas().Overlays().Remove(pop)
 
 	pop.Resize(fyne.NewSize(90, 100))
 	assert.Equal(t, 80, pop.Content.Size().Width)
@@ -238,7 +238,7 @@ func TestModalPopUp_Resize_ConstrainedMin(t *testing.T) {
 	win := test.NewWindow(NewLabel("OK"))
 	win.Resize(fyne.NewSize(80, 80))
 	pop := NewModalPopUp(label, win.Canvas())
-	defer test.Canvas().Overlays().Remove(pop)
+	defer win.Canvas().Overlays().Remove(pop)
 
 	win.Resize(fyne.NewSize(30, 20))
 	assert.Greater(t, pop.Content.Size().Width, 30)

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -118,7 +118,7 @@ func TestPopUp_Resize(t *testing.T) {
 	assert.Equal(t, size.Height-theme.Padding()*2, innerSize.Height)
 
 	popSize := pop.Size()
-	assert.Equal(t, 80, popSize.Width) // these are 50 as the popUp must fill our overlay
+	assert.Equal(t, 80, popSize.Width) // these are 80 as the popUp must fill our overlay
 	assert.Equal(t, 80, popSize.Height)
 }
 
@@ -200,4 +200,49 @@ func TestModalPopUp_TappedSecondary(t *testing.T) {
 	assert.True(t, pop.Visible())
 	assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
 	assert.Equal(t, pop, test.Canvas().Overlays().List()[0])
+}
+
+func TestModalPopUp_Resize(t *testing.T) {
+	label := NewLabel("Hi")
+	win := test.NewWindow(NewLabel("OK"))
+	win.Resize(fyne.NewSize(80, 80))
+	pop := NewModalPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
+
+	assert.Less(t, pop.Content.Size().Width, 70)
+	assert.Less(t, pop.Content.Size().Height, 50)
+
+	pop.Resize(fyne.NewSize(70, 50))
+	assert.Equal(t, 70-theme.Padding()*2, pop.Content.Size().Width)
+	assert.Equal(t, 50-theme.Padding()*2, pop.Content.Size().Height)
+	assert.Equal(t, 80, pop.Size().Width) // these are 80 as the popUp must fill our overlay
+	assert.Equal(t, 80, pop.Size().Height)
+}
+
+func TestModalPopUp_Resize_Constrained(t *testing.T) {
+	label := NewLabel("Hi")
+	win := test.NewWindow(NewLabel("OK"))
+	win.Resize(fyne.NewSize(80, 80))
+	pop := NewModalPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
+
+	pop.Resize(fyne.NewSize(90, 100))
+	assert.Equal(t, 80, pop.Content.Size().Width)
+	assert.Equal(t, 80, pop.Content.Size().Height)
+	assert.Equal(t, 80, pop.Size().Width)
+	assert.Equal(t, 80, pop.Size().Height)
+}
+
+func TestModalPopUp_Resize_ConstrainedMin(t *testing.T) {
+	label := NewLabel("Hi")
+	win := test.NewWindow(NewLabel("OK"))
+	win.Resize(fyne.NewSize(80, 80))
+	pop := NewModalPopUp(label, win.Canvas())
+	defer test.Canvas().Overlays().Remove(pop)
+
+	win.Resize(fyne.NewSize(30, 20))
+	assert.Greater(t, pop.Content.Size().Width, 30)
+	assert.Greater(t, pop.Content.Size().Height, 20)
+	assert.Greater(t, pop.Size().Width, 30)
+	assert.Greater(t, pop.Size().Height, 20)
 }


### PR DESCRIPTION
### Description:
Update the modal layout to respect the popup innerSize changes.
(as it is centred it will ignore innerPosition).

Added Size.Min and Max, deprecated confusingly named Size.Union.

Replaces #757 as it was too much in 1 commit.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.