### PR TITLE
Keep mobile apps within screen bounds whilst ensuring layout updates when required

### DIFF
--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -406,6 +406,7 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 
 	if c.menu != nil && c.overlays.Top() == nil && pos.X > c.menu.Size().Width {
 		c.menu.Hide()
+		c.menu.Refresh()
 		c.menu = nil
 		return
 	}

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -1,7 +1,6 @@
 package gomobile
 
 import (
-	"fmt"
 	"runtime"
 	"strconv"
 	"time"
@@ -143,15 +142,19 @@ func (d *mobileDriver) Run() {
 					canvas.painter.Init() // we cannot init until the context is set above
 				}
 
-				canvas.ensureMinSize()
 				if d.freeDirtyTextures(canvas) {
-					d.paintWindow(current, currentSize)
-					a.Publish()
+					newSize := fyne.NewSize(int(float32(currentSize.WidthPx)/canvas.scale), int(float32(currentSize.HeightPx)/canvas.scale))
 
-					err := d.glctx.GetError()
-					if err != 0 {
-						fyne.LogError(fmt.Sprintf("OpenGL Error: %d", err), nil)
+					if canvas.minSizeChanged() {
+						canvas.ensureMinSize()
+
+						canvas.sizeContent(newSize) // force resize of content
+					} else { // if screen changed
+						current.Resize(newSize)
 					}
+
+					d.paintWindow(current, newSize)
+					a.Publish()
 				}
 
 				time.Sleep(time.Millisecond * 10)
@@ -182,16 +185,13 @@ func (d *mobileDriver) onStart() {
 func (d *mobileDriver) onStop() {
 }
 
-func (d *mobileDriver) paintWindow(window fyne.Window, sz size.Event) {
+func (d *mobileDriver) paintWindow(window fyne.Window, size fyne.Size) {
 	canvas := window.Canvas().(*mobileCanvas)
 
 	r, g, b, a := theme.BackgroundColor().RGBA()
 	max16bit := float32(255 * 255)
 	d.glctx.ClearColor(float32(r)/max16bit, float32(g)/max16bit, float32(b)/max16bit, float32(a)/max16bit)
 	d.glctx.Clear(gl.COLOR_BUFFER_BIT)
-
-	newSize := fyne.NewSize(int(float32(sz.WidthPx)/canvas.scale), int(float32(sz.HeightPx)/canvas.scale))
-	window.Resize(newSize)
 
 	paint := func(obj fyne.CanvasObject, pos fyne.Position, _ fyne.Position, _ fyne.Size) bool {
 		// TODO should this be somehow not scroll container specific?
@@ -201,7 +201,7 @@ func (d *mobileDriver) paintWindow(window fyne.Window, sz size.Event) {
 				obj.Size(),
 			)
 		}
-		canvas.painter.Paint(obj, pos, newSize)
+		canvas.painter.Paint(obj, pos, size)
 		return false
 	}
 	afterPaint := func(obj, _ fyne.CanvasObject) {


### PR DESCRIPTION
### Description:
Fixes the issue when ensureMinSize expanded window outside of screen size.

This stops minSize scans when nothing has changed as well.
Also remove unneeded OpenGL debug now we have error logging.

Fixes #1056

### Checklist:

- [ ] Tests included. <- run in -tags mobile mode and size down, or use a small mobile screen
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
