### PR TITLE
Add missing LoadResourceFromURI

### DIFF
--- a/storage/resource.go
+++ b/storage/resource.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"io/ioutil"
+
+	"fyne.io/fyne"
+)
+
+// LoadResourceFromURI creates a new StaticResource in memory using the contents of the specified URI.
+// The URI will be opened using the current driver, so valid schemas will vary from platform to platform.
+// The file:// schema will always work.
+func LoadResourceFromURI(u fyne.URI) (fyne.Resource, error) {
+	read, err := OpenFileFromURI(u)
+	if err != nil {
+		return nil, err
+	}
+
+	defer read.Close()
+	bytes, err := ioutil.ReadAll(read)
+	if err != nil {
+		return nil, err
+	}
+
+	return fyne.NewStaticResource(u.Name(), bytes), nil
+}

--- a/storage/resource_test.go
+++ b/storage/resource_test.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadResourceFromURI(t *testing.T) {
+	path := filepath.Join("testdata", "test.txt")
+	abs, err := filepath.Abs(path)
+	assert.Nil(t, err)
+
+	uri := NewFileURI(abs)
+	res, err := LoadResourceFromURI(uri)
+	assert.Nil(t, err)
+	assert.Equal(t, "test.txt", res.Name())
+	assert.Equal(t, []byte("Text content"), res.Content())
+}

--- a/storage/testdata/test.txt
+++ b/storage/testdata/test.txt
@@ -1,0 +1,1 @@
+Text content


### PR DESCRIPTION
Missed this with the other storage / uri work that was going on.

Needed to be in storage rather than root, but I expect more such things to move here

More to come in the future once we figure out http/https standard providers etc

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
