### PR TITLE
Fix Typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ Steps to reproduce the behaviour:
 
 
 ### Example code:
-<!-- If applicable, add a short code snippet to help exaplain and simplify reproduction of the problem. -->
+<!-- If applicable, add a short code snippet to help explain and simplify reproduction of the problem. -->
 <!-- Please write the code inside a code block with go syntax, like this:
 ```go
 Write your code here.


### PR DESCRIPTION
### Description:
Removes an extra 'a' from Github issue template.

Fixes #855

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
