### PR TITLE
Mobileclipboard

### DIFF
--- a/internal/driver/gomobile/clipboard.go
+++ b/internal/driver/gomobile/clipboard.go
@@ -10,13 +10,3 @@ var _ fyne.Clipboard = (*mobileClipboard)(nil)
 // mobileClipboard represents the system mobileClipboard
 type mobileClipboard struct {
 }
-
-// Content returns the mobileClipboard content
-func (c *mobileClipboard) Content() string {
-	return "" // TODO implement ticket #414
-}
-
-// SetContent sets the mobileClipboard content
-func (c *mobileClipboard) SetContent(content string) {
-	// TODO implement ticket #414
-}

--- a/internal/driver/gomobile/clipboard_android.go
+++ b/internal/driver/gomobile/clipboard_android.go
@@ -2,12 +2,94 @@
 
 package gomobile
 
+/*
+#cgo LDFLAGS: -landroid -llog -lEGL -lGLESv2
+
+#include <android/log.h>
+#include <jni.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define LOG_FATAL(...) __android_log_print(ANDROID_LOG_FATAL, "GoLog", __VA_ARGS__)
+
+static jmethodID find_method(JNIEnv *env, jclass clazz, const char *name, const char *sig) {
+	jmethodID m = (*env)->GetMethodID(env, clazz, name, sig);
+	if (m == 0) {
+		(*env)->ExceptionClear(env);
+		LOG_FATAL("cannot find method %s %s", name, sig);
+		return 0;
+	}
+	return m;
+}
+
+jobject getClipboard(uintptr_t jni_env, uintptr_t ctx) {
+	JNIEnv* env = (JNIEnv*)jni_env;
+	jclass ctxClass = (*env)->GetObjectClass(env, ctx);
+	jmethodID getSystemService = find_method(env, ctxClass, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+
+	jstring service = (*env)->NewStringUTF(env, "clipboard");
+	return (jobject)(*env)->CallObjectMethod(env, ctx, getSystemService, service);
+}
+
+char *getClipboardContent(uintptr_t java_vm, uintptr_t jni_env, uintptr_t ctx) {
+	JNIEnv* env = (JNIEnv*)jni_env;
+	jobject mgr = getClipboard(jni_env, ctx);
+
+	jclass mgrClass = (*env)->GetObjectClass(env, mgr);
+	jmethodID getText = find_method(env, mgrClass, "getText", "()Ljava/lang/CharSequence;");
+
+	jobject content = (jstring)(*env)->CallObjectMethod(env, mgr, getText);
+	if (content == NULL) {
+		return "";
+	}
+
+	jclass clzCharSequence = (*env)->GetObjectClass(env, content);
+	jmethodID toString = (*env)->GetMethodID(env, clzCharSequence, "toString", "()Ljava/lang/String;");
+	jobject s = (*env)->CallObjectMethod(env, content, toString);
+
+	const char* chars = (*env)->GetStringUTFChars(env, s, NULL);
+	const char *copy = strdup(chars);
+	(*env)->ReleaseStringUTFChars(env, s, chars);
+	return copy;
+}
+
+void setClipboardContent(uintptr_t java_vm, uintptr_t jni_env, uintptr_t ctx, char *content) {
+	JNIEnv* env = (JNIEnv*)jni_env;
+	jobject mgr = getClipboard(jni_env, ctx);
+
+	jclass mgrClass = (*env)->GetObjectClass(env, mgr);
+	jmethodID setText = find_method(env, mgrClass, "setText", "(Ljava/lang/CharSequence;)V");
+
+	jstring str = (*env)->NewStringUTF(env, content);
+	(*env)->CallVoidMethod(env, mgr, setText, str);
+}
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/fyne-io/mobile/app"
+)
+
 // Content returns the clipboard content for Android
 func (c *mobileClipboard) Content() string {
-	return "" // TODO implement ticket #414
+	content := ""
+	app.RunOnJVM(func(vm, env, ctx uintptr) error {
+		chars := C.getClipboardContent(C.uintptr_t(vm), C.uintptr_t(env), C.uintptr_t(ctx))
+		content = C.GoString(chars)
+		C.free(unsafe.Pointer(chars))
+		return nil
+	})
+	return content
 }
 
 // SetContent sets the clipboard content for Android
 func (c *mobileClipboard) SetContent(content string) {
-	// TODO implement ticket #414
+	contentStr := C.CString(content)
+	defer C.free(unsafe.Pointer(contentStr))
+
+	app.RunOnJVM(func(vm, env, ctx uintptr) error {
+		C.setClipboardContent(C.uintptr_t(vm), C.uintptr_t(env), C.uintptr_t(ctx), contentStr)
+		return nil
+	})
 }

--- a/internal/driver/gomobile/clipboard_android.go
+++ b/internal/driver/gomobile/clipboard_android.go
@@ -1,0 +1,13 @@
+// +build android
+
+package gomobile
+
+// Content returns the clipboard content for Android
+func (c *mobileClipboard) Content() string {
+	return "" // TODO implement ticket #414
+}
+
+// SetContent sets the clipboard content for Android
+func (c *mobileClipboard) SetContent(content string) {
+	// TODO implement ticket #414
+}

--- a/internal/driver/gomobile/clipboard_android.go
+++ b/internal/driver/gomobile/clipboard_android.go
@@ -23,7 +23,7 @@ static jmethodID find_method(JNIEnv *env, jclass clazz, const char *name, const 
 }
 
 jobject getClipboard(uintptr_t jni_env, uintptr_t ctx) {
-	JNIEnv* env = (JNIEnv*)jni_env;
+	JNIEnv *env = (JNIEnv*)jni_env;
 	jclass ctxClass = (*env)->GetObjectClass(env, ctx);
 	jmethodID getSystemService = find_method(env, ctxClass, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
 
@@ -32,7 +32,7 @@ jobject getClipboard(uintptr_t jni_env, uintptr_t ctx) {
 }
 
 char *getClipboardContent(uintptr_t java_vm, uintptr_t jni_env, uintptr_t ctx) {
-	JNIEnv* env = (JNIEnv*)jni_env;
+	JNIEnv *env = (JNIEnv*)jni_env;
 	jobject mgr = getClipboard(jni_env, ctx);
 
 	jclass mgrClass = (*env)->GetObjectClass(env, mgr);
@@ -47,14 +47,14 @@ char *getClipboardContent(uintptr_t java_vm, uintptr_t jni_env, uintptr_t ctx) {
 	jmethodID toString = (*env)->GetMethodID(env, clzCharSequence, "toString", "()Ljava/lang/String;");
 	jobject s = (*env)->CallObjectMethod(env, content, toString);
 
-	const char* chars = (*env)->GetStringUTFChars(env, s, NULL);
+	const char *chars = (*env)->GetStringUTFChars(env, s, NULL);
 	const char *copy = strdup(chars);
 	(*env)->ReleaseStringUTFChars(env, s, chars);
 	return copy;
 }
 
 void setClipboardContent(uintptr_t java_vm, uintptr_t jni_env, uintptr_t ctx, char *content) {
-	JNIEnv* env = (JNIEnv*)jni_env;
+	JNIEnv *env = (JNIEnv*)jni_env;
 	jobject mgr = getClipboard(jni_env, ctx);
 
 	jclass mgrClass = (*env)->GetObjectClass(env, mgr);

--- a/internal/driver/gomobile/clipboard_desktop.go
+++ b/internal/driver/gomobile/clipboard_desktop.go
@@ -1,0 +1,16 @@
+// +build !ios,!android
+
+package gomobile
+
+import "fyne.io/fyne"
+
+// Content returns the clipboard content for mobile simulator runs
+func (c *mobileClipboard) Content() string {
+	fyne.LogError("Clipboard is not supported in mobile simulation", nil)
+	return ""
+}
+
+// SetContent sets the clipboard content for mobile simulator runs
+func (c *mobileClipboard) SetContent(content string) {
+	fyne.LogError("Clipboard is not supported in mobile simulation", nil)
+}

--- a/internal/driver/gomobile/clipboard_ios.go
+++ b/internal/driver/gomobile/clipboard_ios.go
@@ -1,0 +1,30 @@
+// +build ios
+
+package gomobile
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation -framework UIKit -framework MobileCoreServices
+
+#include <stdlib.h>
+
+void setClipboardContent(char *content);
+char *getClipboardContent();
+*/
+import "C"
+import "unsafe"
+
+// Content returns the clipboard content for iOS
+func (c *mobileClipboard) Content() string {
+	content := C.getClipboardContent()
+
+	return C.GoString(content)
+}
+
+// SetContent sets the clipboard content for iOS
+func (c *mobileClipboard) SetContent(content string) {
+	contentStr := C.CString(content)
+	defer C.free(unsafe.Pointer(contentStr))
+
+	C.setClipboardContent(contentStr)
+}

--- a/internal/driver/gomobile/clipboard_ios.m
+++ b/internal/driver/gomobile/clipboard_ios.m
@@ -1,0 +1,15 @@
+// +build ios
+
+#import <UIKit/UIKit.h>
+#import <MobileCoreServices/MobileCoreServices.h>
+
+void setClipboardContent(char *content) {
+    NSString *value = [NSString stringWithUTF8String:content];
+    [[UIPasteboard generalPasteboard] setString:value];
+}
+
+char *getClipboardContent() {
+    NSString *str = [[UIPasteboard generalPasteboard] string];
+
+    return [str UTF8String];
+}


### PR DESCRIPTION
### Description:
Add the mobile code required to complete clipobard integration (cut/copy/paste) for iOS and Android.
It does not support copy/paste for the desktop simulation mode as that would pull in GLFW (possible in the future).

The android code could be prettier but I have some plans to refactor after this release.
A lot of this is similar to the gomobile boot code and I'd like to bring it together later on (big change).

Fixes #414

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
