### PR TITLE
added an "uninstall" option to the packaged Makefile

### DIFF
--- a/cmd/fyne/package.go
+++ b/cmd/fyne/package.go
@@ -148,10 +148,15 @@ func (p *packager) packageLinux() error {
 			"\n"+
 			"default:\n"+
 			`	# Run "sudo make install" to install the application.`+"\n"+
+			`	# Run "sudo make uninstall" to uninstall the application.`+"\n"+
 			"install:\n"+
 			"	install -Dm00644 usr/"+local+"share/applications/"+p.name+`.desktop $(DESTDIR)$(PREFIX)/share/applications/`+p.name+".desktop\n"+
 			"	install -Dm00755 usr/"+local+"bin/"+filepath.Base(p.exe)+` $(DESTDIR)$(PREFIX)/bin/`+filepath.Base(p.exe)+"\n"+
-			"	install -Dm00644 usr/"+local+"share/pixmaps/"+p.name+filepath.Ext(p.icon)+` $(DESTDIR)$(PREFIX)/share/pixmaps/`+p.name+filepath.Ext(p.icon)+"\n")
+			"	install -Dm00644 usr/"+local+"share/pixmaps/"+p.name+filepath.Ext(p.icon)+` $(DESTDIR)$(PREFIX)/share/pixmaps/`+p.name+filepath.Ext(p.icon)+"\n"+
+			"uninstall:\n"+
+			"	-rm "+`$(DESTDIR)$(PREFIX)/share/applications/`+p.name+".desktop\n"+
+			"	-rm "+`$(DESTDIR)$(PREFIX)/bin/`+filepath.Base(p.exe)+"\n"+
+			"	-rm "+`$(DESTDIR)$(PREFIX)/share/pixmaps/`+p.name+filepath.Ext(p.icon)+"\n")
 		if err != nil {
 			return errors.Wrap(err, "Failed to write Makefile string")
 		}


### PR DESCRIPTION
### Description:
Just a quick mod as I thought a `make uninstall` option would be handy

I prefix'ed the `rm` commands with a `-` which means that failure is acceptable and it will clean up all effected files (so in the case that someone removed or renamed their `.desktop` file.. the uninstall target would continue..)

![image](https://user-images.githubusercontent.com/462087/96049930-b0c8ae80-0e70-11eb-82c3-62789bf89ae5.png)
