### PR TITLE
Avoid calling os.Create in file open dialog

### DIFF
--- a/internal/driver/glfw/file.go
+++ b/internal/driver/glfw/file.go
@@ -36,7 +36,12 @@ func openFile(uri fyne.URI, create bool) (*file, error) {
 	}
 
 	path := uri.String()[7:]
-	f, err := os.Create(path) // If it exists this will truncate which is what we wanted
-
+	var f *os.File
+	var err error
+	if create {
+		f, err = os.Create(path) // If it exists this will truncate which is what we wanted
+	} else {
+		f, err = os.Open(path)
+	}
 	return &file{File: f, path: path}, err
 }


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
In #1173, fix to call `os.Create` without referring to variable `create`.
So when opening files from file open dialog (not save dialog), it also call `os.Create`.
It seems that file is overwritten and become empty.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
