### PR TITLE
Index svg cache by resource/file name not the resource struct

### DIFF
--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -41,7 +41,7 @@ func PaintImage(img *canvas.Image, c fyne.Canvas, width, height int) image.Image
 		}
 
 		if strings.ToLower(filepath.Ext(name)) == ".svg" {
-			tex := svgCacheGet(img.Resource, width, height)
+			tex := svgCacheGet(name, width, height)
 			if tex == nil {
 				// Not in cache, so load the item and add to cache
 
@@ -82,7 +82,7 @@ func PaintImage(img *canvas.Image, c fyne.Canvas, width, height int) image.Image
 					return nil
 				}
 
-				svgCachePut(img.Resource, tex, width, height)
+				svgCachePut(name, tex, width, height)
 			}
 
 			return tex

--- a/internal/painter/svg_cache.go
+++ b/internal/painter/svg_cache.go
@@ -17,7 +17,7 @@ type rasterInfo struct {
 }
 
 var cacheDuration = time.Minute * 5
-var rasters = make(map[fyne.Resource]*rasterInfo)
+var rasters = make(map[string]*rasterInfo)
 var aspects = make(map[interface{}]float32, 16)
 var rasterMutex sync.RWMutex
 var janitorOnce sync.Once
@@ -61,10 +61,10 @@ func svgCacheJanitor() {
 	})
 }
 
-func svgCacheGet(res fyne.Resource, w int, h int) *image.NRGBA {
+func svgCacheGet(name string, w int, h int) *image.NRGBA {
 	rasterMutex.RLock()
 	defer rasterMutex.RUnlock()
-	v, ok := rasters[res]
+	v, ok := rasters[name]
 	if !ok || v == nil || v.w != w || v.h != h {
 		return nil
 	}
@@ -72,14 +72,14 @@ func svgCacheGet(res fyne.Resource, w int, h int) *image.NRGBA {
 	return v.pix
 }
 
-func svgCachePut(res fyne.Resource, pix *image.NRGBA, w int, h int) {
+func svgCachePut(name string, pix *image.NRGBA, w int, h int) {
 	rasterMutex.Lock()
 	defer rasterMutex.Unlock()
 	defer func() {
 		recover()
 	}()
 
-	rasters[res] = &rasterInfo{
+	rasters[name] = &rasterInfo{
 		pix:     pix,
 		w:       w,
 		h:       h,
@@ -90,7 +90,7 @@ func svgCachePut(res fyne.Resource, pix *image.NRGBA, w int, h int) {
 // SvgCacheReset clears the SVG cache.
 func SvgCacheReset() {
 	rasterMutex.Lock()
-	rasters = make(map[fyne.Resource]*rasterInfo)
+	rasters = make(map[string]*rasterInfo)
 	rasterMutex.Unlock()
 }
 

--- a/internal/painter/svg_cache_test.go
+++ b/internal/painter/svg_cache_test.go
@@ -1,0 +1,58 @@
+package painter
+
+import (
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+)
+
+func TestSvgCacheGet(t *testing.T) {
+	SvgCacheReset()
+	img := addToCache("empty.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>", 25, 25)
+	assert.Equal(t, 1, len(rasters))
+
+	newImg := svgCacheGet("empty.svg", 25, 25)
+	assert.Equal(t, img, newImg)
+
+	miss := svgCacheGet("missing.svg", 25, 25)
+	assert.Nil(t, miss)
+	miss = svgCacheGet("empty.svg", 30, 30)
+	assert.Nil(t, miss)
+}
+
+func TestSvgCacheGet_File(t *testing.T) {
+	SvgCacheReset()
+	img := addFileToCache("testdata/stroke.svg", 25, 25)
+	assert.Equal(t, 1, len(rasters))
+
+	newImg := svgCacheGet("testdata/stroke.svg", 25, 25)
+	assert.Equal(t, img, newImg)
+
+	miss := svgCacheGet("missing.svg", 25, 25)
+	assert.Nil(t, miss)
+	miss = svgCacheGet("testdata/stroke.svg", 30, 30)
+	assert.Nil(t, miss)
+}
+
+func TestSvgCacheReset(t *testing.T) {
+	SvgCacheReset()
+	_ = addToCache("empty.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>", 25, 25)
+	assert.Equal(t, 1, len(rasters))
+
+	SvgCacheReset()
+	assert.Equal(t, 0, len(rasters))
+}
+
+func addFileToCache(path string, w, h int) image.Image {
+	img := canvas.NewImageFromFile(path)
+	return PaintImage(img, nil, w, h)
+}
+
+func addToCache(name, content string, w, h int) image.Image {
+	img := canvas.NewImageFromResource(fyne.NewStaticResource(name, []byte(content)))
+	return PaintImage(img, nil, w, h)
+}


### PR DESCRIPTION
SVG cache was not working when using files, only when using resources.

Fixes #1476

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
