### PR TITLE
More security fixes and improvements

### DIFF
--- a/app/preferences.go
+++ b/app/preferences.go
@@ -50,7 +50,7 @@ func (p *preferences) saveToFile(path string) error {
 		if !os.IsExist(err) {
 			return err
 		}
-		file, err = os.Open(filepath.Clean(path))
+		file, err = os.Open(path) // #nosec
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func (p *preferences) load() {
 }
 
 func (p *preferences) loadFromFile(path string) error {
-	file, err := os.Open(filepath.Clean(path))
+	file, err := os.Open(path) // #nosec
 	if err != nil {
 		if os.IsNotExist(err) {
 			err := os.MkdirAll(filepath.Dir(path), 0700)

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -50,7 +50,7 @@ func (p *preferences) saveToFile(path string) error {
 		if !os.IsExist(err) {
 			return err
 		}
-		file, err = os.Open(path)
+		file, err = os.Open(filepath.Clean(path))
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func (p *preferences) load() {
 }
 
 func (p *preferences) loadFromFile(path string) error {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			err := os.MkdirAll(filepath.Dir(path), 0700)

--- a/app/settings.go
+++ b/app/settings.go
@@ -85,7 +85,7 @@ func (s *settings) load() {
 }
 
 func (s *settings) loadFromFile(path string) error {
-	file, err := os.Open(filepath.Clean(path))
+	file, err := os.Open(path) // #nosec
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/app/settings.go
+++ b/app/settings.go
@@ -85,7 +85,7 @@ func (s *settings) load() {
 }
 
 func (s *settings) loadFromFile(path string) error {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/app/settings_desktop.go
+++ b/app/settings_desktop.go
@@ -68,9 +68,5 @@ func (s *settings) stopWatching() {
 		return
 	}
 
-	err := s.watcher.(*fsnotify.Watcher).Close()
-	if err != nil {
-		fyne.LogError("Failed to close watcher", err)
-		return
-	}
+	s.watcher.(*fsnotify.Watcher).Close() // fsnotify returns false positives, see https://github.com/fsnotify/fsnotify/issues/268
 }

--- a/cmd/fyne/internal/mobile/bind.go
+++ b/cmd/fyne/internal/mobile/bind.go
@@ -25,7 +25,7 @@ func copyFile(dst, src string) error {
 		if buildN {
 			return nil
 		}
-		f, err := os.Open(src)
+		f, err := os.Open(filepath.Clean(src))
 		if err != nil {
 			return err
 		}

--- a/cmd/fyne/internal/mobile/build_androidapp.go
+++ b/cmd/fyne/internal/mobile/build_androidapp.go
@@ -35,7 +35,7 @@ func goAndroidBuild(pkg *packages.Package, bundleID string, androidArchs []strin
 	dir := filepath.Dir(pkg.GoFiles[0])
 
 	manifestPath := filepath.Join(dir, "AndroidManifest.xml")
-	manifestData, err := ioutil.ReadFile(manifestPath)
+	manifestData, err := ioutil.ReadFile(filepath.Clean(manifestPath))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
@@ -274,7 +274,7 @@ func apkwWriteFile(dst, src string, apkw *Writer) error {
 		return err
 	}
 	if !buildN {
-		f, err := os.Open(src)
+		f, err := os.Open(filepath.Clean(src))
 		if err != nil {
 			return err
 		}

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -55,7 +55,7 @@ func resetReadOnlyFlagAll(path string) error {
 		return err
 	}
 	if !fi.IsDir() {
-		return os.Chmod(path, 0666)
+		return os.Chmod(path, 0600)
 	}
 	fd, err := os.Open(filepath.Clean(path))
 	if err != nil {

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -57,7 +57,7 @@ func resetReadOnlyFlagAll(path string) error {
 	if !fi.IsDir() {
 		return os.Chmod(path, 0666)
 	}
-	fd, err := os.Open(path)
+	fd, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return err
 	}

--- a/cmd/fyne/package.go
+++ b/cmd/fyne/package.go
@@ -57,7 +57,7 @@ func copyFileMode(src, tgt string, perm os.FileMode) error {
 		return err
 	}
 
-	source, err := os.Open(src)
+	source, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return err
 	}
@@ -386,6 +386,7 @@ func (p *packager) validate() error {
 
 func calculateExeName(sourceDir, os string) string {
 	exeName := filepath.Base(sourceDir)
+	/* #nosec */
 	if data, err := ioutil.ReadFile(filepath.Join(sourceDir, "go.mod")); err == nil {
 		modulePath := modfile.ModulePath(data)
 		moduleName, _, ok := module.SplitPathVersion(modulePath)

--- a/cmd/fyne/vendor.go
+++ b/cmd/fyne/vendor.go
@@ -126,7 +126,7 @@ func (v *vendor) main() {
 	}
 
 	fmt.Printf("Parsing %s to detect dependency module path for GLFW\n", goModVendorFile)
-	f, err := os.Open(filepath.Join(wd, goModVendorFile))
+	f, err := os.Open(filepath.Join(wd, goModVendorFile)) // #nosec
 	if err != nil {
 		fmt.Printf("Cannot open %s: %v\n", goModVendorFile, err)
 		os.Exit(1)

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -39,7 +39,7 @@ func (s *Settings) saveToFile(path string) error {
 		if !os.IsExist(err) {
 			return err
 		}
-		file, err = os.Open(path)
+		file, err = os.Open(filepath.Clean(path))
 		if err != nil {
 			return err
 		}
@@ -57,7 +57,7 @@ func (s *Settings) load() {
 }
 
 func (s *Settings) loadFromFile(path string) error {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			err := os.MkdirAll(filepath.Dir(path), 0700)

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -39,7 +39,7 @@ func (s *Settings) saveToFile(path string) error {
 		if !os.IsExist(err) {
 			return err
 		}
-		file, err = os.Open(filepath.Clean(path))
+		file, err = os.Open(path) // #nosec
 		if err != nil {
 			return err
 		}
@@ -57,7 +57,7 @@ func (s *Settings) load() {
 }
 
 func (s *Settings) loadFromFile(path string) error {
-	file, err := os.Open(filepath.Clean(path))
+	file, err := os.Open(path) // #nosec
 	if err != nil {
 		if os.IsNotExist(err) {
 			err := os.MkdirAll(filepath.Dir(path), 0700)

--- a/resource.go
+++ b/resource.go
@@ -48,7 +48,7 @@ func NewStaticResource(name string, content []byte) *StaticResource {
 
 // LoadResourceFromPath creates a new StaticResource in memory using the contents of the specified file.
 func LoadResourceFromPath(path string) (Resource, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description:
This PR adds file-path sanitation using `filepath.Clean()` for files that has user interaction and those that does not are marked with `// #nosec` to make `gosec` ignore them while scanning. I also corrected a place where I missed that there was incorrect folder permissions. This means that we now are down to 20 potential security issues being reported.

I also removed error handling from one of the watcher functions because it was making random errors due to the incorrect cross platform behaviour talked about before.

### Checklist:

- [-] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
