### PR TITLE
Add TextFormatter callback for ProgressBar

### DIFF
--- a/cmd/fyne_demo/screens/widget.go
+++ b/cmd/fyne_demo/screens/widget.go
@@ -201,11 +201,25 @@ func makeInputTab() fyne.Widget {
 
 func makeProgressTab() fyne.Widget {
 	progress = widget.NewProgressBar()
+	
+	format := widget.NewProgressBar()
+	format.TextFormatter = func() string {
+		return fmt.Sprintf("%.2f out of %.2f", format.Value, format.Max)
+	}
+	
+	go func() {
+		for format.Value < format.Max {
+			time.Sleep(time.Second)
+			format.SetValue(format.Value+0.01)
+		}	
+	}()
+	
 	infProgress = widget.NewProgressBarInfinite()
 	endProgress = make(chan interface{}, 1)
 
 	return widget.NewVBox(
 		widget.NewLabel("Percent"), progress,
+		widget.NewLabel("Formatted"), format,
 		widget.NewLabel("Infinite"), infProgress)
 }
 

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -22,9 +22,14 @@ type progressRenderer struct {
 // MinSize calculates the minimum size of a progress bar.
 // This is simply the "100%" label size plus padding.
 func (p *progressRenderer) MinSize() fyne.Size {
-	text := fyne.MeasureText("100%", p.label.TextSize, p.label.TextStyle)
+	var tsize fyne.Size
+	if text := p.progress.TextFormatter; text != nil {
+		tsize = fyne.MeasureText(text(), p.label.TextSize, p.label.TextStyle)
+	} else {
+		tsize = fyne.MeasureText("100%", p.label.TextSize, p.label.TextStyle)
+	}
 
-	return fyne.NewSize(text.Width+theme.Padding()*4, text.Height+theme.Padding()*2)
+	return fyne.NewSize(tsize.Width+theme.Padding()*4, tsize.Height+theme.Padding()*2)
 }
 
 func (p *progressRenderer) updateBar() {
@@ -38,7 +43,11 @@ func (p *progressRenderer) updateBar() {
 	delta := float32(p.progress.Max - p.progress.Min)
 	ratio := float32(p.progress.Value-p.progress.Min) / delta
 
-	p.label.Text = fmt.Sprintf(defaultText, int(ratio*100))
+	if text := p.progress.TextFormatter; text != nil {
+		p.label.Text = text()
+	} else {
+		p.label.Text = fmt.Sprintf(defaultText, int(ratio*100))
+	}
 
 	size := p.progress.Size()
 	p.bar.Resize(fyne.NewSize(int(float32(size.Width)*ratio), size.Height))
@@ -73,6 +82,10 @@ type ProgressBar struct {
 	BaseWidget
 
 	Min, Max, Value float64
+
+	// TextFormatter can be used to have a custom format of progress text.
+	// If set, it overrides the percentage readout and runs each time the value updates.
+	TextFormatter func() string
 }
 
 // SetValue changes the current value of this progress bar (from p.Min to p.Max).

--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -1,6 +1,7 @@
 package widget
 
 import (
+	"fmt"
 	"testing"
 
 	"fyne.io/fyne"
@@ -17,6 +18,24 @@ func TestProgressBar_SetValue(t *testing.T) {
 
 	bar.SetValue(.5)
 	assert.Equal(t, .5, bar.Value)
+}
+
+func TestProgressBar_TextFormatter(t *testing.T) {
+	bar := NewProgressBar()
+	formatted := false
+
+	bar.SetValue(0.2)
+	assert.Equal(t, false, formatted)
+
+	formatter := func() string {
+		formatted = true
+		return fmt.Sprintf("%.2f out of %.2f", bar.Value, bar.Max)
+	}
+	bar.TextFormatter = formatter
+
+	bar.SetValue(0.4)
+
+	assert.Equal(t, true, formatted)
 }
 
 func TestProgressRenderer_Layout(t *testing.T) {


### PR DESCRIPTION
### Description:
This adds a function callback for using a custom farmat on progress text.

![progressbar-formatting](https://user-images.githubusercontent.com/25466657/90335690-ff73dc80-dfd6-11ea-8b6b-e02fd647c1cd.gif)

Surpasses #1249 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
