### PR TITLE
Fiz/texscale

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -139,7 +139,9 @@ func (d *gLDriver) repaintWindow(w *window) {
 		updateGLContext(w)
 		canvas.paint(canvas.Size())
 
-		w.viewport.SwapBuffers()
+		if w.viewport != nil {
+			w.viewport.SwapBuffers()
+		}
 	})
 }
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -311,6 +311,12 @@ func (w *window) detectScale() float32 {
 	return calculateDetectedScale(widthMm, widthPx)
 }
 
+func (w *window) detectTextureScale() float32 {
+	winWidth, _ := w.viewport.GetSize()
+	texWidth, _ := w.viewport.GetFramebufferSize()
+	return float32(texWidth) / float32(winWidth)
+}
+
 func (w *window) Show() {
 	go w.doShow()
 }
@@ -476,6 +482,7 @@ func (w *window) frameSized(viewport *glfw.Window, width, height int) {
 	winWidth, _ := viewport.GetSize()
 	texScale := float32(width) / float32(winWidth) // This will be > 1.0 on a HiDPI screen
 	w.canvas.texScale = texScale
+	w.canvas.Refresh(w.canvas.content) // apply texture scale
 }
 
 func (w *window) refresh(viewport *glfw.Window) {
@@ -1148,9 +1155,9 @@ func (w *window) create() {
 
 		w.canvas.detectedScale = w.detectScale()
 		w.canvas.scale = w.calculatedScale()
-		winWidth, _ := win.GetSize()
-		texWidth, _ := win.GetFramebufferSize()
-		w.canvas.texScale = float32(texWidth) / float32(winWidth)
+		w.canvas.texScale = w.detectTextureScale()
+		// update window size now we have scaled detected
+		w.viewport.SetSize(w.screenSize(w.canvas.size))
 
 		for _, fn := range w.pending {
 			fn()


### PR DESCRIPTION
### Description:
Correctly apply textureScale as macOS windows are dragged around.
And fix a couple of niggles around scale init and window shutdown

### Checklist:

- [ ] Tests included.  <- visual inspection with lowDpi->Hi and HiDPI->Low
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
