### PR TITLE
Fix for text widgets not correctly aligning or showing

### DIFF
--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -43,6 +43,13 @@ func (hl *Hyperlink) Cursor() desktop.Cursor {
 	return desktop.PointerCursor
 }
 
+// Resize sets a new size for the hyperlink.
+// Note this should not be used if the widget is being managed by a Layout within a Container.
+func (hl *Hyperlink) Resize(size fyne.Size) {
+	hl.BaseWidget.Resize(size)
+	hl.provider.Resize(size)
+}
+
 // SetText sets the text of the hyperlink
 func (hl *Hyperlink) SetText(text string) {
 	hl.Text = text

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -39,6 +39,28 @@ func TestHyperlink_Alignment(t *testing.T) {
 	assert.Equal(t, fyne.TextAlignTrailing, textRenderTexts(hyperlink)[0].Alignment)
 }
 
+func TestHyperlink_Hide(t *testing.T) {
+	hyperlink := &Hyperlink{Text: "Test"}
+	hyperlink.Hide()
+	hyperlink.Refresh()
+
+	assert.True(t, hyperlink.Hidden)
+	assert.False(t, hyperlink.provider.Hidden) // we don't propagate hide
+
+	hyperlink.Show()
+	assert.False(t, hyperlink.Hidden)
+	assert.False(t, hyperlink.provider.Hidden)
+}
+
+func TestHyperlink_Resize(t *testing.T) {
+	hyperlink := &Hyperlink{Text: "Test"}
+	size := fyne.NewSize(100, 20)
+	hyperlink.Resize(size)
+
+	assert.Equal(t, size, hyperlink.Size())
+	assert.Equal(t, size, hyperlink.provider.Size())
+}
+
 func TestHyperlink_SetText(t *testing.T) {
 	u, err := url.Parse("https://fyne.io/")
 	assert.Nil(t, err)

--- a/widget/label.go
+++ b/widget/label.go
@@ -89,7 +89,6 @@ func (l *Label) object() fyne.Widget {
 func (l *Label) CreateRenderer() fyne.WidgetRenderer {
 	l.ExtendBaseWidget(l)
 	l.provider = newTextProvider(l.Text, l)
-	l.provider.Hidden = l.Hidden
 	return l.provider.CreateRenderer()
 }
 

--- a/widget/label.go
+++ b/widget/label.go
@@ -42,6 +42,13 @@ func (l *Label) Refresh() {
 	l.BaseWidget.Refresh()
 }
 
+// Resize sets a new size for the label.
+// Note this should not be used if the widget is being managed by a Layout within a Container.
+func (l *Label) Resize(size fyne.Size) {
+	l.BaseWidget.Resize(size)
+	l.provider.Resize(size)
+}
+
 // SetText sets the text of the label
 func (l *Label) SetText(text string) {
 	l.Text = text

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLabel_Hide(t *testing.T) {
+	label := NewLabel("Test")
+	label.Hide()
+	label.Refresh()
+
+	assert.True(t, label.Hidden)
+	assert.False(t, label.provider.Hidden) // we don't propagate hide
+
+	label.Show()
+	assert.False(t, label.Hidden)
+	assert.False(t, label.provider.Hidden)
+}
+
 func TestLabel_MinSize(t *testing.T) {
 	label := NewLabel("Test")
 	min := label.MinSize()
@@ -18,6 +31,19 @@ func TestLabel_MinSize(t *testing.T) {
 
 	label.SetText("Longer")
 	assert.True(t, label.MinSize().Width > min.Width)
+}
+
+func TestLabel_Resize(t *testing.T) {
+	label := NewLabel("Test")
+	size := fyne.NewSize(100, 20)
+	label.Resize(size)
+
+	assert.Equal(t, size, label.Size())
+	assert.Equal(t, size, label.provider.Size())
+
+	label.SetText("Longer")
+	assert.Equal(t, size, label.Size())
+	assert.Equal(t, size, label.provider.Size())
 }
 
 func TestLabel_Text(t *testing.T) {

--- a/widget/text.go
+++ b/widget/text.go
@@ -300,7 +300,6 @@ func (r *textRenderer) Refresh() {
 
 		textCanvas.Alignment = r.provider.presenter.textAlign()
 		textCanvas.TextStyle = r.provider.presenter.textStyle()
-		textCanvas.Hidden = r.provider.Hidden
 
 		if add {
 			r.texts = append(r.texts, textCanvas)


### PR DESCRIPTION
### Description:
Two different text fixes - first (alignment) was to resize text provider.
Second was to stop cascading Hidden flag - the driver does this now

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
