### PR TITLE
Fix possible panics on Quit() or window Hide()

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -26,6 +26,7 @@ type gLDriver struct {
 	windows    []fyne.Window
 	device     *glDevice
 	done       chan interface{}
+	drawDone   chan interface{}
 }
 
 func (d *gLDriver) RenderedTextSize(text string, size int, style fyne.TextStyle) fyne.Size {
@@ -118,6 +119,7 @@ func goroutineID() int {
 func NewGLDriver() fyne.Driver {
 	d := new(gLDriver)
 	d.done = make(chan interface{})
+	d.drawDone = make(chan interface{})
 
 	return d
 }

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -111,6 +111,7 @@ func (d *gLDriver) runGL() {
 				if w.viewport.ShouldClose() {
 					reassign = true
 					w.viewLock.Lock()
+					w.visible = false
 					v := w.viewport
 					w.viewport = nil
 					w.viewLock.Unlock()
@@ -160,8 +161,13 @@ func (d *gLDriver) repaintWindow(w *window) {
 		updateGLContext(w)
 		canvas.paint(canvas.Size())
 
-		if w.viewport != nil {
-			w.viewport.SwapBuffers()
+		w.viewLock.RLock()
+		view := w.viewport
+		visible := w.visible
+		w.viewLock.RUnlock()
+
+		if view != nil && visible {
+			view.SwapBuffers()
 		}
 	})
 }

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -90,6 +90,7 @@ func (d *gLDriver) runGL() {
 		select {
 		case <-d.done:
 			eventTick.Stop()
+			d.drawDone <- nil // wait for draw thread to stop
 			glfw.Terminate()
 			return
 		case f := <-funcQueue:
@@ -175,6 +176,8 @@ func (d *gLDriver) startDrawThread() {
 
 		for {
 			select {
+			case <-d.drawDone:
+				return
 			case f := <-drawFuncQueue:
 				f.win.RunWithContext(f.f)
 				if f.done != nil {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -381,9 +381,9 @@ func (w *window) Hide() {
 	}
 
 	runOnMain(func() {
-		w.viewport.Hide()
 		w.viewLock.Lock()
 		w.visible = false
+		w.viewport.Hide()
 		w.viewLock.Unlock()
 
 		// hide top canvas element


### PR DESCRIPTION
### Description:
The crux of this is to make sure we close the draw thread before we shut down the GL library.
Also we should more carefully check our internal state before using GL contexts.

Fixes #1115

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

