### PR TITLE
Hide console on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ It should look like this:
   </table>
 </div>
 
-> Note that Windows applications load from a command prompt by default, which means if you click an icon you may see a command window.
+> Note that Windows applications load from a command prompt by default, which means if you click an icon you may see a command window. Fyne hides this for you at the start of the program but it might still be visible for a split second.
 > To fix this add the parameters `-ldflags -H=windowsgui` to your run or build commands.
 
 # Documentation

--- a/app.go
+++ b/app.go
@@ -5,6 +5,10 @@ import (
 	"sync"
 )
 
+func init() {
+	hideConsoleOnWindows()
+}
+
 // An App is the definition of a graphical application.
 // Apps can have multiple windows, it will exit when the first window to be
 // shown is closed. You can also cause the app to exit by calling Quit().

--- a/hide_console_dummy.go
+++ b/hide_console_dummy.go
@@ -1,0 +1,6 @@
+//+build !windows
+
+package fyne
+
+// hideConsoleOnWindows does nothing on non-Windows operating systems.
+func hideConsoleOnWindows() {}

--- a/hide_console_windows.go
+++ b/hide_console_windows.go
@@ -1,0 +1,63 @@
+//+build windows
+
+package fyne
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// hideConsoleOnWindows hides the associated console window that gets created
+// for Windows applications that are of type console instead of type GUI. When
+// building you can pass the ldflag H=windowsgui to suppress this but if you
+// just go build or go run, a console window will pop open along with the GUI
+// window. hideConsoleOnWindows hides it.
+func hideConsoleOnWindows() {
+	console := getConsoleWindow()
+	if console == 0 {
+		return // No console attached.
+	}
+	// If this application is the process that created the console window, then
+	// this program was not compiled with the -H=windowsgui flag and on start-up
+	// it created a console along with the main application window. In this case
+	// hide the console window. See
+	// http://stackoverflow.com/questions/9009333/how-to-check-if-the-program-is-run-from-a-console
+	_, consoleProcID := getWindowThreadProcessId(console)
+	if getCurrentProcessId() == consoleProcID {
+		const SW_HIDE = 0
+		showWindowAsync(console, SW_HIDE)
+	}
+}
+
+var (
+	kernel32                = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleWindow    = kernel32.NewProc("GetConsoleWindow")
+	procGetCurrentProcessId = kernel32.NewProc("GetCurrentProcessId")
+
+	user32                       = syscall.NewLazyDLL("user32.dll")
+	procGetWindowThreadProcessId = user32.NewProc("GetWindowThreadProcessId")
+	procShowWindowAsync          = user32.NewProc("ShowWindowAsync")
+)
+
+func getConsoleWindow() uintptr {
+	ret, _, _ := procGetConsoleWindow.Call()
+	return ret
+}
+
+func getCurrentProcessId() uint32 {
+	id, _, _ := procGetCurrentProcessId.Call()
+	return uint32(id)
+}
+
+func getWindowThreadProcessId(hwnd uintptr) (uintptr, uint32) {
+	var processId uint32
+	ret, _, _ := procGetWindowThreadProcessId.Call(
+		hwnd,
+		uintptr(unsafe.Pointer(&processId)),
+	)
+	return ret, processId
+}
+
+func showWindowAsync(hwnd uintptr, cmdshow uintptr) {
+	procShowWindowAsync.Call(hwnd, cmdshow)
+}


### PR DESCRIPTION
When not adding -ldflags "-H=windowsgui" to go build/run/install on Windows, a console window shows up when you run the program.

This PR hides the console in an init function. The console window might be visible for a split second but then disappears. This is nice for debugging and might even be used for deployment.

There are some considerations, though:

1. Do we always want to hide the console? It might be useful for programmers during development. Usually you will work in your IDE which shows you the stdout and stderr output but if you really want to click on your .exe and see output, you can using the default console window. We might add an option to not hide the console on Windows.

2. Is this the right place? I just put the code in an init function because I want it to happen right when the program starts and because I do not know where else to put it. What is the code path that every fyne app takes? waiting until ShowAndRun would be too late, settings up things, maybe pulling a database for example, it might take a while for the program to get to show the GUI. Until then we do not want the console to be visible, possibly printing debug output. As said in 1. this might be good for the developer but if this is deployed, it is bad.

This PR was easy for me to make, I do not expect it to be merged without discussion but I wanted to get something out there that people can try before deciding if we really want this to happen and if yes, how to do it.