### PR TITLE
Travis: Test with Go 1.14.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,12 +66,6 @@ matrix:
     - go: 1.12.x
       os: linux
       env: GO111MODULE=on GOFLAGS=
-    - go: 1.12.x
-      os: osx
-      env: GO111MODULE=off GOFLAGS=
-    - go: 1.12.x
-      os: windows
-      env: GO111MODULE=off GOFLAGS=
     - go: 1.13.x
       os: linux
       env: GO111MODULE=off GOFLAGS=
@@ -79,5 +73,14 @@ matrix:
       os: osx
       env: GO111MODULE=on GOFLAGS=-mod=vendor
     - go: 1.13.x
+      os: windows
+      env: GO111MODULE=off GOFLAGS=
+    - go: 1.14.x
+      os: linux
+      env: GO111MODULE=off GOFLAGS=
+    - go: 1.14.x
+      os: osx
+      env: GO111MODULE=on GOFLAGS=-mod=vendor
+    - go: 1.14.x
       os: windows
       env: GO111MODULE=off GOFLAGS=

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,13 +71,13 @@ matrix:
       env: GO111MODULE=off GOFLAGS=
     - go: 1.13.x
       os: osx
-      env: GO111MODULE=on GOFLAGS=-mod=vendor
+      env: GO111MODULE=off GOFLAGS=
     - go: 1.13.x
       os: windows
       env: GO111MODULE=off GOFLAGS=
     - go: 1.14.x
       os: linux
-      env: GO111MODULE=off GOFLAGS=
+      env: GO111MODULE=on GOFLAGS=
     - go: 1.14.x
       os: osx
       env: GO111MODULE=on GOFLAGS=-mod=vendor


### PR DESCRIPTION
We should ideally be testing using the two latest supported releases.
However, we still want to keep one 1.12.x running to ensure no 1.13.x APIs are installed just yet.

### Description:
We should ideally be testing using the two latest supported releases.
However, we still want to keep one 1.12.x running to ensure no 1.13.x APIs are installed just yet.

Follow up to #774, due to me managing to put the branch in an unusable state :confused:
