### PR TITLE
Improve thread safety of all test utilities and the singleton CurretApp

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,6 +1,9 @@
 package fyne
 
-import "net/url"
+import (
+	"net/url"
+	"sync"
+)
 
 // An App is the definition of a graphical application.
 // Apps can have multiple windows, it will exit when the first window to be
@@ -54,13 +57,20 @@ type App interface {
 }
 
 var app App
+var appLock sync.RWMutex
 
 // SetCurrentApp is an internal function to set the app instance currently running.
 func SetCurrentApp(current App) {
+	appLock.Lock()
+	defer appLock.Unlock()
+
 	app = current
 }
 
 // CurrentApp returns the current application, for which there is only 1 per process.
 func CurrentApp() App {
+	appLock.RLock()
+	defer appLock.RUnlock()
+
 	return app
 }

--- a/app/settings.go
+++ b/app/settings.go
@@ -26,7 +26,7 @@ func (sc *SettingsSchema) StoragePath() string {
 var _ fyne.Settings = (*settings)(nil)
 
 type settings struct {
-	themeLock      sync.RWMutex
+	propertyLock   sync.RWMutex
 	theme          fyne.Theme
 	themeSpecified bool
 
@@ -38,8 +38,8 @@ type settings struct {
 }
 
 func (s *settings) Theme() fyne.Theme {
-	s.themeLock.RLock()
-	defer s.themeLock.RUnlock()
+	s.propertyLock.RLock()
+	defer s.propertyLock.RUnlock()
 	return s.theme
 }
 
@@ -49,15 +49,15 @@ func (s *settings) SetTheme(theme fyne.Theme) {
 }
 
 func (s *settings) applyTheme(theme fyne.Theme) {
-	s.themeLock.Lock()
-	defer s.themeLock.Unlock()
+	s.propertyLock.Lock()
+	defer s.propertyLock.Unlock()
 	s.theme = theme
 	s.apply()
 }
 
 func (s *settings) Scale() float32 {
-	s.themeLock.RLock()
-	defer s.themeLock.RUnlock()
+	s.propertyLock.RLock()
+	defer s.propertyLock.RUnlock()
 	return s.schema.Scale
 }
 

--- a/canvas/base.go
+++ b/canvas/base.go
@@ -1,7 +1,11 @@
 // Package canvas contains all of the primitive CanvasObjects that make up a Fyne GUI
 package canvas // import "fyne.io/fyne/canvas"
 
-import "fyne.io/fyne"
+import (
+	"sync"
+
+	"fyne.io/fyne"
+)
 
 type baseObject struct {
 	size     fyne.Size     // The current size of the Rectangle
@@ -9,30 +13,47 @@ type baseObject struct {
 	Hidden   bool          // Is this object currently hidden
 
 	min fyne.Size // The minimum size this object can be
+
+	propertyLock sync.RWMutex
 }
 
 // CurrentSize returns the current size of this rectangle object
 func (r *baseObject) Size() fyne.Size {
+	r.propertyLock.RLock()
+	defer r.propertyLock.RUnlock()
+
 	return r.size
 }
 
 // Resize sets a new size for the rectangle object
 func (r *baseObject) Resize(size fyne.Size) {
+	r.propertyLock.Lock()
+	defer r.propertyLock.Unlock()
+
 	r.size = size
 }
 
 // CurrentPosition gets the current position of this rectangle object, relative to its parent / canvas
 func (r *baseObject) Position() fyne.Position {
+	r.propertyLock.RLock()
+	defer r.propertyLock.RUnlock()
+
 	return r.position
 }
 
 // Move the rectangle object to a new position, relative to its parent / canvas
 func (r *baseObject) Move(pos fyne.Position) {
+	r.propertyLock.Lock()
+	defer r.propertyLock.Unlock()
+
 	r.position = pos
 }
 
 // MinSize returns the specified minimum size, if set, or {1, 1} otherwise
 func (r *baseObject) MinSize() fyne.Size {
+	r.propertyLock.RLock()
+	defer r.propertyLock.RUnlock()
+
 	if r.min.Width == 0 && r.min.Height == 0 {
 		return fyne.NewSize(1, 1)
 	}
@@ -42,21 +63,33 @@ func (r *baseObject) MinSize() fyne.Size {
 
 // SetMinSize specifies the smallest size this object should be
 func (r *baseObject) SetMinSize(size fyne.Size) {
+	r.propertyLock.Lock()
+	defer r.propertyLock.Unlock()
+
 	r.min = size
 }
 
 // IsVisible returns true if this object is visible, false otherwise
 func (r *baseObject) Visible() bool {
+	r.propertyLock.RLock()
+	defer r.propertyLock.RUnlock()
+
 	return !r.Hidden
 }
 
 // Show will set this object to be visible
 func (r *baseObject) Show() {
+	r.propertyLock.Lock()
+	defer r.propertyLock.Unlock()
+
 	r.Hidden = false
 }
 
 // Hide will set this object to not be visible
 func (r *baseObject) Hide() {
+	r.propertyLock.Lock()
+	defer r.propertyLock.Unlock()
+
 	r.Hidden = true
 }
 

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -22,9 +22,10 @@ var canvases = make(map[fyne.CanvasObject]fyne.Canvas)
 var _ fyne.Driver = (*gLDriver)(nil)
 
 type gLDriver struct {
-	windows []fyne.Window
-	device  *glDevice
-	done    chan interface{}
+	windowLock sync.RWMutex
+	windows    []fyne.Window
+	device     *glDevice
+	done       chan interface{}
 }
 
 func (d *gLDriver) RenderedTextSize(text string, size int, style fyne.TextStyle) fyne.Size {
@@ -67,6 +68,18 @@ func (d *gLDriver) Run() {
 		panic("Run() or ShowAndRun() must be called from main goroutine")
 	}
 	d.runGL()
+}
+
+func (d *gLDriver) addWindow(w *window) {
+	d.windowLock.Lock()
+	defer d.windowLock.Unlock()
+	d.windows = append(d.windows, w)
+}
+
+func (d *gLDriver) windowList() []fyne.Window {
+	d.windowLock.RLock()
+	defer d.windowLock.RUnlock()
+	return d.windows
 }
 
 func goroutineID() int {

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -98,7 +98,7 @@ func (d *gLDriver) runGL() {
 			d.tryPollEvents()
 			newWindows := []fyne.Window{}
 			reassign := false
-			for _, win := range d.windows {
+			for _, win := range d.windowList() {
 				w := win.(*window)
 				if w.viewport == nil {
 					continue
@@ -123,7 +123,9 @@ func (d *gLDriver) runGL() {
 				d.repaintWindow(w)
 			}
 			if reassign {
+				d.windowLock.Lock()
 				d.windows = newWindows
+				d.windowLock.Unlock()
 			}
 		}
 	}

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -1,16 +1,24 @@
 package internal
 
-import "fyne.io/fyne"
+import (
+	"sync"
+
+	"fyne.io/fyne"
+)
 
 // OverlayStack implements fyne.OverlayStack
 type OverlayStack struct {
-	overlays []fyne.CanvasObject
+	overlays     []fyne.CanvasObject
+	propertyLock sync.RWMutex
 }
 
 var _ fyne.OverlayStack = (*OverlayStack)(nil)
 
 // Add satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Add(overlay fyne.CanvasObject) {
+	s.propertyLock.Lock()
+	defer s.propertyLock.Unlock()
+
 	if overlay == nil {
 		return
 	}
@@ -19,11 +27,17 @@ func (s *OverlayStack) Add(overlay fyne.CanvasObject) {
 
 // List satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) List() []fyne.CanvasObject {
+	s.propertyLock.RLock()
+	defer s.propertyLock.RUnlock()
+
 	return s.overlays
 }
 
 // Remove satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Remove(overlay fyne.CanvasObject) {
+	s.propertyLock.Lock()
+	defer s.propertyLock.Unlock()
+
 	for i, o := range s.overlays {
 		if o == overlay {
 			s.overlays = s.overlays[:i]
@@ -34,6 +48,9 @@ func (s *OverlayStack) Remove(overlay fyne.CanvasObject) {
 
 // Top satisfies the fyne.OverlayStack interface.
 func (s *OverlayStack) Top() fyne.CanvasObject {
+	s.propertyLock.RLock()
+	defer s.propertyLock.RUnlock()
+
 	if len(s.overlays) == 0 {
 		return nil
 	}

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -187,7 +187,7 @@ func (p *glPainter) glCreateBuffer(points []float32) Buffer {
 
 	texCoordAttrib := uint32(gl.GetAttribLocation(uint32(p.program), gl.Str("vertTexCoord\x00")))
 	gl.EnableVertexAttribArray(texCoordAttrib)
-	gl.VertexAttribPointer(texCoordAttrib, 2, gl.FLOAT, false, 5*4, gl.PtrOffset(3*4))
+	gl.VertexAttribPointer(texCoordAttrib, 2, gl.FLOAT, false, 5*4, gl.PtrOffset(12))
 
 	return Buffer(vbo)
 }

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -131,9 +131,8 @@ func (s *testSettings) AddChangeListener(listener chan fyne.Settings) {
 
 func (s *testSettings) SetTheme(theme fyne.Theme) {
 	s.propertyLock.Lock()
-	defer s.propertyLock.Unlock()
-
 	s.theme = theme
+	s.propertyLock.Unlock()
 
 	s.apply()
 }
@@ -156,7 +155,11 @@ func (s *testSettings) Scale() float32 {
 }
 
 func (s *testSettings) apply() {
-	for _, listener := range s.changeListeners {
+	s.propertyLock.RLock()
+	listeners := s.changeListeners
+	s.propertyLock.RUnlock()
+
+	for _, listener := range listeners {
 		listener <- s
 	}
 }

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -18,9 +18,10 @@ func init() {
 }
 
 type testApp struct {
-	driver   *testDriver
-	settings fyne.Settings
-	prefs    fyne.Preferences
+	driver       *testDriver
+	settings     fyne.Settings
+	prefs        fyne.Preferences
+	propertyLock sync.RWMutex
 
 	// user action variables
 	appliedTheme     fyne.Theme
@@ -61,6 +62,9 @@ func (a *testApp) Driver() fyne.Driver {
 }
 
 func (a *testApp) SendNotification(notify *fyne.Notification) {
+	a.propertyLock.Lock()
+	defer a.propertyLock.Unlock()
+
 	a.lastNotification = notify
 }
 
@@ -72,11 +76,24 @@ func (a *testApp) Preferences() fyne.Preferences {
 	return a.prefs
 }
 
+func (a *testApp) lastAppliedTheme() fyne.Theme {
+	a.propertyLock.Lock()
+	defer a.propertyLock.Unlock()
+
+	return a.appliedTheme
+}
+
+func (a *testApp) lastNotificationSent() *fyne.Notification {
+	a.propertyLock.Lock()
+	defer a.propertyLock.Unlock()
+
+	return a.lastNotification
+}
+
 // NewApp returns a new dummy app used for testing.
 // It loads a test driver which creates a virtual window in memory for testing.
 func NewApp() fyne.App {
 	settings := &testSettings{scale: 1.0}
-	settings.listenerMutex = &sync.Mutex{}
 	prefs := internal.NewInMemoryPreferences()
 	test := &testApp{settings: settings, prefs: prefs, driver: NewDriver().(*testDriver)}
 	fyne.SetCurrentApp(test)
@@ -88,7 +105,10 @@ func NewApp() fyne.App {
 			_ = <-listener
 			painter.SvgCacheReset()
 			app.ApplySettings(test.Settings(), test)
+
+			test.propertyLock.Lock()
 			test.appliedTheme = test.Settings().Theme()
+			test.propertyLock.Unlock()
 		}
 	}()
 
@@ -100,22 +120,28 @@ type testSettings struct {
 	scale float32
 
 	changeListeners []chan fyne.Settings
-	listenerMutex   *sync.Mutex
+	propertyLock    sync.RWMutex
 }
 
 func (s *testSettings) AddChangeListener(listener chan fyne.Settings) {
-	s.listenerMutex.Lock()
-	defer s.listenerMutex.Unlock()
+	s.propertyLock.Lock()
+	defer s.propertyLock.Unlock()
 	s.changeListeners = append(s.changeListeners, listener)
 }
 
 func (s *testSettings) SetTheme(theme fyne.Theme) {
+	s.propertyLock.Lock()
+	defer s.propertyLock.Unlock()
+
 	s.theme = theme
 
 	s.apply()
 }
 
 func (s *testSettings) Theme() fyne.Theme {
+	s.propertyLock.RLock()
+	defer s.propertyLock.RUnlock()
+
 	if s.theme == nil {
 		return theme.DarkTheme()
 	}
@@ -124,12 +150,12 @@ func (s *testSettings) Theme() fyne.Theme {
 }
 
 func (s *testSettings) Scale() float32 {
+	s.propertyLock.RLock()
+	defer s.propertyLock.RUnlock()
 	return s.scale
 }
 
 func (s *testSettings) apply() {
-	s.listenerMutex.Lock()
-	defer s.listenerMutex.Unlock()
 	for _, listener := range s.changeListeners {
 		listener <- s
 	}

--- a/test/util.go
+++ b/test/util.go
@@ -152,7 +152,7 @@ func ApplyTheme(t *testing.T, theme fyne.Theme) {
 	require.IsType(t, &testApp{}, fyne.CurrentApp())
 	a := fyne.CurrentApp().(*testApp)
 	a.Settings().SetTheme(theme)
-	for a.appliedTheme != a.Settings().Theme() {
+	for a.lastAppliedTheme() != theme {
 		time.Sleep(1 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
### Description:

This goes a long way to improving the ability to turn on race checking again.

- [x] Remove race conditions from test utilities

[[[ proposed moving these two to another PR - 210 race conditions in `widget` package
- [ ] Add utility to BaseWidget to provide safe property access
- [ ] Fix race conditions in our codebase :) (this one may not be 100% in this PR)

]]]

This is mostly attempting to address #506 

### Checklist:

- [x] Tests included. <- well, current tests with "-race" added
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.

Tracking packages in which "-race" passes

- [x] .
- [x] app
- [x] canvas
- [x] cmd
- [x] dialog
- [x] driver
- [x] internal
- [x] internal/driver
- [x] internal/painter
- [x] internal/widget
- [x] layout
- [x] test
- [x] theme
- [x] tools
- [ ] widget - for another PR?
