### PR TITLE
Proposal: Custom cursors in Fyne

### DIFF
--- a/driver/desktop/cursor.go
+++ b/driver/desktop/cursor.go
@@ -3,14 +3,20 @@ package desktop
 import "image"
 
 // Cursor interface is used for objects usable as cursor
+//
+// Since: 2.0.0
 type Cursor interface {
 	Image() (image.Image, int, int) // Image returns the image for the given cursor, or nil to hide the cursor
 }
 
 // StandardCursor represents a standard fyne cursor
+//
+// Since: 2.0.0
 type StandardCursor int
 
 // Image will always return nil for StandardCursor
+//
+// Since: 2.0.0
 func (d StandardCursor) Image() (image.Image, int, int) {
 	return nil, 0, 0
 }

--- a/driver/desktop/cursor.go
+++ b/driver/desktop/cursor.go
@@ -2,13 +2,15 @@ package desktop
 
 import "image"
 
-// Cursor represents a standard fyne cursor
+// Cursor interface is used for objects usable as cursor
 type Cursor interface {
-	Image() (image.Image, int, int)
+	Image() (image.Image, int, int) // Image returns the image for the given cursor, or nil to hide the cursor
 }
 
+// StandardCursor represents a standard fyne cursor
 type StandardCursor int
 
+// Image will always return nil for StandardCursor
 func (d StandardCursor) Image() (image.Image, int, int) {
 	return nil, 0, 0
 }

--- a/driver/desktop/cursor.go
+++ b/driver/desktop/cursor.go
@@ -1,11 +1,21 @@
 package desktop
 
+import "image"
+
 // Cursor represents a standard fyne cursor
-type Cursor int
+type Cursor interface {
+	Image() (image.Image, int, int)
+}
+
+type StandardCursor int
+
+func (d StandardCursor) Image() (image.Image, int, int) {
+	return nil, 0, 0
+}
 
 const (
 	// DefaultCursor is the default cursor typically an arrow
-	DefaultCursor Cursor = iota
+	DefaultCursor StandardCursor = iota
 	// TextCursor is the cursor often used to indicate text selection
 	TextCursor
 	// CrosshairCursor is the cursor often used to indicate bitmaps

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -52,12 +52,12 @@ type window struct {
 	decorate   bool
 	fixedSize  bool
 
-	cursor    desktop.Cursor
-	rawCursor *glfw.Cursor // rawCursor is only filled for custom cursors in order to be destroyed when becoming un-needed
-	canvas    *glCanvas
-	title     string
-	icon      fyne.Resource
-	mainmenu  *fyne.MainMenu
+	cursor       desktop.Cursor
+	customCursor *glfw.Cursor
+	canvas       *glCanvas
+	title        string
+	icon         fyne.Resource
+	mainmenu     *fyne.MainMenu
 
 	clipboard fyne.Clipboard
 
@@ -601,12 +601,12 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 			viewport.SetInputMode(glfw.CursorMode, glfw.CursorNormal)
 			viewport.SetCursor(rawCursor)
 		}
-		if w.rawCursor != nil {
-			w.rawCursor.Destroy()
-			w.rawCursor = nil
+		if w.customCursor != nil {
+			w.customCursor.Destroy()
+			w.customCursor = nil
 		}
 		if isCustomCursor {
-			w.rawCursor = rawCursor
+			w.customCursor = rawCursor
 		}
 	}
 	if obj != nil && !w.objIsDragged(obj) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -26,12 +26,12 @@ const (
 )
 
 var (
-	cursorMap    map[desktop.Cursor]*glfw.Cursor
+	cursorMap    map[desktop.StandardCursor]*glfw.Cursor
 	defaultTitle = "Fyne Application"
 )
 
 func initCursors() {
-	cursorMap = map[desktop.Cursor]*glfw.Cursor{
+	cursorMap = map[desktop.StandardCursor]*glfw.Cursor{
 		desktop.DefaultCursor:   glfw.CreateStandardCursor(glfw.ArrowCursor),
 		desktop.TextCursor:      glfw.CreateStandardCursor(glfw.IBeamCursor),
 		desktop.CrosshairCursor: glfw.CreateStandardCursor(glfw.CrosshairCursor),
@@ -52,11 +52,12 @@ type window struct {
 	decorate   bool
 	fixedSize  bool
 
-	cursor   *glfw.Cursor
-	canvas   *glCanvas
-	title    string
-	icon     fyne.Resource
-	mainmenu *fyne.MainMenu
+	cursor    desktop.Cursor
+	rawCursor *glfw.Cursor // rawCursor is only filled for custom cursors in order to be destroyed when becoming un-needed
+	canvas    *glCanvas
+	title     string
+	icon      fyne.Resource
+	mainmenu  *fyne.MainMenu
 
 	clipboard fyne.Clipboard
 
@@ -558,22 +559,31 @@ func (w *window) findObjectAtPositionMatching(canvas *glCanvas, mouse fyne.Posit
 	return driver.FindObjectAtPositionMatching(mouse, matches, canvas.Overlays().Top(), canvas.menu, canvas.Content())
 }
 
-func fyneToNativeCursor(cursor desktop.Cursor) *glfw.Cursor {
-	ret, ok := cursorMap[cursor]
-	if !ok {
-		return cursorMap[desktop.DefaultCursor]
+func fyneToNativeCursor(cursor desktop.Cursor) (*glfw.Cursor, bool) {
+	switch v := cursor.(type) {
+	case desktop.StandardCursor:
+		ret, ok := cursorMap[v]
+		if !ok {
+			return cursorMap[desktop.DefaultCursor], true
+		}
+		return ret, true
+	default:
+		img, x, y := cursor.Image()
+		if img == nil {
+			return nil, true
+		}
+		return glfw.CreateCursor(img, x, y), false
 	}
-	return ret
 }
 
 func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 	w.mousePos = fyne.NewPos(internal.UnscaleInt(w.canvas, int(xpos)), internal.UnscaleInt(w.canvas, int(ypos)))
 
-	cursor := cursorMap[desktop.DefaultCursor]
+	cursor := desktop.Cursor(desktop.DefaultCursor)
+
 	obj, pos, _ := w.findObjectAtPositionMatching(w.canvas, w.mousePos, func(object fyne.CanvasObject) bool {
 		if cursorable, ok := object.(desktop.Cursorable); ok {
-			fyneCursor := cursorable.Cursor()
-			cursor = fyneToNativeCursor(fyneCursor)
+			cursor = cursorable.Cursor()
 		}
 
 		_, hover := object.(desktop.Hoverable)
@@ -582,12 +592,25 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 
 	if w.cursor != cursor {
 		// cursor has changed, store new cursor and apply change via glfw
+		newCursor, isStdCursor := fyneToNativeCursor(cursor)
 		w.cursor = cursor
-		if cursor == nil {
+		oldCursor := w.rawCursor
+
+		if isStdCursor {
+			w.rawCursor = nil
+		} else {
+			w.rawCursor = newCursor
+		}
+
+		if newCursor == nil {
 			viewport.SetInputMode(glfw.CursorMode, glfw.CursorHidden)
 		} else {
 			viewport.SetInputMode(glfw.CursorMode, glfw.CursorNormal)
-			viewport.SetCursor(cursor)
+			viewport.SetCursor(newCursor)
+		}
+		if oldCursor != nil {
+			// destroy old cursor now as to avoid viewport reverting to default cursor even for an instant
+			oldCursor.Destroy()
 		}
 	}
 	if obj != nil && !w.objIsDragged(obj) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -81,16 +81,16 @@ func TestWindow_Cursor(t *testing.T) {
 	w.SetContent(widget.NewVBox(e, h, b))
 
 	w.mouseMoved(w.viewport, 10, float64(e.Position().Y+10))
-	textCursor := cursorMap[desktop.TextCursor]
-	assert.Same(t, textCursor, w.cursor)
+	textCursor := desktop.TextCursor
+	assert.Equal(t, textCursor, w.cursor)
 
 	w.mouseMoved(w.viewport, 10, float64(h.Position().Y+10))
-	pointerCursor := cursorMap[desktop.PointerCursor]
-	assert.Same(t, pointerCursor, w.cursor)
+	pointerCursor := desktop.PointerCursor
+	assert.Equal(t, pointerCursor, w.cursor)
 
 	w.mouseMoved(w.viewport, 10, float64(b.Position().Y+10))
-	defaultCursor := cursorMap[desktop.DefaultCursor]
-	assert.Same(t, defaultCursor, w.cursor)
+	defaultCursor := desktop.DefaultCursor
+	assert.Equal(t, defaultCursor, w.cursor)
 }
 
 func TestWindow_HandleHoverable(t *testing.T) {


### PR DESCRIPTION
This proposal acts by changing desktop.Cursor to be an interface allowing implementation by user so that custom cursors can be used, solving issue #1537 

### Description:

There might be times when the standard cursors aren't enough to convey an action, and custom cursors may be needed. For example a hand cursor (for links) and others are likely missing from the list, and implementing every single possible cursor is likely not an option.

This works by replacing `desktop.Cursor` from its current type int to an interface with a method. The original `desktop.Cursor` becomes `desktop.StandardCursor` which implements a dummy method returning a nil value. Widgets implementing `Cursorable` can now return a `desktop.Cursor` object should they wish.

As far as I can see the change should not break any existing code, considering values such as `desktop.DefaultCursor` still fit into type `desktop.Cursor`.

Minimum implementation for a custom cursor (desktop could have a NewCursorFromImage(img image.Image, x, y int) method, not sure if it makes sense):

```go
import "image"

type fyneCursor struct {
        img  image.Image
        x, y int
}

func (f *fyneCursor) Image() (image.Image, int, int) {
        return f.img, f.x, f.y
}
```

Fixes #1537

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
