### PR TITLE
Add canvasobject pool

### DIFF
--- a/widget/pool.go
+++ b/widget/pool.go
@@ -1,0 +1,32 @@
+package widget
+
+import (
+	"sync"
+
+	"fyne.io/fyne"
+)
+
+type pool interface {
+	Obtain() fyne.CanvasObject
+	Release(fyne.CanvasObject)
+}
+
+var _ pool = (*syncPool)(nil)
+
+type syncPool struct {
+	sync.Pool
+}
+
+// Obtain returns an item from the pool for use
+func (p *syncPool) Obtain() (item fyne.CanvasObject) {
+	o := p.Get()
+	if o != nil {
+		item = o.(fyne.CanvasObject)
+	}
+	return
+}
+
+// Release adds an item into the pool to be used later
+func (p *syncPool) Release(item fyne.CanvasObject) {
+	p.Put(item)
+}

--- a/widget/pool_test.go
+++ b/widget/pool_test.go
@@ -1,0 +1,42 @@
+package widget
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/theme"
+)
+
+func TestSyncPool(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		pool := &syncPool{}
+		assert.Nil(t, pool.Obtain())
+	})
+	t.Run("Single", func(t *testing.T) {
+		pool := &syncPool{}
+		rect := canvas.NewRectangle(theme.PrimaryColor())
+		pool.Release(rect)
+		assert.Equal(t, rect, pool.Obtain())
+		assert.Nil(t, pool.Obtain())
+	})
+	t.Run("Multiple", func(t *testing.T) {
+		pool := &syncPool{}
+		rect := canvas.NewRectangle(theme.PrimaryColor())
+		circle := canvas.NewCircle(theme.PrimaryColor())
+		pool.Release(rect)
+		pool.Release(circle)
+		a := pool.Obtain()
+		b := pool.Obtain()
+		assert.NotNil(t, a)
+		assert.NotNil(t, b)
+		if a == rect && b == circle {
+			// Pass
+		} else if a == circle && b == rect {
+			// Pass
+		} else {
+			t.Error("Obtained incorrect objects")
+		}
+		assert.Nil(t, pool.Obtain())
+	})
+}


### PR DESCRIPTION
### Description:
Adds a pool for reusing canvasobjects

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
