### PR TITLE
Remove Double Tap handling from Tree

### DIFF
--- a/widget/tree.go
+++ b/widget/tree.go
@@ -660,7 +660,6 @@ func (r *treeNodeRenderer) partialRefresh() {
 	canvas.Refresh(r.treeNode.super())
 }
 
-var _ fyne.DoubleTappable = (*branch)(nil)
 var _ fyne.Widget = (*branch)(nil)
 
 type branch struct {
@@ -677,10 +676,6 @@ func newBranch(tree *Tree, content fyne.CanvasObject) (b *branch) {
 	}
 	b.ExtendBaseWidget(b)
 	return
-}
-
-func (b *branch) DoubleTapped(*fyne.PointEvent) {
-	b.tree.ToggleBranch(b.uid)
 }
 
 func (b *branch) update(uid string, depth int) {

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -688,7 +688,6 @@ func (b *branch) update(uid string, depth int) {
 	b.icon.(*branchIcon).update(uid, depth)
 }
 
-var _ fyne.DoubleTappable = (*branchIcon)(nil)
 var _ fyne.Tappable = (*branchIcon)(nil)
 
 type branchIcon struct {
@@ -703,10 +702,6 @@ func newBranchIcon(tree *Tree) (i *branchIcon) {
 	}
 	i.ExtendBaseWidget(i)
 	return
-}
-
-func (i *branchIcon) DoubleTapped(*fyne.PointEvent) {
-	// Do nothing - this stops the event propagating to branch
 }
 
 func (i *branchIcon) Refresh() {

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -317,16 +317,15 @@ func TestTree_Tap(t *testing.T) {
 
 		tree.Refresh() // Force layout
 
-		tapped := make(chan bool)
-		tree.OnBranchOpened = func(uid string) {
-			tapped <- true
+		selected := make(chan bool)
+		tree.OnSelectionChanged = func(uid string) {
+			selected <- true
 		}
-		go test.DoubleTap(getBranch(t, tree, "A"))
+		go test.Tap(getBranch(t, tree, "A"))
 		select {
-		case open := <-tapped:
-			assert.True(t, open, "Branch should be open")
+		case <-selected:
 		case <-time.After(1 * time.Second):
-			assert.Fail(t, "Branch should have been changed")
+			assert.Fail(t, "Branch should have been selected")
 		}
 	})
 	t.Run("BranchIcon", func(t *testing.T) {


### PR DESCRIPTION
### Description:
branch and branchIcon no longer respond to double tap

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
