### PR TITLE
Ensure renderers are up to date

### DIFF
--- a/widget/check.go
+++ b/widget/check.go
@@ -53,8 +53,17 @@ func (c *checkRenderer) applyTheme() {
 
 func (c *checkRenderer) Refresh() {
 	c.applyTheme()
-	c.label.Text = c.check.Text
+	c.updateLabel()
+	c.updateResource()
+	c.updateFocusIndicator()
+	canvas.Refresh(c.check.super())
+}
 
+func (c *checkRenderer) updateLabel() {
+	c.label.Text = c.check.Text
+}
+
+func (c *checkRenderer) updateResource() {
 	res := theme.CheckButtonIcon()
 	if c.check.Checked {
 		res = theme.CheckButtonCheckedIcon()
@@ -62,9 +71,10 @@ func (c *checkRenderer) Refresh() {
 	if c.check.Disabled() {
 		res = theme.NewDisabledResource(res)
 	}
-
 	c.icon.Resource = res
+}
 
+func (c *checkRenderer) updateFocusIndicator() {
 	if c.check.Disabled() {
 		c.focusIndicator.FillColor = theme.BackgroundColor()
 	} else if c.check.focused {
@@ -74,8 +84,6 @@ func (c *checkRenderer) Refresh() {
 	} else {
 		c.focusIndicator.FillColor = theme.BackgroundColor()
 	}
-
-	canvas.Refresh(c.check.super())
 }
 
 // Check widget has a text label and a checked (or unchecked) icon and triggers an event func when toggled
@@ -159,13 +167,18 @@ func (c *Check) CreateRenderer() fyne.WidgetRenderer {
 	text.Alignment = fyne.TextAlignLeading
 
 	focusIndicator := canvas.NewCircle(theme.BackgroundColor())
-	return &checkRenderer{
+	r := &checkRenderer{
 		widget.NewBaseRenderer([]fyne.CanvasObject{focusIndicator, icon, text}),
 		icon,
 		text,
 		focusIndicator,
 		c,
 	}
+	r.applyTheme()
+	r.updateLabel()
+	r.updateResource()
+	r.updateFocusIndicator()
+	return r
 }
 
 // NewCheck creates a new check widget with the set label and change handler

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -32,17 +32,20 @@ func (i *iconRenderer) BackgroundColor() color.Color {
 }
 
 func (i *iconRenderer) Refresh() {
-	i.SetObjects(nil)
+	i.updateObjects()
+	i.Layout(i.image.Size())
+	canvas.Refresh(i.image.super())
+}
 
+func (i *iconRenderer) updateObjects() {
+	var objects []fyne.CanvasObject
 	if i.image.Resource != nil {
+		// TODO this is recreated every time - perhaps cache as long as i.image.Resource doesn't change
 		raster := canvas.NewImageFromResource(i.image.Resource)
 		raster.FillMode = canvas.ImageFillContain
-
-		i.SetObjects([]fyne.CanvasObject{raster})
+		objects = append(objects, raster)
 	}
-	i.Layout(i.image.Size())
-
-	canvas.Refresh(i.image.super())
+	i.SetObjects(objects)
 }
 
 // Icon widget is a basic image component that load's its resource to match the theme.
@@ -67,7 +70,9 @@ func (i *Icon) MinSize() fyne.Size {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (i *Icon) CreateRenderer() fyne.WidgetRenderer {
 	i.ExtendBaseWidget(i)
-	return &iconRenderer{image: i}
+	r := &iconRenderer{image: i}
+	r.updateObjects()
+	return r
 }
 
 // NewIcon returns a new icon widget that displays a themed icon resource

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -102,7 +102,11 @@ func (r *radioRenderer) applyTheme() {
 func (r *radioRenderer) Refresh() {
 	r.applyTheme()
 	r.radio.removeDuplicateOptions()
+	r.updateItems()
+	canvas.Refresh(r.radio.super())
+}
 
+func (r *radioRenderer) updateItems() {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
 			option := r.radio.Options[i]
@@ -144,8 +148,6 @@ func (r *radioRenderer) Refresh() {
 			item.focusIndicator.FillColor = theme.BackgroundColor()
 		}
 	}
-
-	canvas.Refresh(r.radio.super())
 }
 
 // Radio widget has a list of text labels and radio check icons next to each.
@@ -264,7 +266,11 @@ func (r *Radio) CreateRenderer() fyne.WidgetRenderer {
 		items = append(items, &radioRenderItem{icon, text, focusIndicator})
 	}
 
-	return &radioRenderer{widget.NewBaseRenderer(objects), items, r}
+	rr := &radioRenderer{widget.NewBaseRenderer(objects), items, r}
+	rr.applyTheme()
+	r.removeDuplicateOptions()
+	rr.updateItems()
+	return rr
 }
 
 // SetSelected sets the radio option, it can be used to set a default option.

--- a/widget/select.go
+++ b/widget/select.go
@@ -58,6 +58,14 @@ func (s *selectRenderer) BackgroundColor() color.Color {
 }
 
 func (s *selectRenderer) Refresh() {
+	s.updateLabel()
+	s.updateIcon()
+
+	s.Layout(s.combo.Size())
+	canvas.Refresh(s.combo.super())
+}
+
+func (s *selectRenderer) updateLabel() {
 	s.label.Color = theme.TextColor()
 	s.label.TextSize = theme.TextSize()
 
@@ -70,15 +78,14 @@ func (s *selectRenderer) Refresh() {
 	} else {
 		s.label.Text = s.combo.Selected
 	}
+}
 
+func (s *selectRenderer) updateIcon() {
 	if false { // s.combo.down {
 		s.icon.Resource = theme.MenuDropUpIcon()
 	} else {
 		s.icon.Resource = theme.MenuDropDownIcon()
 	}
-
-	s.Layout(s.combo.Size())
-	canvas.Refresh(s.combo.super())
 }
 
 // Select widget has a list of options, with the current one shown, and triggers an event func when clicked
@@ -191,7 +198,10 @@ func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 	text.Alignment = fyne.TextAlignLeading
 
 	objects := []fyne.CanvasObject{text, icon}
-	return &selectRenderer{widget.NewShadowingRenderer(objects, widget.ButtonLevel), icon, text, s}
+	r := &selectRenderer{widget.NewShadowingRenderer(objects, widget.ButtonLevel), icon, text, s}
+	r.updateLabel()
+	r.updateIcon()
+	return r
 }
 
 // ClearSelected clears the current option of the select widget.  After


### PR DESCRIPTION
### Description:
Ensure renderers returned by CreateRenderer are up to date and ready to render.

Fixes #834

### Checklist:

- [ ] Tests included.
- [y] Lint and formatter run with no errors.
- [y] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
