### PR TITLE
Limit Scroll Directions

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -116,12 +116,14 @@ func makeScrollTab() fyne.CanvasObject {
 		}))
 	}
 
-	horiz := widget.NewScrollContainer(list)
-	vert := widget.NewScrollContainer(list2)
+	horiz := widget.NewHorizontalScrollContainer(list)
+	vert := widget.NewVerticalScrollContainer(list2)
+	vert.SetMinSize(fyne.NewSize(32, 128))
 
-	scrolls := fyne.NewContainerWithLayout(layout.NewBorderLayout(horiz, nil, nil, nil),
-		horiz, vert)
-	return fyne.NewContainerWithLayout(layout.NewAdaptiveGridLayout(2), scrolls, makeScrollBothTab())
+	return fyne.NewContainerWithLayout(layout.NewAdaptiveGridLayout(2), widget.NewVBox(
+		horiz,
+		vert,
+	), makeScrollBothTab())
 }
 
 func makeScrollBothTab() fyne.CanvasObject {

--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -118,12 +118,10 @@ func makeScrollTab() fyne.CanvasObject {
 
 	horiz := widget.NewHorizontalScrollContainer(list)
 	vert := widget.NewVerticalScrollContainer(list2)
-	vert.SetMinSize(fyne.NewSize(32, 128))
 
-	return fyne.NewContainerWithLayout(layout.NewAdaptiveGridLayout(2), widget.NewVBox(
-		horiz,
-		vert,
-	), makeScrollBothTab())
+	return fyne.NewContainerWithLayout(layout.NewAdaptiveGridLayout(2),
+		fyne.NewContainerWithLayout(layout.NewBorderLayout(horiz, nil, nil, nil), horiz, vert),
+		makeScrollBothTab())
 }
 
 func makeScrollBothTab() fyne.CanvasObject {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -57,36 +57,6 @@ func TestMultiLineEntry_MinSize(t *testing.T) {
 	assert.Equal(t, singleMin.Height, multiMin.Height)
 }
 
-func TestMultiLineEntry_Scroller_MinSize(t *testing.T) {
-	text := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	size := textMinSize(text, theme.TextSize(), fyne.TextStyle{})
-
-	multi := NewMultiLineEntry()
-	multi.SetText(text)
-	multiMin := multi.MinSize()
-	assert.Equal(t, size.Width+2*theme.Padding()+theme.ScrollBarSize(), multiMin.Width)
-	assert.Equal(t, size.Height*multiLineRows+2*theme.Padding(), multiMin.Height)
-
-	t.Run("Both", func(t *testing.T) {
-		scroller := NewScrollContainer(multi)
-		scrollerMin := scroller.MinSize()
-		assert.Equal(t, 32, scrollerMin.Height)
-		assert.Equal(t, 32, scrollerMin.Width)
-	})
-	t.Run("HorizontalOnly", func(t *testing.T) {
-		scroller := NewHorizontalScrollContainer(multi)
-		scrollerMin := scroller.MinSize()
-		assert.Equal(t, size.Height*multiLineRows+2*theme.Padding(), scrollerMin.Height)
-		assert.Equal(t, 32, scrollerMin.Width)
-	})
-	t.Run("VerticalOnly", func(t *testing.T) {
-		scroller := NewVerticalScrollContainer(multi)
-		scrollerMin := scroller.MinSize()
-		assert.Equal(t, 32, scrollerMin.Height) // TODO FIXME Should equal size.Height*multiLineRows+2*theme.Padding()
-		assert.Equal(t, size.Width+2*theme.Padding()+theme.ScrollBarSize(), scrollerMin.Width)
-	})
-}
-
 func TestEntry_SetPlaceHolder(t *testing.T) {
 	entry := NewEntry()
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -57,6 +57,36 @@ func TestMultiLineEntry_MinSize(t *testing.T) {
 	assert.Equal(t, singleMin.Height, multiMin.Height)
 }
 
+func TestMultiLineEntry_Scroller_MinSize(t *testing.T) {
+	text := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	size := textMinSize(text, theme.TextSize(), fyne.TextStyle{})
+
+	multi := NewMultiLineEntry()
+	multi.SetText(text)
+	multiMin := multi.MinSize()
+	assert.Equal(t, size.Width+2*theme.Padding()+theme.ScrollBarSize(), multiMin.Width)
+	assert.Equal(t, size.Height*multiLineRows+2*theme.Padding(), multiMin.Height)
+
+	t.Run("Both", func(t *testing.T) {
+		scroller := NewScrollContainer(multi)
+		scrollerMin := scroller.MinSize()
+		assert.Equal(t, 32, scrollerMin.Height)
+		assert.Equal(t, 32, scrollerMin.Width)
+	})
+	t.Run("HorizontalOnly", func(t *testing.T) {
+		scroller := NewHorizontalScrollContainer(multi)
+		scrollerMin := scroller.MinSize()
+		assert.Equal(t, size.Height*multiLineRows+2*theme.Padding(), scrollerMin.Height)
+		assert.Equal(t, 32, scrollerMin.Width)
+	})
+	t.Run("VerticalOnly", func(t *testing.T) {
+		scroller := NewVerticalScrollContainer(multi)
+		scrollerMin := scroller.MinSize()
+		assert.Equal(t, 32, scrollerMin.Height) // TODO FIXME Should equal size.Height*multiLineRows+2*theme.Padding()
+		assert.Equal(t, size.Width+2*theme.Padding()+theme.ScrollBarSize(), scrollerMin.Width)
+	})
+}
+
 func TestEntry_SetPlaceHolder(t *testing.T) {
 	entry := NewEntry()
 

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -12,12 +12,10 @@ import (
 // ScrollDirection represents the directions in which a ScrollContainer can scroll its child content.
 type ScrollDirection int
 
+// Constants for valid values of ScrollDirection.
 const (
-	// ScrollBoth allows the ScrollContainer to scroll its child in both horizontal and vertical directions.
 	ScrollBoth ScrollDirection = iota
-	// ScrollHorizontalOnly allows the ScrollContainer to only scroll its child in the horizontal direction.
 	ScrollHorizontalOnly
-	// ScrollVerticalOnly allows the ScrollContainer to only scroll its child in the vertical direction.
 	ScrollVerticalOnly
 )
 

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -43,7 +43,7 @@ func TestScrollContainer_MinSize(t *testing.T) {
 	assert.Equal(t, 0, scroll.Offset.Y)
 }
 
-func TestScrollContainer_Direction(t *testing.T) {
+func TestScrollContainer_MinSize_Direction(t *testing.T) {
 	t.Run("Both", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
@@ -65,6 +65,66 @@ func TestScrollContainer_Direction(t *testing.T) {
 		rect.SetMinSize(fyne.NewSize(100, 100))
 		scroll := NewVerticalScrollContainer(rect)
 		size := scroll.MinSize()
+		assert.Equal(t, 32, size.Height)
+		assert.Equal(t, 100, size.Width)
+	})
+}
+
+func TestScrollContainer_SetMinSize_Direction(t *testing.T) {
+	t.Run("Both", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewScrollContainer(rect)
+		scroll.SetMinSize(fyne.NewSize(50, 50))
+		size := scroll.MinSize()
+		assert.Equal(t, 50, size.Height)
+		assert.Equal(t, 50, size.Width)
+	})
+	t.Run("HorizontalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewHorizontalScrollContainer(rect)
+		scroll.SetMinSize(fyne.NewSize(50, 50))
+		size := scroll.MinSize()
+		assert.Equal(t, 100, size.Height)
+		assert.Equal(t, 50, size.Width)
+	})
+	t.Run("VerticalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewVerticalScrollContainer(rect)
+		scroll.SetMinSize(fyne.NewSize(50, 50))
+		size := scroll.MinSize()
+		assert.Equal(t, 50, size.Height)
+		assert.Equal(t, 100, size.Width)
+	})
+}
+
+func TestScrollContainer_Resize_Direction(t *testing.T) {
+	t.Run("Both", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewScrollContainer(rect)
+		scroll.Resize(scroll.MinSize())
+		size := scroll.Size()
+		assert.Equal(t, 32, size.Height)
+		assert.Equal(t, 32, size.Width)
+	})
+	t.Run("HorizontalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewHorizontalScrollContainer(rect)
+		scroll.Resize(scroll.MinSize())
+		size := scroll.Size()
+		assert.Equal(t, 100, size.Height)
+		assert.Equal(t, 32, size.Width)
+	})
+	t.Run("VerticalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewVerticalScrollContainer(rect)
+		scroll.Resize(scroll.MinSize())
+		size := scroll.Size()
 		assert.Equal(t, 32, size.Height)
 		assert.Equal(t, 100, size.Width)
 	})
@@ -397,6 +457,102 @@ func TestScrollContainerRenderer_LimitBarSize(t *testing.T) {
 
 	assert.Equal(t, 120, areaHoriz.bar.Size().Width)
 	assert.Equal(t, 120, areaVert.bar.Size().Height)
+}
+
+func TestScrollContainerRenderer_Direction(t *testing.T) {
+	t.Run("Both", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewScrollContainer(rect)
+		r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
+		assert.NotNil(t, r.vertArea)
+		assert.NotNil(t, r.topShadow)
+		assert.NotNil(t, r.bottomShadow)
+		assert.NotNil(t, r.horizArea)
+		assert.NotNil(t, r.leftShadow)
+		assert.NotNil(t, r.rightShadow)
+	})
+	t.Run("HorizontalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewHorizontalScrollContainer(rect)
+		r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
+		assert.Nil(t, r.vertArea)
+		assert.Nil(t, r.topShadow)
+		assert.Nil(t, r.bottomShadow)
+		assert.NotNil(t, r.horizArea)
+		assert.NotNil(t, r.leftShadow)
+		assert.NotNil(t, r.rightShadow)
+	})
+	t.Run("VerticalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewVerticalScrollContainer(rect)
+		r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
+		assert.NotNil(t, r.vertArea)
+		assert.NotNil(t, r.topShadow)
+		assert.NotNil(t, r.bottomShadow)
+		assert.Nil(t, r.horizArea)
+		assert.Nil(t, r.leftShadow)
+		assert.Nil(t, r.rightShadow)
+	})
+}
+
+func TestScrollContainerRenderer_MinSize_Direction(t *testing.T) {
+	t.Run("Both", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewScrollContainer(rect)
+		size := test.WidgetRenderer(scroll).MinSize()
+		assert.Equal(t, 32, size.Height)
+		assert.Equal(t, 32, size.Width)
+	})
+	t.Run("HorizontalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewHorizontalScrollContainer(rect)
+		size := test.WidgetRenderer(scroll).MinSize()
+		assert.Equal(t, 100, size.Height)
+		assert.Equal(t, 32, size.Width)
+	})
+	t.Run("VerticalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewVerticalScrollContainer(rect)
+		size := test.WidgetRenderer(scroll).MinSize()
+		assert.Equal(t, 32, size.Height)
+		assert.Equal(t, 100, size.Width)
+	})
+}
+
+func TestScrollContainerRenderer_SetMinSize_Direction(t *testing.T) {
+	t.Run("Both", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewScrollContainer(rect)
+		scroll.SetMinSize(fyne.NewSize(50, 50))
+		size := test.WidgetRenderer(scroll).MinSize()
+		assert.Equal(t, 50, size.Height)
+		assert.Equal(t, 50, size.Width)
+	})
+	t.Run("HorizontalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewHorizontalScrollContainer(rect)
+		scroll.SetMinSize(fyne.NewSize(50, 50))
+		size := test.WidgetRenderer(scroll).MinSize()
+		assert.Equal(t, 100, size.Height)
+		assert.Equal(t, 50, size.Width)
+	})
+	t.Run("VerticalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewVerticalScrollContainer(rect)
+		scroll.SetMinSize(fyne.NewSize(50, 50))
+		size := test.WidgetRenderer(scroll).MinSize()
+		assert.Equal(t, 50, size.Height)
+		assert.Equal(t, 100, size.Width)
+	})
 }
 
 func TestScrollBar_Dragged_ClickedInside(t *testing.T) {

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -43,6 +43,33 @@ func TestScrollContainer_MinSize(t *testing.T) {
 	assert.Equal(t, 0, scroll.Offset.Y)
 }
 
+func TestScrollContainer_Direction(t *testing.T) {
+	t.Run("Both", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewScrollContainer(rect)
+		size := scroll.MinSize()
+		assert.Equal(t, 32, size.Height)
+		assert.Equal(t, 32, size.Width)
+	})
+	t.Run("HorizontalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewHorizontalScrollContainer(rect)
+		size := scroll.MinSize()
+		assert.Equal(t, 100, size.Height)
+		assert.Equal(t, 32, size.Width)
+	})
+	t.Run("VerticalOnly", func(t *testing.T) {
+		rect := canvas.NewRectangle(color.Black)
+		rect.SetMinSize(fyne.NewSize(100, 100))
+		scroll := NewVerticalScrollContainer(rect)
+		size := scroll.MinSize()
+		assert.Equal(t, 32, size.Height)
+		assert.Equal(t, 100, size.Width)
+	})
+}
+
 func TestScrollContainer_Refresh(t *testing.T) {
 	rect := canvas.NewRectangle(color.Black)
 	rect.SetMinSize(fyne.NewSize(1000, 1000))


### PR DESCRIPTION
### Description:
Adds a Direction field to ScrollContainer to specify the allowed directions which defaults to both.

Fixes #763

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed. (no breaking changes)
