### PR TITLE
Deprecate WidgetRenderer.BackgroundColor

### DIFF
--- a/widget.go
+++ b/widget.go
@@ -18,6 +18,9 @@ type Widget interface {
 // function and should be exactly one instance per widget in memory.
 type WidgetRenderer interface {
 	// BackgroundColor returns the color that should be used to draw the background of this renderer’s widget.
+	// Deprecated: Widgets will no longer have a background to support hover and selection indication in collection widgets.
+	// If a widget requires a background color or image, this can be achieved by using a canvas.Rect or canvas.Image
+	// as the first child of a MaxLayout, followed by the rest of the widget components.
 	BackgroundColor() color.Color
 	// Destroy is for internal use.
 	Destroy()

--- a/widget.go
+++ b/widget.go
@@ -18,6 +18,7 @@ type Widget interface {
 // function and should be exactly one instance per widget in memory.
 type WidgetRenderer interface {
 	// BackgroundColor returns the color that should be used to draw the background of this renderer’s widget.
+	//
 	// Deprecated: Widgets will no longer have a background to support hover and selection indication in collection widgets.
 	// If a widget requires a background color or image, this can be achieved by using a canvas.Rect or canvas.Image
 	// as the first child of a MaxLayout, followed by the rest of the widget components.


### PR DESCRIPTION
### Description:
This is the first step of #1338, the second step is to remove existing usages in 2.0 release.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
