### PR TITLE
Fix scrolling of key names so they expand horizontally

### DIFF
--- a/widget/group.go
+++ b/widget/group.go
@@ -64,7 +64,7 @@ func NewGroup(title string, children ...fyne.CanvasObject) *Group {
 // This group will scroll when the available space is less than needed to display the items it contains.
 func NewGroupWithScroller(title string, children ...fyne.CanvasObject) *Group {
 	box := NewVBox(children...)
-	group := &Group{BaseWidget{}, title, box, NewScrollContainer(box)}
+	group := &Group{BaseWidget{}, title, box, NewVScrollContainer(box)}
 
 	Renderer(group).Layout(group.MinSize())
 	return group

--- a/widget/group_test.go
+++ b/widget/group_test.go
@@ -42,3 +42,15 @@ func TestGroup_Text(t *testing.T) {
 
 	assert.Equal(t, "World", test.WidgetRenderer(group).(*groupRenderer).label.Text)
 }
+
+func TestGroup_Scroll(t *testing.T) {
+	group := NewGroupWithScroller("Test",
+		NewLabel("A label"), NewLabel("Another item"))
+	group.Resize(group.MinSize())
+
+	scroll := group.content.(*ScrollContainer)
+	assert.Equal(t, scroll.Direction, ScrollVerticalOnly)
+	assert.Equal(t, group.MinSize().Width, scroll.Content.Size().Width)
+	totalHeight := test.WidgetRenderer(group).(*groupRenderer).label.MinSize().Height + scroll.Content.Size().Height
+	assert.Less(t, group.MinSize().Height, totalHeight)
+}


### PR DESCRIPTION
Advanced screen would scroll keys horizontally and vertically making it hard to read.
This makes it so they only scroll vertically and the grid expands horizontally to fit content.