### PR TITLE
Focusing logic

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -167,6 +167,16 @@ func (c *glCanvas) Focus(obj fyne.Focusable) {
 	c.RLock()
 	focused := c.focused
 	c.RUnlock()
+
+	if focused == obj || obj == nil {
+		return
+	}
+
+	if dis, ok := obj.(fyne.Disableable); ok && dis.Disabled() {
+		c.Unfocus()
+		return
+	}
+
 	if focused != nil {
 		focused.FocusLost()
 	}
@@ -174,23 +184,18 @@ func (c *glCanvas) Focus(obj fyne.Focusable) {
 	c.Lock()
 	c.focused = obj
 	c.Unlock()
-	if obj != nil {
-		obj.FocusGained()
-	}
+	obj.FocusGained()
 }
 
 func (c *glCanvas) Unfocus() {
-	c.RLock()
+	c.Lock()
 	focused := c.focused
-	c.RUnlock()
+	c.focused = nil
+	c.Unlock()
 
 	if focused != nil {
 		focused.FocusLost()
 	}
-
-	c.Lock()
-	c.focused = nil
-	c.Unlock()
 }
 
 func (c *glCanvas) Focused() fyne.Focusable {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -621,16 +621,11 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 		}
 	}
 
-	needsfocus := false
 	if layer != 1 { // 0 - overlay, 1 - menu, 2 - content
-		needsfocus = true
-
-		if wid := w.canvas.Focused(); wid != nil {
-			if wid.(fyne.CanvasObject) != co {
-				w.canvas.Unfocus()
-			} else {
-				needsfocus = false
-			}
+		if wid, ok := co.(fyne.Focusable); ok {
+			w.canvas.Focus(wid)
+		} else {
+			w.canvas.Unfocus()
 		}
 	}
 
@@ -638,13 +633,6 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 		w.mouseButton = button
 	} else if action == glfw.Release {
 		w.mouseButton = 0
-	}
-
-	// we cannot switch here as objects may respond to multiple cases
-	if wid, ok := co.(fyne.Focusable); ok && needsfocus {
-		if dis, ok := wid.(fyne.Disableable); !ok || !dis.Disabled() {
-			w.canvas.Focus(wid)
-		}
 	}
 
 	// Check for double click/tap

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -195,6 +195,37 @@ func TestCanvas_Tappable(t *testing.T) {
 	assert.True(t, content.cancel)
 }
 
+func TestCanvas_Focusable(t *testing.T) {
+	content := newFocusableEntry()
+	c := NewCanvas().(*mobileCanvas)
+	c.SetContent(content)
+
+	c.tapDown(fyne.NewPos(10, 10), 0)
+	assert.Equal(t, 1, content.focusedTimes)
+	assert.Equal(t, 0, content.unfocusedTimes)
+
+	c.tapDown(fyne.NewPos(10, 10), 1)
+	assert.Equal(t, 1, content.focusedTimes)
+	assert.Equal(t, 0, content.unfocusedTimes)
+
+	c.Focus(content)
+	assert.Equal(t, 1, content.focusedTimes)
+	assert.Equal(t, 0, content.unfocusedTimes)
+
+	c.Unfocus()
+	assert.Equal(t, 1, content.focusedTimes)
+	assert.Equal(t, 1, content.unfocusedTimes)
+
+	content.Disable()
+	c.Focus(content)
+	assert.Equal(t, 1, content.focusedTimes)
+	assert.Equal(t, 1, content.unfocusedTimes)
+
+	c.tapDown(fyne.NewPos(10, 10), 2)
+	assert.Equal(t, 1, content.focusedTimes)
+	assert.Equal(t, 1, content.unfocusedTimes)
+}
+
 type touchableLabel struct {
 	*widget.Label
 	down, up, cancel bool
@@ -223,4 +254,26 @@ func (t *tappableLabel) Tapped(_ *fyne.PointEvent) {
 
 func (t *tappableLabel) TappedSecondary(_ *fyne.PointEvent) {
 	t.altTap = true
+}
+
+type focusableEntry struct {
+	widget.Entry
+	focusedTimes   int
+	unfocusedTimes int
+}
+
+func newFocusableEntry() *focusableEntry {
+	entry := &focusableEntry{}
+	entry.ExtendBaseWidget(entry)
+	return entry
+}
+
+func (f *focusableEntry) FocusGained() {
+	f.focusedTimes++
+	f.Entry.FocusGained()
+}
+
+func (f *focusableEntry) FocusLost() {
+	f.unfocusedTimes++
+	f.Entry.FocusLost()
 }

--- a/internal/driver/gomobile/keyboard.go
+++ b/internal/driver/gomobile/keyboard.go
@@ -7,9 +7,13 @@ import (
 )
 
 func showVirtualKeyboard(keyboard mobile.KeyboardType) {
-	fyne.CurrentApp().Driver().(*mobileDriver).app.ShowVirtualKeyboard(app.KeyboardType(keyboard))
+	if driver, ok := fyne.CurrentApp().Driver().(*mobileDriver); ok {
+		driver.app.ShowVirtualKeyboard(app.KeyboardType(keyboard))
+	}
 }
 
 func hideVirtualKeyboard() {
-	fyne.CurrentApp().Driver().(*mobileDriver).app.HideVirtualKeyboard()
+	if driver, ok := fyne.CurrentApp().Driver().(*mobileDriver); ok {
+		driver.app.HideVirtualKeyboard()
+	}
 }


### PR DESCRIPTION
### Description:
Made symmetric changes to focusing logic in glCanvas as in mobileCanvas from #975. Added tests. Focusing already focused object is no-op now and manual focusing disabled objects is now impossible.

Follow-up to #975

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass. --- Test_glCanvas_InsufficientSizeDoesntTriggerResizeIfSizeIsAlreadyMaxedOut doesn't pass on develop, but it's disabled in CI run. Seems like a known issue.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
