### PR TITLE
BaseWidget should not implement CreateRenderer

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -1,6 +1,7 @@
 package glfw
 
 import (
+	"fmt"
 	"runtime"
 	"sync"
 	"time"
@@ -60,7 +61,7 @@ func (d *gLDriver) initGLFW() {
 func (d *gLDriver) tryPollEvents() {
 	defer func() {
 		if r := recover(); r != nil {
-			fyne.LogError("GLFW poll event error (details above)", nil)
+			fyne.LogError(fmt.Sprint("GLFW poll event error: ", r), nil)
 		}
 	}()
 

--- a/widget/select.go
+++ b/widget/select.go
@@ -230,5 +230,7 @@ func (s *Select) updateSelected(text string) {
 
 // NewSelect creates a new select widget with the set list of options and changes handler
 func NewSelect(options []string, changed func(string)) *Select {
-	return &Select{BaseWidget{}, "", options, defaultPlaceHolder, changed, false, nil}
+	s := &Select{BaseWidget{}, "", options, defaultPlaceHolder, changed, false, nil}
+	s.ExtendBaseWidget(s)
+	return s
 }

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -65,11 +65,6 @@ func (w *BaseWidget) MinSize() fyne.Size {
 	return r.MinSize()
 }
 
-// CreateRenderer of BaseWidget does nothing, it must be overridden
-func (w *BaseWidget) CreateRenderer() fyne.WidgetRenderer {
-	return nil
-}
-
 // Visible returns whether or not this widget should be visible.
 // Note that this may not mean it is currently visible if a parent has been hidden.
 func (w *BaseWidget) Visible() bool {
@@ -120,7 +115,9 @@ func (w *BaseWidget) refresh(wid fyne.Widget) {
 // If extended then this is the extending widget, otherwise it is self.
 func (w *BaseWidget) super() fyne.Widget {
 	if w.impl == nil {
-		return w
+		var x interface{}
+		x = w
+		return x.(fyne.Widget)
 	}
 
 	return w.impl


### PR DESCRIPTION
### Description:

The `widget.BaseWidget` should not implement a useless `CreateRenderer` method. It prevents the compiler from raising a meaningful error message if one forgot to implement it. Instead a GLFW error is logged which is almost impossible to debug.

### Checklist:

- ~~[ ] Tests included.~~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
