### PR TITLE
Fix deadlock on resize with popup visible

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -376,8 +376,9 @@ func (c *glCanvas) ensureMinSize() bool {
 	}
 	c.walkTrees(nil, ensureMinSize)
 
+	min := c.MinSize()
 	c.RLock()
-	shouldResize := windowNeedsMinSizeUpdate && (c.size.Width < c.MinSize().Width || c.size.Height < c.MinSize().Height)
+	shouldResize := windowNeedsMinSizeUpdate && (c.size.Width < min.Width || c.size.Height < min.Height)
 	c.RUnlock()
 	if shouldResize {
 		c.Resize(c.Size().Union(c.MinSize()))


### PR DESCRIPTION
### Description:
Fix possible deadlock in resize code

Validate:
* Run fyne_demo
* Go to widgets - input
* open the select drop-down
* resize window
= deadlock

### Checklist:

- [ ] Tests included. <- runtime test in fyne_demo
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
