### PR TITLE
Use fyne.URI in isHidden

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -212,7 +212,7 @@ func (f *fileDialog) refreshDir(dir fyne.ListableURI) {
 		icons = append(icons, fi)
 	}
 	for _, file := range files {
-		if isHidden(file.Name(), dir.Name()) {
+		if isHidden(file) {
 			continue
 		}
 

--- a/dialog/file_mobile.go
+++ b/dialog/file_mobile.go
@@ -14,7 +14,11 @@ func (f *fileDialog) loadPlaces() []fyne.CanvasObject {
 	return nil
 }
 
-func isHidden(file, _ string) bool {
+func isHidden(file fyne.URI) bool {
+	if file.Scheme() != "file" {
+		fyne.LogError("Cannot check if non file is hidden", nil)
+		return false
+	}
 	return false
 }
 

--- a/dialog/file_other_test.go
+++ b/dialog/file_other_test.go
@@ -5,13 +5,14 @@ package dialog
 import (
 	"testing"
 
+	"fyne.io/fyne/storage"
 	"fyne.io/fyne/widget"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIsHidden(t *testing.T) {
-	assert.True(t, isHidden(".nothing", ""))
-	assert.False(t, isHidden("file.txt", ""))
+	assert.True(t, isHidden(storage.NewFileURI(".nothing")))
+	assert.False(t, isHidden(storage.NewFileURI("file.txt")))
 }
 
 func TestFileDialog_LoadPlaces(t *testing.T) {

--- a/dialog/file_unix.go
+++ b/dialog/file_unix.go
@@ -19,8 +19,13 @@ func (f *fileDialog) loadPlaces() []fyne.CanvasObject {
 	})}
 }
 
-func isHidden(file, _ string) bool {
-	return len(file) == 0 || file[0] == '.'
+func isHidden(file fyne.URI) bool {
+	if file.Scheme() != "file" {
+		fyne.LogError("Cannot check if non file is hidden", nil)
+		return false
+	}
+	filePath := file.String()[len(file.Scheme()+3):]
+	return len(filePath) == 0 || filePath[0] == '.'
 }
 
 func fileOpenOSOverride(*FileDialog) bool {

--- a/dialog/file_unix.go
+++ b/dialog/file_unix.go
@@ -24,7 +24,7 @@ func isHidden(file fyne.URI) bool {
 		fyne.LogError("Cannot check if non file is hidden", nil)
 		return false
 	}
-	filePath := file.String()[len(file.Scheme()+3):]
+	filePath := file.String()[len(file.Scheme())+3:]
 	return len(filePath) == 0 || filePath[0] == '.'
 }
 

--- a/dialog/file_windows.go
+++ b/dialog/file_windows.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"os"
-	"path/filepath"
 	"syscall"
 
 	"fyne.io/fyne"
@@ -59,8 +58,13 @@ func (f *fileDialog) loadPlaces() []fyne.CanvasObject {
 	return places
 }
 
-func isHidden(file, dir string) bool {
-	path := filepath.Join(dir, file)
+func isHidden(file fyne.URI) bool {
+	if file.Scheme() != "file" {
+		fyne.LogError("Cannot check if non file is hidden", nil)
+		return false
+	}
+
+	path := file.String()[len(file.Scheme())+3:]
 
 	point, err := syscall.UTF16PtrFromString(path)
 	if err != nil {


### PR DESCRIPTION
### Description:
This fixes the ```isHidden``` function. Previously there were a lot of error logs when isHidden was called which actually slowed down the execution.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
