### PR TITLE
Bugfix/toolbar

### DIFF
--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
@@ -34,6 +35,11 @@ func init() {
 func TestMain(m *testing.M) {
 	d.(*gLDriver).initGLFW()
 	go func() {
+		// Wait for GL loop to be running.
+		// If we try to create windows before the loop is running, this will fail with an exception.
+		for !running() {
+			time.Sleep(10 * time.Millisecond)
+		}
 		os.Exit(m.Run())
 	}()
 	d.Run()

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -174,7 +174,7 @@ func (c *testCanvas) Capture() image.Image {
 // LaidOutObjects returns all fyne.CanvasObject starting at the given fyne.CanvasObject which is laid out previously.
 func LaidOutObjects(o fyne.CanvasObject) (objects []fyne.CanvasObject) {
 	if o != nil {
-		objects = layoutAndCollect(objects, o, o.MinSize().Union(o.Size()))
+		objects = layoutAndCollect(objects, o, o.MinSize().Max(o.Size()))
 	}
 	return objects
 }
@@ -183,6 +183,7 @@ func layoutAndCollect(objects []fyne.CanvasObject, o fyne.CanvasObject, size fyn
 	objects = append(objects, o)
 	if w, ok := o.(fyne.Widget); ok {
 		r := w.CreateRenderer()
+		r.Refresh()
 		r.Layout(size)
 		for _, child := range r.Objects() {
 			objects = layoutAndCollect(objects, child, child.Size())

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -183,7 +183,6 @@ func layoutAndCollect(objects []fyne.CanvasObject, o fyne.CanvasObject, size fyn
 	objects = append(objects, o)
 	if w, ok := o.(fyne.Widget); ok {
 		r := w.CreateRenderer()
-		r.Refresh()
 		r.Layout(size)
 		for _, child := range r.Objects() {
 			objects = layoutAndCollect(objects, child, child.Size())

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -84,8 +84,11 @@ func (t *Toolbar) prepend(item ToolbarItem) {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *Toolbar) CreateRenderer() fyne.WidgetRenderer {
 	t.ExtendBaseWidget(t)
-	for _, item := range t.Items {
-		t.append(item)
+	if len(t.objs) != len(t.Items) {
+		t.objs = []fyne.CanvasObject{}
+		for _, item := range t.Items {
+			t.append(item)
+		}
 	}
 
 	return &toolbarRenderer{toolbar: t, layout: layout.NewHBoxLayout()}

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -67,45 +67,27 @@ func NewToolbarSeparator() ToolbarItem {
 // Toolbar widget creates a horizontal list of tool buttons
 type Toolbar struct {
 	BaseWidget
-
 	Items []ToolbarItem
-
-	objs []fyne.CanvasObject
-}
-
-func (t *Toolbar) append(item ToolbarItem) {
-	t.objs = append(t.objs, item.ToolbarObject())
-}
-
-func (t *Toolbar) prepend(item ToolbarItem) {
-	t.objs = append([]fyne.CanvasObject{item.ToolbarObject()}, t.objs...)
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *Toolbar) CreateRenderer() fyne.WidgetRenderer {
 	t.ExtendBaseWidget(t)
-	if len(t.objs) != len(t.Items) {
-		t.objs = []fyne.CanvasObject{}
-		for _, item := range t.Items {
-			t.append(item)
-		}
-	}
-
-	return &toolbarRenderer{toolbar: t, layout: layout.NewHBoxLayout()}
+	r := &toolbarRenderer{toolbar: t, layout: layout.NewHBoxLayout()}
+	r.resetObjects()
+	return r
 }
 
 // Append a new ToolbarItem to the end of this Toolbar
 func (t *Toolbar) Append(item ToolbarItem) {
 	t.Items = append(t.Items, item)
-
-	t.append(item)
+	t.Refresh()
 }
 
 // Prepend a new ToolbarItem to the start of this Toolbar
 func (t *Toolbar) Prepend(item ToolbarItem) {
 	t.Items = append([]ToolbarItem{item}, t.Items...)
-
-	t.prepend(item)
+	t.Refresh()
 }
 
 // MinSize returns the size that this widget should not shrink below
@@ -126,6 +108,7 @@ func NewToolbar(items ...ToolbarItem) *Toolbar {
 type toolbarRenderer struct {
 	baseRenderer
 	layout  fyne.Layout
+	objs    []fyne.CanvasObject
 	toolbar *Toolbar
 }
 
@@ -142,8 +125,7 @@ func (r *toolbarRenderer) BackgroundColor() color.Color {
 }
 
 func (r *toolbarRenderer) Refresh() {
-	r.setObjects(r.toolbar.objs)
-
+	r.resetObjects()
 	for i, item := range r.toolbar.Items {
 		if _, ok := item.(*ToolbarSeparator); ok {
 			rect := r.Objects()[i].(*canvas.Rectangle)
@@ -152,4 +134,14 @@ func (r *toolbarRenderer) Refresh() {
 	}
 
 	canvas.Refresh(r.toolbar)
+}
+
+func (r *toolbarRenderer) resetObjects() {
+	if len(r.objs) != len(r.toolbar.Items) {
+		r.objs = make([]fyne.CanvasObject, 0, len(r.toolbar.Items))
+		for _, item := range r.toolbar.Items {
+			r.objs = append(r.objs, item.ToolbarObject())
+		}
+	}
+	r.setObjects(r.objs)
 }

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -3,7 +3,10 @@ package widget
 import (
 	"testing"
 
+	"fyne.io/fyne"
+	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,4 +33,25 @@ func TestToolbar_Prepend(t *testing.T) {
 	toolbar.Prepend(prepend)
 	assert.Equal(t, 2, len(toolbar.Items))
 	assert.Equal(t, prepend, toolbar.Items[0])
+}
+
+func TestToolbar_ItemPositioning(t *testing.T) {
+	toolbar := &Toolbar{
+		Items: []ToolbarItem{
+			NewToolbarAction(theme.ContentCopyIcon(), func() {}),
+			NewToolbarAction(theme.ContentPasteIcon(), func() {}),
+		},
+	}
+	toolbar.ExtendBaseWidget(toolbar)
+	toolbar.Refresh()
+	var items []fyne.CanvasObject
+	for _, o := range test.LaidOutObjects(toolbar) {
+		if b, ok := o.(*Button); ok {
+			items = append(items, b)
+		}
+	}
+	if assert.Equal(t, 2, len(items)) {
+		assert.Equal(t, fyne.NewPos(0, 0), items[0].Position())
+		assert.Equal(t, fyne.NewPos(32, 0), items[1].Position())
+	}
 }


### PR DESCRIPTION
### Description:

Toolbar's `CreateRenderer` added the item's objects to the toolbar's objects even if they already existed there.
Besides the fix for this behaviour, this PR contains a refactoring which moves the object handling of toolbar to its renderer.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
