### PR TITLE
Tidy up some resize and Gl flicker on macOS

### DIFF
--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -199,7 +199,6 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToRoot(t *testing.T) {
 	rightCol := widget.NewVBox(rightObj1, rightObj2)
 	content := widget.NewHBox(leftCol, rightCol)
 	w.SetContent(content)
-	w.ignoreResize = true
 	repaintWindow(w)
 
 	oldCanvasSize := fyne.NewSize(100+3*theme.Padding(), 100+3*theme.Padding())
@@ -211,7 +210,6 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToRoot(t *testing.T) {
 
 	expectedCanvasSize := oldCanvasSize.Add(fyne.NewSize(10, 10))
 	assert.Equal(t, expectedCanvasSize, c.Size())
-	w.ignoreResize = false
 }
 
 func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToScroll(t *testing.T) {
@@ -233,7 +231,6 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToScroll(t *testing.T) {
 
 	oldCanvasSize := fyne.NewSize(100+3*theme.Padding(), 100+3*theme.Padding())
 	w.Resize(oldCanvasSize)
-	w.ignoreResize = true // for some reason the window manager is intercepting and setting strange values in tests
 	repaintWindow(w)
 
 	// child size change affects ancestors up to scroll
@@ -248,7 +245,6 @@ func Test_glCanvas_ChildMinSizeChangeAffectsAncestorsUpToScroll(t *testing.T) {
 	assert.Equal(t, oldRightScrollSize, rightColScroll.Size())
 	expectedRightColSize := oldRightColSize.Add(fyne.NewSize(0, 50))
 	assert.Equal(t, expectedRightColSize, rightCol.Size())
-	w.ignoreResize = false
 }
 
 func Test_glCanvas_ChildMinSizeChangesInDifferentScrollAffectAncestorsUpToScroll(t *testing.T) {
@@ -274,7 +270,6 @@ func Test_glCanvas_ChildMinSizeChangesInDifferentScrollAffectAncestorsUpToScroll
 		leftColScroll.MinSize().Height+2*theme.Padding(),
 	)
 	w.Resize(oldCanvasSize)
-	w.ignoreResize = true // for some reason the window manager is intercepting and setting strange values in tests
 	repaintWindow(w)
 
 	oldLeftColSize := leftCol.Size()
@@ -294,12 +289,10 @@ func Test_glCanvas_ChildMinSizeChangesInDifferentScrollAffectAncestorsUpToScroll
 	assert.Equal(t, expectedLeftColSize, leftCol.Size())
 	expectedRightColSize := oldRightColSize.Add(fyne.NewSize(0, 150))
 	assert.Equal(t, expectedRightColSize, rightCol.Size())
-	w.ignoreResize = false
 }
 
 func Test_glCanvas_MinSizeShrinkTriggersLayout(t *testing.T) {
 	w := createWindow("Test").(*window)
-	w.ignoreResize = true // for some reason the test is causing a WM resize event
 	c := w.Canvas().(*glCanvas)
 	leftObj1 := canvas.NewRectangle(color.Black)
 	leftObj1.SetMinSize(fyne.NewSize(50, 50))
@@ -316,7 +309,6 @@ func Test_glCanvas_MinSizeShrinkTriggersLayout(t *testing.T) {
 
 	oldCanvasSize := fyne.NewSize(100+3*theme.Padding(), 100+3*theme.Padding())
 	assert.Equal(t, oldCanvasSize, c.Size())
-	w.ignoreResize = true // for some reason the window manager is intercepting and setting strange values in tests
 	repaintWindow(w)
 
 	oldRightColSize := rightCol.Size()
@@ -334,12 +326,10 @@ func Test_glCanvas_MinSizeShrinkTriggersLayout(t *testing.T) {
 	assert.Equal(t, fyne.NewSize(50, 40), leftObj1.Size())
 	assert.Equal(t, fyne.NewSize(30, 30), rightObj1.Size())
 	assert.Equal(t, fyne.NewSize(30, 20), rightObj2.Size())
-	w.ignoreResize = false
 }
 
 func Test_glCanvas_ContentChangeWithoutMinSizeChangeDoesNotLayout(t *testing.T) {
 	w := createWindow("Test").(*window)
-	w.ignoreResize = true // for some reason the test is causing a WM resize event
 	c := w.Canvas().(*glCanvas)
 	leftObj1 := canvas.NewRectangle(color.Black)
 	leftObj1.SetMinSize(fyne.NewSize(50, 50))
@@ -370,12 +360,10 @@ func Test_glCanvas_ContentChangeWithoutMinSizeChangeDoesNotLayout(t *testing.T) 
 	c.Refresh(rightObj2)
 
 	assert.Nil(t, layout.popLayoutEvent())
-	w.ignoreResize = false
 }
 
 func Test_glCanvas_InsufficientSizeDoesntTriggerResizeIfSizeIsAlreadyMaxedOut(t *testing.T) {
 	w := createWindow("Test").(*window)
-	w.ignoreResize = true
 	c := w.Canvas().(*glCanvas)
 	c.Resize(fyne.NewSize(100, 100))
 	popUpContent := canvas.NewRectangle(color.Black)

--- a/internal/driver/glfw/driver_test.go
+++ b/internal/driver/glfw/driver_test.go
@@ -30,10 +30,7 @@ func Test_gLDriver_AbsolutePositionForObject(t *testing.T) {
 	cr2 := widget.NewHBox(cr2c1, cr2c2, cr2c3)
 	cr3 := widget.NewHBox(cr3c1, cr3c2, cr3c3)
 	content := widget.NewVBox(cr1, cr2, cr3)
-
 	cr2c2.Hide()
-	w.SetContent(content)
-	w.Resize(fyne.NewSize(200, 200))
 
 	mm := fyne.NewMainMenu(
 		fyne.NewMenu("Menu 1", fyne.NewMenuItem("Menu 1 Item", nil)),
@@ -44,12 +41,15 @@ func Test_gLDriver_AbsolutePositionForObject(t *testing.T) {
 	c := w.Canvas().(*glCanvas)
 	movl := buildMenuOverlay(mm, c)
 	c.setMenuOverlay(movl)
+	w.SetContent(content)
+	w.Resize(fyne.NewSize(200, 200))
 
 	ovli1 := widget.NewLabel("Overlay Item 1")
 	ovli2 := widget.NewLabel("Overlay Item 2")
 	ovli3 := widget.NewLabel("Overlay Item 3")
 	ovlContent := widget.NewVBox(ovli1, ovli2, ovli3)
 	ovl := widget.NewModalPopUp(ovlContent, c)
+	ovl.Show()
 
 	repaintWindow(w.(*window))
 	// accessing the menu bar's actual CanvasObjects isn't straight forward

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -118,7 +118,8 @@ func (d *gLDriver) runGL() {
 					continue
 				}
 
-				if w.canvas.ensureMinSize() {
+				if w.shouldExpand {
+					w.shouldExpand = false
 					w.fitContent()
 				}
 
@@ -136,6 +137,9 @@ func (d *gLDriver) runGL() {
 func (d *gLDriver) repaintWindow(w *window) {
 	canvas := w.canvas
 	w.RunWithContext(func() {
+		if w.canvas.ensureMinSize() {
+			w.shouldExpand = true
+		}
 		freeDirtyTextures(canvas)
 
 		updateGLContext(w)
@@ -213,6 +217,7 @@ func updateGLContext(w *window) {
 	canvas := w.Canvas().(*glCanvas)
 	size := canvas.Size()
 
+	// w.width and w.height are not correct if we are maximised, so figure from canvas
 	winWidth := float32(internal.ScaleInt(canvas, size.Width)) * canvas.texScale
 	winHeight := float32(internal.ScaleInt(canvas, size.Height)) * canvas.texScale
 


### PR DESCRIPTION
This improves overall speed and cleans up some resize code.
Strange issue with test meant code had to be reordered, does not affect real apps.

There is an underlying issue that can _some times_ be triggered if you refresh very, very fast to large window sizes on macOS Catalina. This seems to be down to the GLFW implementation wrapping vulkan and we may need to hook in some custom "swapchain" code in place of the swapping buffers. Needless to say that is a lot of work and in the meantime they may fix the issue, which is now very hard to replicate.

Fixes #994

### Checklist:

- [ ] Tests included. <- nah sorry, just load fyne_demo and resize lots, it's better
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
