### PR TITLE
Avoid unnecessary validation check on refresh in widget.Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Fyne package creating invalid windows packages (#1521)
 * Menu bar initially doesn't respond to mouse input on macOS (#505) 
 * CenterOnScreen causes crash on MacOS when called from goroutine (#1539)
+* Avoid unnecessary validation check on Refresh in widget.Form
 
 
 ## 1.4 - 1 November 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 ### Changed
 
 * Table columns can now be different sizes using SetColumnWidth
+* Avoid unnecessary validation check on Refresh in widget.Form
 
 ### Fixed
 
@@ -22,7 +23,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Fyne package creating invalid windows packages (#1521)
 * Menu bar initially doesn't respond to mouse input on macOS (#505) 
 * CenterOnScreen causes crash on MacOS when called from goroutine (#1539)
-* Avoid unnecessary validation check on Refresh in widget.Form
+* Initial validation status in widget.Form is not respected
 
 
 ## 1.4 - 1 November 2020

--- a/widget/form.go
+++ b/widget/form.go
@@ -111,14 +111,16 @@ func (f *Form) updateButtons() {
 	} else {
 		f.buttonBox.Show()
 	}
-
-	f.checkValidation()
 }
 
-func (f *Form) checkValidation() {
+func (f *Form) checkValidation(err error) {
+	if err != nil {
+		f.submitButton.Disable()
+		return
+	}
+
 	for i, item := range f.Items {
 		if item.validationError != nil {
-			f.submitButton.Disable()
 			break
 		} else if i == len(f.Items)-1 {
 			f.submitButton.Enable()
@@ -130,11 +132,7 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 	if w, ok := widget.(fyne.Validatable); ok {
 		w.SetOnValidationChanged(func(err error) {
 			f.Items[i].validationError = err
-			if err != nil {
-				f.submitButton.Disable()
-			} else {
-				f.checkValidation()
-			}
+			f.checkValidation(err)
 		})
 	}
 }

--- a/widget/form.go
+++ b/widget/form.go
@@ -121,11 +121,11 @@ func (f *Form) checkValidation(err error) {
 
 	for i, item := range f.Items {
 		if item.validationError != nil {
-			break
-		} else if i == len(f.Items)-1 {
-			f.submitButton.Enable()
+			return
 		}
 	}
+	
+	f.submitButton.Enable()
 }
 
 func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {


### PR DESCRIPTION
### Description:
The updateButtons() function is called each time the widget is refreshed and the function included the check for validations earlier. This meant that each time the form was refreshed, it would re-iterate through all widgets updating the validation. This was entirely unnecessary as each widget does this themselves when the status changes. 

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
