### PR TITLE
Refactoring: deprecate NewPopUp*

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -23,6 +23,11 @@ func (p1 Position) Add(p2 Position) Position {
 	return Position{p1.X + p2.X, p1.Y + p2.Y}
 }
 
+// IsZero returns whether the Size has zero width and zero height.
+func (p Position) IsZero() bool {
+	return p.X == 0 && p.Y == 0
+}
+
 // Subtract returns a new Position that is the result of offsetting the current
 // position by p2 -X and -Y.
 func (p1 Position) Subtract(p2 Position) Position {

--- a/geometry.go
+++ b/geometry.go
@@ -19,8 +19,8 @@ type Position struct {
 
 // Add returns a new Position that is the result of offsetting the current
 // position by p2 X and Y.
-func (p1 Position) Add(p2 Position) Position {
-	return Position{p1.X + p2.X, p1.Y + p2.Y}
+func (p Position) Add(p2 Position) Position {
+	return Position{p.X + p2.X, p.Y + p2.Y}
 }
 
 // IsZero returns whether the Size has zero width and zero height.
@@ -30,8 +30,8 @@ func (p Position) IsZero() bool {
 
 // Subtract returns a new Position that is the result of offsetting the current
 // position by p2 -X and -Y.
-func (p1 Position) Subtract(p2 Position) Position {
-	return Position{p1.X - p2.X, p1.Y - p2.Y}
+func (p Position) Subtract(p2 Position) Position {
+	return Position{p.X - p2.X, p.Y - p2.Y}
 }
 
 // Size describes something with width and height.

--- a/geometry.go
+++ b/geometry.go
@@ -37,8 +37,8 @@ type Size struct {
 
 // Add returns a new Size that is the result of increasing the current size by
 // s2 Width and Height.
-func (s1 Size) Add(s2 Size) Size {
-	return Size{s1.Width + s2.Width, s1.Height + s2.Height}
+func (s Size) Add(s2 Size) Size {
+	return Size{s.Width + s2.Width, s.Height + s2.Height}
 }
 
 // IsZero returns whether the Size has zero width and zero height.
@@ -47,29 +47,29 @@ func (s Size) IsZero() bool {
 }
 
 // Max returns a new Size that is the maximum of the current Size and s2.
-func (s1 Size) Max(s2 Size) Size {
-	maxW := Max(s1.Width, s2.Width)
-	maxH := Max(s1.Height, s2.Height)
+func (s Size) Max(s2 Size) Size {
+	maxW := Max(s.Width, s2.Width)
+	maxH := Max(s.Height, s2.Height)
 
 	return NewSize(maxW, maxH)
 }
 
 // Min returns a new Size that is the minimum of the current Size and s2.
-func (s1 Size) Min(s2 Size) Size {
-	minW := Min(s1.Width, s2.Width)
-	minH := Min(s1.Height, s2.Height)
+func (s Size) Min(s2 Size) Size {
+	minW := Min(s.Width, s2.Width)
+	minH := Min(s.Height, s2.Height)
 
 	return NewSize(minW, minH)
 }
 
 // Subtract returns a new Size that is the result of decreasing the current size
 // by s2 Width and Height.
-func (s1 Size) Subtract(s2 Size) Size {
-	return Size{s1.Width - s2.Width, s1.Height - s2.Height}
+func (s Size) Subtract(s2 Size) Size {
+	return Size{s.Width - s2.Width, s.Height - s2.Height}
 }
 
 // Union returns a new Size that is the maximum of the current Size and s2.
 // Deprecated: use Max() instead
-func (s1 Size) Union(s2 Size) Size {
-	return s1.Max(s2)
+func (s Size) Union(s2 Size) Size {
+	return s.Max(s2)
 }

--- a/geometry.go
+++ b/geometry.go
@@ -18,7 +18,7 @@ func (p Position) Add(p2 Position) Position {
 	return Position{p.X + p2.X, p.Y + p2.Y}
 }
 
-// IsZero returns whether the Size has zero width and zero height.
+// IsZero returns whether the Position is at the zero-point.
 func (p Position) IsZero() bool {
 	return p.X == 0 && p.Y == 0
 }

--- a/geometry.go
+++ b/geometry.go
@@ -1,43 +1,8 @@
 package fyne
 
-// Size describes something with width and height.
-type Size struct {
-	Width  int // The number of units along the X axis.
-	Height int // The number of units along the Y axis.
-}
-
-// Add returns a new Size that is the result of increasing the current size by
-// s2 Width and Height.
-func (s1 Size) Add(s2 Size) Size {
-	return Size{s1.Width + s2.Width, s1.Height + s2.Height}
-}
-
-// Subtract returns a new Size that is the result of decreasing the current size
-// by s2 Width and Height.
-func (s1 Size) Subtract(s2 Size) Size {
-	return Size{s1.Width - s2.Width, s1.Height - s2.Height}
-}
-
-// Union returns a new Size that is the maximum of the current Size and s2.
-// Deprecated: use Max() instead
-func (s1 Size) Union(s2 Size) Size {
-	return s1.Max(s2)
-}
-
-// Max returns a new Size that is the maximum of the current Size and s2.
-func (s1 Size) Max(s2 Size) Size {
-	maxW := Max(s1.Width, s2.Width)
-	maxH := Max(s1.Height, s2.Height)
-
-	return NewSize(maxW, maxH)
-}
-
-// Min returns a new Size that is the minimum of the current Size and s2.
-func (s1 Size) Min(s2 Size) Size {
-	minW := Min(s1.Width, s2.Width)
-	minH := Min(s1.Height, s2.Height)
-
-	return NewSize(minW, minH)
+// NewPos returns a newly allocated Position representing the specified coordinates.
+func NewPos(x int, y int) Position {
+	return Position{x, y}
 }
 
 // NewSize returns a newly allocated Size of the specified dimensions.
@@ -64,7 +29,42 @@ func (p1 Position) Subtract(p2 Position) Position {
 	return Position{p1.X - p2.X, p1.Y - p2.Y}
 }
 
-// NewPos returns a newly allocated Position representing the specified coordinates.
-func NewPos(x int, y int) Position {
-	return Position{x, y}
+// Size describes something with width and height.
+type Size struct {
+	Width  int // The number of units along the X axis.
+	Height int // The number of units along the Y axis.
+}
+
+// Add returns a new Size that is the result of increasing the current size by
+// s2 Width and Height.
+func (s1 Size) Add(s2 Size) Size {
+	return Size{s1.Width + s2.Width, s1.Height + s2.Height}
+}
+
+// Max returns a new Size that is the maximum of the current Size and s2.
+func (s1 Size) Max(s2 Size) Size {
+	maxW := Max(s1.Width, s2.Width)
+	maxH := Max(s1.Height, s2.Height)
+
+	return NewSize(maxW, maxH)
+}
+
+// Min returns a new Size that is the minimum of the current Size and s2.
+func (s1 Size) Min(s2 Size) Size {
+	minW := Min(s1.Width, s2.Width)
+	minH := Min(s1.Height, s2.Height)
+
+	return NewSize(minW, minH)
+}
+
+// Subtract returns a new Size that is the result of decreasing the current size
+// by s2 Width and Height.
+func (s1 Size) Subtract(s2 Size) Size {
+	return Size{s1.Width - s2.Width, s1.Height - s2.Height}
+}
+
+// Union returns a new Size that is the maximum of the current Size and s2.
+// Deprecated: use Max() instead
+func (s1 Size) Union(s2 Size) Size {
+	return s1.Max(s2)
 }

--- a/geometry.go
+++ b/geometry.go
@@ -41,6 +41,11 @@ func (s1 Size) Add(s2 Size) Size {
 	return Size{s1.Width + s2.Width, s1.Height + s2.Height}
 }
 
+// IsZero returns whether the Size has zero width and zero height.
+func (s Size) IsZero() bool {
+	return s.Width == 0 && s.Height == 0
+}
+
 // Max returns a new Size that is the maximum of the current Size and s2.
 func (s1 Size) Max(s2 Size) Size {
 	maxW := Max(s1.Width, s2.Width)

--- a/geometry.go
+++ b/geometry.go
@@ -1,20 +1,15 @@
 package fyne
 
-// NewPos returns a newly allocated Position representing the specified coordinates.
-func NewPos(x int, y int) Position {
-	return Position{x, y}
-}
-
-// NewSize returns a newly allocated Size of the specified dimensions.
-func NewSize(w int, h int) Size {
-	return Size{w, h}
-}
-
 // Position describes a generic X, Y coordinate relative to a parent Canvas
 // or CanvasObject.
 type Position struct {
 	X int // The position from the parent's left edge
 	Y int // The position from the parent's top edge
+}
+
+// NewPos returns a newly allocated Position representing the specified coordinates.
+func NewPos(x int, y int) Position {
+	return Position{x, y}
 }
 
 // Add returns a new Position that is the result of offsetting the current
@@ -38,6 +33,11 @@ func (p Position) Subtract(p2 Position) Position {
 type Size struct {
 	Width  int // The number of units along the X axis.
 	Height int // The number of units along the Y axis.
+}
+
+// NewSize returns a newly allocated Size of the specified dimensions.
+func NewSize(w int, h int) Size {
+	return Size{w, h}
 }
 
 // Add returns a new Size that is the result of increasing the current size by

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -6,6 +6,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPosition_Add(t *testing.T) {
+	pos1 := NewPos(10, 10)
+	pos2 := NewPos(25, 25)
+
+	pos3 := pos1.Add(pos2)
+
+	assert.Equal(t, 35, pos3.X)
+	assert.Equal(t, 35, pos3.Y)
+}
+
+func TestPosition_Subtract(t *testing.T) {
+	pos1 := NewPos(25, 25)
+	pos2 := NewPos(10, 10)
+
+	pos3 := pos1.Subtract(pos2)
+
+	assert.Equal(t, 15, pos3.X)
+	assert.Equal(t, 15, pos3.Y)
+}
+
 func TestSizeAdd(t *testing.T) {
 	size1 := NewSize(10, 10)
 	size2 := NewSize(25, 25)
@@ -14,26 +34,6 @@ func TestSizeAdd(t *testing.T) {
 
 	assert.Equal(t, 35, size3.Width)
 	assert.Equal(t, 35, size3.Height)
-}
-
-func TestSizeSubtract(t *testing.T) {
-	size1 := NewSize(25, 25)
-	size2 := NewSize(10, 10)
-
-	size3 := size1.Subtract(size2)
-
-	assert.Equal(t, 15, size3.Width)
-	assert.Equal(t, 15, size3.Height)
-}
-
-func TestSizeUnion(t *testing.T) {
-	size1 := NewSize(10, 100)
-	size2 := NewSize(100, 10)
-
-	size3 := size1.Union(size2)
-
-	assert.Equal(t, 100, size3.Width)
-	assert.Equal(t, 100, size3.Height)
 }
 
 func TestSizeMax(t *testing.T) {
@@ -56,22 +56,22 @@ func TestSizeMin(t *testing.T) {
 	assert.Equal(t, 10, size3.Height)
 }
 
-func TestPosition_Add(t *testing.T) {
-	pos1 := NewPos(10, 10)
-	pos2 := NewPos(25, 25)
+func TestSizeSubtract(t *testing.T) {
+	size1 := NewSize(25, 25)
+	size2 := NewSize(10, 10)
 
-	pos3 := pos1.Add(pos2)
+	size3 := size1.Subtract(size2)
 
-	assert.Equal(t, 35, pos3.X)
-	assert.Equal(t, 35, pos3.Y)
+	assert.Equal(t, 15, size3.Width)
+	assert.Equal(t, 15, size3.Height)
 }
 
-func TestPosition_Subtract(t *testing.T) {
-	pos1 := NewPos(25, 25)
-	pos2 := NewPos(10, 10)
+func TestSizeUnion(t *testing.T) {
+	size1 := NewSize(10, 100)
+	size2 := NewSize(100, 10)
 
-	pos3 := pos1.Subtract(pos2)
+	size3 := size1.Union(size2)
 
-	assert.Equal(t, 15, pos3.X)
-	assert.Equal(t, 15, pos3.Y)
+	assert.Equal(t, 100, size3.Width)
+	assert.Equal(t, 100, size3.Height)
 }

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -36,6 +36,23 @@ func TestSize_Add(t *testing.T) {
 	assert.Equal(t, 35, size3.Height)
 }
 
+func TestSize_IsZero(t *testing.T) {
+	for name, tt := range map[string]struct {
+		s    Size
+		want bool
+	}{
+		"zero value":    {Size{}, true},
+		"0x0":           {NewSize(0, 0), true},
+		"zero width":    {NewSize(0, 42), false},
+		"zero height":   {NewSize(17, 0), false},
+		"non-zero area": {NewSize(6, 9), false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.s.IsZero())
+		})
+	}
+}
+
 func TestSize_Max(t *testing.T) {
 	size1 := NewSize(10, 100)
 	size2 := NewSize(100, 10)

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -26,7 +26,7 @@ func TestPosition_Subtract(t *testing.T) {
 	assert.Equal(t, 15, pos3.Y)
 }
 
-func TestSizeAdd(t *testing.T) {
+func TestSize_Add(t *testing.T) {
 	size1 := NewSize(10, 10)
 	size2 := NewSize(25, 25)
 
@@ -36,7 +36,7 @@ func TestSizeAdd(t *testing.T) {
 	assert.Equal(t, 35, size3.Height)
 }
 
-func TestSizeMax(t *testing.T) {
+func TestSize_Max(t *testing.T) {
 	size1 := NewSize(10, 100)
 	size2 := NewSize(100, 10)
 
@@ -46,7 +46,7 @@ func TestSizeMax(t *testing.T) {
 	assert.Equal(t, 100, size3.Height)
 }
 
-func TestSizeMin(t *testing.T) {
+func TestSize_Min(t *testing.T) {
 	size1 := NewSize(10, 100)
 	size2 := NewSize(100, 10)
 
@@ -56,7 +56,7 @@ func TestSizeMin(t *testing.T) {
 	assert.Equal(t, 10, size3.Height)
 }
 
-func TestSizeSubtract(t *testing.T) {
+func TestSize_Subtract(t *testing.T) {
 	size1 := NewSize(25, 25)
 	size2 := NewSize(10, 10)
 
@@ -66,7 +66,7 @@ func TestSizeSubtract(t *testing.T) {
 	assert.Equal(t, 15, size3.Height)
 }
 
-func TestSizeUnion(t *testing.T) {
+func TestSize_Union(t *testing.T) {
 	size1 := NewSize(10, 100)
 	size2 := NewSize(100, 10)
 

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -16,6 +16,23 @@ func TestPosition_Add(t *testing.T) {
 	assert.Equal(t, 35, pos3.Y)
 }
 
+func TestPosition_IsZero(t *testing.T) {
+	for name, tt := range map[string]struct {
+		p    Position
+		want bool
+	}{
+		"zero value":       {Position{}, true},
+		"0,0":              {NewPos(0, 0), true},
+		"zero X":           {NewPos(0, 42), false},
+		"zero Y":           {NewPos(17, 0), false},
+		"non-zero X and Y": {NewPos(6, 9), false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.p.IsZero())
+		})
+	}
+}
+
 func TestPosition_Subtract(t *testing.T) {
 	pos1 := NewPos(25, 25)
 	pos2 := NewPos(10, 10)

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -53,13 +53,22 @@ func (p *PopUp) Resize(size fyne.Size) {
 	p.Refresh()
 }
 
-// Show this widget, if it was previously hidden
+// Show this pop-up as overlay if not already shown.
 func (p *PopUp) Show() {
 	if !p.overlayShown {
+		if (p.Size() == fyne.Size{}) {
+			p.Resize(p.MinSize())
+		}
 		p.Canvas.Overlays().Add(p)
 		p.overlayShown = true
 	}
 	p.BaseWidget.Show()
+}
+
+// ShowAtPosition shows this pop-up at the given position.
+func (p *PopUp) ShowAtPosition(pos fyne.Position) {
+	p.Move(pos)
+	p.Show()
 }
 
 // Tapped is called when the user taps the popUp background - if not modal then dismiss this widget
@@ -97,29 +106,56 @@ func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
 
 // NewPopUpAtPosition creates a new popUp for the specified content at the specified absolute position.
 // It will then display the popup on the passed canvas.
+// Deprecated: Use ShowPopUpAtPosition() instead.
 func NewPopUpAtPosition(content fyne.CanvasObject, canvas fyne.Canvas, pos fyne.Position) *PopUp {
+	p := newPopUp(content, canvas)
+	p.ShowAtPosition(pos)
+	return p
+}
+
+// ShowPopUpAtPosition creates a new popUp for the specified content at the specified absolute position.
+// It will then display the popup on the passed canvas.
+func ShowPopUpAtPosition(content fyne.CanvasObject, canvas fyne.Canvas, pos fyne.Position) {
+	newPopUp(content, canvas).ShowAtPosition(pos)
+}
+
+func newPopUp(content fyne.CanvasObject, canvas fyne.Canvas) *PopUp {
 	ret := &PopUp{Content: content, Canvas: canvas, modal: false}
 	ret.ExtendBaseWidget(ret)
-	ret.Move(pos)
-
-	ret.Resize(ret.MinSize())
-	ret.Show()
 	return ret
 }
 
 // NewPopUp creates a new popUp for the specified content and displays it on the passed canvas.
+// Deprecated: This will no longer show the pop-up in 2.0. Use ShowPopUp() instead.
 func NewPopUp(content fyne.CanvasObject, canvas fyne.Canvas) *PopUp {
 	return NewPopUpAtPosition(content, canvas, fyne.NewPos(0, 0))
 }
 
+// ShowPopUp creates a new popUp for the specified content and displays it on the passed canvas.
+func ShowPopUp(content fyne.CanvasObject, canvas fyne.Canvas) {
+	newPopUp(content, canvas).Show()
+}
+
+func newModalPopUp(content fyne.CanvasObject, canvas fyne.Canvas) *PopUp {
+	p := &PopUp{Content: content, Canvas: canvas, modal: true}
+	p.ExtendBaseWidget(p)
+	return p
+}
+
 // NewModalPopUp creates a new popUp for the specified content and displays it on the passed canvas.
 // A modal PopUp blocks interactions with underlying elements, covered with a semi-transparent overlay.
+// Deprecated: This will no longer show the pop-up in 2.0. Use ShowModalPopUp instead.
 func NewModalPopUp(content fyne.CanvasObject, canvas fyne.Canvas) *PopUp {
-	ret := &PopUp{Content: content, Canvas: canvas, modal: true}
-	ret.ExtendBaseWidget(ret)
-	ret.Resize(ret.MinSize())
-	ret.Show()
-	return ret
+	p := newModalPopUp(content, canvas)
+	p.Show()
+	return p
+}
+
+// ShowModalPopUp creates a new popUp for the specified content and displays it on the passed canvas.
+// A modal PopUp blocks interactions with underlying elements, covered with a semi-transparent overlay.
+func ShowModalPopUp(content fyne.CanvasObject, canvas fyne.Canvas) {
+	p := newModalPopUp(content, canvas)
+	p.Show()
 }
 
 type popUpRenderer struct {

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -56,7 +56,7 @@ func (p *PopUp) Resize(size fyne.Size) {
 // Show this pop-up as overlay if not already shown.
 func (p *PopUp) Show() {
 	if !p.overlayShown {
-		if (p.Size() == fyne.Size{}) {
+		if p.Size().IsZero() {
 			p.Resize(p.MinSize())
 		}
 		p.Canvas.Overlays().Add(p)

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne/theme"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPopUp(t *testing.T) {
@@ -18,6 +19,80 @@ func TestNewPopUp(t *testing.T) {
 	assert.True(t, pop.Visible())
 	assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
 	assert.Equal(t, pop, test.Canvas().Overlays().List()[0])
+}
+
+func TestShowPopUp(t *testing.T) {
+	require.Nil(t, test.Canvas().Overlays().Top())
+
+	label := NewLabel("Hi")
+	ShowPopUp(label, test.Canvas())
+	pop := test.Canvas().Overlays().Top()
+	if assert.NotNil(t, pop) {
+		defer test.Canvas().Overlays().Remove(pop)
+
+		assert.True(t, pop.Visible())
+		assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
+	}
+}
+
+func TestShowPopUpAtPosition(t *testing.T) {
+	c := test.NewCanvas()
+	c.Resize(fyne.NewSize(100, 100))
+	pos := fyne.NewPos(6, 9)
+	label := NewLabel("Hi")
+	ShowPopUpAtPosition(label, c, pos)
+	pop := c.Overlays().Top()
+	if assert.NotNil(t, pop) {
+		assert.True(t, pop.Visible())
+		assert.Equal(t, 1, len(c.Overlays().List()))
+		assert.Equal(t, pos.Add(fyne.NewPos(theme.Padding(), theme.Padding())), pop.(*PopUp).Content.Position())
+	}
+}
+
+func TestShowModalPopUp(t *testing.T) {
+	require.Nil(t, test.Canvas().Overlays().Top())
+
+	label := NewLabel("Hi")
+	ShowModalPopUp(label, test.Canvas())
+	pop := test.Canvas().Overlays().Top()
+	if assert.NotNil(t, pop) {
+		defer test.Canvas().Overlays().Remove(pop)
+
+		assert.True(t, pop.Visible())
+		assert.Equal(t, 1, len(test.Canvas().Overlays().List()))
+	}
+}
+
+func TestPopUp_Show(t *testing.T) {
+	c := test.NewCanvas()
+	cSize := fyne.NewSize(100, 100)
+	c.Resize(cSize)
+	label := NewLabel("Hi")
+	pop := newPopUp(label, c)
+	require.Nil(t, c.Overlays().Top())
+
+	pop.Show()
+	assert.Equal(t, pop, c.Overlays().Top())
+	assert.Equal(t, 1, len(c.Overlays().List()))
+	assert.Equal(t, cSize, pop.Size())
+	assert.Equal(t, label.MinSize(), pop.Content.Size())
+}
+
+func TestPopUp_ShowAtPosition(t *testing.T) {
+	c := test.NewCanvas()
+	cSize := fyne.NewSize(100, 100)
+	c.Resize(cSize)
+	label := NewLabel("Hi")
+	pop := newPopUp(label, c)
+	pos := fyne.NewPos(6, 9)
+	require.Nil(t, c.Overlays().Top())
+
+	pop.ShowAtPosition(pos)
+	assert.Equal(t, pop, c.Overlays().Top())
+	assert.Equal(t, 1, len(c.Overlays().List()))
+	assert.Equal(t, cSize, pop.Size())
+	assert.Equal(t, label.MinSize(), pop.Content.Size())
+	assert.Equal(t, pos.Add(fyne.NewPos(theme.Padding(), theme.Padding())), pop.Content.Position())
 }
 
 func TestPopUp_Hide(t *testing.T) {


### PR DESCRIPTION
### Description:

The `NewPopUp*` methods not only construct a new pop-up widget but also immediately display it as overlay. This makes it impossible to extend the pop-up or pop-up menu without flickering.

With the new `ShowPopUp*` methods the old comfort remains while it is now possible to extend pop-up functionality.
Until 2.0 a developer has to build the pop-up with `widget.PopUp{…}` if he wants to do stuff with it before showing. Internally we can use the private constructors which will replace the deprecated ones in 2.0.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
