### PR TITLE
Reword some popup deprecations for clarity

### DIFF
--- a/widget/popup_menu.go
+++ b/widget/popup_menu.go
@@ -107,7 +107,7 @@ func (p *PopUpMenu) adjustedPosition(pos fyne.Position, size fyne.Size) fyne.Pos
 // NewPopUpMenuAtPosition creates a PopUp widget populated with menu items from the passed menu structure.
 // It will automatically be positioned at the provided location and shown as an overlay on the specified canvas.
 //
-// Deprecated: This will no longer show the pop-up in 2.0. Use ShowPopUpMenuAtPosition() instead.
+// Deprecated: Use ShowPopUpMenuAtPosition() instead.
 func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *PopUp {
 	options := NewVBox()
 	for _, option := range menu.Items {
@@ -134,7 +134,7 @@ func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *
 // NewPopUpMenu creates a PopUp widget populated with menu items from the passed menu structure.
 // It will automatically be shown as an overlay on the specified canvas.
 //
-// Deprecated: Use ShowPopUpMenuAtPosition() with an empty position instead.
+// Deprecated: Use ShowPopUpMenuAtPosition() with a zero position instead.
 func NewPopUpMenu(menu *fyne.Menu, c fyne.Canvas) *PopUp {
 	return NewPopUpMenuAtPosition(menu, c, fyne.NewPos(0, 0))
 }

--- a/widget/popup_menu.go
+++ b/widget/popup_menu.go
@@ -134,7 +134,7 @@ func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *
 // NewPopUpMenu creates a PopUp widget populated with menu items from the passed menu structure.
 // It will automatically be shown as an overlay on the specified canvas.
 //
-// Deprecated: This will no longer show the pop-up in 2.0. Use ShowPopUpMenuAtPosition() instead.
+// Deprecated: Use ShowPopUpMenuAtPosition() with an empty position instead.
 func NewPopUpMenu(menu *fyne.Menu, c fyne.Canvas) *PopUp {
 	return NewPopUpMenuAtPosition(menu, c, fyne.NewPos(0, 0))
 }

--- a/widget/popup_menu.go
+++ b/widget/popup_menu.go
@@ -107,7 +107,7 @@ func (p *PopUpMenu) adjustedPosition(pos fyne.Position, size fyne.Size) fyne.Pos
 // NewPopUpMenuAtPosition creates a PopUp widget populated with menu items from the passed menu structure.
 // It will automatically be positioned at the provided location and shown as an overlay on the specified canvas.
 //
-// Deprecated: Use ShowPopUpMenuAtPosition instead.
+// Deprecated: This will no longer show the pop-up in 2.0. Use ShowPopUpMenuAtPosition() instead.
 func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *PopUp {
 	options := NewVBox()
 	for _, option := range menu.Items {
@@ -134,7 +134,7 @@ func NewPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) *
 // NewPopUpMenu creates a PopUp widget populated with menu items from the passed menu structure.
 // It will automatically be shown as an overlay on the specified canvas.
 //
-// Deprecated: Use ShowPopUpMenuAtPosition instead.
+// Deprecated: This will no longer show the pop-up in 2.0. Use ShowPopUpMenuAtPosition() instead.
 func NewPopUpMenu(menu *fyne.Menu, c fyne.Canvas) *PopUp {
 	return NewPopUpMenuAtPosition(menu, c, fyne.NewPos(0, 0))
 }


### PR DESCRIPTION
### Description:
This rewords the deprecation comments for some of the popup deprecations.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
