### PR TITLE
Fix #1548 by providing a new desktop.HiddenCursor cursor for invisible cursor

### DIFF
--- a/driver/desktop/cursor.go
+++ b/driver/desktop/cursor.go
@@ -16,6 +16,8 @@ const (
 	HResizeCursor
 	// VResizeCursor is the cursor often used to indicate vertical resize
 	VResizeCursor
+	// HiddenCursor will cause the cursor to not be shown
+	HiddenCursor
 )
 
 // Cursorable describes any CanvasObject that needs a cursor change

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -38,6 +38,7 @@ func initCursors() {
 		desktop.PointerCursor:   glfw.CreateStandardCursor(glfw.HandCursor),
 		desktop.HResizeCursor:   glfw.CreateStandardCursor(glfw.HResizeCursor),
 		desktop.VResizeCursor:   glfw.CreateStandardCursor(glfw.VResizeCursor),
+		desktop.HiddenCursor:    nil,
 	}
 }
 
@@ -579,8 +580,16 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 		return hover
 	})
 
-	w.cursor = cursor
-	viewport.SetCursor(cursor)
+	if w.cursor != cursor {
+		// cursor has changed, store new cursor and apply change via glfw
+		w.cursor = cursor
+		if cursor == nil {
+			viewport.SetInputMode(glfw.CursorMode, glfw.CursorHidden)
+		} else {
+			viewport.SetInputMode(glfw.CursorMode, glfw.CursorNormal)
+			viewport.SetCursor(cursor)
+		}
+	}
 	if obj != nil && !w.objIsDragged(obj) {
 		ev := new(desktop.MouseEvent)
 		ev.AbsolutePosition = w.mousePos


### PR DESCRIPTION
### Description:
Add a new `desktop.InvisibleCursor` cursor that can be returned by widgets implementing the `Cursorable` interface.

Fixes #1548 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
