### PR TITLE
Test moving travis to Go 1.15 and speeding up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,27 +65,27 @@ env:
 
 matrix:
   include:
-    - go: 1.12.x
+    - go: 1.13.x
       os: linux
       env: GO111MODULE=on GOFLAGS=
-    - go: 1.13.x
+    - go: 1.14.x
       os: linux
       env: GO111MODULE=off GOFLAGS=
-    - go: 1.13.x
+    - go: 1.14.x
       os: osx
       env: GO111MODULE=off GOFLAGS=
-    - go: 1.13.x
+    - go: 1.14.x
       os: windows
       env: GO111MODULE=off GOFLAGS=
-    - go: 1.14.x
+    - go: 1.15.x
       os: linux
       env: GO111MODULE=on GOFLAGS=
-    - go: 1.14.x
+    - go: 1.15.x
       os: osx
       env: GO111MODULE=on GOFLAGS=-mod=vendor
-    - go: 1.14.x
+    - go: 1.15.x
       os: windows
       env: GO111MODULE=off GOFLAGS=
-    - go: 1.14.x
+    - go: 1.15.x
       os: linux
       env: GO111MODULE=on GOFLAGS=-tags=mobile

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ gobuild_args: "-v -tags ci"
 install: true
 
 cache:
-    directories:
-      - $HOME/.cache/go-build        # Cache the binaries
-      - $HOME/gopath/pkg/mod         # Cache the Go modules
+  directories:
+    - $HOME/gopath/pkg/mod
+  apt: true
 
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
@@ -72,7 +72,7 @@ matrix:
   include:
     - go: 1.13.x
       os: linux
-      env: GO111MODULE=on GOFLAGS=
+      env: GO111MODULE=on GOFLAGS
     - go: 1.14.x
       os: linux
       env: GO111MODULE=off GOFLAGS=

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
   - |
-    if ["$RUN_CODE_CHECKS" = "on" ]
+    if [ "$RUN_CODE_CHECKS" = "on" ]
     then
       GO111MODULE=off go get golang.org/x/tools/cmd/goimports
       GO111MODULE=off go get github.com/fzipp/gocyclo
@@ -42,7 +42,7 @@ script:
     fi
   - |
     # No reason to run code checks on every operating system.
-    if [["$RUN_CODE_CHECKS" = "on" && "$TRAVIS_OS_NAME" != "windows" ]] # Goimports pseaudo diffs on windows and https://github.com/golang/lint/issues/157
+    if [[ "$RUN_CODE_CHECKS" = "on" && "$TRAVIS_OS_NAME" != "windows" ]] # Goimports pseaudo diffs on windows and https://github.com/golang/lint/issues/157
     then
       test -z $(goimports -e -d $GO_FILES | tee /dev/stderr)
       golint -set_exit_status $(go list -tags ci ./...)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ gobuild_args: "-v -tags ci"
 # Disable travis default install step (go get ${gobuild_args} ./...)
 install: true
 
+cache:
+    directories:
+      - $HOME/.cache/go-build        # Cache the binaries
+      - $HOME/gopath/pkg/mod         # Cache the Go modules
+
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
   - GO111MODULE=off go get golang.org/x/tools/cmd/goimports

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,23 +37,15 @@ script:
       go mod tidy && git diff-index --quiet HEAD -- || ( echo "go.mod/go.sum not up-to-date"; git diff-index HEAD --; false )
     fi
   - |
-    if [ "$TRAVIS_OS_NAME" != "windows" ]
+    # No reason to run code checks on every operating system.
+    if [ "$RUN_CODE_CHECKS" = "on" && "$TRAVIS_OS_NAME" != "windows" ] # Goimports pseaudo diffs on windows and https://github.com/golang/lint/issues/157
     then
       test -z $(goimports -e -d $GO_FILES | tee /dev/stderr)
+      golint -set_exit_status $(go list -tags ci ./...)
+      gocyclo -over 50 $GO_FILES
     fi
-# goimports reports a lot of pseudo-diffs on Windows
-#      echo > goimports.out
-#      tail -f goimports.out &
-#      test -z "$(goimports -e -d $GO_FILES | tee goimports.out)"
   - go test -tags ci ./...
   - go vet -tags ci -unsafeptr=false ./...
-# Windows golint alarm probably related to https://github.com/golang/lint/issues/157
-  - |
-    if [ "$TRAVIS_OS_NAME" != "windows" ]
-    then
-      golint -set_exit_status $(go list -tags ci ./...)
-    fi
-  - gocyclo -over 50 $GO_FILES
 
 after_success:
   - |
@@ -72,7 +64,7 @@ matrix:
   include:
     - go: 1.13.x
       os: linux
-      env: GO111MODULE=on GOFLAGS
+      env: RUN_CODE_CHECKS=on GO111MODULE=on GOFLAGS=
     - go: 1.14.x
       os: linux
       env: GO111MODULE=off GOFLAGS=

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ env:
 
 matrix:
   include:
-    - go: 1.13.x
+    - go: 1.12.x
       os: linux
       env: RUN_CODE_CHECKS=on GO111MODULE=on GOFLAGS=
     - go: 1.14.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,13 @@ cache:
 
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
-  - GO111MODULE=off go get golang.org/x/tools/cmd/goimports
-  - GO111MODULE=off go get github.com/fzipp/gocyclo
-  - GO111MODULE=off go get golang.org/x/lint/golint
+  - |
+    if ["$RUN_CODE_CHECKS" = "on" ]
+    then
+      GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+      GO111MODULE=off go get github.com/fzipp/gocyclo
+      GO111MODULE=off go get golang.org/x/lint/golint
+    fi
   - GO111MODULE=off go get github.com/mattn/goveralls
 
 script:
@@ -38,7 +42,7 @@ script:
     fi
   - |
     # No reason to run code checks on every operating system.
-    if [ "$RUN_CODE_CHECKS" = "on" && "$TRAVIS_OS_NAME" != "windows" ] # Goimports pseaudo diffs on windows and https://github.com/golang/lint/issues/157
+    if [["$RUN_CODE_CHECKS" = "on" && "$TRAVIS_OS_NAME" != "windows" ]] # Goimports pseaudo diffs on windows and https://github.com/golang/lint/issues/157
     then
       test -z $(goimports -e -d $GO_FILES | tee /dev/stderr)
       golint -set_exit_status $(go list -tags ci ./...)

--- a/dialog/file_windows.go
+++ b/dialog/file_windows.go
@@ -36,7 +36,7 @@ func listDrives() []string {
 
 	for i := 0; i < 24; i++ {
 		if mask&1 == 1 {
-			letter := string('A' + i)
+			letter := string('A' + rune(i))
 			drives = append(drives, letter+":")
 		}
 		mask >>= 1


### PR DESCRIPTION
### Description:
This PR tries to move Travis to using the latest Go release and also makes sure to apply some changes to make builds faster.
It now uses caching for modules and apt packages while now only running code checks where we tell it to (basically means that we don't run it on each operating system virtual machine).

### Checklist:

- [-] Tests included.
- [-] Lint and formatter run with no errors.
- [ ] Tests all pass.
