### PR TITLE
Optimization: Make list page in fyne_demo load more than twise as fast

### DIFF
--- a/cmd/fyne_demo/tutorials/collection.go
+++ b/cmd/fyne_demo/tutorials/collection.go
@@ -23,9 +23,9 @@ func collectionScreen(_ fyne.Window) fyne.CanvasObject {
 }
 
 func makeListTab(_ fyne.Window) fyne.CanvasObject {
-	var data []string
-	for i := 0; i < 1000; i++ {
-		data = append(data, fmt.Sprintf("Test Item %d", i))
+	data := make([]string, 1000)
+	for i := range data {
+		data[i] = fmt.Sprintf("Test Item %d", i)
 	}
 
 	icon := widget.NewIcon(nil)
@@ -52,6 +52,7 @@ func makeListTab(_ fyne.Window) fyne.CanvasObject {
 		icon.SetResource(nil)
 	}
 	list.Select(125)
+
 	return widget.NewHSplitContainer(list, fyne.NewContainerWithLayout(layout.NewCenterLayout(), hbox))
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
This commit adds a small optimization that makes the list page in `fyne_demo` load twise as fast.
It was not by any means slow before, but creating the page went from `447.304µs` to `214.876µs`.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
