### PR TITLE
Feature/move window method

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -145,6 +145,25 @@ func (w *window) doCenterOnScreen() {
 	w.viewport.SetPos(newX, newY)
 }
 
+func (w *window) Move(pos fyne.Position) {
+	w.runOnMainWhenCreated(func() {
+		// get window dimensions in pixels
+		monitor := w.getMonitorForWindow()
+		monMode := monitor.GetVideoMode()
+
+		// these come into play when dealing with multiple monitors
+		monX, monY := monitor.GetPos()
+
+		// it is not allowed to move window out of the screen bounds
+		if monX+pos.X > monMode.Width || monY+pos.Y > monMode.Height {
+			return
+		}
+
+		// set new window coordinates
+		w.viewport.SetPos(monX+pos.X, monY+pos.Y)
+	}) // end of runOnMain(){}
+}
+
 // minSizeOnScreen gets the padded minimum size of a window content in screen pixels
 func (w *window) minSizeOnScreen() (int, int) {
 	// get minimum size of content inside the window

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -3,7 +3,6 @@ package glfw
 import "C"
 import (
 	"bytes"
-	"fmt"
 	"image"
 	_ "image/png" // for the icon
 	"runtime"
@@ -126,7 +125,6 @@ func (w *window) CenterOnScreen() {
 	w.centered = true
 
 	if w.view() != nil {
-		fmt.Println("CENTER")
 		w.doCenterOnScreen()
 	}
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1239,7 +1239,7 @@ func (w *window) create() {
 		}
 
 		if w.move {
-			w.doMove() // lastly center if that was requested
+			w.doMove() // lastly move if that was requested
 		}
 	})
 }

--- a/internal/driver/gomobile/window.go
+++ b/internal/driver/gomobile/window.go
@@ -56,6 +56,10 @@ func (w *window) CenterOnScreen() {
 	// no-op
 }
 
+func (w *window) Move(_ fyne.Position) {
+	// no-op
+}
+
 func (w *window) Padded() bool {
 	return w.canvas.padded
 }

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -32,6 +32,10 @@ func (w *testWindow) CenterOnScreen() {
 	// no-op
 }
 
+func (w *testWindow) Move(_ fyne.Position) {
+	// no-op
+}
+
 func (w *testWindow) Clipboard() fyne.Clipboard {
 	return w.clipboard
 }

--- a/window.go
+++ b/window.go
@@ -35,6 +35,10 @@ type Window interface {
 	// the Window object is currently positioned on.
 	CenterOnScreen()
 
+	// Move places a window to the position given on the monitor
+	// the Window object is currently positioned on.
+	Move(Position)
+
 	// Padded, normally true, states whether the window should have inner
 	// padding so that components do not touch the window edge.
 	Padded() bool

--- a/window.go
+++ b/window.go
@@ -35,8 +35,8 @@ type Window interface {
 	// the Window object is currently positioned on.
 	CenterOnScreen()
 
-	// Move places a window to the position given on the monitor
-	// the Window object is currently positioned on.
+	// Move places a window on the monitor the Window object is currently
+	// positioned on according to the position given.
 	Move(Position)
 
 	// Padded, normally true, states whether the window should have inner


### PR DESCRIPTION
This was done in order to allow for repositioning of the window.

### Description:

Added a Move method on the window object of the mobile and desktop driver, the test window, and the Window interface.

Fixes #1155
### Checklist:

- [ ] Tests included.
_Since the CenterOnScreen is not tested I guess this is not an easy one to test._
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
_Tests in the develop branch generally doesn't pass at the moment. So hard to say._

#### Where applicable:

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
_There should be no breaking changes. Except the fact that a method has been added to the Window interface._
