### PR TITLE
Add missing comment for SetOnClosed()

### DIFF
--- a/window.go
+++ b/window.go
@@ -61,6 +61,7 @@ type Window interface {
 	// The way this is rendered will depend on the loaded driver.
 	SetMainMenu(*MainMenu)
 
+	// SetOnClosed sets a function that runs when the window is closed.
 	SetOnClosed(func())
 
 	// Show the window on screen.


### PR DESCRIPTION
### Description:

This PR adds a missing comment for the function callback to run on window close.
I think that it might be worth back-porting this to master and the v1.3.1 in my opinion.

### Checklist:

- [-] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
 - I am seeing test failures but none that are due to my change.
