### PR TITLE
Moving container API to make mimssing layout explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 This file lists the main changes with each version of the Fyne toolkit.
 More detailed release notes can be found on the [releases page](https://github.com/fyne-io/fyne/releases). 
 
+## 1.4 - Ongoing
+
+### Added
+
+*
+
+### Changed
+
+* Deprecate NewContainer in favour of NewContainerWithoutLayout
+
+### Fixed
+
+*
+
+
 ## 1.3.2 - 11 July 2020
 
 ### Added

--- a/container.go
+++ b/container.go
@@ -108,7 +108,14 @@ func (c *Container) Refresh() {
 }
 
 // NewContainer returns a new Container instance holding the specified CanvasObjects.
+// Deprecated: Use NewContainerWithoutLayout to create a container that uses manual layout.
 func NewContainer(objects ...CanvasObject) *Container {
+	return NewContainerWithoutLayout(objects...)
+}
+
+// NewContainerWithoutLayout returns a new Container instance holding the specified CanvasObjects
+// that are manually arranged.
+func NewContainerWithoutLayout(objects ...CanvasObject) *Container {
 	ret := &Container{
 		Objects: objects,
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -10,7 +10,7 @@ func TestMinSize(t *testing.T) {
 	box := new(dummyObject)
 	minSize := box.MinSize()
 
-	container := NewContainer(box)
+	container := NewContainerWithoutLayout(box)
 	assert.Equal(t, minSize, container.MinSize())
 
 	container.AddObject(box)
@@ -19,7 +19,7 @@ func TestMinSize(t *testing.T) {
 
 func TestMove(t *testing.T) {
 	box := new(dummyObject)
-	container := NewContainer(box)
+	container := NewContainerWithoutLayout(box)
 
 	size := NewSize(100, 100)
 	pos := NewPos(0, 0)
@@ -38,7 +38,7 @@ func TestMove(t *testing.T) {
 func TestNilLayout(t *testing.T) {
 	box := new(dummyObject)
 	boxSize := box.size
-	container := NewContainer(box)
+	container := NewContainerWithoutLayout(box)
 
 	size := NewSize(100, 100)
 	container.Resize(size)
@@ -58,7 +58,7 @@ func (c *customLayout) Layout(objs []CanvasObject, size Size) {
 	}
 }
 
-func (c *customLayout) MinSize(objects []CanvasObject) Size {
+func (c *customLayout) MinSize(_ []CanvasObject) Size {
 	return NewSize(10, 10)
 }
 
@@ -78,7 +78,7 @@ func TestCustomLayout(t *testing.T) {
 
 func TestContainer_Hide(t *testing.T) {
 	box := new(dummyObject)
-	container := NewContainer(box)
+	container := NewContainerWithoutLayout(box)
 
 	assert.True(t, container.Visible())
 	assert.True(t, box.Visible())
@@ -89,7 +89,7 @@ func TestContainer_Hide(t *testing.T) {
 
 func TestContainer_Show(t *testing.T) {
 	box := new(dummyObject)
-	container := NewContainer(box)
+	container := NewContainerWithoutLayout(box)
 
 	container.Hide()
 	assert.True(t, box.Visible())


### PR DESCRIPTION
### Description:
Starting removal of the old `NewContainer(items)` - in 2.0 we will make the default `NewContainer(layout, items)`.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
