### PR TITLE
Fix some trivial problems in `fyne_demo` app

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -31,7 +31,7 @@ func makeButtonTab() fyne.Widget {
 
 	return widget.NewVBox(
 		widget.NewButton("Button (text only)", func() { fmt.Println("tapped text button") }),
-		widget.NewButtonWithIcon("Button (test & icon)", theme.ConfirmIcon(), func() { fmt.Println("tapped text & icon button") }),
+		widget.NewButtonWithIcon("Button (text & icon)", theme.ConfirmIcon(), func() { fmt.Println("tapped text & icon button") }),
 		disabled,
 	)
 }

--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -61,8 +61,6 @@ func makeTextTab() fyne.CanvasObject {
 
 	label.Wrapping = fyne.TextWrapWord
 	hyperlink.Wrapping = fyne.TextWrapWord
-	entry.Wrapping = fyne.TextWrapWord
-	entryDisabled.Wrapping = fyne.TextWrapWord
 	entryMultiLine.Wrapping = fyne.TextWrapWord
 	entryLoremIpsum.Wrapping = fyne.TextWrapWord
 
@@ -100,15 +98,13 @@ func makeTextTab() fyne.CanvasObject {
 
 		label.Wrapping = wrap
 		hyperlink.Wrapping = wrap
-		entry.Wrapping = wrap
-		entryDisabled.Wrapping = wrap
-		entryMultiLine.Wrapping = wrap
-		entryLoremIpsum.Wrapping = wrap
+		if wrap != fyne.TextTruncate {
+			entryMultiLine.Wrapping = wrap
+			entryLoremIpsum.Wrapping = wrap
+		}
 
 		label.Refresh()
 		hyperlink.Refresh()
-		entry.Refresh()
-		entryDisabled.Refresh()
 		entryMultiLine.Refresh()
 		entryLoremIpsum.Refresh()
 		entryLoremIpsumScroller.Refresh()


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixed some problems in the demo app.

- The error log is printed when `fyne_demo` started.
  - As described in the error,  the single line entry is set with an inappropriate option.
```
2020/04/08 21:54:21 Fyne error:  Entry cannot wrap single line
2020/04/08 21:54:21   At: /Users/kyo/go/src/github.com/lusingander/fyne/widget/entry.go:1008
2020/04/08 21:54:21 Fyne error:  Entry cannot wrap single line
2020/04/08 21:54:21   At: /Users/kyo/go/src/github.com/lusingander/fyne/widget/entry.go:1008
```
- The error log is printed when text alignment radio buttons are toggled.
  - it doesn't seem to make sense to set `wrap` for label and hyperlink as sample...
```
2020/04/08 22:22:45 Fyne error:  Entry does not allow Truncation
2020/04/08 22:22:45   At: /Users/kyo/go/src/github.com/lusingander/fyne/widget/entry.go:1004
2020/04/08 22:22:45 Fyne error:  Entry does not allow Truncation
2020/04/08 22:22:45   At: /Users/kyo/go/src/github.com/lusingander/fyne/widget/entry.go:1004
```
- Fix typo

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
