### PR TITLE
fix #1498: resize parameter passed to sips to be the requested size

### DIFF
--- a/cmd/fyne/commands/package-mobile.go
+++ b/cmd/fyne/commands/package-mobile.go
@@ -34,6 +34,6 @@ func (p *packager) packageIOS() error {
 }
 
 func copyResizeIcon(size, dir string) error {
-	cmd := exec.Command("sips", "-o", dir+"/Icon_"+size+".png", "-Z", "120", dir+"/Icon.png")
+	cmd := exec.Command("sips", "-o", dir+"/Icon_"+size+".png", "-Z", size, dir+"/Icon.png")
 	return cmd.Run()
 }


### PR DESCRIPTION
### Description:

Fixes #1498: resize parameter passed to sips to be the requested size

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
