### PR TITLE
fix GLFW initialisation

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -22,6 +22,7 @@ type funcData struct {
 var funcQueue = make(chan funcData)
 var runFlag = false
 var runMutex = &sync.Mutex{}
+var initOnce = &sync.Once{}
 
 // Arrange that main.main runs on main thread.
 func init() {
@@ -49,13 +50,15 @@ func runOnMain(f func()) {
 }
 
 func (d *gLDriver) initGLFW() {
-	err := glfw.Init()
-	if err != nil {
-		fyne.LogError("failed to initialise GLFW", err)
-		return
-	}
+	initOnce.Do(func() {
+		err := glfw.Init()
+		if err != nil {
+			fyne.LogError("failed to initialise GLFW", err)
+			return
+		}
 
-	initCursors()
+		initCursors()
+	})
 }
 
 func (d *gLDriver) tryPollEvents() {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -29,7 +29,6 @@ const (
 
 var (
 	cursorMap    map[desktop.Cursor]*glfw.Cursor
-	initOnce     = &sync.Once{}
 	defaultTitle = "Fyne Application"
 )
 
@@ -1096,7 +1095,7 @@ func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 		title = defaultTitle
 	}
 	runOnMain(func() {
-		initOnce.Do(d.initGLFW)
+		d.initGLFW()
 
 		// make the window hidden, we will set it up and then show it later
 		glfw.WindowHint(glfw.Visible, 0)

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -32,6 +32,7 @@ func init() {
 // TestMain makes sure that our driver is running on the main thread.
 // This must be done for some of our tests to function correctly.
 func TestMain(m *testing.M) {
+	d.(*gLDriver).initGLFW()
 	go func() {
 		os.Exit(m.Run())
 	}()


### PR DESCRIPTION
### Description:

The reason for #782 maybe is missing multi-threading safety in the GLFW initialisation process.
At least it can be fixed by initialising GLFW before separating the test thread from the main thread.
It might be that #782 would have been fixed by modifications made in this area on the GLFW master branch (might become 3.4). However, with this fix it doesn't matter.

When hunting the bug, I found that GLFW was initialised twice: by `CreateWindow` (limited to one call) and by `runGL`. I moved the `initOnce` into `initGLFW` itself. Thus, GLFW is never initialised twice.

Fixes #782

### Checklist:

- ~~[ ] Tests included.~~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
