### PR TITLE
DO NOT MERGE: Benchmark Empty Size Checks

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -40,6 +40,11 @@ func (s1 Size) Min(s2 Size) Size {
 	return NewSize(minW, minH)
 }
 
+// Empty returns true if the size has a width and height of 0.
+func (s *Size) Empty() bool {
+	return s.Width == 0 && s.Height == 0
+}
+
 // NewSize returns a newly allocated Size of the specified dimensions.
 func NewSize(w int, h int) Size {
 	return Size{w, h}

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -1,6 +1,7 @@
 package fyne
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,4 +75,26 @@ func TestPosition_Subtract(t *testing.T) {
 
 	assert.Equal(t, 15, pos3.X)
 	assert.Equal(t, 15, pos3.Y)
+}
+
+func BenchmarkSize_isEmpty_Comparison(b *testing.B) {
+	size := NewSize(0, 0)
+	result := 0
+	for i := 0; i < b.N; i++ {
+		if (size == Size{}) {
+			result++
+		}
+	}
+	fmt.Sprintf("result: %d\n", result)
+}
+
+func BenchmarkSize_isEmpty_Function(b *testing.B) {
+	size := NewSize(0, 0)
+	result := 0
+	for i := 0; i < b.N; i++ {
+		if size.Empty() {
+			result++
+		}
+	}
+	fmt.Sprintf("result: %d\n", result)
 }


### PR DESCRIPTION
Adds two benchmarks to compare ways to check if a fyne.Size is empty. The first way compares the size to a newly-created, empty size. The second way calls a function that returns true if width == 0 & height == 0.

9 times out of 10 calling the function is quicker.

```
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.312 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.300 ns/op
PASS
ok      fyne.io/fyne    0.794s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.316 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.298 ns/op
PASS
ok      fyne.io/fyne    0.766s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.321 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.297 ns/op
PASS
ok      fyne.io/fyne    0.798s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.302 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.299 ns/op
PASS
ok      fyne.io/fyne    0.752s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.298 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.305 ns/op
PASS
ok      fyne.io/fyne    0.755s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.310 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.297 ns/op
PASS
ok      fyne.io/fyne    0.759s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.310 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.297 ns/op
PASS
ok      fyne.io/fyne    0.757s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.303 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.297 ns/op
PASS
ok      fyne.io/fyne    0.793s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.304 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.301 ns/op
PASS
ok      fyne.io/fyne    0.756s
$ go test -bench=. fyne.io/fyne/
goos: darwin
goarch: amd64
pkg: fyne.io/fyne
BenchmarkSize_isEmpty_Comparison-4      1000000000           0.306 ns/op
BenchmarkSize_isEmpty_Function-4        1000000000           0.302 ns/op
PASS
ok      fyne.io/fyne    0.759s
```
