### PR TITLE
Windows on Windows now respect system scale.

### DIFF
--- a/cmd/fyne_demo/screens/advanced.go
+++ b/cmd/fyne_demo/screens/advanced.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"fmt"
+	"time"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/driver/desktop"
@@ -17,6 +18,14 @@ func prependTo(g *widget.Group, s string) {
 	g.Prepend(widget.NewLabel(s))
 }
 
+func setScaleText(obj *widget.Label, win fyne.Window) {
+	for obj.Visible() {
+		obj.SetText(scaleString(win.Canvas()))
+
+		time.Sleep(time.Second)
+	}
+}
+
 // AdvancedScreen loads a panel that shows details and settings that are a bit
 // more detailed than normally needed.
 func AdvancedScreen(win fyne.Window) fyne.CanvasObject {
@@ -26,7 +35,7 @@ func AdvancedScreen(win fyne.Window) fyne.CanvasObject {
 		&widget.FormItem{Text: "Scale", Widget: scale},
 	))
 
-	scale.SetText(scaleString(win.Canvas()))
+	go setScaleText(scale, win)
 
 	label := widget.NewLabel("Just type...")
 	generic := widget.NewGroupWithScroller("Generic")

--- a/device.go
+++ b/device.go
@@ -29,7 +29,7 @@ type Device interface {
 	Orientation() DeviceOrientation
 	IsMobile() bool
 	HasKeyboard() bool
-	SystemScale() float32
+	SystemScale(Window) float32
 }
 
 // CurrentDevice returns the device information for the current hardware (via the driver)

--- a/device.go
+++ b/device.go
@@ -29,7 +29,10 @@ type Device interface {
 	Orientation() DeviceOrientation
 	IsMobile() bool
 	HasKeyboard() bool
-	SystemScale(Window) float32
+	SystemScaleForWindow(Window) float32
+
+	// Deprecated: Use SystemScaleForWindow instead - system scale can vary depending on window placement
+	SystemScale() float32
 }
 
 // CurrentDevice returns the device information for the current hardware (via the driver)

--- a/internal/driver/glfw/device.go
+++ b/internal/driver/glfw/device.go
@@ -24,7 +24,16 @@ func (*glDevice) HasKeyboard() bool {
 	return true // TODO actually check - we could be in tablet mode
 }
 
-func (*glDevice) SystemScale(w fyne.Window) float32 {
+// Deprecated: SystemScaleForWindow provides an accurate answer, this method may return incorrect results!
+func (d *glDevice) SystemScale() float32 {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return 1.0
+	}
+
+	return fyne.SettingsScaleAuto
+}
+
+func (*glDevice) SystemScaleForWindow(w fyne.Window) float32 {
 	if runtime.GOOS == "darwin" {
 		return 1.0 // macOS scaling is done at the texture level
 	}

--- a/internal/driver/glfw/device.go
+++ b/internal/driver/glfw/device.go
@@ -24,9 +24,13 @@ func (*glDevice) HasKeyboard() bool {
 	return true // TODO actually check - we could be in tablet mode
 }
 
-func (*glDevice) SystemScale() float32 {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		return 1.0
+func (*glDevice) SystemScale(w fyne.Window) float32 {
+	if runtime.GOOS == "darwin" {
+		return 1.0 // macOS scaling is done at the texture level
+	}
+	if runtime.GOOS == "windows" {
+		xScale, _ := w.(*window).viewport.GetContentScale()
+		return xScale
 	}
 
 	return fyne.SettingsScaleAuto

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -325,7 +325,7 @@ func calculateScale(user, system, detected float32) float32 {
 	return system * user
 }
 func (w *window) calculatedScale() float32 {
-	val := calculateScale(w.userScale(), fyne.CurrentDevice().SystemScale(w), w.detectScale())
+	val := calculateScale(w.userScale(), fyne.CurrentDevice().SystemScaleForWindow(w), w.detectScale())
 	val = float32(math.Round(float64(val*10.0))) / 10.0
 
 	return val

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -325,7 +325,7 @@ func calculateScale(user, system, detected float32) float32 {
 	return system * user
 }
 func (w *window) calculatedScale() float32 {
-	val := calculateScale(w.userScale(), fyne.CurrentDevice().SystemScale(), w.detectScale())
+	val := calculateScale(w.userScale(), fyne.CurrentDevice().SystemScale(w), w.detectScale())
 	val = float32(math.Round(float64(val*10.0))) / 10.0
 
 	return val
@@ -462,7 +462,6 @@ func (w *window) moved(viewport *glfw.Window, x, y int) {
 
 	w.canvas.detectedScale = w.detectScale()
 	go w.canvas.SetScale(fyne.SettingsScaleAuto) // scale is ignored
-	w.rescaleOnMain()
 }
 
 func (w *window) resized(viewport *glfw.Window, width, height int) {

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -77,7 +77,7 @@ func (c *mobileCanvas) Refresh(obj fyne.CanvasObject) {
 }
 
 func (c *mobileCanvas) edgePadding() (topLeft, bottomRight fyne.Size) {
-	scale := fyne.CurrentDevice().SystemScale(nil) // we don't need a window parameter on mobile
+	scale := fyne.CurrentDevice().SystemScaleForWindow(nil) // we don't need a window parameter on mobile
 
 	return fyne.NewSize(int(float32(c.insetLeft)/scale), int(float32(c.insetTop)/scale)),
 		fyne.NewSize(int(float32(c.insetRight)/scale), int(float32(c.insetBottom)/scale))
@@ -157,7 +157,7 @@ func (c *mobileCanvas) Scale() float32 {
 
 // Deprecated: Settings are now calculated solely on the user configuration and system setup.
 func (c *mobileCanvas) SetScale(_ float32) {
-	c.scale = fyne.CurrentDevice().SystemScale(nil) // we don't need a window parameter on mobile
+	c.scale = fyne.CurrentDevice().SystemScaleForWindow(nil) // we don't need a window parameter on mobile
 }
 
 func (c *mobileCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
@@ -395,7 +395,7 @@ func isEntry(obj fyne.Focusable) bool {
 // NewCanvas creates a new gomobile mobileCanvas. This is a mobileCanvas that will render on a mobile device using OpenGL.
 func NewCanvas() fyne.Canvas {
 	ret := &mobileCanvas{padded: true}
-	ret.scale = fyne.CurrentDevice().SystemScale(nil) // we don't need a window parameter on mobile
+	ret.scale = fyne.CurrentDevice().SystemScaleForWindow(nil) // we don't need a window parameter on mobile
 	ret.refreshQueue = make(chan fyne.CanvasObject, 1024)
 	ret.touched = make(map[int]mobile.Touchable)
 	ret.lastTapDownPos = make(map[int]fyne.Position)

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -77,7 +77,7 @@ func (c *mobileCanvas) Refresh(obj fyne.CanvasObject) {
 }
 
 func (c *mobileCanvas) edgePadding() (topLeft, bottomRight fyne.Size) {
-	scale := fyne.CurrentDevice().SystemScale()
+	scale := fyne.CurrentDevice().SystemScale(nil) // we don't need a window parameter on mobile
 
 	return fyne.NewSize(int(float32(c.insetLeft)/scale), int(float32(c.insetTop)/scale)),
 		fyne.NewSize(int(float32(c.insetRight)/scale), int(float32(c.insetBottom)/scale))
@@ -157,7 +157,7 @@ func (c *mobileCanvas) Scale() float32 {
 
 // Deprecated: Settings are now calculated solely on the user configuration and system setup.
 func (c *mobileCanvas) SetScale(_ float32) {
-	c.scale = fyne.CurrentDevice().SystemScale()
+	c.scale = fyne.CurrentDevice().SystemScale(nil) // we don't need a window parameter on mobile
 }
 
 func (c *mobileCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
@@ -395,7 +395,7 @@ func isEntry(obj fyne.Focusable) bool {
 // NewCanvas creates a new gomobile mobileCanvas. This is a mobileCanvas that will render on a mobile device using OpenGL.
 func NewCanvas() fyne.Canvas {
 	ret := &mobileCanvas{padded: true}
-	ret.scale = fyne.CurrentDevice().SystemScale()
+	ret.scale = fyne.CurrentDevice().SystemScale(nil) // we don't need a window parameter on mobile
 	ret.refreshQueue = make(chan fyne.CanvasObject, 1024)
 	ret.touched = make(map[int]mobile.Touchable)
 	ret.lastTapDownPos = make(map[int]fyne.Position)

--- a/internal/driver/gomobile/canvas_android.go
+++ b/internal/driver/gomobile/canvas_android.go
@@ -2,7 +2,7 @@
 
 package gomobile
 
-func (*device) SystemScale() float32 {
+func (*device) SystemScale(_ fyne.Window) float32 {
 	if currentDPI >= 600 {
 		return 4
 	} else if currentDPI >= 405 {

--- a/internal/driver/gomobile/canvas_android.go
+++ b/internal/driver/gomobile/canvas_android.go
@@ -2,6 +2,8 @@
 
 package gomobile
 
+import "fyne.io/fyne"
+
 func (*device) SystemScale(_ fyne.Window) float32 {
 	if currentDPI >= 600 {
 		return 4

--- a/internal/driver/gomobile/canvas_desktop.go
+++ b/internal/driver/gomobile/canvas_desktop.go
@@ -1,9 +1,0 @@
-// +build !ios,!android
-
-package gomobile
-
-import "fyne.io/fyne"
-
-func (*device) SystemScale(_ fyne.Window) float32 {
-	return 2
-}

--- a/internal/driver/gomobile/canvas_desktop.go
+++ b/internal/driver/gomobile/canvas_desktop.go
@@ -2,6 +2,8 @@
 
 package gomobile
 
-func (*device) SystemScale() float32 {
+import "fyne.io/fyne"
+
+func (*device) SystemScale(_ fyne.Window) float32 {
 	return 2
 }

--- a/internal/driver/gomobile/device.go
+++ b/internal/driver/gomobile/device.go
@@ -34,6 +34,10 @@ func (*device) HasKeyboard() bool {
 	return false
 }
 
+func (d *device) SystemScale() float32 {
+	return d.SystemScaleForWindow(nil)
+}
+
 func (*device) ShowVirtualKeyboard() {
 	showVirtualKeyboard()
 }

--- a/internal/driver/gomobile/device_android.go
+++ b/internal/driver/gomobile/device_android.go
@@ -4,7 +4,7 @@ package gomobile
 
 import "fyne.io/fyne"
 
-func (*device) SystemScale(_ fyne.Window) float32 {
+func (*device) SystemScaleForWindow(_ fyne.Window) float32 {
 	if currentDPI >= 600 {
 		return 4
 	} else if currentDPI >= 405 {

--- a/internal/driver/gomobile/device_desktop.go
+++ b/internal/driver/gomobile/device_desktop.go
@@ -1,0 +1,9 @@
+// +build !ios,!android
+
+package gomobile
+
+import "fyne.io/fyne"
+
+func (*device) SystemScaleForWindow(_ fyne.Window) float32 {
+	return 2 // this is simply due to the high number of pixels on a mobile device - just an approximation
+}

--- a/internal/driver/gomobile/device_ios.go
+++ b/internal/driver/gomobile/device_ios.go
@@ -2,7 +2,9 @@
 
 package gomobile
 
-func (*device) SystemScale() float32 {
+import "fyne.io/fyne"
+
+func (*device) SystemScaleForWindow(_ fyne.Window) float32 {
 	if currentDPI >= 450 {
 		return 3
 	} else if currentDPI >= 340 {

--- a/test/device.go
+++ b/test/device.go
@@ -20,6 +20,10 @@ func (d *device) HasKeyboard() bool {
 	return false
 }
 
-func (d *device) SystemScale(fyne.Window) float32 {
+func (d *device) SystemScale() float32 {
+	return d.SystemScaleForWindow(nil)
+}
+
+func (d *device) SystemScaleForWindow(fyne.Window) float32 {
 	return 1
 }

--- a/test/device.go
+++ b/test/device.go
@@ -20,6 +20,6 @@ func (d *device) HasKeyboard() bool {
 	return false
 }
 
-func (d *device) SystemScale() float32 {
+func (d *device) SystemScale(fyne.Window) float32 {
 	return 1
 }


### PR DESCRIPTION
### Description:
This PR fixes windows on Windows to use the correct (configured) system scale.
It also updates the window scale as it moves to different screens. Nifty :)

Unfortunately it is technically a breaking change - the old Device API asserted that a system scale is global. I realise now it clearly is not - it's per screen, and a window can move screens. So this needed a parameter added :(.

Fixes #635 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Any breaking changes have a deprecation path or have been discussed. (discussion below, sorry)

Options here:

1) Accept this breaking change, which should have no external impact
2) Add a new method "SystemScaleForWindow" and deprecate the old one...

Option 2 is technically still a breaking change, but would only impact custom driver implementations, of which I am not aware of.

Thoughts?