### PR TITLE
Fix notifications to work on Oreo target so we can update again

### DIFF
--- a/cmd/fyne/internal/mobile/binres/binres.go
+++ b/cmd/fyne/internal/mobile/binres/binres.go
@@ -281,7 +281,7 @@ func UnmarshalXML(r io.Reader, withIcon bool) (*XML, error) {
 									Space: androidSchema,
 									Local: "targetSdkVersion",
 								},
-								Value: "25",
+								Value: "28",
 							},
 						},
 					}


### PR DESCRIPTION
Just check the version number, and if Oreo we need to set up a channel too

Fixes #1057

### Checklist:

- [ ] Tests included. <- manually caused notification from API 16 and API 28 phones
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
