### PR TITLE
Fix Label Refresh error

### DIFF
--- a/widget/label.go
+++ b/widget/label.go
@@ -94,7 +94,7 @@ func (l *Label) concealed() bool {
 
 // object returns the root object of the widget so it can be referenced
 func (l *Label) object() fyne.Widget {
-	return l
+	return l.super()
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer


### PR DESCRIPTION
### Description:
The custom widget label don't refresh changes until you resize the application window

Fixes 

### Checklist:

- [ ] Tests included.
- [x ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
