### PR TITLE
Fixes #1497 #1498 Skip build of darwin/arm and pass correct parameter to sips

### DIFF
--- a/cmd/fyne/commands/package-mobile.go
+++ b/cmd/fyne/commands/package-mobile.go
@@ -34,6 +34,6 @@ func (p *packager) packageIOS() error {
 }
 
 func copyResizeIcon(size, dir string) error {
-	cmd := exec.Command("sips", "-o", dir+"/Icon_"+size+".png", "-Z", "120", dir+"/Icon.png")
+	cmd := exec.Command("sips", "-o", dir+"/Icon_"+size+".png", "-Z", size, dir+"/Icon.png")
 	return cmd.Run()
 }

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -152,7 +152,7 @@ func runBuildImpl(cmd *command) (*packages.Package, error) {
 			return nil, fmt.Errorf("-os=ios requires XCode")
 		}
 		if buildRelease {
-			targetArchs = []string{"arm", "arm64"}
+			targetArchs = []string{"arm64"}
 		}
 
 		if pkg.Name != "main" {


### PR DESCRIPTION
### Description:

Fixes #1497 #1498: Skip build of darwin/arm and pass correct parameter to sips

Note that I haven't been able to test this due to the way go modules work. I'm not sure how to get this to work locally, and I am not sure if removing `darwin/arm` has any impact on anything else.

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [x] Tests all pass.
