### PR TITLE
Fix for application not having any focused windows on macOS

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -76,6 +76,24 @@ func (d *gLDriver) addWindow(w *window) {
 	d.windows = append(d.windows, w)
 }
 
+// a trivial implementation of "focus previous" - return to the most recently opened, or master if set.
+// This may not do the right thing if your app has 3 or more windows open, but it was agreed this was not much
+// of an issue, and the added complexity to track focus was not needed at this time.
+func (d *gLDriver) focusPreviousWindow() {
+	var chosen fyne.Window
+	for _, w := range d.windows {
+		chosen = w
+		if w.(*window).master {
+			break
+		}
+	}
+
+	if chosen == nil {
+		return
+	}
+	chosen.RequestFocus()
+}
+
 func (d *gLDriver) windowList() []fyne.Window {
 	d.windowLock.RLock()
 	defer d.windowLock.RUnlock()

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -431,7 +431,6 @@ func (w *window) closed(viewport *glfw.Window) {
 	if w.onClosed != nil {
 		w.queueEvent(w.onClosed)
 	}
-
 }
 
 // destroy this window and, if it's the last window quit the app
@@ -452,6 +451,8 @@ func (w *window) destroy(d *gLDriver) {
 
 	if w.master || len(d.windowList()) == 0 {
 		d.Quit()
+	} else if runtime.GOOS == "darwin" {
+		d.focusPreviousWindow()
 	}
 }
 


### PR DESCRIPTION
When closing go to master or most recently opened.
This does not add focus tracking - we agreed it might be too much work for the small benefit.

Fixes #226

### Checklist:

- [ ] Tests included. <- I could not think of a sensible way to test whether we asked GLFW for focus
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

Technically tests could be written if we intercept the focus request calls and stack them. But for such a small change a visual inspection (with master on and off) felt sufficient.