### PR TITLE
Fix the flicker on originalFill image load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Respect SelectEntry datta changes on refresh (#1462)
 * Incorrect SelectEntry dropdown button position (#1361)
 * don't allow both single and double tap events to fire (#1381)
+* Fix issue where long or tall images could jump on load (#1266, #1432)
 * Add missing raster support in software render
 * Respect GOOS/GOARCH in fyne command utilities
 * BSD support in build tools


### PR DESCRIPTION
This is not pretty but what we have to do is return the visible portion pixel for pixel.
The image is immediately refreshed so the correct, full, image (with aspect applied) is then used.

Fixes #1432

### Checklist:

- [ ] Tests included. <- as before, this is only seen on gl driver rendering,  reproduction code was good to replicate
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
