### PR TITLE
Fix to update tab names during refresh if the data changes

### DIFF
--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -347,8 +347,10 @@ func (t *tabContainerRenderer) Refresh() {
 	t.line.Refresh()
 
 	for i, child := range t.container.Items {
-		old := t.objects[i]
+		tab := t.tabBar.Objects[i].(*tabButton)
+		tab.setText(child.Text)
 
+		old := t.objects[i]
 		if old == child.Content {
 			continue
 		}
@@ -401,6 +403,15 @@ type tabButton struct {
 func (b *tabButton) MinSize() fyne.Size {
 	b.ExtendBaseWidget(b)
 	return b.BaseWidget.MinSize()
+}
+
+func (b *tabButton) setText(text string) {
+	if text == b.Text {
+		return
+	}
+
+	b.Text = text
+	b.Refresh()
 }
 
 func (b *tabButton) CreateRenderer() fyne.WidgetRenderer {
@@ -529,6 +540,7 @@ func (r *tabButtonRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (r *tabButtonRenderer) Refresh() {
+	r.label.Text = r.button.Text
 	r.label.Color = theme.TextColor()
 	r.label.TextSize = theme.TextSize()
 

--- a/widget/tabcontainer_test.go
+++ b/widget/tabcontainer_test.go
@@ -467,3 +467,20 @@ func TestTabButtonRenderer_ApplyTheme(t *testing.T) {
 
 	assert.NotEqual(t, textSize, customTextSize)
 }
+
+func Test_tabButtonRenderer_SetText(t *testing.T) {
+	item := &TabItem{Text: "Test", Content: NewLabel("Content")}
+	tabs := NewTabContainer(item)
+	tabRenderer := test.WidgetRenderer(tabs).(*tabContainerRenderer)
+	tabButton := tabRenderer.tabBar.Objects[0].(*tabButton)
+	renderer := test.WidgetRenderer(tabButton).(*tabButtonRenderer)
+
+	assert.Equal(t, "Test", renderer.label.Text)
+
+	tabButton.setText("Temp")
+	assert.Equal(t, "Temp", renderer.label.Text)
+
+	item.Text = "Replace"
+	tabs.Refresh()
+	assert.Equal(t, "Replace", renderer.label.Text)
+}


### PR DESCRIPTION
### Description:
Tabs currently do not change their text after initial draw. 
This should be fixed on Refresh() if the data has changed.

Fixes #870 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
