### PR TITLE
Panic on bad start

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -4,12 +4,16 @@ package glfw
 
 import (
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/internal/driver"
 	"fyne.io/fyne/internal/painter"
 )
+
+const mainGoroutineID = 1
 
 var canvasMutex sync.RWMutex
 var canvases = make(map[fyne.CanvasObject]fyne.Canvas)
@@ -59,11 +63,20 @@ func (d *gLDriver) Quit() {
 }
 
 func (d *gLDriver) Run() {
-	count := runtime.Callers(4, make([]uintptr, 1))
-	if count == 0 {
-		panic("Run() must be called from main goroutine")
+	if goroutineID() != mainGoroutineID {
+		panic("Run() or ShowAndRun() must be called from main goroutine")
 	}
 	d.runGL()
+}
+
+func goroutineID() int {
+	b := make([]byte, 64)
+	b = b[:runtime.Stack(b, false)]
+	// string format expects "goroutine X [running..."
+	id := strings.Split(strings.TrimSpace(string(b)), " ")[1]
+
+	num, _ := strconv.Atoi(id)
+	return num
 }
 
 // NewGLDriver sets up a new Driver instance implemented using the GLFW Go library and OpenGL bindings.

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -3,6 +3,7 @@
 package glfw
 
 import (
+	"runtime"
 	"sync"
 
 	"fyne.io/fyne"
@@ -58,6 +59,10 @@ func (d *gLDriver) Quit() {
 }
 
 func (d *gLDriver) Run() {
+	count := runtime.Callers(4, make([]uintptr, 1))
+	if count == 0 {
+		panic("Run() must be called from main goroutine")
+	}
 	d.runGL()
 }
 

--- a/internal/driver/glfw/driver_test.go
+++ b/internal/driver/glfw/driver_test.go
@@ -3,6 +3,7 @@
 package glfw
 
 import (
+	"sync"
 	"testing"
 
 	"fyne.io/fyne"
@@ -97,4 +98,35 @@ func Test_gLDriver_AbsolutePositionForObject(t *testing.T) {
 			assert.Equal(t, tt.want, d.AbsolutePositionForObject(tt.object))
 		})
 	}
+}
+
+var mainRoutineID int
+
+func init() {
+	mainRoutineID = goroutineID()
+}
+
+func TestGoroutineID(t *testing.T) {
+	assert.Equal(t, 1, mainRoutineID)
+
+	var childID1, childID2 int
+	testID1 := goroutineID()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		childID1 = goroutineID()
+		wg.Done()
+	}()
+	go func() {
+		childID2 = goroutineID()
+		wg.Done()
+	}()
+	wg.Wait()
+	testID2 := goroutineID()
+
+	assert.Equal(t, testID1, testID2)
+	assert.Greater(t, childID1, 0)
+	assert.NotEqual(t, testID1, childID1)
+	assert.Greater(t, childID2, 0)
+	assert.NotEqual(t, childID1, childID2)
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -389,11 +389,6 @@ func (w *window) Close() {
 }
 
 func (w *window) ShowAndRun() {
-	count := runtime.Callers(4, make([]uintptr, 1))
-	if count == 0 {
-		panic("ShowAndRun() must be called from main goroutine")
-	}
-
 	w.Show()
 	fyne.CurrentApp().Driver().Run()
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -389,6 +389,11 @@ func (w *window) Close() {
 }
 
 func (w *window) ShowAndRun() {
+	count := runtime.Callers(4, make([]uintptr, 1))
+	if count == 0 {
+		panic("ShowAndRun() must be called from main goroutine")
+	}
+
 	w.Show()
 	fyne.CurrentApp().Driver().Run()
 }


### PR DESCRIPTION
### Description:
We regularly get bug reports like #829 that say things don't work well if started from a goroutine.
This is true on Linux, but on macOS it will just crash. We don't support it as graphics must be kicked off on the main goroutine.

This change kills the application with a `panic()` if this occurs.
I considered a `fyne.LogError` but it seems like this is a fundamental issue that should not continue.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
