### PR TITLE
Add desktop.InvisibleCursor as option

### DIFF
--- a/driver/desktop/cursor.go
+++ b/driver/desktop/cursor.go
@@ -16,6 +16,8 @@ const (
 	HResizeCursor
 	// VResizeCursor is the cursor often used to indicate vertical resize
 	VResizeCursor
+	// InvisibleCursor is an invisible cursor, useful if it shouldn't be shown
+	InvisibleCursor
 )
 
 // Cursorable describes any CanvasObject that needs a cursor change

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -38,6 +38,7 @@ func initCursors() {
 		desktop.PointerCursor:   glfw.CreateStandardCursor(glfw.HandCursor),
 		desktop.HResizeCursor:   glfw.CreateStandardCursor(glfw.HResizeCursor),
 		desktop.VResizeCursor:   glfw.CreateStandardCursor(glfw.VResizeCursor),
+		desktop.InvisibleCursor: glfw.CreateCursor(image.NewNRGBA(image.Rectangle{Max: image.Point{X: 16, Y: 16}}), 0, 0),
 	}
 }
 


### PR DESCRIPTION
### Description:
Add a new `desktop.InvisibleCursor` cursor that can be returned by widgets implementing the `Cursorable` interface.

Fixes #1548 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
