### PR TITLE
Some pre-allocation optimizations for accordion, radio_group and fyne_demo

### DIFF
--- a/cmd/fyne_demo/tutorials/icons.go
+++ b/cmd/fyne_demo/tutorials/icons.go
@@ -72,9 +72,9 @@ func checkerPattern(x, y, _, _ int) color.Color {
 }
 
 func iconList() []string {
-	var ret []string
-	for _, icon := range icons {
-		ret = append(ret, icon.name)
+	ret := make([]string, len(icons))
+	for i, icon := range icons {
+		ret[i] = icon.name
 	}
 
 	return ret

--- a/widget/accordion.go
+++ b/widget/accordion.go
@@ -194,6 +194,7 @@ func (r *accordionRenderer) Refresh() {
 func (r *accordionRenderer) updateObjects() {
 	is := len(r.container.Items)
 	hs := len(r.headers)
+	ds := len(r.dividers)
 	i := 0
 	for ; i < is; i++ {
 		ai := r.container.Items[i]
@@ -232,21 +233,21 @@ func (r *accordionRenderer) updateObjects() {
 		r.headers[i].Hide()
 	}
 	// Set objects
-	objects := make([]fyne.CanvasObject, len(r.headers)+len(r.container.Items))
+	objects := make([]fyne.CanvasObject, hs+is+ds)
 	for i, header := range r.headers {
 		objects[i] = header
 	}
 	for i, item := range r.container.Items {
-		objects[len(r.headers)+i] = item.Detail
+		objects[hs+i] = item.Detail
 	}
 	// add dividers
-	for i = 0; i < len(r.dividers); i++ {
+	for i = 0; i < ds; i++ {
 		if i < len(r.container.Items)-1 {
 			r.dividers[i].Show()
 		} else {
 			r.dividers[i].Hide()
 		}
-		objects = append(objects, r.dividers[i])
+		objects[hs+is+i] = r.dividers[i]
 	}
 	// make new dividers
 	for ; i < is-1; i++ {

--- a/widget/accordion.go
+++ b/widget/accordion.go
@@ -232,7 +232,7 @@ func (r *accordionRenderer) updateObjects() {
 		r.headers[i].Hide()
 	}
 	// Set objects
-	objects := make([]fyne.CanvasObject, len(r.headers)+len(r.container.Items)) // Pre-allocate instead of appending, for better performance
+	objects := make([]fyne.CanvasObject, len(r.headers)+len(r.container.Items))
 	for i, header := range r.headers {
 		objects[i] = header
 	}

--- a/widget/accordion.go
+++ b/widget/accordion.go
@@ -232,12 +232,12 @@ func (r *accordionRenderer) updateObjects() {
 		r.headers[i].Hide()
 	}
 	// Set objects
-	var objects []fyne.CanvasObject
-	for _, h := range r.headers {
-		objects = append(objects, h)
+	objects := make([]fyne.CanvasObject, len(r.headers)+len(r.container.Items)) // Pre-allocate instead of appending, for better performance
+	for i, header := range r.headers {
+		objects[i] = header
 	}
-	for _, i := range r.container.Items {
-		objects = append(objects, i.Detail)
+	for i, item := range r.container.Items {
+		objects[len(r.headers)+i] = item.Detail
 	}
 	// add dividers
 	for i = 0; i < len(r.dividers); i++ {

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -51,10 +51,11 @@ func (r *RadioGroup) CreateRenderer() fyne.WidgetRenderer {
 	defer r.propertyLock.Unlock()
 
 	r.update()
-	var objects []fyne.CanvasObject
-	for _, item := range r.items {
-		objects = append(objects, item)
+	objects := make([]fyne.CanvasObject, len(r.items))
+	for i, item := range r.items {
+		objects[i] = item
 	}
+
 	return &radioGroupRenderer{widget.NewBaseRenderer(objects), r.items, r}
 }
 


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This applies the per-allocation optimization to a few more places. There are probably a few more that could be added but this is a good step forward in the meantime, fixing the more straight-forward cases. In summary, it boils down to:
- Setting the objects in accordion went from (a total time over three calls) `10.022µs` to `1.567µs` (6.4x faster).
- Adding all objects in CreateRenderer of radio_group went from (a total time over four calls) `2.327µs` to `1.486µs` (1.5x faster).
- Creating the icon strings in fyne_demo went from `11.444µs` to `3.566µs` (3.2x faster). 

### Checklist:
<!-- Please tick these as appropriate using [x] -->
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
