### PR TITLE
Rename FixedGridLayout to GridWrapLayout

### DIFF
--- a/cmd/fyne_demo/screens/graphics.go
+++ b/cmd/fyne_demo/screens/graphics.go
@@ -31,7 +31,7 @@ func GraphicsScreen() fyne.CanvasObject {
 			canvas.Refresh(gradient)
 		}
 	}()
-	content := fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(90, 90)),
+	content := fyne.NewContainerWithLayout(layout.NewGridWrapLayout(fyne.NewSize(90, 90)),
 		&canvas.Rectangle{FillColor: color.RGBA{0x80, 0, 0, 0xff},
 			StrokeColor: color.RGBA{0xff, 0xff, 0xff, 0xff},
 			StrokeWidth: 1},

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -106,7 +106,7 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 	footer := fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, nil, buttons),
 		buttons, f.fileName)
 
-	f.files = fyne.NewContainerWithLayout(layout.NewFixedGridLayout(fyne.NewSize(fileIconCellWidth,
+	f.files = fyne.NewContainerWithLayout(layout.NewGridWrapLayout(fyne.NewSize(fileIconCellWidth,
 		fileIconSize+theme.Padding()+fileTextSize)),
 	)
 	f.fileScroll = widget.NewScrollContainer(f.files)

--- a/layout/fixedgridlayout.go
+++ b/layout/fixedgridlayout.go
@@ -1,63 +1,11 @@
 package layout
 
 import (
-	"math"
-
 	"fyne.io/fyne"
-	"fyne.io/fyne/theme"
 )
 
-// Declare conformity with Layout interface
-var _ fyne.Layout = (*fixedGridLayout)(nil)
-
-type fixedGridLayout struct {
-	CellSize fyne.Size
-	colCount int
-	rowCount int
-}
-
-// Layout is called to pack all child objects into a specified size.
-// For a FixedGridLayout this will attempt to lay all the child objects in a row
-// and wrap to a new row if the size is not large enough.
-func (g *fixedGridLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	g.colCount = 1
-	g.rowCount = 1
-
-	if size.Width > g.CellSize.Width {
-		g.colCount = int(math.Floor(float64(size.Width+theme.Padding()) / float64(g.CellSize.Width+theme.Padding())))
-	}
-
-	x, y := 0, 0
-	for i, child := range objects {
-		if !child.Visible() {
-			continue
-		}
-
-		child.Move(fyne.NewPos(x, y))
-		child.Resize(g.CellSize)
-
-		if (i+1)%g.colCount == 0 {
-			x = 0
-			y += g.CellSize.Height + theme.Padding()
-			if i > 0 {
-				g.rowCount++
-			}
-		} else {
-			x += g.CellSize.Width + theme.Padding()
-		}
-	}
-}
-
-// MinSize finds the smallest size that satisfies all the child objects.
-// For a FixedGridLayout this is simply the specified cellsize as a single column
-// layout has no padding. The returned size does not take into account the number
-// of columns as this layout re-flows dynamically.
-func (g *fixedGridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
-	return fyne.NewSize(g.CellSize.Width,
-		(g.CellSize.Height*g.rowCount)+((g.rowCount-1)*theme.Padding()))
-}
-
 // NewFixedGridLayout returns a new FixedGridLayout instance
+// Deprecated: use the replacement NewGridWrapLayout. This method will be removed in 2.0.
 func NewFixedGridLayout(size fyne.Size) fyne.Layout {
-	return &fixedGridLayout{size, 1, 1}
+	return NewGridWrapLayout(size)
 }

--- a/layout/gridwraplayout.go
+++ b/layout/gridwraplayout.go
@@ -1,0 +1,63 @@
+package layout
+
+import (
+	"math"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/theme"
+)
+
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*gridWrapLayout)(nil)
+
+type gridWrapLayout struct {
+	CellSize fyne.Size
+	colCount int
+	rowCount int
+}
+
+// Layout is called to pack all child objects into a specified size.
+// For a GridWrapLayout this will attempt to lay all the child objects in a row
+// and wrap to a new row if the size is not large enough.
+func (g *gridWrapLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	g.colCount = 1
+	g.rowCount = 1
+
+	if size.Width > g.CellSize.Width {
+		g.colCount = int(math.Floor(float64(size.Width+theme.Padding()) / float64(g.CellSize.Width+theme.Padding())))
+	}
+
+	x, y := 0, 0
+	for i, child := range objects {
+		if !child.Visible() {
+			continue
+		}
+
+		child.Move(fyne.NewPos(x, y))
+		child.Resize(g.CellSize)
+
+		if (i+1)%g.colCount == 0 {
+			x = 0
+			y += g.CellSize.Height + theme.Padding()
+			if i > 0 {
+				g.rowCount++
+			}
+		} else {
+			x += g.CellSize.Width + theme.Padding()
+		}
+	}
+}
+
+// MinSize finds the smallest size that satisfies all the child objects.
+// For a GridWrapLayout this is simply the specified cellsize as a single column
+// layout has no padding. The returned size does not take into account the number
+// of columns as this layout re-flows dynamically.
+func (g *gridWrapLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	return fyne.NewSize(g.CellSize.Width,
+		(g.CellSize.Height*g.rowCount)+((g.rowCount-1)*theme.Padding()))
+}
+
+// NewGridWrapLayout returns a new GridWrapLayout instance
+func NewGridWrapLayout(size fyne.Size) fyne.Layout {
+	return &gridWrapLayout{size, 1, 1}
+}

--- a/layout/gridwraplayout_test.go
+++ b/layout/gridwraplayout_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFixedGridLayout_Layout(t *testing.T) {
+func TestGridLWrapLayout_Layout(t *testing.T) {
 	gridSize := fyne.NewSize(125, 125)
 	cellSize := fyne.NewSize(50, 50)
 
@@ -25,7 +25,7 @@ func TestFixedGridLayout_Layout(t *testing.T) {
 	}
 	container.Resize(gridSize)
 
-	layout.NewFixedGridLayout(cellSize).Layout(container.Objects, gridSize)
+	layout.NewGridWrapLayout(cellSize).Layout(container.Objects, gridSize)
 
 	assert.Equal(t, obj1.Size(), cellSize)
 	cell2Pos := fyne.NewPos(50+theme.Padding(), 0)
@@ -34,7 +34,7 @@ func TestFixedGridLayout_Layout(t *testing.T) {
 	assert.Equal(t, obj3.Position(), cell3Pos)
 }
 
-func TestFixedGridLayout_Layout_Min(t *testing.T) {
+func TestGridLWrapLayout_Layout_Min(t *testing.T) {
 	cellSize := fyne.NewSize(50, 50)
 
 	obj1 := canvas.NewRectangle(color.RGBA{0, 0, 0, 0})
@@ -45,7 +45,7 @@ func TestFixedGridLayout_Layout_Min(t *testing.T) {
 		Objects: []fyne.CanvasObject{obj1, obj2, obj3},
 	}
 
-	layout.NewFixedGridLayout(cellSize).Layout(container.Objects, container.MinSize())
+	layout.NewGridWrapLayout(cellSize).Layout(container.Objects, container.MinSize())
 
 	assert.Equal(t, obj1.Size(), cellSize)
 	cell2Pos := fyne.NewPos(0, 50+theme.Padding())
@@ -54,7 +54,7 @@ func TestFixedGridLayout_Layout_Min(t *testing.T) {
 	assert.Equal(t, obj3.Position(), cell3Pos)
 }
 
-func TestFixedGridLayout_Layout_HiddenItem(t *testing.T) {
+func TestGridLWrapLayout_Layout_HiddenItem(t *testing.T) {
 	gridSize := fyne.NewSize(125, 125)
 	cellSize := fyne.NewSize(50, 50)
 
@@ -68,19 +68,19 @@ func TestFixedGridLayout_Layout_HiddenItem(t *testing.T) {
 	}
 	container.Resize(gridSize)
 
-	layout.NewFixedGridLayout(cellSize).Layout(container.Objects, gridSize)
+	layout.NewGridWrapLayout(cellSize).Layout(container.Objects, gridSize)
 
 	assert.Equal(t, obj1.Size(), cellSize)
 	cell3Pos := fyne.NewPos(50+theme.Padding(), 0)
 	assert.Equal(t, obj3.Position(), cell3Pos)
 }
 
-func TestFixedGridLayout_MinSize(t *testing.T) {
+func TestGridLWrapLayout_MinSize(t *testing.T) {
 	cellSize := fyne.NewSize(50, 50)
 	minSize := cellSize
 
 	container := fyne.NewContainer(canvas.NewRectangle(color.RGBA{0, 0, 0, 0}))
-	layout := layout.NewFixedGridLayout(cellSize)
+	layout := layout.NewGridWrapLayout(cellSize)
 
 	layoutMin := layout.MinSize(container.Objects)
 	assert.Equal(t, minSize, layoutMin)
@@ -91,12 +91,12 @@ func TestFixedGridLayout_MinSize(t *testing.T) {
 	assert.Equal(t, minSize, layoutMin)
 }
 
-func TestFixedGridLayout_Resize_LessThanMinSize(t *testing.T) {
+func TestGridLWrapLayout_Resize_LessThanMinSize(t *testing.T) {
 	cellSize := fyne.NewSize(50, 50)
 	minSize := cellSize
 
 	container := fyne.NewContainer(canvas.NewRectangle(color.RGBA{0, 0, 0, 0}))
-	l := layout.NewFixedGridLayout(cellSize)
+	l := layout.NewGridWrapLayout(cellSize)
 	container.Resize(fyne.NewSize(25, 25))
 
 	layoutMin := l.MinSize(container.Objects)


### PR DESCRIPTION
### Description:
Rename layout, leave in, but deprecate, the old NewFixedGridLayout constructor.

Fixes #836

### Checklist:

- [x] Tests included. <- same tests as before
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Any breaking changes have a deprecation path or have been discussed.
