### PR TITLE
Fix a possible crash if opening a window during shutdown

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -137,6 +137,10 @@ func (d *gLDriver) runGL() {
 				d.windowLock.Lock()
 				d.windows = newWindows
 				d.windowLock.Unlock()
+
+				if len(newWindows) == 0 {
+					d.Quit()
+				}
 			}
 		}
 	}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -452,7 +452,7 @@ func (w *window) destroy(d *gLDriver) {
 		w.eventLock.Unlock()
 	}
 
-	if w.master || len(d.windowList()) == 0 {
+	if w.master {
 		d.Quit()
 	} else if runtime.GOOS == "darwin" {
 		d.focusPreviousWindow()


### PR DESCRIPTION
This may not be the desired solution as it commits to close as soon as there are no windows.
A future change could address #467 to add a veto-close function.

This is not a behavior change to address the underlying, merely fixes the crash caused.

Fixes #1106 

### Checklist:

- [ ] Tests included. <- try to add and show a window in your first window's OnClosed
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
