### PR TITLE
Run code checks on newest go, not oldest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
   include:
     - go: 1.12.x
       os: linux
-      env: RUN_CODE_CHECKS=on GO111MODULE=on GOFLAGS=
+      env: GO111MODULE=on GOFLAGS=
     - go: 1.14.x
       os: linux
       env: GO111MODULE=off GOFLAGS=
@@ -89,4 +89,4 @@ matrix:
       env: GO111MODULE=off GOFLAGS=
     - go: 1.15.x
       os: linux
-      env: GO111MODULE=on GOFLAGS=-tags=mobile
+      env: RUN_CODE_CHECKS=on GO111MODULE=on GOFLAGS=-tags=mobile


### PR DESCRIPTION
### Description:
This makes sure that we run our code checks on the latest version of Go, not the oldest. Should help us hopefully catch a few more things than what we otherwise would have done.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
