### PR TITLE
Fix crash when calling List.Layout before init

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -123,6 +123,9 @@ func (l *listRenderer) Layout(size fyne.Size) {
 
 	// Relayout What Is Visible - no scroll change - initial layout or possibly from a resize.
 	l.visibleItemCount = int(math.Ceil(float64(l.scroller.size.Height) / float64(l.list.itemMin.Height)))
+	if l.visibleItemCount == 0 {
+		return
+	}
 	min := int(math.Min(float64(l.list.Length()), float64(l.visibleItemCount)))
 	if len(l.children) > min {
 		for i := len(l.children); i >= min; i-- {


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
When calling List.Layout before initializing, panic occurred because of out of range.
This could happens, for example, when switching themes right after startup with `fyne_demo` app.
I suppose that it is due to the fact that the `visibleItemCount` is no longer checked in #1330.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
