### PR TITLE
Improve native menus

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -66,6 +66,7 @@ func main() {
 	newItem := fyne.NewMenuItem("New", func() { fmt.Println("Menu New") })
 	newItem.Separate = true
 	settingsItem := fyne.NewMenuItem("Settings", func() { fmt.Println("Menu Settings") })
+	settingsItem.KeyEquivalent = ","
 	settingsItem.PlaceInNativeMenu = true
 	settingsItem.Separate = true
 

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -63,20 +63,21 @@ func main() {
 	a.SetIcon(theme.FyneLogo())
 
 	w := a.NewWindow("Fyne Demo")
+	newItem := fyne.NewMenuItem("New", func() { fmt.Println("Menu New") })
+	newItem.Separate = true
 	settingsItem := fyne.NewMenuItem("Settings", func() { fmt.Println("Menu Settings") })
 	settingsItem.PlaceInNativeMenu = true
-	newItem := fyne.NewMenuItem("New", func() { fmt.Println("Menu New") })
+	settingsItem.Separate = true
 
 	cutItem := fyne.NewMenuItem("Cut", func() { fmt.Println("Menu Cut") })
 	copyItem := fyne.NewMenuItem("Copy", func() { fmt.Println("Menu Copy") })
 	pasteItem := fyne.NewMenuItem("Paste", func() { fmt.Println("Menu Paste") })
+	findItem := fyne.NewMenuItem("Find", func() { fmt.Println("Menu Find") })
+	findItem.Separate = true
 	mainMenu := fyne.NewMainMenu(
 		// a quit item will be appended to our first menu
-		fyne.NewMenu("File",
-			settingsItem,
-			newItem,
-		),
-		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem),
+		fyne.NewMenu("File", newItem, settingsItem),
+		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem, findItem),
 	)
 	w.SetMainMenu(mainMenu)
 	w.SetMaster()

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -63,25 +63,25 @@ func main() {
 	a.SetIcon(theme.FyneLogo())
 
 	w := a.NewWindow("Fyne Demo")
+
 	newItem := fyne.NewMenuItem("New", func() { fmt.Println("Menu New") })
-	newItem.Separate = true
+	settingsSeparator := fyne.NewMenuItemSeparator()
+	settingsSeparator.PlaceInNativeMenu = true
 	settingsItem := fyne.NewMenuItem("Settings", func() { fmt.Println("Menu Settings") })
 	settingsItem.KeyEquivalent = ","
 	settingsItem.PlaceInNativeMenu = true
-	settingsItem.Separate = true
 
 	cutItem := fyne.NewMenuItem("Cut", func() { fmt.Println("Menu Cut") })
 	copyItem := fyne.NewMenuItem("Copy", func() { fmt.Println("Menu Copy") })
 	pasteItem := fyne.NewMenuItem("Paste", func() { fmt.Println("Menu Paste") })
 	findItem := fyne.NewMenuItem("Find", func() { fmt.Println("Menu Find") })
-	findItem.Separate = true
 
 	helpMenu := fyne.NewMenu("Help", fyne.NewMenuItem("Help", func() { fmt.Println("Help Menu") }))
 	helpMenu.AfterNativeMenus = true
 	mainMenu := fyne.NewMainMenu(
 		// a quit item will be appended to our first menu
-		fyne.NewMenu("File", newItem, settingsItem),
-		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem, findItem),
+		fyne.NewMenu("File", newItem, settingsSeparator, settingsItem),
+		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem, fyne.NewMenuItemSeparator(), findItem),
 		helpMenu,
 	)
 	w.SetMainMenu(mainMenu)

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -63,14 +63,22 @@ func main() {
 	a.SetIcon(theme.FyneLogo())
 
 	w := a.NewWindow("Fyne Demo")
-	w.SetMainMenu(fyne.NewMainMenu(fyne.NewMenu("File",
-		fyne.NewMenuItem("New", func() { fmt.Println("Menu New") }),
+	settingsItem := fyne.NewMenuItem("Settings", func() { fmt.Println("Menu Settings") })
+	settingsItem.PlaceInNativeMenu = true
+	newItem := fyne.NewMenuItem("New", func() { fmt.Println("Menu New") })
+
+	cutItem := fyne.NewMenuItem("Cut", func() { fmt.Println("Menu Cut") })
+	copyItem := fyne.NewMenuItem("Copy", func() { fmt.Println("Menu Copy") })
+	pasteItem := fyne.NewMenuItem("Paste", func() { fmt.Println("Menu Paste") })
+	mainMenu := fyne.NewMainMenu(
 		// a quit item will be appended to our first menu
-	), fyne.NewMenu("Edit",
-		fyne.NewMenuItem("Cut", func() { fmt.Println("Menu Cut") }),
-		fyne.NewMenuItem("Copy", func() { fmt.Println("Menu Copy") }),
-		fyne.NewMenuItem("Paste", func() { fmt.Println("Menu Paste") }),
-	)))
+		fyne.NewMenu("File",
+			settingsItem,
+			newItem,
+		),
+		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem),
+	)
+	w.SetMainMenu(mainMenu)
 	w.SetMaster()
 
 	tabs := widget.NewTabContainer(

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -75,10 +75,14 @@ func main() {
 	pasteItem := fyne.NewMenuItem("Paste", func() { fmt.Println("Menu Paste") })
 	findItem := fyne.NewMenuItem("Find", func() { fmt.Println("Menu Find") })
 	findItem.Separate = true
+
+	helpMenu := fyne.NewMenu("Help", fyne.NewMenuItem("Help", func() { fmt.Println("Help Menu") }))
+	helpMenu.AfterNativeMenus = true
 	mainMenu := fyne.NewMainMenu(
 		// a quit item will be appended to our first menu
 		fyne.NewMenu("File", newItem, settingsItem),
 		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem, findItem),
+		helpMenu,
 	)
 	w.SetMainMenu(mainMenu)
 	w.SetMaster()

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -65,10 +65,7 @@ func main() {
 	w := a.NewWindow("Fyne Demo")
 
 	newItem := fyne.NewMenuItem("New", func() { fmt.Println("Menu New") })
-	settingsSeparator := fyne.NewMenuItemSeparator()
-	settingsSeparator.PlaceInNativeMenu = true
 	settingsItem := fyne.NewMenuItem("Settings", func() { fmt.Println("Menu Settings") })
-	settingsItem.PlaceInNativeMenu = true
 
 	cutItem := fyne.NewMenuItem("Cut", func() { fmt.Println("Menu Cut") })
 	copyItem := fyne.NewMenuItem("Copy", func() { fmt.Println("Menu Copy") })
@@ -76,10 +73,9 @@ func main() {
 	findItem := fyne.NewMenuItem("Find", func() { fmt.Println("Menu Find") })
 
 	helpMenu := fyne.NewMenu("Help", fyne.NewMenuItem("Help", func() { fmt.Println("Help Menu") }))
-	helpMenu.AfterNativeMenus = true
 	mainMenu := fyne.NewMainMenu(
 		// a quit item will be appended to our first menu
-		fyne.NewMenu("File", newItem, settingsSeparator, settingsItem),
+		fyne.NewMenu("File", newItem, fyne.NewMenuItemSeparator(), settingsItem),
 		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem, fyne.NewMenuItemSeparator(), findItem),
 		helpMenu,
 	)

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -68,7 +68,6 @@ func main() {
 	settingsSeparator := fyne.NewMenuItemSeparator()
 	settingsSeparator.PlaceInNativeMenu = true
 	settingsItem := fyne.NewMenuItem("Settings", func() { fmt.Println("Menu Settings") })
-	settingsItem.KeyEquivalent = ","
 	settingsItem.PlaceInNativeMenu = true
 
 	cutItem := fyne.NewMenuItem("Cut", func() { fmt.Println("Menu Cut") })

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -479,13 +479,13 @@ func (c *glCanvas) setupThemeListener() {
 	}()
 }
 
-func (c *glCanvas) buildMenuBar(m *fyne.MainMenu) {
+func (c *glCanvas) buildMenuBar(w *window, m *fyne.MainMenu) {
 	c.setMenuBar(nil)
 	if m == nil {
 		return
 	}
 	if hasNativeMenu() {
-		setupNativeMenu(m)
+		setupNativeMenu(w, m)
 	} else {
 		c.setMenuBar(buildMenuBar(m, c))
 	}

--- a/internal/driver/glfw/menu.go
+++ b/internal/driver/glfw/menu.go
@@ -31,10 +31,11 @@ func newMenuBarAction(menu *fyne.Menu, c fyne.Canvas) widget.ToolbarItem {
 
 func newMenuBarActionWithQuit(menu *fyne.Menu, c fyne.Canvas) widget.ToolbarItem {
 	if menu.Items[len(menu.Items)-1].Label != "Quit" { // make sure the first menu always has a quit option
-		// TODO append a separator as well
-		menu.Items = append(menu.Items, fyne.NewMenuItem("Quit", func() {
+		quitItem := fyne.NewMenuItem("Quit", func() {
 			fyne.CurrentApp().Quit()
-		}))
+		})
+		quitItem.Separate = true
+		menu.Items = append(menu.Items, quitItem)
 	}
 	return &menuBarAction{menu.Label, menu, c}
 }

--- a/internal/driver/glfw/menu.go
+++ b/internal/driver/glfw/menu.go
@@ -34,8 +34,7 @@ func newMenuBarActionWithQuit(menu *fyne.Menu, c fyne.Canvas) widget.ToolbarItem
 		quitItem := fyne.NewMenuItem("Quit", func() {
 			fyne.CurrentApp().Quit()
 		})
-		quitItem.Separate = true
-		menu.Items = append(menu.Items, quitItem)
+		menu.Items = append(menu.Items, fyne.NewMenuItemSeparator(), quitItem)
 	}
 	return &menuBarAction{menu.Label, menu, c}
 }

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -17,7 +17,7 @@ import (
 // Using void* as type for pointers is a workaround. See https://github.com/golang/go/issues/12065.
 const void* darwinAppMenu();
 const void* createDarwinMenu(const char* label);
-void insertDarwinMenuItem(const void* menu, const char* label, const char* keyEquivalent, int id, int index, bool separate);
+void insertDarwinMenuItem(const void* menu, const char* label, const char* keyEquivalent, int id, int index, bool isSeparator);
 void completeDarwinMenu(void* menu, bool prepend);
 */
 import "C"
@@ -62,6 +62,7 @@ func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int
 		nsMenu = C.createDarwinMenu(C.CString(menu.Label))
 	}
 
+	appMenuIndex := 1
 	for _, item := range menu.Items {
 		if item.PlaceInNativeMenu {
 			C.insertDarwinMenuItem(
@@ -69,9 +70,10 @@ func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int
 				C.CString(item.Label),
 				C.CString(item.KeyEquivalent),
 				C.int(nextItemID),
-				C.int(1),
-				C.bool(item.Separate),
+				C.int(appMenuIndex),
+				C.bool(item.IsSeparator),
 			)
+			appMenuIndex++
 		} else {
 			C.insertDarwinMenuItem(
 				nsMenu,
@@ -79,7 +81,7 @@ func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int
 				C.CString(item.KeyEquivalent),
 				C.int(nextItemID),
 				C.int(-1),
-				C.bool(item.Separate),
+				C.bool(item.IsSeparator),
 			)
 		}
 		callbacks = append(callbacks, func() { w.queueEvent(item.Action) })

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -24,8 +24,8 @@ import "C"
 
 var callbacks []func()
 
-//export menu_callback
-func menu_callback(id int) {
+//export menuCallback
+func menuCallback(id int) {
 	callbacks[id]()
 }
 

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -17,7 +17,7 @@ import (
 // Using void* as type for pointers is a workaround. See https://github.com/golang/go/issues/12065.
 const void* darwinAppMenu();
 const void* createDarwinMenu(const char* label);
-void insertDarwinMenuItem(const void* menu, const char* label, int id, int index, bool separate);
+void insertDarwinMenuItem(const void* menu, const char* label, const char* keyEquivalent, int id, int index, bool separate);
 void completeDarwinMenu(void* menu);
 */
 import "C"
@@ -59,6 +59,7 @@ func addNativeMenu(menu *fyne.Menu, nextItemID int) int {
 			C.insertDarwinMenuItem(
 				C.darwinAppMenu(),
 				C.CString(item.Label),
+				C.CString(item.KeyEquivalent),
 				C.int(nextItemID),
 				C.int(1),
 				C.bool(item.Separate),
@@ -67,6 +68,7 @@ func addNativeMenu(menu *fyne.Menu, nextItemID int) int {
 			C.insertDarwinMenuItem(
 				nsMenu,
 				C.CString(item.Label),
+				C.CString(item.KeyEquivalent),
 				C.int(nextItemID),
 				C.int(-1),
 				C.bool(item.Separate),

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -17,7 +17,7 @@ import (
 // Using void* as type for pointers is a workaround. See https://github.com/golang/go/issues/12065.
 const void* darwinAppMenu();
 const void* createDarwinMenu(const char* label);
-void insertDarwinMenuItem(const void* menu, const char* label, const char* keyEquivalent, int id, int index, bool isSeparator);
+void insertDarwinMenuItem(const void* menu, const char* label, int id, int index, bool isSeparator);
 void completeDarwinMenu(void* menu, bool prepend);
 */
 import "C"
@@ -68,7 +68,6 @@ func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int
 			C.insertDarwinMenuItem(
 				C.darwinAppMenu(),
 				C.CString(item.Label),
-				C.CString(item.KeyEquivalent),
 				C.int(nextItemID),
 				C.int(appMenuIndex),
 				C.bool(item.IsSeparator),
@@ -78,7 +77,6 @@ func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int
 			C.insertDarwinMenuItem(
 				nsMenu,
 				C.CString(item.Label),
-				C.CString(item.KeyEquivalent),
 				C.int(nextItemID),
 				C.int(-1),
 				C.bool(item.IsSeparator),

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -12,10 +12,12 @@ import (
 #cgo CFLAGS: -x objective-c
 #cgo LDFLAGS: -framework Foundation -framework AppKit
 
+#include <AppKit/AppKit.h>
+
 // Using void* as type for pointers is a workaround. See https://github.com/golang/go/issues/12065.
 const void* darwinAppMenu();
 const void* createDarwinMenu(const char* label);
-void insertDarwinMenuItem(const void* menu, const char* label, int id, int index);
+void insertDarwinMenuItem(const void* menu, const char* label, int id, int index, bool separate);
 void completeDarwinMenu(void* menu);
 */
 import "C"
@@ -59,6 +61,7 @@ func addNativeMenu(menu *fyne.Menu, nextItemID int) int {
 				C.CString(item.Label),
 				C.int(nextItemID),
 				C.int(1),
+				C.bool(item.Separate),
 			)
 		} else {
 			C.insertDarwinMenuItem(
@@ -66,6 +69,7 @@ func addNativeMenu(menu *fyne.Menu, nextItemID int) int {
 				C.CString(item.Label),
 				C.int(nextItemID),
 				C.int(-1),
+				C.bool(item.Separate),
 			)
 		}
 		callbacks = append(callbacks, item.Action)

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -33,22 +33,22 @@ func hasNativeMenu() bool {
 	return true
 }
 
-func setupNativeMenu(main *fyne.MainMenu) {
+func setupNativeMenu(w *window, main *fyne.MainMenu) {
 	nextItemID := 0
 	for i := len(main.Items) - 1; i >= 0; i-- {
 		menu := main.Items[i]
 		if !menu.AfterNativeMenus {
-			nextItemID = addNativeMenu(menu, nextItemID, true)
+			nextItemID = addNativeMenu(w, menu, nextItemID, true)
 		}
 	}
 	for _, menu := range main.Items {
 		if menu.AfterNativeMenus {
-			nextItemID = addNativeMenu(menu, nextItemID, false)
+			nextItemID = addNativeMenu(w, menu, nextItemID, false)
 		}
 	}
 }
 
-func addNativeMenu(menu *fyne.Menu, nextItemID int, prepend bool) int {
+func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int {
 	createMenu := false
 	for _, item := range menu.Items {
 		if !item.PlaceInNativeMenu {
@@ -82,7 +82,7 @@ func addNativeMenu(menu *fyne.Menu, nextItemID int, prepend bool) int {
 				C.bool(item.Separate),
 			)
 		}
-		callbacks = append(callbacks, item.Action)
+		callbacks = append(callbacks, func() { w.queueEvent(item.Action) })
 		nextItemID++
 	}
 

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -82,7 +82,8 @@ func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int
 				C.bool(item.IsSeparator),
 			)
 		}
-		callbacks = append(callbacks, func() { w.queueEvent(item.Action) })
+		action := item.Action // catch
+		callbacks = append(callbacks, func() { w.queueEvent(action) })
 		nextItemID++
 	}
 

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -29,7 +29,7 @@ const void* createDarwinMenu(const char* label) {
     return (void*)[[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:label]];
 }
 
-void insertDarwinMenuItem(const void* m, const char* label, const char* keyEquivalent, int id, int index, bool isSeparator) {
+void insertDarwinMenuItem(const void* m, const char* label, int id, int index, bool isSeparator) {
     NSMenu* menu = (NSMenu*)m;
     NSMenuItem* item;
 
@@ -42,7 +42,7 @@ void insertDarwinMenuItem(const void* m, const char* label, const char* keyEquiv
         item = [[NSMenuItem alloc]
             initWithTitle:[NSString stringWithUTF8String:label]
             action:@selector(tapped:)
-            keyEquivalent:[NSString stringWithUTF8String:keyEquivalent]];
+            keyEquivalent:@""];
         [item setTarget:tapper];
         [item setTag:id];
     }

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -59,11 +59,15 @@ void insertDarwinMenuItem(const void* m, const char* label, const char* keyEquiv
     [item release];
 }
 
-void completeDarwinMenu(const void* m) {
+void completeDarwinMenu(const void* m, bool prepend) {
     NSMenu* menu = (NSMenu*)m;
     NSMenu* main = nativeMainMenu();
     NSMenuItem* top = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
-    [main addItem:top];
+    if (prepend) {
+        [main insertItem:top atIndex:1];
+    } else {
+        [main addItem:top];
+    }
     [main setSubmenu:menu forItem:top];
     [menu release]; // release the menu created in createDarwinMenu() function
     menu = Nil;

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -29,31 +29,27 @@ const void* createDarwinMenu(const char* label) {
     return (void*)[[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:label]];
 }
 
-void insertDarwinMenuItem(const void* m, const char* label, const char* keyEquivalent, int id, int index, bool separate) {
+void insertDarwinMenuItem(const void* m, const char* label, const char* keyEquivalent, int id, int index, bool isSeparator) {
     NSMenu* menu = (NSMenu*)m;
-    // NSMenuItem's target is a weak reference, therefore we must not release it.
-    // TODO: Keep a reference in Go and release it when the menu of a window changes or the window is released.
-    FyneMenuItem* tapper = [[FyneMenuItem alloc] init];
-    NSMenuItem* item = [[NSMenuItem alloc]
-        initWithTitle:[NSString stringWithUTF8String:label]
-        action:@selector(tapped:)
-        keyEquivalent:[NSString stringWithUTF8String:keyEquivalent]];
-    [item setTarget:tapper];
-    [item setTag:id];
+    NSMenuItem* item;
+
+    if (isSeparator) {
+        item = [NSMenuItem separatorItem];
+    } else {
+        // NSMenuItem's target is a weak reference, therefore we must not release it.
+        // TODO: Keep a reference in Go and release it when the menu of a window changes or the window is released.
+        FyneMenuItem* tapper = [[FyneMenuItem alloc] init];
+        item = [[NSMenuItem alloc]
+            initWithTitle:[NSString stringWithUTF8String:label]
+            action:@selector(tapped:)
+            keyEquivalent:[NSString stringWithUTF8String:keyEquivalent]];
+        [item setTarget:tapper];
+        [item setTag:id];
+    }
 
     if (index > -1) {
         [menu insertItem:item atIndex:index];
-        if (separate) {
-            NSMenuItem* sep = [NSMenuItem separatorItem];
-            [menu insertItem:sep atIndex:index];
-            [sep release];
-        }
     } else {
-        if (separate) {
-            NSMenuItem* sep = [NSMenuItem separatorItem];
-            [menu addItem:sep];
-            [sep release];
-        }
         [menu addItem:item];
     }
     [item release];

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -21,19 +21,19 @@ NSMenu* nativeMainMenu() {
     return [app mainMenu];
 }
 
-NSMenu* menu;
-
-void createDarwinMenu(const char* label) {
-    menu = [[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:label]];
-
-    // the menu is released at the end of the completeDarwinMenu() function
+const void* createDarwinMenu(const char* label) {
+    return (void*)[[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:label]];
 }
 
-void addDarwinMenuItem(const char* label, int id) {
-    FyneMenuItem* tapper = [[FyneMenuItem alloc] init]; // we cannot release this or the menu does not function...
-
-    NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:[NSString stringWithUTF8String:label]
-        action:@selector(tapped:) keyEquivalent:@""];
+void insertDarwinMenuItem(const void* m, const char* label, int id) {
+    NSMenu* menu = (NSMenu*)m;
+    // NSMenuItem's target is a weak reference, therefore we must not release it.
+    // TODO: Keep a reference in Go and release it when the menu of a window changes or the window is released.
+    FyneMenuItem* tapper = [[FyneMenuItem alloc] init];
+    NSMenuItem* item = [[NSMenuItem alloc]
+        initWithTitle:[NSString stringWithUTF8String:label]
+        action:@selector(tapped:)
+        keyEquivalent:@""];
     [item setTarget:tapper];
     [item setTag:id];
 
@@ -41,9 +41,9 @@ void addDarwinMenuItem(const char* label, int id) {
     [item release];
 }
 
-void completeDarwinMenu() {
+void completeDarwinMenu(const void* m) {
+    NSMenu* menu = (NSMenu*)m;
     NSMenu* main = nativeMainMenu();
-
     NSMenuItem* top = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
     [main addItem:top];
     [main setSubmenu:menu forItem:top];

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -3,7 +3,7 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
 
-extern void menu_callback(int);
+extern void menuCallback(int);
 
 @interface FyneMenuItem : NSObject {
 
@@ -12,7 +12,7 @@ extern void menu_callback(int);
 
 @implementation FyneMenuItem
 - (void) tapped:(id) sender {
-    menu_callback([sender tag]);
+    menuCallback([sender tag]);
 }
 @end
 

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -21,11 +21,15 @@ NSMenu* nativeMainMenu() {
     return [app mainMenu];
 }
 
+const void* darwinAppMenu() {
+    return [[nativeMainMenu() itemAtIndex:0] submenu];
+}
+
 const void* createDarwinMenu(const char* label) {
     return (void*)[[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:label]];
 }
 
-void insertDarwinMenuItem(const void* m, const char* label, int id) {
+void insertDarwinMenuItem(const void* m, const char* label, int id, int index) {
     NSMenu* menu = (NSMenu*)m;
     // NSMenuItem's target is a weak reference, therefore we must not release it.
     // TODO: Keep a reference in Go and release it when the menu of a window changes or the window is released.
@@ -37,7 +41,11 @@ void insertDarwinMenuItem(const void* m, const char* label, int id) {
     [item setTarget:tapper];
     [item setTag:id];
 
-    [menu addItem:item];
+    if (index > -1) {
+        [menu insertItem:item atIndex:index];
+    } else {
+        [menu addItem:item];
+    }
     [item release];
 }
 

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -29,7 +29,7 @@ const void* createDarwinMenu(const char* label) {
     return (void*)[[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:label]];
 }
 
-void insertDarwinMenuItem(const void* m, const char* label, int id, int index, bool separate) {
+void insertDarwinMenuItem(const void* m, const char* label, const char* keyEquivalent, int id, int index, bool separate) {
     NSMenu* menu = (NSMenu*)m;
     // NSMenuItem's target is a weak reference, therefore we must not release it.
     // TODO: Keep a reference in Go and release it when the menu of a window changes or the window is released.
@@ -37,7 +37,7 @@ void insertDarwinMenuItem(const void* m, const char* label, int id, int index, b
     NSMenuItem* item = [[NSMenuItem alloc]
         initWithTitle:[NSString stringWithUTF8String:label]
         action:@selector(tapped:)
-        keyEquivalent:@""];
+        keyEquivalent:[NSString stringWithUTF8String:keyEquivalent]];
     [item setTarget:tapper];
     [item setTag:id];
 

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -29,7 +29,7 @@ const void* createDarwinMenu(const char* label) {
     return (void*)[[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:label]];
 }
 
-void insertDarwinMenuItem(const void* m, const char* label, int id, int index) {
+void insertDarwinMenuItem(const void* m, const char* label, int id, int index, bool separate) {
     NSMenu* menu = (NSMenu*)m;
     // NSMenuItem's target is a weak reference, therefore we must not release it.
     // TODO: Keep a reference in Go and release it when the menu of a window changes or the window is released.
@@ -43,7 +43,17 @@ void insertDarwinMenuItem(const void* m, const char* label, int id, int index) {
 
     if (index > -1) {
         [menu insertItem:item atIndex:index];
+        if (separate) {
+            NSMenuItem* sep = [NSMenuItem separatorItem];
+            [menu insertItem:sep atIndex:index];
+            [sep release];
+        }
     } else {
+        if (separate) {
+            NSMenuItem* sep = [NSMenuItem separatorItem];
+            [menu addItem:sep];
+            [sep release];
+        }
         [menu addItem:item];
     }
     [item release];

--- a/internal/driver/glfw/menu_other.go
+++ b/internal/driver/glfw/menu_other.go
@@ -8,6 +8,6 @@ func hasNativeMenu() bool {
 	return false
 }
 
-func setupNativeMenu(menu *fyne.MainMenu) {
+func setupNativeMenu(_ *window, _ *fyne.MainMenu) {
 	// no-op
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -229,7 +229,7 @@ func (w *window) MainMenu() *fyne.MainMenu {
 
 func (w *window) SetMainMenu(menu *fyne.MainMenu) {
 	w.mainmenu = menu
-	w.canvas.buildMenuBar(menu)
+	w.canvas.buildMenuBar(w, menu)
 }
 
 func (w *window) fitContent() {

--- a/menu.go
+++ b/menu.go
@@ -16,6 +16,7 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 type MenuItem struct {
 	Label             string
 	PlaceInNativeMenu bool
+	Separate          bool
 	Action            func()
 }
 

--- a/menu.go
+++ b/menu.go
@@ -3,9 +3,8 @@ package fyne
 // Menu stores the information required for a standard menu.
 // A menu can pop down from a MainMenu or could be a pop out menu.
 type Menu struct {
-	Label            string
-	Items            []*MenuItem
-	AfterNativeMenus bool
+	Label string
+	Items []*MenuItem
 }
 
 // NewMenu creates a new menu given the specified label (to show in a MainMenu) and list of items to display.
@@ -15,10 +14,9 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
-	IsSeparator       bool
-	Label             string
-	PlaceInNativeMenu bool
-	Action            func()
+	IsSeparator bool
+	Label       string
+	Action      func()
 }
 
 // NewMenuItem creates a new menu item from the passed label and action parameters.

--- a/menu.go
+++ b/menu.go
@@ -17,7 +17,6 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 type MenuItem struct {
 	IsSeparator       bool
 	Label             string
-	KeyEquivalent     string
 	PlaceInNativeMenu bool
 	Action            func()
 }

--- a/menu.go
+++ b/menu.go
@@ -14,13 +14,14 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
-	Label  string
-	Action func()
+	Label             string
+	PlaceInNativeMenu bool
+	Action            func()
 }
 
 // NewMenuItem creates a new menu item from the passed label and action parameters.
 func NewMenuItem(label string, action func()) *MenuItem {
-	return &MenuItem{label, action}
+	return &MenuItem{Label: label, Action: action}
 }
 
 // MainMenu defines the data required to show a menu bar (desktop) or other appropriate top level menu.

--- a/menu.go
+++ b/menu.go
@@ -12,7 +12,7 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 	return &Menu{label, items}
 }
 
-// MenuItem is a sligne item within any menu, it contains a dispay Label and Action function that is called when tapped.
+// MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
 	Label  string
 	Action func()

--- a/menu.go
+++ b/menu.go
@@ -15,6 +15,7 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
 	Label             string
+	KeyEquivalent     string
 	PlaceInNativeMenu bool
 	Separate          bool
 	Action            func()

--- a/menu.go
+++ b/menu.go
@@ -3,13 +3,14 @@ package fyne
 // Menu stores the information required for a standard menu.
 // A menu can pop down from a MainMenu or could be a pop out menu.
 type Menu struct {
-	Label string
-	Items []*MenuItem
+	Label            string
+	Items            []*MenuItem
+	AfterNativeMenus bool
 }
 
 // NewMenu creates a new menu given the specified label (to show in a MainMenu) and list of items to display.
 func NewMenu(label string, items ...*MenuItem) *Menu {
-	return &Menu{label, items}
+	return &Menu{Label: label, Items: items}
 }
 
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.

--- a/menu.go
+++ b/menu.go
@@ -15,16 +15,21 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
+	IsSeparator       bool
 	Label             string
 	KeyEquivalent     string
 	PlaceInNativeMenu bool
-	Separate          bool
 	Action            func()
 }
 
 // NewMenuItem creates a new menu item from the passed label and action parameters.
 func NewMenuItem(label string, action func()) *MenuItem {
 	return &MenuItem{Label: label, Action: action}
+}
+
+// NewMenuItemSeparator creates a menu item that is to be used as a separator.
+func NewMenuItemSeparator() *MenuItem {
+	return &MenuItem{IsSeparator: true, Action: func() {}}
 }
 
 // MainMenu defines the data required to show a menu bar (desktop) or other appropriate top level menu.

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -15,19 +15,24 @@ func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *
 	options := NewVBox()
 	for _, option := range menu.Items {
 		opt := option // capture value
-		options.Append(newTappableLabel(opt.Label))
+		if opt.IsSeparator {
+			options.Append(newSeparator())
+		} else {
+			options.Append(newTappableLabel(opt.Label))
+		}
 	}
 	pop := NewPopUpAtPosition(options, c, pos)
 	focused := c.Focused()
 	for i, o := range options.Children {
-		label := o.(*menuItemWidget)
-		item := menu.Items[i]
-		label.OnTapped = func() {
-			if c.Focused() == nil {
-				c.Focus(focused)
+		if label, ok := o.(*menuItemWidget); ok {
+			item := menu.Items[i]
+			label.OnTapped = func() {
+				if c.Focused() == nil {
+					c.Focus(focused)
+				}
+				pop.Hide()
+				item.Action()
 			}
-			pop.Hide()
-			item.Action()
 		}
 	}
 	return pop
@@ -88,4 +93,8 @@ func (h *hoverLabelRenderer) BackgroundColor() color.Color {
 	}
 
 	return theme.BackgroundColor()
+}
+
+func newSeparator() fyne.CanvasObject {
+	return canvas.NewLine(theme.DisabledTextColor())
 }


### PR DESCRIPTION
### Description:

This PR adds some improvements regarding native menus (MacOS):

- allow menu items to be added to the native app menu (Settings for instance)
- allow menu items to have a “key equivalent” which is a way to define a short-cut
- allow menus to be placed before (default) or after the additional native menus (“Window” on MacOS)
- allow items to wish for a separator to the prior items

All those changes only affect the native menus because there is no support for menu short-cuts or separators in Fyne menus, currently.
Because of this, there seems to be no good way to test this automatically for now :(.

Menu short-cuts interfere with Fyne short-cuts. That's why one has to be careful to not use `"c"`, `"x"` or `"v"` as key equivalent for now.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.