### PR TITLE
Fix `selectAll` to do nothing when entry is empty

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -780,6 +780,9 @@ func (e *Entry) rowColFromTextPos(pos int) (row int, col int) {
 
 // selectAll selects all text in entry
 func (e *Entry) selectAll() {
+	if e.textProvider().len() == 0 {
+		return
+	}
 	e.setFieldsAndRefresh(func() {
 		e.selectRow = 0
 		e.selectColumn = 0

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1091,6 +1091,13 @@ func TestEntry_SelectAll(t *testing.T) {
 	assert.Equal(t, 9, e.CursorColumn)
 }
 
+func TestEntry_SelectAll_EmptyEntry(t *testing.T) {
+	entry := widget.NewEntry()
+	entry.TypedShortcut(&fyne.ShortcutSelectAll{})
+
+	assert.Equal(t, "", entry.SelectedText())
+}
+
 func TestEntry_SelectSnapRight(t *testing.T) {
 	e, window := setupSelection(false)
 	defer teardownImageTest(window)


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
When executing `selectAll` with an empty entry, selected area becomes invalid status.
So when we called `SelectedText` (or cut, copy, ...) here, panic has occurred by out of range of slice.

I think that `selectAll` should do nothing when entry is empty.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
