### PR TITLE
Refactoring/menu prerequisites

### DIFF
--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -448,8 +448,8 @@ func TestEntry_TappedSecondary(t *testing.T) {
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
 	cont := over.(*PopUp).Content
-	assert.Equal(t, pos.X+theme.Padding()+tapPos.X, cont.Position().X)
-	assert.Equal(t, pos.Y+theme.Padding()+tapPos.Y, cont.Position().Y)
+	assert.Equal(t, pos.X+tapPos.X, cont.Position().X)
+	assert.Equal(t, pos.Y+tapPos.Y, cont.Position().Y)
 
 	items := cont.(*Box).Children
 	assert.Equal(t, 4, len(items)) // Cut, Copy, Paste, Select All

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -17,7 +17,7 @@ func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *
 		if item.IsSeparator {
 			options.Append(newSeparator())
 		} else {
-			options.Append(newMenuItemWidget(item.Label, item.Action))
+			options.Append(newMenuItemWidget(item))
 		}
 	}
 	pop := newPopUp(options, c)
@@ -45,21 +45,21 @@ func NewPopUpMenu(menu *fyne.Menu, c fyne.Canvas) *PopUp {
 
 type menuItemWidget struct {
 	BaseWidget
-	Action        func()
 	DismissAction func()
-	Label         string
-	hovered       bool
+	Item          *fyne.MenuItem
+
+	hovered bool
 }
 
 func (t *menuItemWidget) Tapped(*fyne.PointEvent) {
-	t.Action()
+	t.Item.Action()
 	if t.DismissAction != nil {
 		t.DismissAction()
 	}
 }
 
 func (t *menuItemWidget) CreateRenderer() fyne.WidgetRenderer {
-	text := canvas.NewText(t.Label, theme.TextColor())
+	text := canvas.NewText(t.Item.Label, theme.TextColor())
 	return &menuItemWidgetRenderer{baseRenderer{[]fyne.CanvasObject{text}}, text, t}
 }
 
@@ -79,8 +79,8 @@ func (t *menuItemWidget) MouseOut() {
 func (t *menuItemWidget) MouseMoved(*desktop.MouseEvent) {
 }
 
-func newMenuItemWidget(label string, action func()) *menuItemWidget {
-	ret := &menuItemWidget{Label: label, Action: action}
+func newMenuItemWidget(item *fyne.MenuItem) *menuItemWidget {
+	ret := &menuItemWidget{Item: item}
 	ret.ExtendBaseWidget(ret)
 	return ret
 }

--- a/widget/menu_test.go
+++ b/widget/menu_test.go
@@ -1,10 +1,14 @@
 package widget
 
 import (
+	"image/color"
 	"testing"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/test"
+	"fyne.io/fyne/theme"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,4 +22,27 @@ func TestNewPopUpMenu(t *testing.T) {
 
 	pop.Hide()
 	assert.Equal(t, 0, len(c.Overlays().List()))
+}
+
+func TestPopUpMenu_Size(t *testing.T) {
+	win := test.NewWindow(NewLabel("OK"))
+	defer win.Close()
+	win.Resize(fyne.NewSize(100, 100))
+	menu := fyne.NewMenu("Foo",
+		fyne.NewMenuItem("A", func() {}),
+		fyne.NewMenuItem("A", func() {}),
+	)
+	menuItemSize := canvas.NewText("A", color.Black).MinSize().Add(fyne.NewSize(theme.Padding()*4, theme.Padding()*2))
+	expectedSize := menuItemSize.Add(fyne.NewSize(0, menuItemSize.Height)).Add(fyne.NewSize(0, theme.Padding()))
+	c := win.Canvas()
+
+	pop := NewPopUpMenu(menu, c)
+	defer pop.Hide()
+	assert.Equal(t, expectedSize, pop.Content.Size())
+
+	for _, o := range test.LaidOutObjects(pop) {
+		if s, ok := o.(*shadow); ok {
+			assert.Equal(t, expectedSize, s.Size(), "infer pop-up’s inner size from shadow’s size")
+		}
+	}
 }

--- a/widget/select_entry_test.go
+++ b/widget/select_entry_test.go
@@ -101,7 +101,7 @@ func TestSelectEntry_DropDown(t *testing.T) {
 
 	popUp := c.Overlays().Top().(*widget.PopUp)
 	entryMinWidth := dropDownIconWidth() + emptyTextWidth() + 4*theme.Padding()
-	assert.Equal(t, optionsMinSize(options).Union(fyne.NewSize(entryMinWidth-2*theme.Padding(), 0)).Add(fyne.NewSize(0, 2*theme.Padding())), popUp.Content.Size())
+	assert.Equal(t, optionsMinSize(options).Max(fyne.NewSize(entryMinWidth, 0)).Add(fyne.NewSize(0, 2*theme.Padding())), popUp.Content.Size())
 	assert.Equal(t, options, popUpOptions(popUp), "drop down menu texts don't match SelectEntry options")
 
 	tapPopUpItem(popUp, 1)

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -5,7 +5,6 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/test"
-	"fyne.io/fyne/theme"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -151,8 +150,8 @@ func TestSelect_Tapped(t *testing.T) {
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(over)
 
 	cont := over.(*PopUp).Content
-	assert.Equal(t, cont.Position().X, pos.X+theme.Padding())
-	assert.True(t, cont.Position().Y > pos.Y)
+	assert.Equal(t, cont.Position().X, pos.X)
+	assert.Equal(t, cont.Position().Y, pos.Y)
 
 	items := cont.(*Box).Children
 	assert.Equal(t, 2, len(items))


### PR DESCRIPTION
### Description:

The next prerequisite PR for the upcoming menu change. We get closer!
In this PR the `menuItemWidget` no longer embeds `Label` and handles the dismiss action separately from the menu's action. It also knows about the `fyne.MenuItem`.

In addition the padding in pop-up's is optional now.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
