### PR TITLE
Support Empty Tabber

### DIFF
--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -268,59 +268,60 @@ func (t *tabContainerRenderer) Layout(size fyne.Size) {
 		tabLocation = TabLocationBottom
 	}
 
+	tabBarMinSize := t.tabBar.MinSize()
+	var tabBarPos fyne.Position
+	var tabBarSize fyne.Size
+	var linePos fyne.Position
+	var lineSize fyne.Size
+	var childPos fyne.Position
+	var childSize fyne.Size
 	switch tabLocation {
 	case TabLocationTop:
-		buttonHeight := t.tabBar.MinSize().Height
-		t.tabBar.Move(fyne.NewPos(0, 0))
-		t.tabBar.Resize(fyne.NewSize(size.Width, buttonHeight))
-		t.line.Move(fyne.NewPos(0, buttonHeight))
-		t.line.Resize(fyne.NewSize(size.Width, theme.Padding()))
-
-		if t.container.current < len(t.container.Items) {
-			child := t.container.Items[t.container.current].Content
-			barHeight := buttonHeight + theme.Padding()
-			child.Move(fyne.NewPos(0, barHeight))
-			child.Resize(fyne.NewSize(size.Width, size.Height-barHeight))
-		}
-	case TabLocationLeading:
-		buttonWidth := t.tabBar.MinSize().Width
-		t.tabBar.Move(fyne.NewPos(0, 0))
-		t.tabBar.Resize(fyne.NewSize(buttonWidth, size.Height))
-		t.line.Move(fyne.NewPos(buttonWidth, 0))
-		t.line.Resize(fyne.NewSize(theme.Padding(), size.Height))
-
-		if t.container.current < len(t.container.Items) {
-			child := t.container.Items[t.container.current].Content
-			barWidth := buttonWidth + theme.Padding()
-			child.Move(fyne.NewPos(barWidth, 0))
-			child.Resize(fyne.NewSize(size.Width-barWidth, size.Height))
-		}
-	case TabLocationBottom:
-		buttonHeight := t.tabBar.MinSize().Height
-		t.tabBar.Move(fyne.NewPos(0, size.Height-buttonHeight))
-		t.tabBar.Resize(fyne.NewSize(size.Width, buttonHeight))
+		buttonHeight := tabBarMinSize.Height
+		tabBarPos = fyne.NewPos(0, 0)
+		tabBarSize = fyne.NewSize(size.Width, buttonHeight)
+		linePos = fyne.NewPos(0, buttonHeight)
+		lineSize = fyne.NewSize(size.Width, theme.Padding())
 		barHeight := buttonHeight + theme.Padding()
-		t.line.Move(fyne.NewPos(0, size.Height-barHeight))
-		t.line.Resize(fyne.NewSize(size.Width, theme.Padding()))
-
-		if t.container.current < len(t.container.Items) {
-			child := t.container.Items[t.container.current].Content
-			child.Move(fyne.NewPos(0, 0))
-			child.Resize(fyne.NewSize(size.Width, size.Height-barHeight))
-		}
-	case TabLocationTrailing:
-		buttonWidth := t.tabBar.MinSize().Width
-		t.tabBar.Move(fyne.NewPos(size.Width-buttonWidth, 0))
-		t.tabBar.Resize(fyne.NewSize(buttonWidth, size.Height))
+		childPos = fyne.NewPos(0, barHeight)
+		childSize = fyne.NewSize(size.Width, size.Height-barHeight)
+	case TabLocationLeading:
+		buttonWidth := tabBarMinSize.Width
+		tabBarPos = fyne.NewPos(0, 0)
+		tabBarSize = fyne.NewSize(buttonWidth, size.Height)
+		linePos = fyne.NewPos(buttonWidth, 0)
+		lineSize = fyne.NewSize(theme.Padding(), size.Height)
 		barWidth := buttonWidth + theme.Padding()
-		t.line.Move(fyne.NewPos(size.Width-barWidth, 0))
-		t.line.Resize(fyne.NewSize(theme.Padding(), size.Height))
+		childPos = fyne.NewPos(barWidth, 0)
+		childSize = fyne.NewSize(size.Width-barWidth, size.Height)
+	case TabLocationBottom:
+		buttonHeight := tabBarMinSize.Height
+		tabBarPos = fyne.NewPos(0, size.Height-buttonHeight)
+		tabBarSize = fyne.NewSize(size.Width, buttonHeight)
+		barHeight := buttonHeight + theme.Padding()
+		linePos = fyne.NewPos(0, size.Height-barHeight)
+		lineSize = fyne.NewSize(size.Width, theme.Padding())
+		childPos = fyne.NewPos(0, 0)
+		childSize = fyne.NewSize(size.Width, size.Height-barHeight)
+	case TabLocationTrailing:
+		buttonWidth := tabBarMinSize.Width
+		tabBarPos = fyne.NewPos(size.Width-buttonWidth, 0)
+		tabBarSize = fyne.NewSize(buttonWidth, size.Height)
+		barWidth := buttonWidth + theme.Padding()
+		linePos = fyne.NewPos(size.Width-barWidth, 0)
+		lineSize = fyne.NewSize(theme.Padding(), size.Height)
+		childPos = fyne.NewPos(0, 0)
+		childSize = fyne.NewSize(size.Width-barWidth, size.Height)
+	}
 
-		if t.container.current < len(t.container.Items) {
-			child := t.container.Items[t.container.current].Content
-			child.Move(fyne.NewPos(0, 0))
-			child.Resize(fyne.NewSize(size.Width-barWidth, size.Height))
-		}
+	t.tabBar.Move(tabBarPos)
+	t.tabBar.Resize(tabBarSize)
+	t.line.Move(linePos)
+	t.line.Resize(lineSize)
+	if t.container.current < len(t.container.Items) {
+		child := t.container.Items[t.container.current].Content
+		child.Move(childPos)
+		child.Resize(childSize)
 	}
 }
 

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -70,6 +70,9 @@ func (t *TabContainer) SelectTab(item *TabItem) {
 
 // CurrentTab returns the currently selected TabItem.
 func (t *TabContainer) CurrentTab() *TabItem {
+	if t.current < 0 || t.current >= len(t.Items) {
+		return nil
+	}
 	return t.Items[t.current]
 }
 
@@ -214,7 +217,11 @@ func (t *TabContainer) mismatchedContent() bool {
 
 // NewTabContainer creates a new tab bar widget that allows the user to choose between different visible containers
 func NewTabContainer(items ...*TabItem) *TabContainer {
-	tabs := &TabContainer{BaseWidget: BaseWidget{}, Items: items}
+	tabs := &TabContainer{BaseWidget: BaseWidget{}, Items: items, current: -1}
+	if len(items) > 0 {
+		// Current is first tab item
+		tabs.current = 0
+	}
 	tabs.ExtendBaseWidget(tabs)
 
 	if tabs.mismatchedContent() {

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -269,10 +269,12 @@ func (t *tabContainerRenderer) Layout(size fyne.Size) {
 		t.line.Move(fyne.NewPos(0, buttonHeight))
 		t.line.Resize(fyne.NewSize(size.Width, theme.Padding()))
 
-		child := t.container.Items[t.container.current].Content
-		barHeight := buttonHeight + theme.Padding()
-		child.Move(fyne.NewPos(0, barHeight))
-		child.Resize(fyne.NewSize(size.Width, size.Height-barHeight))
+		if t.container.current < len(t.container.Items) {
+			child := t.container.Items[t.container.current].Content
+			barHeight := buttonHeight + theme.Padding()
+			child.Move(fyne.NewPos(0, barHeight))
+			child.Resize(fyne.NewSize(size.Width, size.Height-barHeight))
+		}
 	case TabLocationLeading:
 		buttonWidth := t.tabBar.MinSize().Width
 		t.tabBar.Move(fyne.NewPos(0, 0))
@@ -280,10 +282,12 @@ func (t *tabContainerRenderer) Layout(size fyne.Size) {
 		t.line.Move(fyne.NewPos(buttonWidth, 0))
 		t.line.Resize(fyne.NewSize(theme.Padding(), size.Height))
 
-		child := t.container.Items[t.container.current].Content
-		barWidth := buttonWidth + theme.Padding()
-		child.Move(fyne.NewPos(barWidth, 0))
-		child.Resize(fyne.NewSize(size.Width-barWidth, size.Height))
+		if t.container.current < len(t.container.Items) {
+			child := t.container.Items[t.container.current].Content
+			barWidth := buttonWidth + theme.Padding()
+			child.Move(fyne.NewPos(barWidth, 0))
+			child.Resize(fyne.NewSize(size.Width-barWidth, size.Height))
+		}
 	case TabLocationBottom:
 		buttonHeight := t.tabBar.MinSize().Height
 		t.tabBar.Move(fyne.NewPos(0, size.Height-buttonHeight))
@@ -292,9 +296,11 @@ func (t *tabContainerRenderer) Layout(size fyne.Size) {
 		t.line.Move(fyne.NewPos(0, size.Height-barHeight))
 		t.line.Resize(fyne.NewSize(size.Width, theme.Padding()))
 
-		child := t.container.Items[t.container.current].Content
-		child.Move(fyne.NewPos(0, 0))
-		child.Resize(fyne.NewSize(size.Width, size.Height-barHeight))
+		if t.container.current < len(t.container.Items) {
+			child := t.container.Items[t.container.current].Content
+			child.Move(fyne.NewPos(0, 0))
+			child.Resize(fyne.NewSize(size.Width, size.Height-barHeight))
+		}
 	case TabLocationTrailing:
 		buttonWidth := t.tabBar.MinSize().Width
 		t.tabBar.Move(fyne.NewPos(size.Width-buttonWidth, 0))
@@ -303,9 +309,11 @@ func (t *tabContainerRenderer) Layout(size fyne.Size) {
 		t.line.Move(fyne.NewPos(size.Width-barWidth, 0))
 		t.line.Resize(fyne.NewSize(theme.Padding(), size.Height))
 
-		child := t.container.Items[t.container.current].Content
-		child.Move(fyne.NewPos(0, 0))
-		child.Resize(fyne.NewSize(size.Width-barWidth, size.Height))
+		if t.container.current < len(t.container.Items) {
+			child := t.container.Items[t.container.current].Content
+			child.Move(fyne.NewPos(0, 0))
+			child.Resize(fyne.NewSize(size.Width-barWidth, size.Height))
+		}
 	}
 }
 

--- a/widget/tabcontainer_test.go
+++ b/widget/tabcontainer_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTabContainer_Empty(t *testing.T) {
+	tabs := NewTabContainer()
+	assert.Equal(t, 0, len(tabs.Items))
+	assert.Equal(t, -1, tabs.CurrentTabIndex())
+	assert.Nil(t, tabs.CurrentTab())
+	min := tabs.MinSize()
+	assert.Equal(t, 4, min.Height)
+	assert.Equal(t, 0, min.Width)
+}
+
 func TestTabContainer_CurrentTabIndex(t *testing.T) {
 	tabs := NewTabContainer(&TabItem{Text: "Test", Content: NewLabel("Test")})
 


### PR DESCRIPTION
Previously tabcontainer would panic if rendered without any children

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running, locked to thread]:
fyne.io/fyne/widget.(*tabContainerRenderer).Layout(0xc0001aadb0, 0x0, 0x6b)
	fyne.io/fyne/widget/tabcontainer.go:272 +0x781
```