### PR TITLE
Fix key lookup on AZERTY

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -766,6 +766,10 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyHome:      fyne.KeyHome,
 	glfw.KeyEnd:       fyne.KeyEnd,
 
+	glfw.KeySpace:   fyne.KeySpace,
+	glfw.KeyKPEnter: fyne.KeyEnter,
+
+	// functions
 	glfw.KeyF1:  fyne.KeyF1,
 	glfw.KeyF2:  fyne.KeyF2,
 	glfw.KeyF3:  fyne.KeyF3,
@@ -779,59 +783,17 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyF11: fyne.KeyF11,
 	glfw.KeyF12: fyne.KeyF12,
 
-	glfw.KeyKPEnter: fyne.KeyEnter,
-
-	// printable
-	glfw.KeySpace:      fyne.KeySpace,
-	glfw.KeyApostrophe: fyne.KeyApostrophe,
-	glfw.KeyComma:      fyne.KeyComma,
-	glfw.KeyMinus:      fyne.KeyMinus,
-	glfw.KeyPeriod:     fyne.KeyPeriod,
-	glfw.KeySlash:      fyne.KeySlash,
-
-	glfw.Key0:         fyne.Key0,
-	glfw.Key1:         fyne.Key1,
-	glfw.Key2:         fyne.Key2,
-	glfw.Key3:         fyne.Key3,
-	glfw.Key4:         fyne.Key4,
-	glfw.Key5:         fyne.Key5,
-	glfw.Key6:         fyne.Key6,
-	glfw.Key7:         fyne.Key7,
-	glfw.Key8:         fyne.Key8,
-	glfw.Key9:         fyne.Key9,
-	glfw.KeySemicolon: fyne.KeySemicolon,
-	glfw.KeyEqual:     fyne.KeyEqual,
-
-	glfw.KeyA: fyne.KeyA,
-	glfw.KeyB: fyne.KeyB,
-	glfw.KeyC: fyne.KeyC,
-	glfw.KeyD: fyne.KeyD,
-	glfw.KeyE: fyne.KeyE,
-	glfw.KeyF: fyne.KeyF,
-	glfw.KeyG: fyne.KeyG,
-	glfw.KeyH: fyne.KeyH,
-	glfw.KeyI: fyne.KeyI,
-	glfw.KeyJ: fyne.KeyJ,
-	glfw.KeyK: fyne.KeyK,
-	glfw.KeyL: fyne.KeyL,
-	glfw.KeyM: fyne.KeyM,
-	glfw.KeyN: fyne.KeyN,
-	glfw.KeyO: fyne.KeyO,
-	glfw.KeyP: fyne.KeyP,
-	glfw.KeyQ: fyne.KeyQ,
-	glfw.KeyR: fyne.KeyR,
-	glfw.KeyS: fyne.KeyS,
-	glfw.KeyT: fyne.KeyT,
-	glfw.KeyU: fyne.KeyU,
-	glfw.KeyV: fyne.KeyV,
-	glfw.KeyW: fyne.KeyW,
-	glfw.KeyX: fyne.KeyX,
-	glfw.KeyY: fyne.KeyY,
-	glfw.KeyZ: fyne.KeyZ,
-
-	glfw.KeyLeftBracket:  fyne.KeyLeftBracket,
-	glfw.KeyBackslash:    fyne.KeyBackslash,
-	glfw.KeyRightBracket: fyne.KeyRightBracket,
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	glfw.Key0: fyne.Key0,
+	glfw.Key1: fyne.Key1,
+	glfw.Key2: fyne.Key2,
+	glfw.Key3: fyne.Key3,
+	glfw.Key4: fyne.Key4,
+	glfw.Key5: fyne.Key5,
+	glfw.Key6: fyne.Key6,
+	glfw.Key7: fyne.Key7,
+	glfw.Key8: fyne.Key8,
+	glfw.Key9: fyne.Key9,
 
 	// desktop
 	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
@@ -845,8 +807,57 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyMenu:         desktop.KeyMenu,
 }
 
-func keyToName(code glfw.Key) fyne.KeyName {
+var keyNameMap = map[string]fyne.KeyName{
+	"'": fyne.KeyApostrophe,
+	",": fyne.KeyComma,
+	"-": fyne.KeyMinus,
+	".": fyne.KeyPeriod,
+	"/": fyne.KeySlash,
+	"`": fyne.KeyBackTick,
+
+	";": fyne.KeySemicolon,
+	"=": fyne.KeyEqual,
+
+	"a": fyne.KeyA,
+	"b": fyne.KeyB,
+	"c": fyne.KeyC,
+	"d": fyne.KeyD,
+	"e": fyne.KeyE,
+	"f": fyne.KeyF,
+	"g": fyne.KeyG,
+	"h": fyne.KeyH,
+	"i": fyne.KeyI,
+	"j": fyne.KeyJ,
+	"k": fyne.KeyK,
+	"l": fyne.KeyL,
+	"m": fyne.KeyM,
+	"n": fyne.KeyN,
+	"o": fyne.KeyO,
+	"p": fyne.KeyP,
+	"q": fyne.KeyQ,
+	"r": fyne.KeyR,
+	"s": fyne.KeyS,
+	"t": fyne.KeyT,
+	"u": fyne.KeyU,
+	"v": fyne.KeyV,
+	"w": fyne.KeyW,
+	"x": fyne.KeyX,
+	"y": fyne.KeyY,
+	"z": fyne.KeyZ,
+
+	"[":  fyne.KeyLeftBracket,
+	"\\": fyne.KeyBackslash,
+	"]":  fyne.KeyRightBracket,
+}
+
+func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	ret, ok := keyCodeMap[code]
+	if ok {
+		return ret
+	}
+
+	keyName := glfw.GetKeyName(code, scancode)
+	ret, ok = keyNameMap[keyName]
 	if !ok {
 		return ""
 	}
@@ -855,7 +866,7 @@ func keyToName(code glfw.Key) fyne.KeyName {
 }
 
 func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
-	keyName := keyToName(key)
+	keyName := keyToName(key, scancode)
 	if keyName == "" {
 		return
 	}

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -331,6 +331,7 @@ var keyCodeMap = map[key.Code]fyne.KeyName{
 	key.CodeLeftSquareBracket:  fyne.KeyLeftBracket,
 	key.CodeBackslash:          fyne.KeyBackslash,
 	key.CodeRightSquareBracket: fyne.KeyRightBracket,
+	key.CodeGraveAccent:        fyne.KeyBackTick,
 }
 
 func keyToName(code key.Code) fyne.KeyName {

--- a/key.go
+++ b/key.go
@@ -161,4 +161,6 @@ const (
 	KeySemicolon KeyName = ";"
 	// KeyEqual is the key "="
 	KeyEqual KeyName = "="
+	// KeyBackTick is the key "`" on a US keyboard
+	KeyBackTick KeyName = "`"
 )


### PR DESCRIPTION
### Description:
Our previous lookup was returning position based key names instead of their actual name.
This broke shortcuts for AZERTY users... but also it was declaring KeyQ but printing 'a', rather confusing.
Change to actual key names, not name encoded position codes

Whils this fixes the issue It does leave un-mapped the following AZERTY keys: ':', 'ù', '$', '^', ')', '<'.
They work fine through rune callbacks but they do not generate key events as we don't currently recognise them as keys. I expect that we could add them, but am I doing the wrong thing?

Fixes #790 

### Checklist:

- [ ] Tests included. - I could not figure out how to simulate AZERTY in glfw keyboard events
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
