### PR TITLE
Fixes https://github.com/fyne-io/fyne/issues/1143

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -186,6 +186,7 @@ func NewCustomConfirm(title, confirm, dismiss string, content fyne.CanvasObject,
 	callback func(bool), parent fyne.Window) Dialog {
 	d := &dialog{content: content, title: title, icon: nil, parent: parent}
 	d.callback = callback
+	d.sendResponse = true
 
 	d.dismiss = &widget.Button{Text: dismiss, Icon: theme.CancelIcon(),
 		OnTapped: d.Hide,

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -186,6 +186,9 @@ func NewCustomConfirm(title, confirm, dismiss string, content fyne.CanvasObject,
 	callback func(bool), parent fyne.Window) Dialog {
 	d := &dialog{content: content, title: title, icon: nil, parent: parent}
 	d.callback = callback
+	// TODO: This is required to avoid confusion.
+	// Normally this function should only provide the dialog, but currently it is also displayed, which is wrong.
+	// For this case the ShowCustomConfirm() method was built.
 	d.sendResponse = true
 
 	d.dismiss = &widget.Button{Text: dismiss, Icon: theme.CancelIcon(),


### PR DESCRIPTION
This method requires a callback. To call a callback it is necessary to set sendResponse() to true. Else dialog.hideWithResponse() will not call the callback.

### Description:
Fixes #1143

Bugfix has no tests because it is an abstraction of a dialog.

### Checklist:

- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
