### PR TITLE
Add caching to widget.Icon

### DIFF
--- a/widget/icon.go
+++ b/widget/icon.go
@@ -32,9 +32,12 @@ func (i *iconRenderer) BackgroundColor() color.Color {
 }
 
 func (i *iconRenderer) Refresh() {
-	i.image.propertyLock.RLock()
-	i.updateObjects()
-	i.image.propertyLock.RUnlock()
+	if i.image.Resource != i.image.cachedRes {
+		i.image.propertyLock.RLock()
+		i.updateObjects()
+		i.image.propertyLock.RUnlock()
+	}
+
 	i.Layout(i.image.Size())
 	canvas.Refresh(i.image.super())
 }
@@ -42,7 +45,6 @@ func (i *iconRenderer) Refresh() {
 func (i *iconRenderer) updateObjects() {
 	var objects []fyne.CanvasObject
 	if i.image.Resource != nil {
-		// TODO this is recreated every time - perhaps cache as long as i.image.Resource doesn't change
 		raster := canvas.NewImageFromResource(i.image.Resource)
 		raster.FillMode = canvas.ImageFillContain
 		objects = append(objects, raster)
@@ -54,12 +56,14 @@ func (i *iconRenderer) updateObjects() {
 type Icon struct {
 	BaseWidget
 
-	Resource fyne.Resource // The resource for this icon
+	Resource  fyne.Resource // The resource for this icon
+	cachedRes fyne.Resource
 }
 
 // SetResource updates the resource rendered in this icon widget
 func (i *Icon) SetResource(res fyne.Resource) {
 	i.Resource = res
+	i.cachedRes = res
 	i.Refresh()
 }
 

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -64,7 +64,7 @@ type Icon struct {
 // SetResource updates the resource rendered in this icon widget
 func (i *Icon) SetResource(res fyne.Resource) {
 	i.Resource = res
-	i.cachedRes = res
+	i.cachedRes = nil
 	i.Refresh()
 }
 

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -35,6 +35,7 @@ func (i *iconRenderer) Refresh() {
 	if i.image.Resource != i.image.cachedRes {
 		i.image.propertyLock.RLock()
 		i.updateObjects()
+		i.image.cachedRes = i.image.Resource
 		i.image.propertyLock.RUnlock()
 	}
 


### PR DESCRIPTION
### Description:
This commit adds some simple caching to widget.Icon.
Testing seems to indicate that the calls to updateObjects in fyne_demo shrunk to less than half of what it was before.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
