### PR TITLE
Fix resize flicker, at last :)

### DIFF
--- a/canvas/raster.go
+++ b/canvas/raster.go
@@ -28,6 +28,11 @@ func (r *Raster) Alpha() float64 {
 	return 1.0 - r.Translucency
 }
 
+func (r *Raster) Resize(s fyne.Size) {
+	r.baseObject.Resize(s)
+	Refresh(r)
+}
+
 // Refresh causes this object to be redrawn in it's current state
 func (r *Raster) Refresh() {
 	Refresh(r)

--- a/canvas/raster.go
+++ b/canvas/raster.go
@@ -28,6 +28,8 @@ func (r *Raster) Alpha() float64 {
 	return 1.0 - r.Translucency
 }
 
+// Resize on a raster image causes the new size to be set and then calls Refresh.
+// This causes the underlying data to be recalculated and a new output to be drawn.
 func (r *Raster) Resize(s fyne.Size) {
 	r.baseObject.Resize(s)
 	Refresh(r)

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -524,7 +524,7 @@ func (w *window) frameSized(viewport *glfw.Window, width, height int) {
 	w.canvas.Refresh(w.canvas.Content())                   // apply texture scale
 }
 
-func (w *window) refresh(viewport *glfw.Window) {
+func (w *window) refresh(_ *glfw.Window) {
 	refreshWindow(w)
 }
 
@@ -877,7 +877,7 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	return ret
 }
 
-func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
+func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 	keyName := keyToName(key, scancode)
 	if keyName == "" {
 		return
@@ -1007,7 +1007,7 @@ func desktopModifier(mods glfw.ModifierKey) desktop.Modifier {
 // Unicode character is input.
 //
 // Characters do not map 1:1 to physical keys, as a key may produce zero, one or more characters.
-func (w *window) charInput(viewport *glfw.Window, char rune) {
+func (w *window) charInput(_ *glfw.Window, char rune) {
 	if w.canvas.Focused() == nil && w.canvas.onTypedRune == nil {
 		return
 	}
@@ -1020,7 +1020,7 @@ func (w *window) charInput(viewport *glfw.Window, char rune) {
 	}
 }
 
-func (w *window) focused(viewport *glfw.Window, focused bool) {
+func (w *window) focused(_ *glfw.Window, focused bool) {
 	if w.canvas.focused == nil {
 		return
 	}
@@ -1061,7 +1061,7 @@ func (w *window) rescaleOnMain() {
 		return
 	}
 
-	size := w.canvas.size.Union(w.canvas.MinSize())
+	size := w.canvas.size.Max(w.canvas.MinSize())
 	newWidth, newHeight := w.screenSize(size)
 	w.viewport.SetSize(newWidth, newHeight)
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -503,7 +503,7 @@ func (w *window) resized(_ *glfw.Window, width, height int) {
 	}
 
 	d, ok := fyne.CurrentApp().Driver().(*gLDriver)
-	if !ok { // don't wait to redraw in this way if we are running on test
+	if !ok || !w.visible { // don't wait to redraw in this way if we are running on test or not yet drawn
 		w.canvas.Resize(canvasSize)
 		return
 	}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -501,7 +501,17 @@ func (w *window) resized(_ *glfw.Window, width, height int) {
 		w.width = internal.ScaleInt(w.canvas, canvasSize.Width)
 		w.height = internal.ScaleInt(w.canvas, canvasSize.Height)
 	}
-	w.canvas.Resize(canvasSize)
+
+	d, ok := fyne.CurrentApp().Driver().(*gLDriver)
+	if !ok { // don't wait to redraw in this way if we are running on test
+		w.canvas.Resize(canvasSize)
+		return
+	}
+
+	runOnDraw(w, func() {
+		w.canvas.Resize(canvasSize)
+		d.repaintWindow(w)
+	})
 }
 
 func (w *window) frameSized(viewport *glfw.Window, width, height int) {


### PR DESCRIPTION
### Description:
Sync threads when resizing on main, this makes draw appear the right size then returns to resizing.
Fixes most of the flicker issues. Though it re-introduces a little lag.
Now we have decent resize AND animations continue on move/resize.

Fixes #1114, #1122, #1140

### Checklist:

- [ ] Tests included. <- Just resize your window, but on lots of different OS combinations :)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

