### PR TITLE
EnsureMinSize on mobile

### DIFF
--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/driver/mobile"
 	"fyne.io/fyne/internal"
 	"fyne.io/fyne/internal/app"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/internal/driver"
 	"fyne.io/fyne/internal/painter/gl"
 	"fyne.io/fyne/theme"
@@ -195,6 +196,53 @@ func (c *mobileCanvas) AddShortcut(shortcut fyne.Shortcut, handler func(shortcut
 
 func (c *mobileCanvas) Capture() image.Image {
 	return c.painter.Capture(c)
+}
+
+func (c *mobileCanvas) ensureMinSize() {
+	if c.Content() == nil {
+		return
+	}
+	var lastParent fyne.CanvasObject
+
+	ensureMinSize := func(obj, parent fyne.CanvasObject) {
+		if !obj.Visible() {
+			return
+		}
+		minSize := obj.MinSize()
+
+		objToLayout := obj
+		if parent != nil {
+			objToLayout = parent
+		} else {
+			size := obj.Size()
+			expectedSize := minSize.Union(size)
+			if expectedSize != size && size != c.size {
+				objToLayout = nil
+				obj.Resize(expectedSize)
+			}
+		}
+
+		if objToLayout != lastParent {
+			updateLayout(lastParent)
+			lastParent = objToLayout
+		}
+	}
+	c.walkTree(nil, ensureMinSize)
+
+	if lastParent != nil {
+		updateLayout(lastParent)
+	}
+}
+
+func updateLayout(objToLayout fyne.CanvasObject) {
+	switch cont := objToLayout.(type) {
+	case *fyne.Container:
+		if cont.Layout != nil {
+			cont.Layout.Layout(cont.Objects, cont.Size())
+		}
+	case fyne.Widget:
+		cache.Renderer(cont).Layout(cont.Size())
+	}
 }
 
 func (c *mobileCanvas) objectTrees() []fyne.CanvasObject {

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -3,16 +3,46 @@
 package gomobile
 
 import (
+	"image/color"
 	"testing"
 	"time"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/mobile"
+	"fyne.io/fyne/layout"
 	_ "fyne.io/fyne/test"
+	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCanvas_ChildMinSizeChangeAffectsAncestorsUpToRoot(t *testing.T) {
+	c := NewCanvas().(*mobileCanvas)
+	leftObj1 := canvas.NewRectangle(color.Black)
+	leftObj1.SetMinSize(fyne.NewSize(100, 50))
+	leftObj2 := canvas.NewRectangle(color.Black)
+	leftObj2.SetMinSize(fyne.NewSize(100, 50))
+	leftCol := widget.NewVBox(leftObj1, leftObj2)
+	rightObj1 := canvas.NewRectangle(color.Black)
+	rightObj1.SetMinSize(fyne.NewSize(100, 50))
+	rightObj2 := canvas.NewRectangle(color.Black)
+	rightObj2.SetMinSize(fyne.NewSize(100, 50))
+	rightCol := widget.NewVBox(rightObj1, rightObj2)
+	content := widget.NewHBox(leftCol, rightCol)
+	c.SetContent(fyne.NewContainerWithLayout(layout.NewCenterLayout(), content))
+	c.resize(fyne.NewSize(300, 300))
+
+	oldContentSize := fyne.NewSize(200+theme.Padding(), 100+theme.Padding())
+	assert.Equal(t, oldContentSize, content.Size())
+
+	leftObj1.SetMinSize(fyne.NewSize(110, 60))
+	c.ensureMinSize()
+
+	expectedContentSize := oldContentSize.Add(fyne.NewSize(10, 10))
+	assert.Equal(t, expectedContentSize, content.Size())
+}
 
 func TestCanvas_PixelCoordinateAtPosition(t *testing.T) {
 	c := NewCanvas().(*mobileCanvas)

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -143,6 +143,7 @@ func (d *mobileDriver) Run() {
 					canvas.painter.Init() // we cannot init until the context is set above
 				}
 
+				canvas.ensureMinSize()
 				if d.freeDirtyTextures(canvas) {
 					d.paintWindow(current, currentSize)
 					a.Publish()


### PR DESCRIPTION
Mimics glfw driver without the need to resize window
and so caching is less important - though we could add it if required.

Fixes #972

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
