### PR TITLE
Add to the package heading explaining the nature of the canvas types.

### DIFF
--- a/canvas/base.go
+++ b/canvas/base.go
@@ -1,4 +1,10 @@
 // Package canvas contains all of the primitive CanvasObjects that make up a Fyne GUI
+//
+// The types implemented in this package are used as building blocks in order
+// to build higher order functionality. These types are designed to be
+// non-interactive, by design. If additional functonality is required,
+// it's usually a sign that this type should be used as part of a custom
+// Widget.
 package canvas // import "fyne.io/fyne/canvas"
 
 import "fyne.io/fyne"


### PR DESCRIPTION
This is hopefully the first of a few of these, I'd like to add a bit more documentation in a few places, but the first is to leave a note that would have short circuit a few hours of time.

This change adds a note to the package overview leaving a breadcrumb for
attentive readers of the documentation to look to Widgets when attempting
to extend functionality.