### PR TITLE
Reduce the binary size when packaging

### DIFF
--- a/cmd/fyne/build.go
+++ b/cmd/fyne/build.go
@@ -9,6 +9,7 @@ import (
 
 type builder struct {
 	os, srcdir string
+	release    bool
 }
 
 func (b *builder) build() error {
@@ -19,9 +20,17 @@ func (b *builder) build() error {
 
 	var cmd *exec.Cmd
 	if goos == "windows" {
-		cmd = exec.Command("go", "build", "-ldflags", "-H=windowsgui", ".")
+		if b.release {
+			cmd = exec.Command("go", "build", "-ldflags", "-s -w -H=windowsgui", ".")
+		} else {
+			cmd = exec.Command("go", "build", "-ldflags", "-H=windowsgui", ".")
+		}
 	} else {
-		cmd = exec.Command("go", "build", ".")
+		if b.release {
+			cmd = exec.Command("go", "build", "-ldflags", "-s -w", ".")
+		} else {
+			cmd = exec.Command("go", "build", ".")
+		}
 	}
 	cmd.Dir = b.srcdir
 	env := os.Environ()

--- a/cmd/fyne/package.go
+++ b/cmd/fyne/package.go
@@ -347,8 +347,9 @@ func (*packager) printHelp(indent string) {
 
 func (p *packager) buildPackage() error {
 	b := &builder{
-		os:     p.os,
-		srcdir: p.srcDir,
+		os:      p.os,
+		srcdir:  p.srcDir,
+		release: p.release,
 	}
 
 	return b.build()


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR tries to strip the DWARF tables needed for debuggers and reduce the binary size significantly. In may case, which can reduce the size from 30MB to 14MB. The size can be reduced to 5MB after applying upx.

See： https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/

### Checklist:

- [x] Tests included.
   manual test

- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
