### PR TITLE
Ensure tab children are resized before being shown

### DIFF
--- a/widget/tabcontainer.go
+++ b/widget/tabcontainer.go
@@ -301,6 +301,7 @@ func (r *tabContainerRenderer) Refresh() {
 	} else {
 		current := r.container.current
 		if current >= 0 && current < len(r.objects) && !r.objects[current].Visible() {
+			r.Layout(r.container.Size())
 			for i, o := range r.objects {
 				if i == current {
 					o.Show()
@@ -308,7 +309,6 @@ func (r *tabContainerRenderer) Refresh() {
 					o.Hide()
 				}
 			}
-			r.Layout(r.container.Size())
 		}
 		for i, button := range r.tabBar.Objects {
 			if i == current {


### PR DESCRIPTION
### Description:
TabContainer calls Show before calling Resize, resulting in content being laid out with 0x0 size.

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
