### PR TITLE
Fix slow resize on linux

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -502,16 +502,12 @@ func (w *window) resized(_ *glfw.Window, width, height int) {
 		w.height = internal.ScaleInt(w.canvas, canvasSize.Height)
 	}
 
-	d, ok := fyne.CurrentApp().Driver().(*gLDriver)
-	if !ok || !w.visible { // don't wait to redraw in this way if we are running on test or not yet drawn
+	if !w.visible { // don't redraw if hidden
 		w.canvas.Resize(canvasSize)
 		return
 	}
 
-	runOnDraw(w, func() {
-		w.canvas.Resize(canvasSize)
-		d.repaintWindow(w)
-	})
+	w.platformResize(canvasSize)
 }
 
 func (w *window) frameSized(viewport *glfw.Window, width, height int) {

--- a/internal/driver/glfw/window_linux.go
+++ b/internal/driver/glfw/window_linux.go
@@ -1,0 +1,8 @@
+package glfw
+
+import "fyne.io/fyne"
+
+func (w *window) platformResize(canvasSize fyne.Size) {
+	w.canvas.Resize(canvasSize)
+	w.canvas.Refresh(w.canvas.content)
+}

--- a/internal/driver/glfw/window_other.go
+++ b/internal/driver/glfw/window_other.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package glfw
+
+import "fyne.io/fyne"
+
+func (w *window) platformResize(canvasSize fyne.Size) {
+	d, ok := fyne.CurrentApp().Driver().(*gLDriver)
+	if !ok { // don't wait to redraw in this way if we are running on test
+		w.canvas.Resize(canvasSize)
+		return
+	}
+
+	runOnDraw(w, func() {
+		w.canvas.Resize(canvasSize)
+		d.repaintWindow(w)
+	})
+}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -476,6 +476,7 @@ func TestWindow_TappedIgnoresScrollerClip(t *testing.T) {
 
 	base := fyne.NewContainerWithLayout(layout.NewGridLayout(1), rect, scroll)
 	w.SetContent(base)
+	refreshWindow(w) // ensure any async resize is done
 
 	w.mousePos = fyne.NewPos(10, 80)
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)


### PR DESCRIPTION
The way that Xorg sends resize events we were just queueing them.
Instead let's redraw like it's v1.3.0 ;)

Fixes #1159

### Checklist:

- [ ] Tests included. <- resize an app on Linux, then on non-Linux. Both are now happy
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

