### PR TITLE
Fix flickering on the Progress tab in demo app

### DIFF
--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -239,6 +239,8 @@ func makeInputTab(_ fyne.Window) fyne.CanvasObject {
 }
 
 func makeProgressTab(_ fyne.Window) fyne.CanvasObject {
+	stopProgress()
+
 	progress = widget.NewProgressBar()
 
 	fprogress = widget.NewProgressBar()
@@ -311,11 +313,12 @@ func startProgress() {
 	}
 
 	go func() {
+		end := endProgress
 		num := 0.0
 		for num < 1.0 {
 			time.Sleep(100 * time.Millisecond)
 			select {
-			case <-endProgress:
+			case <-end:
 				return
 			default:
 			}


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
In the demo app, opening the progress tab over and over again causes the progress bar to flicker.

![201101-fyne](https://user-images.githubusercontent.com/31386431/97791430-93883400-1c15-11eb-9b9c-1e4fe87b01db.gif)

This is because every time the tab is opened, goroutine is started to do refresh progress bars.
So fixed to call `stopProgress` to quit the goroutine when the Progress tab is opened.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
