### PR TITLE
window. add close button interceptor to react on the window closing before anything is done

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -74,8 +74,7 @@ type window struct {
 	mouseLastClick     fyne.CanvasObject
 	mousePressed       fyne.CanvasObject
 	onClosed           func()
-	willClose          func() bool
-	closing            bool
+	willClose          func()
 
 	xpos, ypos    int
 	width, height int
@@ -294,7 +293,7 @@ func (w *window) SetOnClosed(closed func()) {
 	w.onClosed = closed
 }
 
-func (w *window) SetWillClose(willClose func() bool) {
+func (w *window) SetWillClose(willClose func()) {
 	w.willClose = willClose
 }
 
@@ -410,7 +409,7 @@ func (w *window) Close() {
 	if w.viewport == nil {
 		return
 	}
-	w.closed(w.viewport)
+	w.doClose(w.viewport)
 }
 
 func (w *window) ShowAndRun() {
@@ -453,24 +452,13 @@ func (w *window) Canvas() fyne.Canvas {
 
 func (w *window) closed(viewport *glfw.Window) {
 	viewport.SetShouldClose(false)
-	if w.closing {
+
+	if w.willClose != nil {
+		w.willClose()
 		return
 	}
-	w.closing = true
 
-	go func() {
-		defer func() {
-			w.closing = false
-		}()
-
-		if w.willClose != nil {
-			if !w.willClose() {
-				return
-			}
-		}
-
-		w.doClose(viewport)
-	}()
+	w.doClose(viewport)
 }
 
 func (w *window) doClose(viewport *glfw.Window) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -74,7 +74,7 @@ type window struct {
 	mouseLastClick     fyne.CanvasObject
 	mousePressed       fyne.CanvasObject
 	onClosed           func()
-	willClose          func()
+	onCloseIntercepted func()
 
 	xpos, ypos    int
 	width, height int
@@ -293,8 +293,8 @@ func (w *window) SetOnClosed(closed func()) {
 	w.onClosed = closed
 }
 
-func (w *window) SetWillClose(willClose func()) {
-	w.willClose = willClose
+func (w *window) SetCloseIntercept(callback func()) {
+	w.onCloseIntercepted = callback
 }
 
 func (w *window) getMonitorForWindow() *glfw.Monitor {
@@ -412,13 +412,6 @@ func (w *window) Close() {
 	w.closed(w.viewport)
 }
 
-func (w *window) DoClose() {
-	if w.viewport == nil {
-		return
-	}
-	w.doClose(w.viewport)
-}
-
 func (w *window) ShowAndRun() {
 	w.Show()
 	fyne.CurrentApp().Driver().Run()
@@ -460,15 +453,11 @@ func (w *window) Canvas() fyne.Canvas {
 func (w *window) closed(viewport *glfw.Window) {
 	viewport.SetShouldClose(false)
 
-	if w.willClose != nil {
-		w.willClose()
+	if w.onCloseIntercepted != nil {
+		w.onCloseIntercepted()
 		return
 	}
 
-	w.doClose(viewport)
-}
-
-func (w *window) doClose(viewport *glfw.Window) {
 	viewport.SetShouldClose(true)
 
 	w.canvas.walkTrees(nil, func(node *renderCacheNode) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -409,6 +409,13 @@ func (w *window) Close() {
 	if w.viewport == nil {
 		return
 	}
+	w.closed(w.viewport)
+}
+
+func (w *window) DoClose() {
+	if w.viewport == nil {
+		return
+	}
 	w.doClose(w.viewport)
 }
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -467,7 +467,7 @@ func (w *window) closed(viewport *glfw.Window) {
 	viewport.SetShouldClose(false)
 
 	if w.onCloseIntercepted != nil {
-		w.onCloseIntercepted()
+		w.queueEvent(w.onCloseIntercepted)
 		return
 	}
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -821,6 +821,42 @@ func TestWindow_Clipboard(t *testing.T) {
 	cb.SetContent(cliboardContent)
 }
 
+func TestWindow_WillClose(t *testing.T) {
+	closed := make(chan bool)
+
+	createLocaWindow := func() fyne.Window {
+		w := createWindow("Test")
+		w.SetOnClosed(func() {
+			closed <- true
+		})
+		return w
+	}
+
+	checkClosed := func() bool {
+		select {
+		case <-closed:
+			return true
+		case <-time.After(100 * time.Millisecond):
+			return false
+		}
+	}
+
+	w := createLocaWindow()
+	w.SetWillClose(func() {})
+	w.Close()
+	assert.False(t, checkClosed())
+
+	w.SetWillClose(func() {
+		w.DoClose()
+	})
+	w.Close()
+	assert.True(t, checkClosed())
+
+	w = createLocaWindow()
+	w.Close()
+	assert.True(t, checkClosed())
+}
+
 // This test makes our developer screens flash, let's not run it regularly...
 //func TestWindow_Shortcut(t *testing.T) {
 //	w := createWindow("Test")

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -826,35 +826,31 @@ func TestWindow_CloseInterception(t *testing.T) {
 	w := d.CreateWindow("test").(*window)
 	w.create()
 
-	// Close is not calling the interceptor
-	intercepted := false
+	onIntercepted := false
+	onClosed := false
 	w.SetCloseIntercept(func() {
-		intercepted = true
+		onIntercepted = true
+	})
+	w.SetOnClosed(func() {
+		onClosed = true
 	})
 	w.Close()
 	w.waitForEvents()
-	assert.False(t, intercepted)
+	assert.False(t, onIntercepted) // The interceptor is not called by the Close.
+	assert.True(t, onClosed)
 
-	// closed is calling the interceptor
+	onIntercepted = false
+	onClosed = false
 	w.closed(w.viewport)
 	w.waitForEvents()
-	assert.True(t, intercepted)
+	assert.True(t, onIntercepted) // The interceptor is called by the closed.
+	assert.False(t, onClosed)     // If the interceptor is set Close is not called.
 
-	// the interceptor is not calling Close if set
-	intercepted = false
-	w.SetCloseIntercept(func() {})
-	w.SetOnClosed(func() {
-		intercepted = true
-	})
-	w.closed(w.viewport)
-	w.waitForEvents()
-	assert.False(t, intercepted)
-
-	// Close is called if the interceptor is not set
+	onClosed = false
 	w.SetCloseIntercept(nil)
 	w.closed(w.viewport)
 	w.waitForEvents()
-	assert.True(t, intercepted)
+	assert.True(t, onClosed) // Close is called if the interceptor is not set.
 }
 
 // This test makes our developer screens flash, let's not run it regularly...

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -821,6 +821,42 @@ func TestWindow_Clipboard(t *testing.T) {
 	cb.SetContent(cliboardContent)
 }
 
+func TestWindow_CloseInterception(t *testing.T) {
+	d := NewGLDriver()
+	w := d.CreateWindow("test").(*window)
+	w.create()
+
+	// Close is not calling the interceptor
+	intercepted := false
+	w.SetCloseIntercept(func() {
+		intercepted = true
+	})
+	w.Close()
+	w.waitForEvents()
+	assert.False(t, intercepted)
+
+	// closed is calling the interceptor
+	w.closed(w.viewport)
+	w.waitForEvents()
+	assert.True(t, intercepted)
+
+	// the interceptor is not calling Close if set
+	intercepted = false
+	w.SetCloseIntercept(func() {})
+	w.SetOnClosed(func() {
+		intercepted = true
+	})
+	w.closed(w.viewport)
+	w.waitForEvents()
+	assert.False(t, intercepted)
+
+	// Close is called if the interceptor is not set
+	w.SetCloseIntercept(nil)
+	w.closed(w.viewport)
+	w.waitForEvents()
+	assert.True(t, intercepted)
+}
+
 // This test makes our developer screens flash, let's not run it regularly...
 //func TestWindow_Shortcut(t *testing.T) {
 //	w := createWindow("Test")

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -821,49 +821,6 @@ func TestWindow_Clipboard(t *testing.T) {
 	cb.SetContent(cliboardContent)
 }
 
-func TestWindow_WillClose(t *testing.T) {
-	closed := make(chan bool)
-
-	createLocaWindow := func() fyne.Window {
-		w := createWindow("Test")
-		w.SetCloseIntercept(func() {
-			go func() {
-				closed <- true
-				w.Close()
-			}()
-		})
-		return w
-	}
-
-	checkClosed := func() bool {
-		select {
-		case <-closed:
-			return true
-		case <-time.After(100 * time.Millisecond):
-			return false
-		}
-	}
-
-	w := createLocaWindow()
-	w.SetCloseIntercept(func() {})
-	w.Close()
-	assert.False(t, checkClosed())
-
-	w.SetCloseIntercept(func() {
-		go func() {
-			w.SetCloseIntercept(nil)
-			closed <- true
-			w.Close()
-		}()
-	})
-	w.Close()
-	assert.True(t, checkClosed())
-
-	w = createLocaWindow()
-	w.Close()
-	assert.True(t, checkClosed())
-}
-
 // This test makes our developer screens flash, let's not run it regularly...
 //func TestWindow_Shortcut(t *testing.T) {
 //	w := createWindow("Test")

--- a/internal/driver/gomobile/window.go
+++ b/internal/driver/gomobile/window.go
@@ -92,6 +92,10 @@ func (w *window) SetOnClosed(callback func()) {
 	w.onClosed = callback
 }
 
+func (w *window) SetWillClose(_ func() bool) {
+	// no-op
+}
+
 func (w *window) Show() {
 	menu := fyne.CurrentApp().Driver().(*mobileDriver).findMenu(w)
 	menuButton := widget.NewButtonWithIcon("", theme.MenuIcon(), func() {

--- a/internal/driver/gomobile/window.go
+++ b/internal/driver/gomobile/window.go
@@ -108,7 +108,7 @@ func (w *window) Show() {
 
 	if w.isChild {
 		exit := widget.NewButtonWithIcon("", theme.CancelIcon(), func() {
-			w.Close()
+			w.tryClose()
 		})
 		title := widget.NewLabel(w.title)
 		title.Alignment = fyne.TextAlignCenter
@@ -134,12 +134,16 @@ func (w *window) Hide() {
 	}
 }
 
-func (w *window) Close() {
+func (w *window) tryClose() {
 	if w.onCloseIntercepted != nil {
 		w.onCloseIntercepted()
 		return
 	}
 
+	w.Close()
+}
+
+func (w *window) Close() {
 	d := fyne.CurrentApp().Driver().(*mobileDriver)
 	pos := -1
 	for i, win := range d.windows {

--- a/internal/driver/gomobile/window.go
+++ b/internal/driver/gomobile/window.go
@@ -143,6 +143,10 @@ func (w *window) Close() {
 	w.doClose()
 }
 
+func (w *window) DoClose() {
+	w.doClose()
+}
+
 func (w *window) doClose() {
 	d := fyne.CurrentApp().Driver().(*mobileDriver)
 	pos := -1

--- a/internal/driver/gomobile/window.go
+++ b/internal/driver/gomobile/window.go
@@ -9,11 +9,11 @@ import (
 )
 
 type window struct {
-	title     string
-	visible   bool
-	onClosed  func()
-	willClose func()
-	isChild   bool
+	title              string
+	visible            bool
+	onClosed           func()
+	onCloseIntercepted func()
+	isChild            bool
 
 	clipboard fyne.Clipboard
 	canvas    *mobileCanvas
@@ -93,8 +93,8 @@ func (w *window) SetOnClosed(callback func()) {
 	w.onClosed = callback
 }
 
-func (w *window) SetWillClose(callback func()) {
-	w.willClose = callback
+func (w *window) SetCloseIntercept(callback func()) {
+	w.onCloseIntercepted = callback
 }
 
 func (w *window) Show() {
@@ -135,19 +135,11 @@ func (w *window) Hide() {
 }
 
 func (w *window) Close() {
-	if w.willClose != nil {
-		w.willClose()
+	if w.onCloseIntercepted != nil {
+		w.onCloseIntercepted()
 		return
 	}
 
-	w.doClose()
-}
-
-func (w *window) DoClose() {
-	w.doClose()
-}
-
-func (w *window) doClose() {
 	d := fyne.CurrentApp().Driver().(*mobileDriver)
 	pos := -1
 	for i, win := range d.windows {

--- a/internal/driver/gomobile/window.go
+++ b/internal/driver/gomobile/window.go
@@ -12,8 +12,7 @@ type window struct {
 	title     string
 	visible   bool
 	onClosed  func()
-	willClose func() bool
-	clossing  bool
+	willClose func()
 	isChild   bool
 
 	clipboard fyne.Clipboard
@@ -94,7 +93,7 @@ func (w *window) SetOnClosed(callback func()) {
 	w.onClosed = callback
 }
 
-func (w *window) SetWillClose(callback func() bool) {
+func (w *window) SetWillClose(callback func()) {
 	w.willClose = callback
 }
 
@@ -136,21 +135,12 @@ func (w *window) Hide() {
 }
 
 func (w *window) Close() {
-	if w.clossing {
+	if w.willClose != nil {
+		w.willClose()
 		return
 	}
-	w.clossing = true
-	go func() {
-		defer func() { w.clossing = false }()
 
-		if w.willClose != nil {
-			if !w.willClose() {
-				return
-			}
-		}
-
-		w.doClose()
-	}()
+	w.doClose()
 }
 
 func (w *window) doClose() {

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -5,12 +5,12 @@ import (
 )
 
 type testWindow struct {
-	title      string
-	fullScreen bool
-	fixedSize  bool
-	focused    bool
-	onClosed   func()
-	willClose  func()
+	title              string
+	fullScreen         bool
+	fixedSize          bool
+	focused            bool
+	onClosed           func()
+	onCloseIntercepted func()
 
 	canvas    *testCanvas
 	clipboard fyne.Clipboard
@@ -37,20 +37,17 @@ func (w *testWindow) Clipboard() fyne.Clipboard {
 	return w.clipboard
 }
 
-func (w *testWindow) DoClose() {
+func (w *testWindow) Close() {
+	if w.onCloseIntercepted != nil {
+		w.onCloseIntercepted()
+		return
+	}
+
 	if w.onClosed != nil {
 		w.onClosed()
 	}
 	w.focused = false
 	w.driver.removeWindow(w)
-}
-
-func (w *testWindow) Close() {
-	if w.willClose != nil {
-		w.willClose()
-		return
-	}
-	w.DoClose()
 }
 
 func (w *testWindow) Content() fyne.CanvasObject {
@@ -121,8 +118,8 @@ func (w *testWindow) SetOnClosed(closed func()) {
 	w.onClosed = closed
 }
 
-func (w *testWindow) SetWillClose(willClose func()) {
-	w.willClose = willClose
+func (w *testWindow) SetCloseIntercept(callback func()) {
+	w.onCloseIntercepted = callback
 }
 
 func (w *testWindow) SetPadded(padded bool) {

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -10,6 +10,7 @@ type testWindow struct {
 	fixedSize  bool
 	focused    bool
 	onClosed   func()
+	willClose  func()
 
 	canvas    *testCanvas
 	clipboard fyne.Clipboard
@@ -36,12 +37,20 @@ func (w *testWindow) Clipboard() fyne.Clipboard {
 	return w.clipboard
 }
 
-func (w *testWindow) Close() {
+func (w *testWindow) DoClose() {
 	if w.onClosed != nil {
 		w.onClosed()
 	}
 	w.focused = false
 	w.driver.removeWindow(w)
+}
+
+func (w *testWindow) Close() {
+	if w.willClose != nil {
+		w.willClose()
+		return
+	}
+	w.DoClose()
 }
 
 func (w *testWindow) Content() fyne.CanvasObject {
@@ -112,8 +121,8 @@ func (w *testWindow) SetOnClosed(closed func()) {
 	w.onClosed = closed
 }
 
-func (w *testWindow) SetWillClose(_ func()) {
-	// no-op
+func (w *testWindow) SetWillClose(willClose func()) {
+	w.willClose = willClose
 }
 
 func (w *testWindow) SetPadded(padded bool) {

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -38,11 +38,6 @@ func (w *testWindow) Clipboard() fyne.Clipboard {
 }
 
 func (w *testWindow) Close() {
-	if w.onCloseIntercepted != nil {
-		w.onCloseIntercepted()
-		return
-	}
-
 	if w.onClosed != nil {
 		w.onClosed()
 	}

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -112,7 +112,7 @@ func (w *testWindow) SetOnClosed(closed func()) {
 	w.onClosed = closed
 }
 
-func (w *testWindow) SetWillClose(_ func() bool) {
+func (w *testWindow) SetWillClose(_ func()) {
 	// no-op
 }
 

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -112,6 +112,10 @@ func (w *testWindow) SetOnClosed(closed func()) {
 	w.onClosed = closed
 }
 
+func (w *testWindow) SetWillClose(_ func() bool) {
+	// no-op
+}
+
 func (w *testWindow) SetPadded(padded bool) {
 	w.canvas.SetPadded(padded)
 }

--- a/window.go
+++ b/window.go
@@ -64,6 +64,10 @@ type Window interface {
 	// SetOnClosed sets a function that runs when the window is closed.
 	SetOnClosed(func())
 
+	// SetWillClose sets a function that runs before the window is closed
+	// and can block closing
+	SetWillClose(func() bool)
+
 	// Show the window on screen.
 	Show()
 	// Hide the window from the user.

--- a/window.go
+++ b/window.go
@@ -64,8 +64,8 @@ type Window interface {
 	// SetOnClosed sets a function that runs when the window is closed.
 	SetOnClosed(func())
 
-	// SetWillClose sets a function that runs instead of closing if defined
-	SetWillClose(func())
+	// SetCloseIntercept sets a function that runs instead of closing if defined
+	SetCloseIntercept(func())
 
 	// Show the window on screen.
 	Show()
@@ -75,10 +75,6 @@ type Window interface {
 	// Close the window.
 	// If it is the only open window, or the "master" window the app will Quit.
 	Close()
-
-	// DoClose the window without pre-checks.
-	// If it is the only open window, or the "master" window the app will Quit.
-	DoClose()
 
 	// ShowAndRun is a shortcut to show the window and then run the application.
 	// This should be called near the end of a main() function as it will block.

--- a/window.go
+++ b/window.go
@@ -66,7 +66,7 @@ type Window interface {
 
 	// SetWillClose sets a function that runs before the window is closed
 	// and can block closing
-	SetWillClose(func() bool)
+	SetWillClose(func())
 
 	// Show the window on screen.
 	Show()

--- a/window.go
+++ b/window.go
@@ -64,7 +64,8 @@ type Window interface {
 	// SetOnClosed sets a function that runs when the window is closed.
 	SetOnClosed(func())
 
-	// SetCloseIntercept sets a function that runs instead of closing if defined
+	// SetCloseIntercept sets a function that runs instead of closing if defined.
+	// Close() should be called explicitly in the interceptor to close the window.
 	SetCloseIntercept(func())
 
 	// Show the window on screen.

--- a/window.go
+++ b/window.go
@@ -64,8 +64,7 @@ type Window interface {
 	// SetOnClosed sets a function that runs when the window is closed.
 	SetOnClosed(func())
 
-	// SetWillClose sets a function that runs before the window is closed
-	// and can block closing
+	// SetWillClose sets a function that runs instead of closing if defined
 	SetWillClose(func())
 
 	// Show the window on screen.
@@ -76,6 +75,10 @@ type Window interface {
 	// Close the window.
 	// If it is the only open window, or the "master" window the app will Quit.
 	Close()
+
+	// DoClose the window without pre-checks.
+	// If it is the only open window, or the "master" window the app will Quit.
+	DoClose()
 
 	// ShowAndRun is a shortcut to show the window and then run the application.
 	// This should be called near the end of a main() function as it will block.


### PR DESCRIPTION
### Description:
adding wrapper to closing handler so that we can react on the window closing before the window is destroyed.
for example it can serve window closing confirmation

Fixes #467 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass on win10

#### Where applicable:
- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.

#### example:
```go
func main() {
	app := app.New()
	win := app.NewWindow("window title")
	win.Resize(fyne.NewSize(200, 100))

	win.SetCloseIntercept(func() {
		dialog.ShowConfirm("title", "close?",
			func(response bool) {
				if response {
					win.Close()
				}
			}, win)
	})

	win.SetContent(widget.NewHBox(
		widget.NewLabel("long text to exceed initial window width"),
	))

	win.ShowAndRun()
}
```
