### PR TITLE
Reset all associated Entry variables when text is out of sync

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1034,7 +1034,7 @@ func (r *entryRenderer) Refresh() {
 	r.entry.propertyLock.RUnlock()
 
 	if content != string(provider.buffer) {
-		provider.setText(content)
+		r.entry.SetText(content)
 		return
 	}
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -134,6 +134,22 @@ func TestEntry_SetText_Manual(t *testing.T) {
 	test.AssertImageMatches(t, "entry/set_text_changed.png", c.Capture())
 }
 
+func TestEntry_SetText_Underflow(t *testing.T) {
+	entry := widget.NewEntry()
+	test.Type(entry, "test")
+	assert.Equal(t, 4, entry.CursorColumn)
+
+	entry.Text = ""
+	entry.Refresh()
+	assert.Equal(t, 0, entry.CursorColumn)
+
+	key := &fyne.KeyEvent{Name: fyne.KeyBackspace}
+	entry.TypedKey(key)
+
+	assert.Equal(t, 0, entry.CursorColumn)
+	assert.Equal(t, "", entry.Text)
+}
+
 func TestEntry_OnKeyDown(t *testing.T) {
 	entry := widget.NewEntry()
 


### PR DESCRIPTION

### Description:
When Entry.Text is set to a shorter string than the cursor position it was not correctly reset.
This change increases the scope of logic when we see the field has been manually changed.

Fixes #1096

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
