### PR TITLE
A theme related gift for @toaster :)

### DIFF
--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -56,3 +56,26 @@ func TestOverrideTheme(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestOverrideTheme_IgnoresSettingsChange(t *testing.T) {
+	// check that a file-load does not overwrite our value
+	set := &settings{}
+	err := os.Setenv("FYNE_THEME", "light")
+	if err != nil {
+		t.Error(err)
+	}
+	set.setupTheme()
+	assert.Equal(t, theme.LightTheme(), set.Theme())
+	err = os.Setenv("FYNE_THEME", "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = set.loadFromFile(filepath.Join("testdata", "dark-theme.json"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	set.setupTheme()
+	assert.Equal(t, theme.LightTheme(), set.Theme())
+}

--- a/widget/box.go
+++ b/widget/box.go
@@ -21,7 +21,9 @@ type Box struct {
 
 // Refresh updates this box to match the current theme
 func (b *Box) Refresh() {
-	b.background = theme.BackgroundColor()
+	if b.background != nil {
+		b.background = theme.BackgroundColor()
+	}
 
 	b.BaseWidget.Refresh()
 }


### PR DESCRIPTION
### Description:
When a theme was specified via FYNE_THEME or app.Settings().SetTheme() then it could be overridden by settings changing. Now it doesn't.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

To check:

Run 2 instances of fyne_demo (or other app) built against this version
- 1 instance run as normal
- 1 instance run with FYNE_THEME=light

run fyne_settings and change the theme.
You should see that one app updates and the other does not.