### PR TITLE
canvas.Text cannot set min size

### DIFF
--- a/canvas/text.go
+++ b/canvas/text.go
@@ -28,6 +28,11 @@ func (t *Text) MinSize() fyne.Size {
 	return fyne.MeasureText(t.Text, t.TextSize, t.TextStyle)
 }
 
+// SetMinSize has no effect as the smallest size this canvas object can be is based on its font size and content.
+func (t *Text) SetMinSize(size fyne.Size) {
+	// no-op
+}
+
 // Refresh causes this object to be redrawn in it's current state
 func (t *Text) Refresh() {
 	Refresh(t)


### PR DESCRIPTION
### Description:
canvas.Text.MinSize is solely dependant on the font size and content, therefore SetMinSize does nothing.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
