### PR TITLE
Add OnTabSelected callback to tab container

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -88,7 +88,9 @@ func main() {
 		widget.NewTabItemWithIcon("Graphics", theme.DocumentCreateIcon(), screens.GraphicsScreen()),
 		widget.NewTabItemWithIcon("Windows", theme.ViewFullScreenIcon(), screens.DialogScreen(w)),
 		widget.NewTabItemWithIcon("Advanced", theme.SettingsIcon(), screens.AdvancedScreen(w)))
-	tabs.SetTabLocation(widget.TabLocationLeading)
+	tabs.OnTabSelected = func(tab *widget.TabItem) {
+		fmt.Printf("%s tab selected\n", tab.Text)
+	}
 	tabs.SelectTabIndex(a.Preferences().Int(preferenceCurrentTab))
 	w.SetContent(tabs)
 

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -88,6 +88,7 @@ func main() {
 		widget.NewTabItemWithIcon("Graphics", theme.DocumentCreateIcon(), screens.GraphicsScreen()),
 		widget.NewTabItemWithIcon("Windows", theme.ViewFullScreenIcon(), screens.DialogScreen(w)),
 		widget.NewTabItemWithIcon("Advanced", theme.SettingsIcon(), screens.AdvancedScreen(w)))
+	tabs.SetTabLocation(widget.TabLocationLeading)
 	tabs.OnChanged = func(tab *widget.TabItem) {
 		fmt.Printf("%s tab selected\n", tab.Text)
 	}

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -88,7 +88,7 @@ func main() {
 		widget.NewTabItemWithIcon("Graphics", theme.DocumentCreateIcon(), screens.GraphicsScreen()),
 		widget.NewTabItemWithIcon("Windows", theme.ViewFullScreenIcon(), screens.DialogScreen(w)),
 		widget.NewTabItemWithIcon("Advanced", theme.SettingsIcon(), screens.AdvancedScreen(w)))
-	tabs.OnTabSelected = func(tab *widget.TabItem) {
+	tabs.OnChanged = func(tab *widget.TabItem) {
 		fmt.Printf("%s tab selected\n", tab.Text)
 	}
 	tabs.SelectTabIndex(a.Preferences().Int(preferenceCurrentTab))

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -46,9 +46,10 @@ const (
 type TabContainer struct {
 	BaseWidget
 
-	Items       []*TabItem
-	current     int
-	tabLocation TabLocation
+	Items         []*TabItem
+	OnTabSelected func(tab *TabItem)
+	current       int
+	tabLocation   TabLocation
 }
 
 // Show this widget, if it was previously hidden
@@ -80,6 +81,8 @@ func (t *TabContainer) CurrentTab() *TabItem {
 func (t *TabContainer) SelectTabIndex(index int) {
 	if index < 0 || index >= len(t.Items) {
 		return
+	} else if t.current == index {
+		return
 	}
 
 	t.current = index
@@ -95,6 +98,11 @@ func (t *TabContainer) SelectTabIndex(index int) {
 	r := cache.Renderer(t).(*tabContainerRenderer)
 	r.Layout(t.size)
 	t.Refresh()
+
+	callback := t.OnTabSelected
+	if callback != nil {
+		callback(t.Items[t.current])
+	}
 }
 
 // CurrentTabIndex returns the index of the currently selected TabItem.

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -97,8 +97,8 @@ func (t *TabContainer) SelectTabIndex(index int) {
 	r.Layout(t.size)
 	t.Refresh()
 
-	if callback := t.OnChanged; callback != nil {
-		callback(t.Items[t.current])
+	if t.OnChanged != nil {
+		t.OnChanged(t.Items[t.current])
 	}
 }
 

--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -46,10 +46,10 @@ const (
 type TabContainer struct {
 	BaseWidget
 
-	Items         []*TabItem
-	OnTabSelected func(tab *TabItem)
-	current       int
-	tabLocation   TabLocation
+	Items       []*TabItem
+	OnChanged   func(tab *TabItem)
+	current     int
+	tabLocation TabLocation
 }
 
 // Show this widget, if it was previously hidden
@@ -79,9 +79,7 @@ func (t *TabContainer) CurrentTab() *TabItem {
 
 // SelectTabIndex sets the TabItem at the specific index to be selected and its content visible.
 func (t *TabContainer) SelectTabIndex(index int) {
-	if index < 0 || index >= len(t.Items) {
-		return
-	} else if t.current == index {
+	if index < 0 || index >= len(t.Items) || t.current == index {
 		return
 	}
 
@@ -99,8 +97,7 @@ func (t *TabContainer) SelectTabIndex(index int) {
 	r.Layout(t.size)
 	t.Refresh()
 
-	callback := t.OnTabSelected
-	if callback != nil {
+	if callback := t.OnChanged; callback != nil {
 		callback(t.Items[t.current])
 	}
 }

--- a/widget/tabcontainer_test.go
+++ b/widget/tabcontainer_test.go
@@ -54,7 +54,18 @@ func TestTabContainer_SelectTab(t *testing.T) {
 	assert.Equal(t, 2, len(tabs.Items))
 	assert.Equal(t, tab1, tabs.CurrentTab())
 
+	var selectedTab *TabItem
+	tabs.OnTabSelected = func(tab *TabItem) {
+		selectedTab = tab
+	}
 	tabs.SelectTab(tab2)
+	assert.Equal(t, tab2, tabs.CurrentTab())
+	assert.Equal(t, tab2, selectedTab)
+
+	tabs.OnTabSelected = func(tab *TabItem) {
+		assert.Fail(t, "unexpected tab selection")
+	}
+	tabs.SelectTab(NewTabItem("Test3", NewLabel("Test3")))
 	assert.Equal(t, tab2, tabs.CurrentTab())
 }
 
@@ -65,8 +76,13 @@ func TestTabContainer_SelectTabIndex(t *testing.T) {
 	assert.Equal(t, 2, len(tabs.Items))
 	assert.Equal(t, 0, tabs.CurrentTabIndex())
 
+	var selectedTab *TabItem
+	tabs.OnTabSelected = func(tab *TabItem) {
+		selectedTab = tab
+	}
 	tabs.SelectTabIndex(1)
 	assert.Equal(t, 1, tabs.CurrentTabIndex())
+	assert.Equal(t, tabs.Items[1], selectedTab)
 }
 
 func TestTabItem_Content(t *testing.T) {

--- a/widget/tabcontainer_test.go
+++ b/widget/tabcontainer_test.go
@@ -55,14 +55,14 @@ func TestTabContainer_SelectTab(t *testing.T) {
 	assert.Equal(t, tab1, tabs.CurrentTab())
 
 	var selectedTab *TabItem
-	tabs.OnTabSelected = func(tab *TabItem) {
+	tabs.OnChanged = func(tab *TabItem) {
 		selectedTab = tab
 	}
 	tabs.SelectTab(tab2)
 	assert.Equal(t, tab2, tabs.CurrentTab())
 	assert.Equal(t, tab2, selectedTab)
 
-	tabs.OnTabSelected = func(tab *TabItem) {
+	tabs.OnChanged = func(tab *TabItem) {
 		assert.Fail(t, "unexpected tab selection")
 	}
 	tabs.SelectTab(NewTabItem("Test3", NewLabel("Test3")))
@@ -77,7 +77,7 @@ func TestTabContainer_SelectTabIndex(t *testing.T) {
 	assert.Equal(t, 0, tabs.CurrentTabIndex())
 
 	var selectedTab *TabItem
-	tabs.OnTabSelected = func(tab *TabItem) {
+	tabs.OnChanged = func(tab *TabItem) {
 		selectedTab = tab
 	}
 	tabs.SelectTabIndex(1)


### PR DESCRIPTION
### Description:
Add `OnTabSelected` to TabContainer widget. Also removed unnecessary computations if tab already selected.

My primary use-case was to update data from external source and avoid background polling. I think it would be useful for others as well.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
