### PR TITLE
Update baseline DPI to 120 for autodetecting systems

### DIFF
--- a/internal/driver/glfw/scale.go
+++ b/internal/driver/glfw/scale.go
@@ -1,0 +1,61 @@
+package glfw
+
+import (
+	"math"
+	"os"
+	"strconv"
+
+	"fyne.io/fyne"
+)
+
+const (
+	baselineDPI = 120.0
+	scaleEnvKey = "FYNE_SCALE"
+)
+
+func calculateDetectedScale(widthMm, widthPx int) float32 {
+	dpi := float32(widthPx) / (float32(widthMm) / 25.4)
+	if dpi > 1000 || dpi < 10 {
+		dpi = baselineDPI
+	}
+
+	scale := float32(float64(dpi) / baselineDPI)
+	if scale < 1.0 {
+		return 1.0
+	}
+	return scale
+}
+
+func calculateScale(user, system, detected float32) float32 {
+	if user == fyne.SettingsScaleAuto {
+		user = 1.0
+	}
+
+	if system == fyne.SettingsScaleAuto {
+		system = detected
+	}
+
+	raw := system * user
+	return float32(math.Round(float64(raw*10.0))) / 10.0
+}
+
+func userScale() float32 {
+	env := os.Getenv(scaleEnvKey)
+
+	if env != "" && env != "auto" {
+		scale, err := strconv.ParseFloat(env, 32)
+		if err == nil && scale != 0 {
+			return float32(scale)
+		}
+		fyne.LogError("Error reading scale", err)
+	}
+
+	if env != "auto" {
+		setting := fyne.CurrentApp().Settings().Scale()
+		if setting != fyne.SettingsScaleAuto && setting != 0.0 {
+			return setting
+		}
+	}
+
+	return 1.0 // user preference for auto is now passed as 1 so the system auto is picked up
+}

--- a/internal/driver/glfw/scale_test.go
+++ b/internal/driver/glfw/scale_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"fyne.io/fyne"
+	_ "fyne.io/fyne/test"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/driver/glfw/scale_test.go
+++ b/internal/driver/glfw/scale_test.go
@@ -1,3 +1,5 @@
+// +build !ci,!windows
+
 package glfw
 
 import (

--- a/internal/driver/glfw/scale_test.go
+++ b/internal/driver/glfw/scale_test.go
@@ -1,0 +1,72 @@
+package glfw
+
+import (
+	"os"
+	"testing"
+
+	"fyne.io/fyne"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateDetectedScale(t *testing.T) {
+	lowDPI := calculateDetectedScale(300, 1600)
+	assert.Equal(t, float32(1.1288888), lowDPI)
+
+	hiDPI := calculateDetectedScale(420, 3800)
+	assert.Equal(t, float32(1.9150794), hiDPI)
+}
+
+func TestCalculateDetectedScale_Min(t *testing.T) {
+	lowDPI := calculateDetectedScale(300, 1280)
+	assert.Equal(t, float32(1), lowDPI)
+}
+
+func TestCalculateScale(t *testing.T) {
+	one := calculateScale(1.0, 1.0, 1.0)
+	assert.Equal(t, float32(1.0), one)
+
+	larger := calculateScale(1.5, 1.0, 1.0)
+	assert.Equal(t, float32(1.5), larger)
+
+	smaller := calculateScale(0.8, 1.0, 1.0)
+	assert.Equal(t, float32(0.8), smaller)
+
+	auto := calculateScale(fyne.SettingsScaleAuto, fyne.SettingsScaleAuto, 1.1)
+	assert.Equal(t, float32(1.1), auto)
+
+	autoUser := calculateScale(fyne.SettingsScaleAuto, 1.0, 1.1)
+	assert.Equal(t, float32(1.0), autoUser)
+
+	hiDPI := calculateScale(0.8, 2.0, 1.0)
+	assert.Equal(t, float32(1.6), hiDPI)
+
+	hiDPIAuto := calculateScale(0.8, fyne.SettingsScaleAuto, 2.0)
+	assert.Equal(t, float32(1.6), hiDPIAuto)
+
+	large := calculateScale(1.5, 2.0, 2.0)
+	assert.Equal(t, float32(3.0), large)
+}
+
+func TestCalculateScale_Round(t *testing.T) {
+	trunc := calculateScale(1.04321, 1.0, 1.0)
+	assert.Equal(t, float32(1.0), trunc)
+
+	round := calculateScale(1.1, 1.1, 1.0)
+	assert.Equal(t, float32(1.2), round)
+}
+
+func TestUserScale(t *testing.T) {
+	envVal := os.Getenv(scaleEnvKey)
+	defer os.Setenv(scaleEnvKey, envVal)
+
+	_ = os.Setenv(scaleEnvKey, "auto")
+	set := fyne.CurrentApp().Settings().Scale()
+	if set == float32(0.0) { // no config set
+		assert.Equal(t, float32(1.0), userScale())
+	} else {
+		assert.Equal(t, set, userScale())
+	}
+
+	_ = os.Setenv(scaleEnvKey, "1.2")
+	assert.Equal(t, float32(1.2), userScale())
+}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -5,10 +5,7 @@ import (
 	"bytes"
 	"image"
 	_ "image/png" // for the icon
-	"math"
-	"os"
 	"runtime"
-	"strconv"
 	"sync"
 	"time"
 
@@ -296,43 +293,8 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 	return monitor
 }
 
-func (w *window) userScale() float32 {
-	env := os.Getenv("FYNE_SCALE")
-
-	if env != "" && env != "auto" {
-		scale, err := strconv.ParseFloat(env, 32)
-		if err == nil && scale != 0 {
-			return float32(scale)
-		}
-		fyne.LogError("Error reading scale", err)
-	}
-
-	if env != "auto" {
-		setting := fyne.CurrentApp().Settings().Scale()
-		if setting != fyne.SettingsScaleAuto && setting != 0.0 {
-			return setting
-		}
-	}
-
-	return 1.0 // user preference for auto is now passed as 1 so the system auto is picked up
-}
-
-func calculateScale(user, system, detected float32) float32 {
-	if user == fyne.SettingsScaleAuto {
-		user = 1.0
-	}
-
-	if system == fyne.SettingsScaleAuto {
-		system = detected
-	}
-
-	return system * user
-}
 func (w *window) calculatedScale() float32 {
-	val := calculateScale(w.userScale(), fyne.CurrentDevice().SystemScaleForWindow(w), w.detectScale())
-	val = float32(math.Round(float64(val*10.0))) / 10.0
-
-	return val
+	return calculateScale(userScale(), fyne.CurrentDevice().SystemScaleForWindow(w), w.detectScale())
 }
 
 func (w *window) detectScale() float32 {
@@ -340,12 +302,7 @@ func (w *window) detectScale() float32 {
 	widthMm, _ := monitor.GetPhysicalSize()
 	widthPx := monitor.GetVideoMode().Width
 
-	dpi := float32(widthPx) / (float32(widthMm) / 25.4)
-	if dpi > 1000 || dpi < 10 {
-		dpi = 96
-	}
-
-	return float32(float64(dpi) / 96.0)
+	return calculateDetectedScale(widthMm, widthPx)
 }
 
 func (w *window) Show() {


### PR DESCRIPTION
### Description:
Update the baseline DPI from 96 to 120 for Linux, as discussed in #862.
Also refactor out the scale handling to a separate file that is well tested

Fixes #862

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Any breaking changes have a deprecation path or have been discussed.
