### PR TITLE
Look at key name for shortcuts

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -885,23 +885,23 @@ func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, a
 		ctrlMod = desktop.SuperModifier
 	}
 	if keyDesktopModifier == ctrlMod {
-		switch keyName {
-		case fyne.KeyV:
+		switch glfw.GetKeyName(key, 0) {
+		case "v":
 			// detect paste shortcut
 			shortcut = &fyne.ShortcutPaste{
 				Clipboard: w.Clipboard(),
 			}
-		case fyne.KeyC:
+		case "c":
 			// detect copy shortcut
 			shortcut = &fyne.ShortcutCopy{
 				Clipboard: w.Clipboard(),
 			}
-		case fyne.KeyX:
+		case "x":
 			// detect cut shortcut
 			shortcut = &fyne.ShortcutCut{
 				Clipboard: w.Clipboard(),
 			}
-		case fyne.KeyA:
+		case "a":
 			// detect selectAll shortcut
 			shortcut = &fyne.ShortcutSelectAll{}
 		}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -830,24 +830,18 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyMenu:         desktop.KeyMenu,
 }
 
-func keyToName(code glfw.Key) fyne.KeyName {
-	ret, ok := keyCodeMap[code]
-	if !ok {
-		return ""
-	}
-
-	return ret
-}
 
 func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
-	keyName := keyToName(key)
-	if keyName == "" {
+	keyCode, found := keyCodeMap[key]
+	if !found {
 		return
 	}
-	keyEvent := &fyne.KeyEvent{Name: keyName}
+	keyName := glfw.GetKeyName(key, scancode)
+
+	keyEvent := &fyne.KeyEvent{Name: keyCode}
 	keyDesktopModifier := desktopModifier(mods)
 
-	if keyName == fyne.KeyTab {
+	if keyCode == fyne.KeyTab {
 		if keyDesktopModifier == 0 {
 			if action != glfw.Release {
 				w.canvas.focusMgr.FocusNext(w.canvas.focused)
@@ -885,7 +879,7 @@ func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, a
 		ctrlMod = desktop.SuperModifier
 	}
 	if keyDesktopModifier == ctrlMod {
-		switch glfw.GetKeyName(key, 0) {
+		switch keyName {
 		case "v":
 			// detect paste shortcut
 			shortcut = &fyne.ShortcutPaste{
@@ -908,7 +902,7 @@ func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, a
 	}
 	if shortcut == nil && keyDesktopModifier != 0 && keyDesktopModifier != desktop.ShiftModifier {
 		shortcut = &desktop.CustomShortcut{
-			KeyName:  keyName,
+			KeyName:  keyCode,
 			Modifier: keyDesktopModifier,
 		}
 	}


### PR DESCRIPTION
### Description:
Shortcuts where based on key, not on keyname, which causes issues for non-qwerty keyboards.

Fixes #790

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

I am new to fyne development and couldn't find any test for the current method.  I don't really know how to make a test for this.

I couldn't find instructions on lint to use. `gofmt -d internal/driver/glfw/window.go` returned nothing

Some tests in window_test.go fail, but this seems unrelated.
