### PR TITLE
Add support for removing values in the Preferences API

### DIFF
--- a/app/preferences_ios.go
+++ b/app/preferences_ios.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"errors"
 	"unsafe"
 
 	"fyne.io/fyne"
@@ -104,6 +105,11 @@ func (p *iOSPreferences) SetString(key string, value string) {
 	defer C.free(unsafe.Pointer(cValue))
 
 	C.setPreferenceString(cKey, cValue)
+}
+
+// TODO: Implement the support for RemoveValue on iOS to make it work across all platforms.
+func (p *iOSPreferences) RemoveValue(key string) {
+	fyne.LogError("Calling RemoveValue() on iOS", errors.New("It is currently not supported to use RemoveValue on iOS"))
 }
 
 func newPreferences() *iOSPreferences {

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -33,6 +33,13 @@ func (p *InMemoryPreferences) get(key string) (interface{}, bool) {
 	return v, err
 }
 
+func (p *InMemoryPreferences) remove(key string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	delete(p.values, key)
+}
+
 // Values provides access to the underlying value map - for internal use only...
 func (p *InMemoryPreferences) Values() map[string]interface{} {
 	p.lock.RLock()
@@ -143,6 +150,11 @@ func (p *InMemoryPreferences) StringWithFallback(key, fallback string) string {
 // SetString saves a string value for the given key
 func (p *InMemoryPreferences) SetString(key string, value string) {
 	p.set(key, value)
+}
+
+// RemoveValue deletes a value on the given key
+func (p *InMemoryPreferences) RemoveValue(key string) {
+	p.remove(key)
 }
 
 // NewInMemoryPreferences creates a new preferences implementation stored in memory

--- a/internal/preferences_test.go
+++ b/internal/preferences_test.go
@@ -129,3 +129,22 @@ func TestInMemoryPreferences_OnChange(t *testing.T) {
 
 	assert.True(t, called)
 }
+
+func TestRemoveValue(t *testing.T) {
+	p := NewInMemoryPreferences()
+
+	p.SetBool("dummy", true)
+	p.SetFloat("pi", 3.14)
+	p.SetInt("number", 2)
+	p.SetString("month", "January")
+
+	p.RemoveValue("dummy")
+	p.RemoveValue("pi")
+	p.RemoveValue("number")
+	p.RemoveValue("month")
+
+	assert.Equal(t, false, p.Bool("dummy"))
+	assert.Equal(t, float64(0), p.Float("pi"))
+	assert.Equal(t, 0, p.Int("number"))
+	assert.Equal(t, "", p.String("month"))
+}

--- a/preferences.go
+++ b/preferences.go
@@ -29,4 +29,7 @@ type Preferences interface {
 	StringWithFallback(key, fallback string) string
 	// SetString saves a string value for the given key
 	SetString(key string, value string)
+
+	// RemoveValue removes a value for the given key
+	RemoveValue(key string)
 }

--- a/preferences.go
+++ b/preferences.go
@@ -30,6 +30,6 @@ type Preferences interface {
 	// SetString saves a string value for the given key
 	SetString(key string, value string)
 
-	// RemoveValue removes a value for the given key
+	// RemoveValue removes a value for the given key (not currently supported on iOS)
 	RemoveValue(key string)
 }


### PR DESCRIPTION
### Description:
It may be necessary to be able to delete values stored in the preferences. For example, I am planning of storing the hashed passwords on a per user basis and if a user deletes their account, the hashed password can be deleted too (hashed passwords are only used for comparison and noting is encrypted using the hash).

This PR basically adds that feature and adds the relevant test.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style (well kind of, but it did not seem appropriate to have a remove function per data type).
- [-] Any breaking changes have a deprecation path or have been discussed.
