### PR TITLE
Rename constructors for consistency

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -54,7 +54,7 @@ func makeTextTab() fyne.CanvasObject {
 	entryMultiLine.SetPlaceHolder("MultiLine Entry")
 	entryLoremIpsum := widget.NewMultiLineEntry()
 	entryLoremIpsum.SetText(loremIpsum)
-	entryLoremIpsumScroller := widget.NewVerticalScrollContainer(entryLoremIpsum)
+	entryLoremIpsumScroller := widget.NewVScrollContainer(entryLoremIpsum)
 
 	label.Alignment = fyne.TextAlignLeading
 	hyperlink.Alignment = fyne.TextAlignLeading
@@ -215,8 +215,8 @@ func makeScrollTab() fyne.CanvasObject {
 		}))
 	}
 
-	horiz := widget.NewHorizontalScrollContainer(list)
-	vert := widget.NewVerticalScrollContainer(list2)
+	horiz := widget.NewHScrollContainer(list)
+	vert := widget.NewVScrollContainer(list2)
 
 	return fyne.NewContainerWithLayout(layout.NewAdaptiveGridLayout(2),
 		fyne.NewContainerWithLayout(layout.NewBorderLayout(horiz, nil, nil, nil), horiz, vert),

--- a/widget/scroller.go
+++ b/widget/scroller.go
@@ -472,15 +472,15 @@ func NewScrollContainer(content fyne.CanvasObject) *ScrollContainer {
 	return newScrollContainerWithDirection(ScrollBoth, content)
 }
 
-// NewHorizontalScrollContainer create a scrollable parent wrapping the specified content.
+// NewHScrollContainer create a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize.Width to be smaller than that of the passed object.
-func NewHorizontalScrollContainer(content fyne.CanvasObject) *ScrollContainer {
+func NewHScrollContainer(content fyne.CanvasObject) *ScrollContainer {
 	return newScrollContainerWithDirection(ScrollHorizontalOnly, content)
 }
 
-// NewVerticalScrollContainer create a scrollable parent wrapping the specified content.
+// NewVScrollContainer create a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize.Height to be smaller than that of the passed object.
-func NewVerticalScrollContainer(content fyne.CanvasObject) *ScrollContainer {
+func NewVScrollContainer(content fyne.CanvasObject) *ScrollContainer {
 	return newScrollContainerWithDirection(ScrollVerticalOnly, content)
 }
 

--- a/widget/scroller_test.go
+++ b/widget/scroller_test.go
@@ -55,7 +55,7 @@ func TestScrollContainer_MinSize_Direction(t *testing.T) {
 	t.Run("HorizontalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewHorizontalScrollContainer(rect)
+		scroll := NewHScrollContainer(rect)
 		size := scroll.MinSize()
 		assert.Equal(t, 100, size.Height)
 		assert.Equal(t, 32, size.Width)
@@ -63,7 +63,7 @@ func TestScrollContainer_MinSize_Direction(t *testing.T) {
 	t.Run("VerticalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewVerticalScrollContainer(rect)
+		scroll := NewVScrollContainer(rect)
 		size := scroll.MinSize()
 		assert.Equal(t, 32, size.Height)
 		assert.Equal(t, 100, size.Width)
@@ -83,7 +83,7 @@ func TestScrollContainer_SetMinSize_Direction(t *testing.T) {
 	t.Run("HorizontalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewHorizontalScrollContainer(rect)
+		scroll := NewHScrollContainer(rect)
 		scroll.SetMinSize(fyne.NewSize(50, 50))
 		size := scroll.MinSize()
 		assert.Equal(t, 100, size.Height)
@@ -92,7 +92,7 @@ func TestScrollContainer_SetMinSize_Direction(t *testing.T) {
 	t.Run("VerticalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewVerticalScrollContainer(rect)
+		scroll := NewVScrollContainer(rect)
 		scroll.SetMinSize(fyne.NewSize(50, 50))
 		size := scroll.MinSize()
 		assert.Equal(t, 50, size.Height)
@@ -113,7 +113,7 @@ func TestScrollContainer_Resize_Direction(t *testing.T) {
 	t.Run("HorizontalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewHorizontalScrollContainer(rect)
+		scroll := NewHScrollContainer(rect)
 		scroll.Resize(scroll.MinSize())
 		size := scroll.Size()
 		assert.Equal(t, 100, size.Height)
@@ -122,7 +122,7 @@ func TestScrollContainer_Resize_Direction(t *testing.T) {
 	t.Run("VerticalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewVerticalScrollContainer(rect)
+		scroll := NewVScrollContainer(rect)
 		scroll.Resize(scroll.MinSize())
 		size := scroll.Size()
 		assert.Equal(t, 32, size.Height)
@@ -475,7 +475,7 @@ func TestScrollContainerRenderer_Direction(t *testing.T) {
 	t.Run("HorizontalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewHorizontalScrollContainer(rect)
+		scroll := NewHScrollContainer(rect)
 		r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 		assert.Nil(t, r.vertArea)
 		assert.Nil(t, r.topShadow)
@@ -487,7 +487,7 @@ func TestScrollContainerRenderer_Direction(t *testing.T) {
 	t.Run("VerticalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewVerticalScrollContainer(rect)
+		scroll := NewVScrollContainer(rect)
 		r := test.WidgetRenderer(scroll).(*scrollContainerRenderer)
 		assert.NotNil(t, r.vertArea)
 		assert.NotNil(t, r.topShadow)
@@ -510,7 +510,7 @@ func TestScrollContainerRenderer_MinSize_Direction(t *testing.T) {
 	t.Run("HorizontalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewHorizontalScrollContainer(rect)
+		scroll := NewHScrollContainer(rect)
 		size := test.WidgetRenderer(scroll).MinSize()
 		assert.Equal(t, 100, size.Height)
 		assert.Equal(t, 32, size.Width)
@@ -518,7 +518,7 @@ func TestScrollContainerRenderer_MinSize_Direction(t *testing.T) {
 	t.Run("VerticalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewVerticalScrollContainer(rect)
+		scroll := NewVScrollContainer(rect)
 		size := test.WidgetRenderer(scroll).MinSize()
 		assert.Equal(t, 32, size.Height)
 		assert.Equal(t, 100, size.Width)
@@ -538,7 +538,7 @@ func TestScrollContainerRenderer_SetMinSize_Direction(t *testing.T) {
 	t.Run("HorizontalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewHorizontalScrollContainer(rect)
+		scroll := NewHScrollContainer(rect)
 		scroll.SetMinSize(fyne.NewSize(50, 50))
 		size := test.WidgetRenderer(scroll).MinSize()
 		assert.Equal(t, 100, size.Height)
@@ -547,7 +547,7 @@ func TestScrollContainerRenderer_SetMinSize_Direction(t *testing.T) {
 	t.Run("VerticalOnly", func(t *testing.T) {
 		rect := canvas.NewRectangle(color.Black)
 		rect.SetMinSize(fyne.NewSize(100, 100))
-		scroll := NewVerticalScrollContainer(rect)
+		scroll := NewVScrollContainer(rect)
 		scroll.SetMinSize(fyne.NewSize(50, 50))
 		size := test.WidgetRenderer(scroll).MinSize()
 		assert.Equal(t, 50, size.Height)


### PR DESCRIPTION
### Description:
Renames scroller constructors for consistency with the rest of the API.

Fixes #795

### Checklist:

- [n/a] Tests included.
- [y] Lint and formatter run with no errors.
- [y] Tests all pass.

#### Where applicable:

- [Y] Public APIs match existing style.
- [n/a] Any breaking changes have a deprecation path or have been discussed.
