### PR TITLE
CI: Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,23 @@ script:
       # check that go mod tidy does not change go.mod/go.sum
       go mod tidy && git diff-index --quiet HEAD -- || ( echo "go.mod/go.sum not up-to-date"; git diff-index HEAD --; false )
     fi
-  - test -z "$(goimports -e -d $GO_FILES | tee /dev/stderr)"
+  - |
+    if [ "$TRAVIS_OS_NAME" != "windows" ]
+    then
+      test -z $(goimports -e -d $GO_FILES | tee /dev/stderr)
+    fi
+# goimports reports a lot of pseudo-diffs on Windows
+#      echo > goimports.out
+#      tail -f goimports.out &
+#      test -z "$(goimports -e -d $GO_FILES | tee goimports.out)"
   - go test -tags ci ./...
   - go vet -tags ci -unsafeptr=false ./...
-  - golint -set_exit_status $(go list -tags ci ./...)
+# Windows golint alarm probably related to https://github.com/golang/lint/issues/157
+  - |
+    if [ "$TRAVIS_OS_NAME" != "windows" ]
+    then
+      golint -set_exit_status $(go list -tags ci ./...)
+    fi
   - gocyclo -over 50 $GO_FILES
   - |
     set -e
@@ -56,9 +69,15 @@ matrix:
     - go: 1.12.x
       os: osx
       env: GO111MODULE=off GOFLAGS=
+    - go: 1.12.x
+      os: windows
+      env: GO111MODULE=off GOFLAGS=
     - go: 1.13.x
       os: linux
       env: GO111MODULE=off GOFLAGS=
     - go: 1.13.x
       os: osx
       env: GO111MODULE=on GOFLAGS=-mod=vendor
+    - go: 1.13.x
+      os: windows
+      env: GO111MODULE=off GOFLAGS=

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -1,3 +1,5 @@
+// +build !windows !ci
+
 package gomobile
 
 import (

--- a/internal/driver/gomobile/menu_test.go
+++ b/internal/driver/gomobile/menu_test.go
@@ -1,3 +1,5 @@
+// +build !windows !ci
+
 package gomobile
 
 import (

--- a/internal/painter/gl/draw_test.go
+++ b/internal/painter/gl/draw_test.go
@@ -1,3 +1,5 @@
+// +build !windows !ci
+
 package gl
 
 import (


### PR DESCRIPTION
This adds basic CI support for Windows. All GL based tests are filtered out because of a missing DLL (https://travis-ci.community/t/cgo-and-exit-status-3221225781).

golint is disabled because of https://github.com/golang/lint/issues/157.
goimports is disabled because it reports pseudo-diffs. I guess it's because CR to CR+LF conversations. Someone with Windows should debug this :).