### PR TITLE
Remove 32bit from iOS apps, Go 1.15 does not allow it

### DIFF
--- a/cmd/fyne/internal/mobile/bind.go
+++ b/cmd/fyne/internal/mobile/bind.go
@@ -65,14 +65,14 @@ func writeFile(filename string, generate func(io.Writer) error) error {
 	return generate(f)
 }
 
-func packagesConfig(targetOS string) *packages.Config {
+func packagesConfig(targetOS, targetArch string) *packages.Config {
 	config := &packages.Config{}
 	// Add CGO_ENABLED=1 explicitly since Cgo is disabled when GOOS is different from host OS.
-	config.Env = append(os.Environ(), "GOARCH=arm", "GOOS="+targetOS, "CGO_ENABLED=1")
+	config.Env = append(os.Environ(), "GOARCH="+targetArch, "GOOS="+targetOS, "CGO_ENABLED=1")
 	if targetOS == "android" {
 		// with Cgo enabled we need to ensure the C compiler is set via CC to
 		// avoid the error: "gcc: error: unrecognized command line option '-marm'"
-		config.Env = append(os.Environ(), androidEnv["arm"]...)
+		config.Env = append(os.Environ(), androidEnv[targetArch]...)
 	}
 	tags := buildTags
 	if targetOS == "darwin" {

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -113,7 +113,7 @@ func runBuildImpl(cmd *command) (*packages.Package, error) {
 		cmd.usage()
 		os.Exit(1)
 	}
-	pkgs, err := packages.Load(packagesConfig(targetOS), buildPath)
+	pkgs, err := packages.Load(packagesConfig(targetOS, targetArchs[0]), buildPath)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func runBuildImpl(cmd *command) (*packages.Package, error) {
 			return nil, fmt.Errorf("-os=ios requires XCode")
 		}
 		if buildRelease {
-			targetArchs = []string{"arm", "arm64"}
+			targetArchs = []string{"arm64"}
 		}
 
 		if pkg.Name != "main" {
@@ -381,8 +381,8 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	}
 
 	// verify all archs are supported one while deduping.
-	isSupported := func(arch string) bool {
-		for _, a := range allArchs {
+	isSupported := func(os, arch string) bool {
+		for _, a := range allArchs[os] {
 			if a == arch {
 				return true
 			}
@@ -395,7 +395,7 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 		if _, ok := seen[arch]; ok {
 			continue
 		}
-		if !isSupported(arch) {
+		if !isSupported(os, arch) {
 			return "", nil, fmt.Errorf(`unsupported arch: %q`, arch)
 		}
 
@@ -408,7 +408,7 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 		targetOS = "darwin"
 	}
 	if all {
-		return targetOS, allArchs, nil
+		return targetOS, allArchs[os], nil
 	}
 	return targetOS, archs, nil
 }

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -306,7 +306,7 @@ var infoplistTmpl = template.Must(template.New("infoplist").Parse(`<?xml version
   <string>LaunchScreen</string>
   <key>UIRequiredDeviceCapabilities</key>
   <array>
-    <string>armv7</string>
+    <string>armv64</string>
   </array>
   <key>UIRequiresFullScreen</key>
   <true/>

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -27,7 +27,7 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 	// Detect the team ID
 	teamID, err := DetectIOSTeamID(cert)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to look up certificate %s: %s", cert, err.Error())
 	}
 
 	projPbxproj := new(bytes.Buffer)
@@ -306,7 +306,7 @@ var infoplistTmpl = template.Must(template.New("infoplist").Parse(`<?xml version
   <string>LaunchScreen</string>
   <key>UIRequiredDeviceCapabilities</key>
   <array>
-    <string>armv64</string>
+    <string>arm64</string>
   </array>
   <key>UIRequiresFullScreen</key>
   <true/>

--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -23,7 +23,9 @@ var (
 
 	darwinArmNM string
 
-	allArchs = []string{"arm", "arm64", "386", "amd64"}
+	allArchs = map[string][]string{
+		"android": {"arm", "arm64", "386", "amd64"},
+		"ios":     {"arm64", "amd64"}}
 
 	bitcodeEnabled bool
 )
@@ -136,7 +138,7 @@ func envInit() (err error) {
 
 	darwinArmNM = "nm"
 	darwinEnv = make(map[string][]string)
-	for _, arch := range allArchs {
+	for _, arch := range allArchs["ios"] {
 		var env []string
 		var err error
 		var clang, cflags string


### PR DESCRIPTION
Also this was stopped by Apple many years ago (iPhone 5s)

Fixes #1497

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

