### PR TITLE
When a menu is dismissed on mobile dismiss the bar too

### DIFF
--- a/internal/driver/gomobile/menu.go
+++ b/internal/driver/gomobile/menu.go
@@ -5,6 +5,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+	internalWidget "fyne.io/fyne/internal/widget"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
@@ -15,23 +16,33 @@ type menuLabel struct {
 	label *widget.Label
 
 	menu   *fyne.Menu
-	canvas fyne.Canvas
+	bar    *widget.Box
+	canvas *mobileCanvas
 }
 
 func (m *menuLabel) Tapped(*fyne.PointEvent) {
 	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(m)
 	widget.ShowPopUpMenuAtPosition(m.menu, m.canvas, fyne.NewPos(pos.X+m.Size().Width, pos.Y))
+
+	// TODO use NewPopUpMenu in 2.0 once the Deprecated
+	menu := m.canvas.Overlays().Top().(*internalWidget.OverlayContainer).Content.(*widget.Menu)
+	menuDismiss := menu.OnDismiss // this dismisses the menu stack
+	menu.OnDismiss = func() {
+		menuDismiss()
+		m.bar.Hide() // dismiss the overlay menu bar
+		m.canvas.menu = nil
+	}
 }
 
 func (m *menuLabel) CreateRenderer() fyne.WidgetRenderer {
 	return widget.Renderer(m.Box)
 }
 
-func newMenuLabel(item *fyne.Menu, c *mobileCanvas) *menuLabel {
+func newMenuLabel(item *fyne.Menu, parent *widget.Box, c *mobileCanvas) *menuLabel {
 	label := widget.NewLabel(item.Label)
 	box := widget.NewHBox(layout.NewSpacer(), label, layout.NewSpacer(), widget.NewIcon(theme.MenuExpandIcon()))
 
-	m := &menuLabel{box, label, item, c}
+	m := &menuLabel{box, label, item, parent, c}
 	return m
 }
 
@@ -43,7 +54,7 @@ func (c *mobileCanvas) showMenu(menu *fyne.MainMenu) {
 	}))
 	panel = widget.NewVBox(top)
 	for _, item := range menu.Items {
-		panel.Append(newMenuLabel(item, c))
+		panel.Append(newMenuLabel(item, panel, c))
 	}
 	shadow := canvas.NewHorizontalGradient(theme.ShadowColor(), color.Transparent)
 	c.menu = fyne.NewContainer(panel, shadow)

--- a/internal/driver/gomobile/menu_test.go
+++ b/internal/driver/gomobile/menu_test.go
@@ -9,7 +9,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
-	widget2 "fyne.io/fyne/internal/widget"
+	internalWidget "fyne.io/fyne/internal/widget"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
 )
@@ -42,7 +42,7 @@ func TestMobileCanvas_DismissMenu(t *testing.T) {
 	point := &fyne.PointEvent{Position: fyne.NewPos(10, 10)}
 	menuObj.Tapped(point)
 
-	tapMeItem := c.overlays.Top().(*widget2.OverlayContainer).Content.(*widget.Menu).Items[0].(fyne.Tappable)
+	tapMeItem := c.overlays.Top().(*internalWidget.OverlayContainer).Content.(*widget.Menu).Items[0].(fyne.Tappable)
 	tapMeItem.Tapped(point)
 	assert.Nil(t, c.menu)
 }

--- a/internal/driver/gomobile/menu_test.go
+++ b/internal/driver/gomobile/menu_test.go
@@ -5,11 +5,47 @@ package gomobile
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	widget2 "fyne.io/fyne/internal/widget"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
-	"github.com/stretchr/testify/assert"
 )
+
+func TestMobileCanvas_DismissBar(t *testing.T) {
+	c := NewCanvas().(*mobileCanvas)
+	c.SetContent(canvas.NewRectangle(theme.BackgroundColor()))
+	menu := fyne.NewMainMenu(
+		fyne.NewMenu("Test"))
+	c.showMenu(menu)
+	c.resize(fyne.NewSize(100, 100))
+
+	assert.NotNil(t, c.menu)
+	// simulate tap as the test util does not know about our menu...
+	c.tapDown(fyne.NewPos(80, 20), 1)
+	c.tapUp(fyne.NewPos(80, 20), 1, nil, nil, nil)
+	assert.Nil(t, c.menu)
+}
+
+func TestMobileCanvas_DismissMenu(t *testing.T) {
+	c := NewCanvas().(*mobileCanvas)
+	c.SetContent(canvas.NewRectangle(theme.BackgroundColor()))
+	menu := fyne.NewMainMenu(
+		fyne.NewMenu("Test", fyne.NewMenuItem("TapMe", func() {})))
+	c.showMenu(menu)
+	c.resize(fyne.NewSize(100, 100))
+
+	assert.NotNil(t, c.menu)
+	menuObj := c.menu.(*fyne.Container).Objects[0].(*widget.Box).Children[1].(*menuLabel)
+	point := &fyne.PointEvent{Position: fyne.NewPos(10, 10)}
+	menuObj.Tapped(point)
+
+	tapMeItem := c.overlays.Top().(*widget2.OverlayContainer).Content.(*widget.Menu).Items[0].(fyne.Tappable)
+	tapMeItem.Tapped(point)
+	assert.Nil(t, c.menu)
+}
 
 func TestMobileCanvas_Menu(t *testing.T) {
 	c := &mobileCanvas{}

--- a/internal/driver/gomobile/menu_test.go
+++ b/internal/driver/gomobile/menu_test.go
@@ -5,13 +5,13 @@ package gomobile
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	internalWidget "fyne.io/fyne/internal/widget"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMobileCanvas_DismissBar(t *testing.T) {


### PR DESCRIPTION
### Description:
Close menu bar when an item is selected

Thanks to @toaster's menu work - this was not possible before.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

