### PR TITLE
Fix error of backspace keydown to MultiLineEntry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -388,7 +388,7 @@ func (e *Entry) rowColFromTextPos(pos int) (row int, col int) {
 	provider := e.textProvider()
 	for i := 0; i < provider.rows(); i++ {
 		b := provider.rowBoundary(i)
-		if b[0] < pos {
+		if b[0] <= pos {
 			if b[1] < pos {
 				row++
 			}

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -258,6 +258,27 @@ func TestEntry_OnKeyDown_BackspaceNewline(t *testing.T) {
 	assert.Equal(t, "Hi", entry.Text)
 }
 
+func TestEntry_OnKeyDown_BackspaceBeyondTextAndNewLine(t *testing.T) {
+	entry := NewMultiLineEntry()
+	entry.SetText("H\ni")
+
+	down := &fyne.KeyEvent{Name: fyne.KeyDown}
+	entry.TypedKey(down)
+	right := &fyne.KeyEvent{Name: fyne.KeyRight}
+	entry.TypedKey(right)
+
+	key := &fyne.KeyEvent{Name: fyne.KeyBackspace}
+	entry.TypedKey(key)
+
+	assert.Equal(t, 1, entry.CursorRow)
+	assert.Equal(t, 0, entry.CursorColumn)
+	entry.TypedKey(key)
+
+	assert.Equal(t, 0, entry.CursorRow)
+	assert.Equal(t, 1, entry.CursorColumn)
+	assert.Equal(t, "H", entry.Text)
+}
+
 func TestEntry_OnKeyDown_Backspace_Unicode(t *testing.T) {
 	entry := NewEntry()
 


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Pressing the backspace key several times in MultiLineEntry may cause panic.

For example, press BS twice in the following situation:
```
aaa
b|
```
When the cursor is at the beginning of a line, the value of row/col is wrong.
The calculation of the boundaries modified by #712 seemed to be little wrong, so I fixed it.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
