### PR TITLE
Ensure slider values are within range even on initial display

### DIFF
--- a/widget/slider.go
+++ b/widget/slider.go
@@ -97,19 +97,29 @@ func (s *Slider) getRatio(e *fyne.PointEvent) float64 {
 	return 0.0
 }
 
-func (s *Slider) updateValue(ratio float64) {
-	v := s.Min + ratio*(s.Max-s.Min)
+func (s *Slider) clampValueToRange() {
+	if s.Value >= s.Max {
+		s.Value = s.Max
+		return
+	} else if s.Value <= s.Min {
+		s.Value = s.Min
+		return
+	}
+
+	if s.Step == 0 { // extended Slider may not have this set - assume value is not adjusted
+		return
+	}
 
 	i := -(math.Log10(s.Step))
 	p := math.Pow(10, i)
 
-	if v >= s.Max {
-		s.Value = s.Max
-	} else if v <= s.Min {
-		s.Value = s.Min
-	} else {
-		s.Value = float64(int(v*p)) / p
-	}
+	s.Value = float64(int(s.Value*p)) / p
+}
+
+func (s *Slider) updateValue(ratio float64) {
+	s.Value = s.Min + ratio*(s.Max-s.Min)
+
+	s.clampValueToRange()
 }
 
 // MinSize returns the size that this widget should not shrink below
@@ -153,6 +163,7 @@ func (s *sliderRenderer) Refresh() {
 	s.thumb.FillColor = theme.TextColor()
 	s.active.FillColor = theme.TextColor()
 
+	s.slider.clampValueToRange()
 	s.Layout(s.slider.Size())
 	canvas.Refresh(s.slider.super())
 }

--- a/widget/slider_test.go
+++ b/widget/slider_test.go
@@ -28,6 +28,13 @@ func TestSlider_HorizontalLayout(t *testing.T) {
 	assert.Equal(t, theme.Padding(), aSize.Height)
 }
 
+func TestSlider_OutOfRange(t *testing.T) {
+	slider := NewSlider(2, 5)
+	slider.Resize(fyne.NewSize(100, 10))
+
+	assert.Equal(t, float64(2), slider.Value)
+}
+
 func TestSlider_VerticalLayout(t *testing.T) {
 	slider := NewSlider(0, 1)
 	slider.Orientation = Vertical


### PR DESCRIPTION
### Description:
Fix for the slider initially appearing out of bounds if 0 was not in the slider range.

Fixes #1128 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
