### PR TITLE
Modify function to avoid launching a subprocess with variable

### DIFF
--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -227,7 +227,7 @@ func printcmd(format string, args ...interface{}) {
 	if gomobilepath != "" {
 		cmd = strings.Replace(cmd, gomobilepath, "$GOMOBILE", -1)
 	}
-	if gopath := goEnv("GOPATH"); gopath != "" {
+	if gopath := goEnv(); gopath != "" {
 		cmd = strings.Replace(cmd, gopath, "$GOPATH", -1)
 	}
 	if env := os.Getenv("HOMEPATH"); env != "" {

--- a/cmd/fyne/internal/mobile/clean.go
+++ b/cmd/fyne/internal/mobile/clean.go
@@ -20,7 +20,7 @@ Clean removes object files and cached NDK files downloaded by gomobile init
 }
 
 func runClean(cmd *command) (err error) {
-	gopaths := filepath.SplitList(goEnv("GOPATH"))
+	gopaths := filepath.SplitList(goEnv())
 	if len(gopaths) == 0 {
 		return fmt.Errorf("GOPATH is not set")
 	}

--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -31,7 +31,7 @@ var (
 
 func buildEnvInit() (cleanup func(), err error) {
 	// Find gomobilepath.
-	gopath := goEnv("GOPATH")
+	gopath := goEnv()
 	for _, p := range filepath.SplitList(gopath) {
 		gomobilepath = filepath.Join(p, "pkg", "gomobile")
 		if _, err := os.Stat(gomobilepath); buildN || err == nil {

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -73,11 +73,11 @@ func resetReadOnlyFlagAll(path string) error {
 	return nil
 }
 
-func goEnv(name string) string {
-	if val := os.Getenv(name); val != "" {
+func goEnv() string {
+	if val := os.Getenv("GOPATH"); val != "" {
 		return val
 	}
-	val, err := exec.Command("go", "env", name).Output()
+	val, err := exec.Command("go", "env", "GOPATH").Output()
 	if err != nil {
 		panic(err) // the Go tool was tested to work earlier
 	}


### PR DESCRIPTION
### Description:
The function was always called with the same string everywhere in the code base, so we should be able to just remove the function parameter. We are now down to 19 issues reported by `gosec`.

### Checklist:

- [-] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [-] Public APIs match existing style.
- [-] Any breaking changes have a deprecation path or have been discussed.
