### PR TITLE
fix hyperlink & label regarding CreateRenderer

### DIFF
--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -12,12 +12,13 @@ import (
 // Hyperlink widget is a text component with appropriate padding and layout.
 // When clicked, the default web browser should open with a URL
 type Hyperlink struct {
-	textProvider
+	BaseWidget
 	Text      string
 	URL       *url.URL
 	Alignment fyne.TextAlign // The alignment of the Text
 	Wrapping  fyne.TextWrap  // The wrapping of the Text
 	TextStyle fyne.TextStyle // The style of the hyperlink text
+	provider  textProvider
 }
 
 // NewHyperlink creates a new hyperlink widget with the set text content
@@ -45,7 +46,7 @@ func (hl *Hyperlink) Cursor() desktop.Cursor {
 // SetText sets the text of the hyperlink
 func (hl *Hyperlink) SetText(text string) {
 	hl.Text = text
-	hl.textProvider.SetText(text) // calls refresh
+	hl.provider.SetText(text) // calls refresh
 }
 
 // SetURL sets the URL of the hyperlink, taking in a URL type
@@ -105,9 +106,9 @@ func (hl *Hyperlink) Tapped(*fyne.PointEvent) {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (hl *Hyperlink) CreateRenderer() fyne.WidgetRenderer {
-	hl.textProvider = newTextProvider(hl.Text, hl)
 	hl.ExtendBaseWidget(hl)
-	return hl.textProvider.CreateRenderer()
+	hl.provider = newTextProvider(hl.Text, hl)
+	return hl.provider.CreateRenderer()
 }
 
 // MinSize returns the smallest size this widget can shrink to

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -9,6 +9,7 @@ import (
 	_ "fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHyperlink_MinSize(t *testing.T) {
@@ -62,4 +63,22 @@ func TestHyperlink_SetUrl(t *testing.T) {
 	assert.Nil(t, err)
 	hyperlink.SetURL(sURL)
 	assert.Equal(t, sURL, hyperlink.URL)
+}
+
+func TestHyperlink_CreateRendererDoesNotAffectSize(t *testing.T) {
+	url, err := url.Parse("https://github.com/fyne-io/fyne")
+	require.NoError(t, err)
+	link := NewHyperlink("Test", url)
+	link.Resize(link.MinSize())
+	assert.NotEqual(t, fyne.NewSize(0, 0), link.Size())
+	assert.Equal(t, link.Size(), link.MinSize())
+	size := link.Size()
+
+	r := link.CreateRenderer()
+	assert.Equal(t, size, link.Size())
+	assert.Equal(t, size, link.MinSize())
+	assert.Equal(t, size, r.MinSize())
+	r.Layout(size)
+	assert.Equal(t, size, link.Size())
+	assert.Equal(t, size, link.MinSize())
 }

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne/driver/desktop"
 	_ "fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestHyperlink_SetText(t *testing.T) {
 	assert.Nil(t, err)
 
 	hyperlink := &Hyperlink{Text: "Test", URL: u}
-	Refresh(hyperlink)
+	hyperlink.Refresh()
 	hyperlink.SetText("New")
 
 	assert.Equal(t, "New", hyperlink.Text)
@@ -66,13 +67,13 @@ func TestHyperlink_SetUrl(t *testing.T) {
 }
 
 func TestHyperlink_CreateRendererDoesNotAffectSize(t *testing.T) {
-	url, err := url.Parse("https://github.com/fyne-io/fyne")
+	u, err := url.Parse("https://github.com/fyne-io/fyne")
 	require.NoError(t, err)
-	link := NewHyperlink("Test", url)
+	link := NewHyperlink("Test", u)
 	link.Resize(link.MinSize())
-	assert.NotEqual(t, fyne.NewSize(0, 0), link.Size())
-	assert.Equal(t, link.Size(), link.MinSize())
 	size := link.Size()
+	assert.NotEqual(t, fyne.NewSize(0, 0), size)
+	assert.Equal(t, size, link.MinSize())
 
 	r := link.CreateRenderer()
 	assert.Equal(t, size, link.Size())

--- a/widget/label.go
+++ b/widget/label.go
@@ -9,11 +9,12 @@ import (
 
 // Label widget is a label component with appropriate padding and layout.
 type Label struct {
-	textProvider
+	BaseWidget
 	Text      string
 	Alignment fyne.TextAlign // The alignment of the Text
 	Wrapping  fyne.TextWrap  // The wrapping of the Text
 	TextStyle fyne.TextStyle // The style of the label text
+	provider  textProvider
 }
 
 // NewLabel creates a new label widget with the set text content
@@ -34,8 +35,8 @@ func NewLabelWithStyle(text string, alignment fyne.TextAlign, style fyne.TextSty
 
 // Refresh checks if the text content should be updated then refreshes the graphical context
 func (l *Label) Refresh() {
-	if l.Text != string(l.buffer) {
-		l.textProvider.SetText(l.Text)
+	if l.Text != string(l.provider.buffer) {
+		l.provider.SetText(l.Text)
 	}
 
 	l.BaseWidget.Refresh()
@@ -44,7 +45,7 @@ func (l *Label) Refresh() {
 // SetText sets the text of the label
 func (l *Label) SetText(text string) {
 	l.Text = text
-	l.textProvider.SetText(text) // calls refresh
+	l.provider.SetText(text) // calls refresh
 }
 
 // textAlign tells the rendering textProvider our alignment
@@ -80,10 +81,9 @@ func (l *Label) object() fyne.Widget {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (l *Label) CreateRenderer() fyne.WidgetRenderer {
 	l.ExtendBaseWidget(l)
-	hidden := l.Hidden
-	l.textProvider = newTextProvider(l.Text, l)
-	l.textProvider.Hidden = hidden
-	return l.textProvider.CreateRenderer()
+	l.provider = newTextProvider(l.Text, l)
+	l.provider.Hidden = l.Hidden
+	return l.provider.CreateRenderer()
 }
 
 // MinSize returns the size that this widget should not shrink below

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -5,8 +5,8 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/test"
-	_ "fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,16 +68,16 @@ func TestLabel_Alignment_Later(t *testing.T) {
 }
 
 func TestText_MinSize_MultiLine(t *testing.T) {
-	text := NewLabel("Break")
-	min := text.MinSize()
-	text = NewLabel("Bre\nak")
-	min2 := text.MinSize()
+	textOneLine := NewLabel("Break")
+	min := textOneLine.MinSize()
+	textMultiLine := NewLabel("Bre\nak")
+	min2 := textMultiLine.MinSize()
 
 	assert.True(t, min2.Width < min.Width)
 	assert.True(t, min2.Height > min.Height)
 
 	yPos := -1
-	for _, text := range test.WidgetRenderer(text).(*textRenderer).texts {
+	for _, text := range test.WidgetRenderer(textMultiLine).(*textRenderer).texts {
 		assert.True(t, text.Size().Height < min2.Height)
 		assert.True(t, text.Position().Y > yPos)
 		yPos = text.Position().Y
@@ -110,9 +110,9 @@ func TestLabel_ApplyTheme(t *testing.T) {
 func TestLabel_CreateRendererDoesNotAffectSize(t *testing.T) {
 	text := NewLabel("Hello")
 	text.Resize(text.MinSize())
-	assert.NotEqual(t, fyne.NewSize(0, 0), text.Size())
-	assert.Equal(t, text.Size(), text.MinSize())
 	size := text.Size()
+	assert.NotEqual(t, fyne.NewSize(0, 0), size)
+	assert.Equal(t, size, text.MinSize())
 
 	r := text.CreateRenderer()
 	assert.Equal(t, size, text.Size())

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -94,7 +94,7 @@ func TestText_MinSizeAdjustsWithContent(t *testing.T) {
 
 	text.SetText("Line 1\nLine 2\n")
 	assert.Equal(t, initialMin, text.MinSize())
-	assert.Equal(t, initialMin, text.textProvider.MinSize())
+	assert.Equal(t, initialMin, text.provider.MinSize())
 }
 
 func TestLabel_ApplyTheme(t *testing.T) {
@@ -105,4 +105,20 @@ func TestLabel_ApplyTheme(t *testing.T) {
 	assert.Equal(t, theme.TextColor(), render.texts[0].Color)
 	text.Show()
 	assert.Equal(t, theme.TextColor(), render.texts[0].Color)
+}
+
+func TestLabel_CreateRendererDoesNotAffectSize(t *testing.T) {
+	text := NewLabel("Hello")
+	text.Resize(text.MinSize())
+	assert.NotEqual(t, fyne.NewSize(0, 0), text.Size())
+	assert.Equal(t, text.Size(), text.MinSize())
+	size := text.Size()
+
+	r := text.CreateRenderer()
+	assert.Equal(t, size, text.Size())
+	assert.Equal(t, size, text.MinSize())
+	assert.Equal(t, size, r.MinSize())
+	r.Layout(size)
+	assert.Equal(t, size, text.Size())
+	assert.Equal(t, size, text.MinSize())
 }

--- a/widget/text_test.go
+++ b/widget/text_test.go
@@ -265,7 +265,7 @@ func TestTextRenderer_ApplyTheme(t *testing.T) {
 func TestTextProvider_LineSizeToColumn(t *testing.T) {
 	label := NewLabel("Test")
 	label.CreateRenderer() // TODO make this a simple refresh call once it's in
-	provider := label.textProvider
+	provider := label.provider
 
 	fullSize := provider.lineSizeToColumn(4, 0)
 	assert.Equal(t, fullSize, provider.lineSizeToColumn(10, 0))


### PR DESCRIPTION
### Description:

The `Hyperlink` and `Label` widgets were implemented in a way which made `CreateRenderer` breaking the widget's size.

This PR fixes this issue.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
