### PR TITLE
Refactoring: separate radio item

### DIFF
--- a/widget/radio.go
+++ b/widget/radio.go
@@ -51,8 +51,8 @@ func (r *Radio) Append(option string) {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (r *Radio) CreateRenderer() fyne.WidgetRenderer {
 	r.ExtendBaseWidget(r)
-	r.propertyLock.RLock()
-	defer r.propertyLock.RUnlock()
+	r.propertyLock.Lock()
+	defer r.propertyLock.Unlock()
 	var items []*radioRenderItem
 	var objects []fyne.CanvasObject
 
@@ -258,11 +258,11 @@ func (r *radioRenderer) MinSize() fyne.Size {
 }
 
 func (r *radioRenderer) Refresh() {
-	r.radio.propertyLock.RLock()
+	r.radio.propertyLock.Lock()
 	r.applyTheme()
 	r.radio.removeDuplicateOptions()
 	r.updateItems()
-	r.radio.propertyLock.RUnlock()
+	r.radio.propertyLock.Unlock()
 	canvas.Refresh(r.radio.super())
 }
 

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -12,6 +12,187 @@ import (
 
 const noRadioItemIndex = -1
 
+// Radio widget has a list of text labels and radio check icons next to each.
+// Changing the selection (only one can be selected) will trigger the changed func.
+type Radio struct {
+	DisableableWidget
+	Horizontal bool
+	Required   bool
+	OnChanged  func(string) `json:"-"`
+	Options    []string
+	Selected   string
+
+	hoveredItemIndex int
+	hovered          bool
+}
+
+// NewRadio creates a new radio widget with the set options and change handler
+func NewRadio(options []string, changed func(string)) *Radio {
+	r := &Radio{
+		DisableableWidget: DisableableWidget{},
+		Options:           options,
+		OnChanged:         changed,
+	}
+
+	r.removeDuplicateOptions()
+	r.ExtendBaseWidget(r)
+	return r
+}
+
+// Append adds a new option to the end of a Radio widget.
+func (r *Radio) Append(option string) {
+	r.Options = append(r.Options, option)
+
+	r.Refresh()
+}
+
+// CreateRenderer is a private method to Fyne which links this widget to its renderer
+func (r *Radio) CreateRenderer() fyne.WidgetRenderer {
+	r.ExtendBaseWidget(r)
+	r.propertyLock.RLock()
+	defer r.propertyLock.RUnlock()
+	var items []*radioRenderItem
+	var objects []fyne.CanvasObject
+
+	for _, option := range r.Options {
+		icon := canvas.NewImageFromResource(theme.RadioButtonIcon())
+
+		text := canvas.NewText(option, theme.TextColor())
+		text.Alignment = fyne.TextAlignLeading
+
+		focusIndicator := canvas.NewCircle(theme.BackgroundColor())
+
+		objects = append(objects, focusIndicator, icon, text)
+		items = append(items, &radioRenderItem{icon, text, focusIndicator})
+	}
+
+	rr := &radioRenderer{widget.NewBaseRenderer(objects), items, r}
+	rr.applyTheme()
+	r.removeDuplicateOptions()
+	rr.updateItems()
+	return rr
+}
+
+// MinSize returns the size that this widget should not shrink below
+func (r *Radio) MinSize() fyne.Size {
+	r.ExtendBaseWidget(r)
+	return r.BaseWidget.MinSize()
+}
+
+// MouseIn is called when a desktop pointer enters the widget
+func (r *Radio) MouseIn(event *desktop.MouseEvent) {
+	if r.Disabled() {
+		return
+	}
+
+	r.hoveredItemIndex = r.indexByPosition(event.Position)
+	r.hovered = true
+	r.Refresh()
+}
+
+// MouseMoved is called when a desktop pointer hovers over the widget
+func (r *Radio) MouseMoved(event *desktop.MouseEvent) {
+	if r.Disabled() {
+		return
+	}
+
+	r.hoveredItemIndex = r.indexByPosition(event.Position)
+	r.hovered = true
+	r.Refresh()
+}
+
+// MouseOut is called when a desktop pointer exits the widget
+func (r *Radio) MouseOut() {
+	r.hoveredItemIndex = noRadioItemIndex
+	r.hovered = false
+	r.Refresh()
+}
+
+// SetSelected sets the radio option, it can be used to set a default option.
+func (r *Radio) SetSelected(option string) {
+	if r.Selected == option {
+		return
+	}
+
+	r.Selected = option
+
+	if r.OnChanged != nil {
+		r.OnChanged(option)
+	}
+
+	r.Refresh()
+}
+
+// Tapped is called when a pointer tapped event is captured and triggers any change handler
+func (r *Radio) Tapped(event *fyne.PointEvent) {
+	if r.Disabled() {
+		return
+	}
+
+	index := r.indexByPosition(event.Position)
+
+	if index < 0 || index >= len(r.Options) { // in the padding
+		return
+	}
+	clicked := r.Options[index]
+
+	if r.Selected == clicked {
+		if r.Required {
+			return
+		}
+		r.Selected = ""
+	} else {
+		r.Selected = clicked
+	}
+
+	if r.OnChanged != nil {
+		r.OnChanged(r.Selected)
+	}
+	r.Refresh()
+}
+
+// indexByPosition returns the item index for a specified position or noRadioItemIndex if any
+func (r *Radio) indexByPosition(pos fyne.Position) int {
+	index := 0
+	if r.Horizontal {
+		index = int(math.Floor(float64(pos.X) / float64(r.itemWidth())))
+	} else {
+		index = int(math.Floor(float64(pos.Y) / float64(r.itemHeight())))
+	}
+	if index < 0 || index >= len(r.Options) { // in the padding
+		return noRadioItemIndex
+	}
+	return index
+}
+
+func (r *Radio) itemHeight() int {
+	if r.Horizontal {
+		return r.MinSize().Height
+	}
+
+	count := 1
+	if r.Options != nil && len(r.Options) > 0 {
+		count = len(r.Options)
+	}
+	return r.MinSize().Height / count
+}
+
+func (r *Radio) itemWidth() int {
+	if !r.Horizontal {
+		return r.MinSize().Width
+	}
+
+	count := 1
+	if r.Options != nil && len(r.Options) > 0 {
+		count = len(r.Options)
+	}
+	return r.MinSize().Width / count
+}
+
+func (r *Radio) removeDuplicateOptions() {
+	r.Options = removeDuplicates(r.Options)
+}
+
 type radioRenderItem struct {
 	icon  *canvas.Image
 	label *canvas.Text
@@ -23,42 +204,6 @@ type radioRenderer struct {
 	widget.BaseRenderer
 	items []*radioRenderItem
 	radio *Radio
-}
-
-func removeDuplicates(options []string) []string {
-	var result []string
-	found := make(map[string]bool)
-
-	for _, option := range options {
-		if _, ok := found[option]; !ok {
-			found[option] = true
-			result = append(result, option)
-		}
-	}
-
-	return result
-}
-
-// MinSize calculates the minimum size of a radio item.
-// This is based on the contained text, the radio icon and a standard amount of padding
-// between each item.
-func (r *radioRenderer) MinSize() fyne.Size {
-	width := 0
-	height := 0
-	for _, item := range r.items {
-		itemMin := item.label.MinSize().Add(fyne.NewSize(theme.Padding()*4, theme.Padding()*2))
-		itemMin = itemMin.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0))
-
-		if r.radio.Horizontal {
-			height = fyne.Max(height, itemMin.Height)
-			width += itemMin.Width
-		} else {
-			width = fyne.Max(width, itemMin.Width)
-			height += itemMin.Height
-		}
-	}
-
-	return fyne.NewSize(width, height)
 }
 
 // Layout the components of the radio widget
@@ -88,15 +233,26 @@ func (r *radioRenderer) Layout(size fyne.Size) {
 	}
 }
 
-// applyTheme updates this Radio to match the current system theme
-func (r *radioRenderer) applyTheme() {
+// MinSize calculates the minimum size of a radio item.
+// This is based on the contained text, the radio icon and a standard amount of padding
+// between each item.
+func (r *radioRenderer) MinSize() fyne.Size {
+	width := 0
+	height := 0
 	for _, item := range r.items {
-		item.label.Color = theme.TextColor()
-		item.label.TextSize = theme.TextSize()
-		if r.radio.Disabled() {
-			item.label.Color = theme.DisabledTextColor()
+		itemMin := item.label.MinSize().Add(fyne.NewSize(theme.Padding()*4, theme.Padding()*2))
+		itemMin = itemMin.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0))
+
+		if r.radio.Horizontal {
+			height = fyne.Max(height, itemMin.Height)
+			width += itemMin.Width
+		} else {
+			width = fyne.Max(width, itemMin.Width)
+			height += itemMin.Height
 		}
 	}
+
+	return fyne.NewSize(width, height)
 }
 
 func (r *radioRenderer) Refresh() {
@@ -106,6 +262,17 @@ func (r *radioRenderer) Refresh() {
 	r.updateItems()
 	r.radio.propertyLock.RUnlock()
 	canvas.Refresh(r.radio.super())
+}
+
+// applyTheme updates this Radio to match the current system theme
+func (r *radioRenderer) applyTheme() {
+	for _, item := range r.items {
+		item.label.Color = theme.TextColor()
+		item.label.TextSize = theme.TextSize()
+		if r.radio.Disabled() {
+			item.label.Color = theme.DisabledTextColor()
+		}
+	}
 }
 
 func (r *radioRenderer) updateItems() {
@@ -152,183 +319,16 @@ func (r *radioRenderer) updateItems() {
 	}
 }
 
-// Radio widget has a list of text labels and radio check icons next to each.
-// Changing the selection (only one can be selected) will trigger the changed func.
-type Radio struct {
-	DisableableWidget
-	Horizontal bool
-	Required   bool
-	OnChanged  func(string) `json:"-"`
-	Options    []string
-	Selected   string
+func removeDuplicates(options []string) []string {
+	var result []string
+	found := make(map[string]bool)
 
-	hoveredItemIndex int
-	hovered          bool
-}
-
-// indexByPosition returns the item index for a specified position or noRadioItemIndex if any
-func (r *Radio) indexByPosition(pos fyne.Position) int {
-	index := 0
-	if r.Horizontal {
-		index = int(math.Floor(float64(pos.X) / float64(r.itemWidth())))
-	} else {
-		index = int(math.Floor(float64(pos.Y) / float64(r.itemHeight())))
-	}
-	if index < 0 || index >= len(r.Options) { // in the padding
-		return noRadioItemIndex
-	}
-	return index
-}
-
-// MouseIn is called when a desktop pointer enters the widget
-func (r *Radio) MouseIn(event *desktop.MouseEvent) {
-	if r.Disabled() {
-		return
-	}
-
-	r.hoveredItemIndex = r.indexByPosition(event.Position)
-	r.hovered = true
-	r.Refresh()
-}
-
-// MouseOut is called when a desktop pointer exits the widget
-func (r *Radio) MouseOut() {
-	r.hoveredItemIndex = noRadioItemIndex
-	r.hovered = false
-	r.Refresh()
-}
-
-// MouseMoved is called when a desktop pointer hovers over the widget
-func (r *Radio) MouseMoved(event *desktop.MouseEvent) {
-	if r.Disabled() {
-		return
-	}
-
-	r.hoveredItemIndex = r.indexByPosition(event.Position)
-	r.hovered = true
-	r.Refresh()
-}
-
-// Append adds a new option to the end of a Radio widget.
-func (r *Radio) Append(option string) {
-	r.Options = append(r.Options, option)
-
-	r.Refresh()
-}
-
-// Tapped is called when a pointer tapped event is captured and triggers any change handler
-func (r *Radio) Tapped(event *fyne.PointEvent) {
-	if r.Disabled() {
-		return
-	}
-
-	index := r.indexByPosition(event.Position)
-
-	if index < 0 || index >= len(r.Options) { // in the padding
-		return
-	}
-	clicked := r.Options[index]
-
-	if r.Selected == clicked {
-		if r.Required {
-			return
+	for _, option := range options {
+		if _, ok := found[option]; !ok {
+			found[option] = true
+			result = append(result, option)
 		}
-		r.Selected = ""
-	} else {
-		r.Selected = clicked
 	}
 
-	if r.OnChanged != nil {
-		r.OnChanged(r.Selected)
-	}
-	r.Refresh()
-}
-
-// MinSize returns the size that this widget should not shrink below
-func (r *Radio) MinSize() fyne.Size {
-	r.ExtendBaseWidget(r)
-	return r.BaseWidget.MinSize()
-}
-
-// CreateRenderer is a private method to Fyne which links this widget to its renderer
-func (r *Radio) CreateRenderer() fyne.WidgetRenderer {
-	r.ExtendBaseWidget(r)
-	r.propertyLock.RLock()
-	defer r.propertyLock.RUnlock()
-	var items []*radioRenderItem
-	var objects []fyne.CanvasObject
-
-	for _, option := range r.Options {
-		icon := canvas.NewImageFromResource(theme.RadioButtonIcon())
-
-		text := canvas.NewText(option, theme.TextColor())
-		text.Alignment = fyne.TextAlignLeading
-
-		focusIndicator := canvas.NewCircle(theme.BackgroundColor())
-
-		objects = append(objects, focusIndicator, icon, text)
-		items = append(items, &radioRenderItem{icon, text, focusIndicator})
-	}
-
-	rr := &radioRenderer{widget.NewBaseRenderer(objects), items, r}
-	rr.applyTheme()
-	r.removeDuplicateOptions()
-	rr.updateItems()
-	return rr
-}
-
-// SetSelected sets the radio option, it can be used to set a default option.
-func (r *Radio) SetSelected(option string) {
-	if r.Selected == option {
-		return
-	}
-
-	r.Selected = option
-
-	if r.OnChanged != nil {
-		r.OnChanged(option)
-	}
-
-	r.Refresh()
-}
-
-func (r *Radio) itemHeight() int {
-	if r.Horizontal {
-		return r.MinSize().Height
-	}
-
-	count := 1
-	if r.Options != nil && len(r.Options) > 0 {
-		count = len(r.Options)
-	}
-	return r.MinSize().Height / count
-}
-
-func (r *Radio) itemWidth() int {
-	if !r.Horizontal {
-		return r.MinSize().Width
-	}
-
-	count := 1
-	if r.Options != nil && len(r.Options) > 0 {
-		count = len(r.Options)
-	}
-	return r.MinSize().Width / count
-}
-
-func (r *Radio) removeDuplicateOptions() {
-	r.Options = removeDuplicates(r.Options)
-}
-
-// NewRadio creates a new radio widget with the set options and change handler
-func NewRadio(options []string, changed func(string)) *Radio {
-	r := &Radio{
-		DisableableWidget: DisableableWidget{},
-		Options:           options,
-		OnChanged:         changed,
-	}
-
-	r.removeDuplicateOptions()
-	r.ExtendBaseWidget(r)
-	return r
+	return result
 }

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -26,6 +26,8 @@ type Radio struct {
 	hovered          bool
 }
 
+var _ fyne.Widget = (*Radio)(nil)
+
 // NewRadio creates a new radio widget with the set options and change handler
 func NewRadio(options []string, changed func(string)) *Radio {
 	r := &Radio{

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -44,7 +44,7 @@ func (r *Radio) Append(option string) {
 func (r *Radio) CreateRenderer() fyne.WidgetRenderer {
 	r.ExtendBaseWidget(r)
 	r.propertyLock.Lock()
-	r.propertyLock.Unlock()
+	defer r.propertyLock.Unlock()
 
 	r.update()
 	var objects []fyne.CanvasObject

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -5,9 +5,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
-	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/internal/widget"
-	"fyne.io/fyne/theme"
 )
 
 const noRadioItemIndex = -1
@@ -22,8 +20,7 @@ type Radio struct {
 	Options    []string
 	Selected   string
 
-	hoveredItemIndex int
-	hovered          bool
+	items []*radioItem
 }
 
 var _ fyne.Widget = (*Radio)(nil)
@@ -35,9 +32,8 @@ func NewRadio(options []string, changed func(string)) *Radio {
 		Options:           options,
 		OnChanged:         changed,
 	}
-
-	r.removeDuplicateOptions()
 	r.ExtendBaseWidget(r)
+	r.update()
 	return r
 }
 
@@ -52,27 +48,14 @@ func (r *Radio) Append(option string) {
 func (r *Radio) CreateRenderer() fyne.WidgetRenderer {
 	r.ExtendBaseWidget(r)
 	r.propertyLock.Lock()
-	defer r.propertyLock.Unlock()
-	var items []*radioRenderItem
+	r.propertyLock.Unlock()
+
+	r.update()
 	var objects []fyne.CanvasObject
-
-	for _, option := range r.Options {
-		icon := canvas.NewImageFromResource(theme.RadioButtonIcon())
-
-		text := canvas.NewText(option, theme.TextColor())
-		text.Alignment = fyne.TextAlignLeading
-
-		focusIndicator := canvas.NewCircle(theme.BackgroundColor())
-
-		objects = append(objects, focusIndicator, icon, text)
-		items = append(items, &radioRenderItem{icon, text, focusIndicator})
+	for _, item := range r.items {
+		objects = append(objects, item)
 	}
-
-	rr := &radioRenderer{widget.NewBaseRenderer(objects), items, r}
-	rr.applyTheme()
-	r.removeDuplicateOptions()
-	rr.updateItems()
-	return rr
+	return &radioRenderer{widget.NewBaseRenderer(objects), r.items, r}
 }
 
 // MinSize returns the size that this widget should not shrink below
@@ -81,33 +64,14 @@ func (r *Radio) MinSize() fyne.Size {
 	return r.BaseWidget.MinSize()
 }
 
-// MouseIn is called when a desktop pointer enters the widget
-func (r *Radio) MouseIn(event *desktop.MouseEvent) {
-	if r.Disabled() {
-		return
-	}
-
-	r.hoveredItemIndex = r.indexByPosition(event.Position)
-	r.hovered = true
-	r.Refresh()
-}
-
-// MouseMoved is called when a desktop pointer hovers over the widget
-func (r *Radio) MouseMoved(event *desktop.MouseEvent) {
-	if r.Disabled() {
-		return
-	}
-
-	r.hoveredItemIndex = r.indexByPosition(event.Position)
-	r.hovered = true
-	r.Refresh()
-}
-
-// MouseOut is called when a desktop pointer exits the widget
-func (r *Radio) MouseOut() {
-	r.hoveredItemIndex = noRadioItemIndex
-	r.hovered = false
-	r.Refresh()
+// Refresh causes this widget to be redrawn in it's current state.
+//
+// Implements: fyne.CanvasObject
+func (r *Radio) Refresh() {
+	r.propertyLock.Lock()
+	r.update()
+	r.propertyLock.Unlock()
+	r.BaseWidget.Refresh()
 }
 
 // SetSelected sets the radio option, it can be used to set a default option.
@@ -122,34 +86,6 @@ func (r *Radio) SetSelected(option string) {
 		r.OnChanged(option)
 	}
 
-	r.Refresh()
-}
-
-// Tapped is called when a pointer tapped event is captured and triggers any change handler
-func (r *Radio) Tapped(event *fyne.PointEvent) {
-	if r.Disabled() {
-		return
-	}
-
-	index := r.indexByPosition(event.Position)
-
-	if index < 0 || index >= len(r.Options) { // in the padding
-		return
-	}
-	clicked := r.Options[index]
-
-	if r.Selected == clicked {
-		if r.Required {
-			return
-		}
-		r.Selected = ""
-	} else {
-		r.Selected = clicked
-	}
-
-	if r.OnChanged != nil {
-		r.OnChanged(r.Selected)
-	}
 	r.Refresh()
 }
 
@@ -191,42 +127,61 @@ func (r *Radio) itemWidth() int {
 	return r.MinSize().Width / count
 }
 
-func (r *Radio) removeDuplicateOptions() {
-	r.Options = removeDuplicates(r.Options)
+func (r *Radio) itemTapped(item *radioItem) {
+	if r.Disabled() {
+		return
+	}
+
+	if r.Selected == item.Label {
+		if r.Required {
+			return
+		}
+		r.Selected = ""
+		item.SetSelected(false)
+	} else {
+		r.Selected = item.Label
+		item.SetSelected(true)
+	}
+
+	if r.OnChanged != nil {
+		r.OnChanged(r.Selected)
+	}
+	r.Refresh()
 }
 
-type radioRenderItem struct {
-	icon  *canvas.Image
-	label *canvas.Text
-
-	focusIndicator *canvas.Circle
+func (r *Radio) update() {
+	r.Options = removeDuplicates(r.Options)
+	if len(r.items) < len(r.Options) {
+		for i := len(r.items); i < len(r.Options); i++ {
+			item := newRadioItem(r.Options[i], r.itemTapped)
+			r.items = append(r.items, item)
+		}
+	} else if len(r.items) > len(r.Options) {
+		r.items = r.items[:len(r.Options)]
+	}
+	for i, item := range r.items {
+		item.Label = r.Options[i]
+		item.Selected = item.Label == r.Selected
+		item.DisableableWidget.disabled = r.disabled
+		item.Refresh()
+	}
 }
 
 type radioRenderer struct {
 	widget.BaseRenderer
-	items []*radioRenderItem
+	items []*radioItem
 	radio *Radio
 }
 
 // Layout the components of the radio widget
-func (r *radioRenderer) Layout(size fyne.Size) {
+func (r *radioRenderer) Layout(_ fyne.Size) {
 	itemWidth := r.radio.itemWidth()
 	itemHeight := r.radio.itemHeight()
-	labelSize := fyne.NewSize(itemWidth, itemHeight)
-	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.Padding()*2, theme.IconInlineSize()+theme.Padding()*2)
-
+	itemSize := fyne.NewSize(itemWidth, itemHeight)
 	x, y := 0, 0
 	for _, item := range r.items {
-		item.focusIndicator.Resize(focusIndicatorSize)
-		item.focusIndicator.Move(fyne.NewPos(x, y+(itemHeight-focusIndicatorSize.Height)/2))
-
-		item.label.Resize(labelSize)
-		item.label.Move(fyne.NewPos(x+focusIndicatorSize.Width+theme.Padding(), y))
-
-		item.icon.Resize(fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize()))
-		item.icon.Move(fyne.NewPos(x+theme.Padding(),
-			y+(labelSize.Height-theme.IconInlineSize())/2))
-
+		item.Resize(itemSize)
+		item.Move(fyne.NewPos(x, y))
 		if r.radio.Horizontal {
 			x += itemWidth
 		} else {
@@ -242,9 +197,7 @@ func (r *radioRenderer) MinSize() fyne.Size {
 	width := 0
 	height := 0
 	for _, item := range r.items {
-		itemMin := item.label.MinSize().Add(fyne.NewSize(theme.Padding()*4, theme.Padding()*2))
-		itemMin = itemMin.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0))
-
+		itemMin := item.MinSize()
 		if r.radio.Horizontal {
 			height = fyne.Max(height, itemMin.Height)
 			width += itemMin.Width
@@ -258,66 +211,27 @@ func (r *radioRenderer) MinSize() fyne.Size {
 }
 
 func (r *radioRenderer) Refresh() {
-	r.radio.propertyLock.Lock()
-	r.applyTheme()
-	r.radio.removeDuplicateOptions()
 	r.updateItems()
-	r.radio.propertyLock.Unlock()
 	canvas.Refresh(r.radio.super())
-}
-
-// applyTheme updates this Radio to match the current system theme
-func (r *radioRenderer) applyTheme() {
-	for _, item := range r.items {
-		item.label.Color = theme.TextColor()
-		item.label.TextSize = theme.TextSize()
-		if r.radio.Disabled() {
-			item.label.Color = theme.DisabledTextColor()
-		}
-	}
 }
 
 func (r *radioRenderer) updateItems() {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
-			option := r.radio.Options[i]
-			icon := canvas.NewImageFromResource(theme.RadioButtonIcon())
-
-			text := canvas.NewText(option, theme.TextColor())
-			text.Alignment = fyne.TextAlignLeading
-
-			focusIndicator := canvas.NewCircle(theme.BackgroundColor())
-
-			r.SetObjects(append(r.Objects(), focusIndicator, icon, text))
-			r.items = append(r.items, &radioRenderItem{icon, text, focusIndicator})
+			item := newRadioItem(r.radio.Options[i], r.radio.itemTapped)
+			r.SetObjects(append(r.Objects(), item))
+			r.items = append(r.items, item)
 		}
 		r.Layout(r.radio.Size())
 	} else if len(r.items) > len(r.radio.Options) {
 		total := len(r.radio.Options)
 		r.items = r.items[:total]
-		r.SetObjects(r.Objects()[:total*2])
+		r.SetObjects(r.Objects()[:total])
 	}
-
 	for i, item := range r.items {
-		option := r.radio.Options[i]
-		item.label.Text = option
-
-		res := theme.RadioButtonIcon()
-		if r.radio.Selected == option {
-			res = theme.RadioButtonCheckedIcon()
-		}
-		if r.radio.Disabled() {
-			res = theme.NewDisabledResource(res)
-		}
-		item.icon.Resource = res
-
-		if r.radio.Disabled() {
-			item.focusIndicator.FillColor = theme.BackgroundColor()
-		} else if r.radio.hovered && r.radio.hoveredItemIndex == i {
-			item.focusIndicator.FillColor = theme.HoverColor()
-		} else {
-			item.focusIndicator.FillColor = theme.BackgroundColor()
-		}
+		item.Label = r.radio.Options[i]
+		item.Selected = item.Label == r.radio.Selected
+		item.Refresh()
 	}
 }
 

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -1,14 +1,10 @@
 package widget
 
 import (
-	"math"
-
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/internal/widget"
 )
-
-const noRadioItemIndex = -1
 
 // Radio widget has a list of text labels and radio check icons next to each.
 // Changing the selection (only one can be selected) will trigger the changed func.
@@ -87,20 +83,6 @@ func (r *Radio) SetSelected(option string) {
 	}
 
 	r.Refresh()
-}
-
-// indexByPosition returns the item index for a specified position or noRadioItemIndex if any
-func (r *Radio) indexByPosition(pos fyne.Position) int {
-	index := 0
-	if r.Horizontal {
-		index = int(math.Floor(float64(pos.X) / float64(r.itemWidth())))
-	} else {
-		index = int(math.Floor(float64(pos.Y) / float64(r.itemHeight())))
-	}
-	if index < 0 || index >= len(r.Options) { // in the padding
-		return noRadioItemIndex
-	}
-	return index
 }
 
 func (r *Radio) itemHeight() int {

--- a/widget/radio.go
+++ b/widget/radio.go
@@ -85,30 +85,6 @@ func (r *Radio) SetSelected(option string) {
 	r.Refresh()
 }
 
-func (r *Radio) itemHeight() int {
-	if r.Horizontal {
-		return r.MinSize().Height
-	}
-
-	count := 1
-	if r.Options != nil && len(r.Options) > 0 {
-		count = len(r.Options)
-	}
-	return r.MinSize().Height / count
-}
-
-func (r *Radio) itemWidth() int {
-	if !r.Horizontal {
-		return r.MinSize().Width
-	}
-
-	count := 1
-	if r.Options != nil && len(r.Options) > 0 {
-		count = len(r.Options)
-	}
-	return r.MinSize().Width / count
-}
-
 func (r *Radio) itemTapped(item *radioItem) {
 	if r.Disabled() {
 		return
@@ -157,8 +133,20 @@ type radioRenderer struct {
 
 // Layout the components of the radio widget
 func (r *radioRenderer) Layout(_ fyne.Size) {
-	itemWidth := r.radio.itemWidth()
-	itemHeight := r.radio.itemHeight()
+	count := 1
+	if r.items != nil && len(r.items) > 0 {
+		count = len(r.items)
+	}
+	var itemHeight, itemWidth int
+	minSize := r.radio.MinSize()
+	if r.radio.Horizontal {
+		itemHeight = minSize.Height
+		itemWidth = minSize.Width / count
+	} else {
+		itemHeight = minSize.Height / count
+		itemWidth = minSize.Width
+	}
+
 	itemSize := fyne.NewSize(itemWidth, itemHeight)
 	x, y := 0, 0
 	for _, item := range r.items {

--- a/widget/radio_extended_test.go
+++ b/widget/radio_extended_test.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,6 +21,7 @@ func newExtendedRadio(opts []string, f func(string)) *extendedRadio {
 	ret.Options = opts
 	ret.OnChanged = f
 	ret.ExtendBaseWidget(ret)
+	ret.update() // Not needed for extending Radio but for the tests to be able to access items without creating a renderer first.
 
 	return ret
 }
@@ -36,7 +38,7 @@ func TestRadio_Extended_Selected(t *testing.T) {
 	radio := newExtendedRadio([]string{"Hi"}, func(sel string) {
 		selected = sel
 	})
-	radio.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
 
 	assert.Equal(t, "Hi", selected)
 }
@@ -47,7 +49,7 @@ func TestRadio_Extended_Unselected(t *testing.T) {
 		selected = sel
 	})
 	radio.Selected = selected
-	radio.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
 
 	assert.Equal(t, "", selected)
 }
@@ -93,7 +95,7 @@ func TestRadio_Extended_Disable(t *testing.T) {
 	})
 
 	radio.Disable()
-	radio.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
 
 	assert.Equal(t, "", selected, "Radio should have been disabled.")
 }
@@ -105,11 +107,11 @@ func TestRadio_Extended_Enable(t *testing.T) {
 	})
 
 	radio.Disable()
-	radio.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
 	assert.Equal(t, "", selected, "Radio should have been disabled.")
 
 	radio.Enable()
-	radio.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
 	assert.Equal(t, "Hi", selected, "Radio should have been re-enabled.")
 }
 
@@ -135,59 +137,48 @@ func TestRadio_Extended_Hovered(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			radio := newExtendedRadio(tt.options, nil)
 			radio.Horizontal = tt.isHorizontal
-			render := cache.Renderer(radio).(*radioRenderer)
+			item1 := radio.items[0]
+			render1 := cache.Renderer(item1).(*radioItemRenderer)
+			render2 := cache.Renderer(radio.items[1]).(*radioItemRenderer)
 
-			assert.Equal(t, false, radio.hovered)
-			assert.Equal(t, theme.BackgroundColor(), render.items[0].focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render.items[1].focusIndicator.FillColor)
+			assert.False(t, item1.hovered)
+			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
+			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
 
 			radio.SetSelected("Hi")
-			assert.Equal(t, theme.BackgroundColor(), render.items[0].focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render.items[1].focusIndicator.FillColor)
+			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
+			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
 
 			radio.SetSelected("Another")
-			assert.Equal(t, theme.BackgroundColor(), render.items[0].focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render.items[1].focusIndicator.FillColor)
+			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
+			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
 
-			radio.MouseIn(&desktop.MouseEvent{
+			item1.MouseIn(&desktop.MouseEvent{
 				PointEvent: fyne.PointEvent{
 					Position: fyne.NewPos(theme.Padding(), theme.Padding()),
 				},
 			})
-			assert.Equal(t, 0, radio.hoveredItemIndex)
-			assert.Equal(t, true, radio.hovered)
-			assert.Equal(t, theme.HoverColor(), render.items[0].focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render.items[1].focusIndicator.FillColor)
+			assert.True(t, item1.hovered)
+			assert.Equal(t, theme.HoverColor(), render1.focusIndicator.FillColor)
+			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
 
-			var mouseMove fyne.Position
-			if tt.isHorizontal {
-				mouseMove = fyne.NewPos(radio.MinSize().Width-theme.Padding(), theme.Padding())
-			} else {
-				mouseMove = fyne.NewPos(theme.Padding(), radio.MinSize().Height-theme.Padding())
-			}
-
-			radio.MouseMoved(&desktop.MouseEvent{
-				PointEvent: fyne.PointEvent{
-					Position: mouseMove,
-				},
-			})
-			assert.Equal(t, 1, radio.hoveredItemIndex)
-			assert.Equal(t, theme.BackgroundColor(), render.items[0].focusIndicator.FillColor)
-			assert.Equal(t, theme.HoverColor(), render.items[1].focusIndicator.FillColor)
+			item1.MouseOut()
+			assert.False(t, item1.hovered)
+			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
+			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
 		})
 	}
 }
 
 func TestRadioRenderer_Extended_ApplyTheme(t *testing.T) {
 	radio := newExtendedRadio([]string{"Test"}, func(string) {})
-	render := cache.Renderer(radio).(*radioRenderer)
+	render := cache.Renderer(radio.items[0]).(*radioItemRenderer)
 
-	item := render.items[0]
-	textSize := item.label.TextSize
+	textSize := render.label.TextSize
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {
-		render.applyTheme()
-		customTextSize = item.label.TextSize
+		render.Refresh()
+		customTextSize = render.label.TextSize
 	})
 
 	assert.NotEqual(t, textSize, customTextSize)

--- a/widget/radio_internal_test.go
+++ b/widget/radio_internal_test.go
@@ -132,7 +132,7 @@ func TestRadio_Append(t *testing.T) {
 	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 
 	radio.Options = append(radio.Options, "Another")
-	Refresh(radio)
+	radio.Refresh()
 
 	assert.Equal(t, 2, len(radio.Options))
 	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioRenderer).items))
@@ -145,7 +145,7 @@ func TestRadio_Remove(t *testing.T) {
 	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioRenderer).items))
 
 	radio.Options = radio.Options[:1]
-	Refresh(radio)
+	radio.Refresh()
 
 	assert.Equal(t, 1, len(radio.Options))
 	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioRenderer).items))
@@ -168,7 +168,7 @@ func TestRadio_SetSelectedWithSameOption(t *testing.T) {
 	radio := NewRadio([]string{"Hi", "Another"}, nil)
 
 	radio.Selected = "Another"
-	Refresh(radio)
+	radio.Refresh()
 
 	radio.SetSelected("Another")
 
@@ -179,7 +179,7 @@ func TestRadio_SetSelectedEmpty(t *testing.T) {
 	radio := NewRadio([]string{"Hi", "Another"}, nil)
 
 	radio.Selected = "Another"
-	Refresh(radio)
+	radio.Refresh()
 
 	radio.SetSelected("")
 

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -1,0 +1,148 @@
+package widget
+
+import (
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/driver/desktop"
+	"fyne.io/fyne/internal/widget"
+	"fyne.io/fyne/theme"
+)
+
+var _ fyne.Widget = (*radioItem)(nil)
+var _ desktop.Hoverable = (*radioItem)(nil)
+var _ fyne.Tappable = (*radioItem)(nil)
+
+func newRadioItem(label string, onTap func(*radioItem)) *radioItem {
+	i := &radioItem{Label: label, onTap: onTap}
+	i.ExtendBaseWidget(i)
+	return i
+}
+
+type radioItem struct {
+	DisableableWidget
+
+	Label    string
+	Selected bool
+
+	hovered bool
+	onTap   func(item *radioItem)
+}
+
+func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
+	focusIndicator := canvas.NewCircle(theme.BackgroundColor())
+	icon := canvas.NewImageFromResource(theme.RadioButtonIcon())
+	label := canvas.NewText(i.Label, theme.TextColor())
+	label.Alignment = fyne.TextAlignLeading
+	r := &radioItemRenderer{
+		BaseRenderer:   widget.NewBaseRenderer([]fyne.CanvasObject{focusIndicator, icon, label}),
+		focusIndicator: focusIndicator,
+		icon:           icon,
+		item:           i,
+		label:          label,
+	}
+	r.update()
+	return r
+}
+
+func (i *radioItem) MouseIn(_ *desktop.MouseEvent) {
+	if i.Disabled() {
+		return
+	}
+
+	i.hovered = true
+	i.Refresh()
+}
+
+func (i *radioItem) MouseMoved(_ *desktop.MouseEvent) {
+}
+
+func (i *radioItem) MouseOut() {
+	if i.Disabled() {
+		return
+	}
+
+	i.hovered = false
+	i.Refresh()
+}
+
+func (i *radioItem) SetSelected(selected bool) {
+	if i.Disabled() {
+		return
+	}
+	if i.Selected == selected {
+		return
+	}
+	i.Selected = selected
+	i.Refresh()
+}
+
+func (i *radioItem) Tapped(_ *fyne.PointEvent) {
+	if i.Disabled() {
+		return
+	}
+	if i.onTap == nil {
+		return
+	}
+
+	i.onTap(i)
+}
+
+type radioItemRenderer struct {
+	widget.BaseRenderer
+
+	focusIndicator *canvas.Circle
+	icon           *canvas.Image
+	item           *radioItem
+	label          *canvas.Text
+}
+
+func (r *radioItemRenderer) Layout(size fyne.Size) {
+	labelSize := fyne.NewSize(size.Width, size.Height)
+	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.Padding()*2, theme.IconInlineSize()+theme.Padding()*2)
+
+	r.focusIndicator.Resize(focusIndicatorSize)
+	r.focusIndicator.Move(fyne.NewPos(0, (size.Height-focusIndicatorSize.Height)/2))
+
+	r.label.Resize(labelSize)
+	r.label.Move(fyne.NewPos(focusIndicatorSize.Width+theme.Padding(), 0))
+
+	r.icon.Resize(fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize()))
+	r.icon.Move(fyne.NewPos(theme.Padding(), (labelSize.Height-theme.IconInlineSize())/2))
+}
+
+func (r *radioItemRenderer) MinSize() fyne.Size {
+	return r.label.MinSize().
+		Add(fyne.NewSize(theme.Padding()*4, theme.Padding()*2)).
+		Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0))
+}
+
+func (r *radioItemRenderer) Refresh() {
+	r.update()
+	canvas.Refresh(r.item.super())
+}
+
+func (r *radioItemRenderer) update() {
+	r.label.Text = r.item.Label
+	r.label.Color = theme.TextColor()
+	r.label.TextSize = theme.TextSize()
+	if r.item.Disabled() {
+		r.label.Color = theme.DisabledTextColor()
+	}
+
+	res := theme.RadioButtonIcon()
+	if r.item.Selected {
+		res = theme.RadioButtonCheckedIcon()
+	}
+	if r.item.Disabled() {
+		res = theme.NewDisabledResource(res)
+	}
+	r.icon.Resource = res
+
+	if r.item.Disabled() {
+		r.focusIndicator.FillColor = theme.BackgroundColor()
+	} else if r.item.hovered {
+		r.focusIndicator.FillColor = theme.HoverColor()
+	} else {
+		r.focusIndicator.FillColor = theme.BackgroundColor()
+	}
+}

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -1,0 +1,21 @@
+package widget
+
+import (
+	"testing"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/test"
+	"fyne.io/fyne/theme"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
+	item := newRadioItem("Hello", nil)
+	render := test.WidgetRenderer(item).(*radioItemRenderer)
+	render.Layout(fyne.NewSize(200, 100))
+
+	focusIndicatorSize := theme.IconInlineSize() + theme.Padding()*2
+	heightCenterOffset := (100 - focusIndicatorSize) / 2
+	assert.Equal(t, fyne.NewPos(0, heightCenterOffset), render.focusIndicator.Position1)
+}


### PR DESCRIPTION
### Description:

This PR extracts the radio item into a separate widget.
This helps implementing the keyboard control and also simplifies the hovering and tapping code.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
