### PR TITLE
Make file filter case-insensitive

### DIFF
--- a/storage/filter.go
+++ b/storage/filter.go
@@ -27,7 +27,7 @@ type MimeTypeFileFilter struct {
 func (e *ExtensionFileFilter) Matches(uri fyne.URI) bool {
 	extension := uri.Extension()
 	for _, ext := range e.Extensions {
-		if extension == ext {
+		if strings.EqualFold(extension, ext) {
 			return true
 		}
 	}

--- a/storage/filter_test.go
+++ b/storage/filter_test.go
@@ -1,0 +1,25 @@
+package storage_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/storage"
+
+	_ "fyne.io/fyne/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFIleFilter(t *testing.T) {
+	filter := storage.NewExtensionFileFilter([]string{".jpg", ".png"})
+
+	assert.NotNil(t, filter)
+	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.JPG")))
+	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.jpg")))
+	
+	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.PNG")))
+	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.png")))
+	
+	assert.Equal(t, false, filter.Matches(storage.NewURI("content:///otherapp/something/pic.TIFF")))
+	assert.Equal(t, false, filter.Matches(storage.NewURI("content:///otherapp/something/pic.tiff")))
+}

--- a/storage/filter_test.go
+++ b/storage/filter_test.go
@@ -16,10 +16,10 @@ func TestFIleFilter(t *testing.T) {
 	assert.NotNil(t, filter)
 	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.JPG")))
 	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.jpg")))
-	
+
 	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.PNG")))
 	assert.Equal(t, true, filter.Matches(storage.NewURI("content:///otherapp/something/pic.png")))
-	
+
 	assert.Equal(t, false, filter.Matches(storage.NewURI("content:///otherapp/something/pic.TIFF")))
 	assert.Equal(t, false, filter.Matches(storage.NewURI("content:///otherapp/something/pic.tiff")))
 }


### PR DESCRIPTION
### Description:
Currently, a file filter set as ".jpg" would not pick up and files that was saved using ".JPG". This updates the filter to use strings.EqualFold() for case-insensitive lookup.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
  - Tested with ".png" and ".PNG" files inside `fyne_demo`.
