### PR TITLE
Android entry selection improvements

### DIFF
--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -330,6 +330,7 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 		c.dragging.DragEnd()
 
 		c.dragging = nil
+		return
 	}
 
 	duration := time.Since(c.lastTapDown[tapID])

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -313,7 +313,6 @@ func (c *mobileCanvas) tapMove(pos fyne.Position, tapID int,
 			return
 		}
 	}
-	objPos = pos.Subtract(c.dragging.(fyne.CanvasObject).Position())
 
 	ev := new(fyne.DragEvent)
 	ev.Position = objPos

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -165,7 +165,11 @@ func (e *Entry) DragEnd() {
 // It updates the selection accordingly.
 // Implements: fyne.Draggable
 func (e *Entry) Dragged(d *fyne.DragEvent) {
-	e.selecting = true
+	if !e.selecting {
+		e.selectRow, e.selectColumn = e.getRowCol(&d.PointEvent)
+
+		e.selecting = true
+	}
 	e.updateMousePointer(&d.PointEvent, false)
 }
 
@@ -338,6 +342,10 @@ func (e *Entry) SetText(text string) {
 // Tapped is called when this entry has been tapped so we should update the cursor position.
 // Implements: fyne.Tappable
 func (e *Entry) Tapped(ev *fyne.PointEvent) {
+	if fyne.CurrentDevice().IsMobile() && e.selecting {
+		e.selecting = false
+		return
+	}
 	e.updateMousePointer(ev, false)
 }
 
@@ -871,11 +879,7 @@ func (e *Entry) textWrap() fyne.TextWrap {
 	return e.Wrapping
 }
 
-func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
-	if !e.focused && !e.Disabled() {
-		e.FocusGained()
-	}
-
+func (e *Entry) getRowCol(ev *fyne.PointEvent) (int, int) {
 	rowHeight := e.textProvider().charMinSize().Height
 	row := int(math.Floor(float64(ev.Position.Y-theme.Padding()) / float64(rowHeight)))
 	col := 0
@@ -887,6 +891,16 @@ func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
 	} else {
 		col = e.cursorColAt(e.textProvider().row(row), ev.Position)
 	}
+
+	return row, col
+}
+
+func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
+	if !e.focused && !e.Disabled() {
+		e.FocusGained()
+	}
+
+	row, col := e.getRowCol(ev)
 
 	e.Lock()
 	if !rightClick || rightClick && !e.selecting {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -344,7 +344,6 @@ func (e *Entry) SetText(text string) {
 func (e *Entry) Tapped(ev *fyne.PointEvent) {
 	if fyne.CurrentDevice().IsMobile() && e.selecting {
 		e.selecting = false
-		return
 	}
 	e.updateMousePointer(ev, false)
 }

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1086,6 +1086,8 @@ func (r *entryRenderer) buildSelection() {
 		r.selection = r.selection[:rowCount]
 	}
 
+	r.entry.Lock()
+	defer r.entry.Unlock()
 	// build a rectangle for each row and add it to r.selection
 	for i := 0; i < rowCount; i++ {
 		if len(r.selection) <= i {


### PR DESCRIPTION
### Description:
Various fixes to how mobile selections are handled.
Some bad maths, some events that don't map exactly between desktop and mobile.
And a bug fix (race condition) :).

Fixes #963

### Checklist:

- [ ] Tests included. <- Now that Tilo has mobile testing running this should have been possible, but as a race condition and user interaction I could not think of reasonable test cases.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
