### PR TITLE
Correctly reset texture cache

### DIFF
--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -85,13 +85,15 @@ func (p *glPainter) SetOutputSize(width, height int) {
 }
 
 func (p *glPainter) freeTexture(obj fyne.CanvasObject) {
-	texture := textures[obj]
-	if texture != 0 {
-		tex := uint32(texture)
-		gl.DeleteTextures(1, &tex)
-		logError()
-		delete(textures, obj)
+	texture, ok := textures[obj]
+	if !ok {
+		return
 	}
+
+	tex := uint32(texture)
+	gl.DeleteTextures(1, &tex)
+	logError()
+	delete(textures, obj)
 }
 
 func glInit() {

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -86,13 +86,15 @@ func (p *glPainter) SetOutputSize(width, height int) {
 }
 
 func (p *glPainter) freeTexture(obj fyne.CanvasObject) {
-	texture := textures[obj]
-	if texture != 0 {
-		tex := uint32(texture)
-		gl.DeleteTextures(1, &tex)
-		logError()
-		delete(textures, obj)
+	texture, ok := textures[obj]
+	if !ok {
+		return
 	}
+
+	tex := uint32(texture)
+	gl.DeleteTextures(1, &tex)
+	logError()
+	delete(textures, obj)
 }
 
 func glInit() {

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -95,11 +95,13 @@ func (p *glPainter) SetOutputSize(width, height int) {
 
 func (p *glPainter) freeTexture(obj fyne.CanvasObject) {
 	texture, ok := textures[obj]
-	if ok {
-		p.glctx().DeleteTexture(gl.Texture(texture))
-		p.logError()
-		delete(textures, obj)
+	if !ok {
+		return
 	}
+
+	p.glctx().DeleteTexture(gl.Texture(texture))
+	p.logError()
+	delete(textures, obj)
 }
 
 func (p *glPainter) compileShader(source string, shaderType gl.Enum) (gl.Shader, error) {


### PR DESCRIPTION
This includes 'missing' textures as refresh may fix them
Previously an empty image that has a resource set then called Refresh() could have stayed empty as the "0" texture ID was kept

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
