### PR TITLE
fixed a couple of focus manager bugs/misbehaviours

### DIFF
--- a/internal/app/focus_manager.go
+++ b/internal/app/focus_manager.go
@@ -25,7 +25,10 @@ func (f *FocusManager) Focus(obj fyne.Focusable) {
 	f.Lock()
 	defer f.Unlock()
 	if obj != nil {
-		found := driver.WalkCompleteObjectTree(
+		if dis, ok := obj.(fyne.Disableable); ok && dis.Disabled() {
+			return
+		}
+		found := driver.WalkVisibleObjectTree(
 			f.content,
 			func(object fyne.CanvasObject, _, _ fyne.Position, _ fyne.Size) bool {
 				return object == obj.(fyne.CanvasObject)
@@ -79,14 +82,6 @@ func (f *FocusManager) FocusPrevious() {
 func (f *FocusManager) focus(obj fyne.Focusable) {
 	if f.focused == obj {
 		return
-	}
-
-	if dis, ok := obj.(fyne.Disableable); ok && dis.Disabled() {
-		obj = nil
-	}
-
-	if hid, ok := obj.(fyne.CanvasObject); ok && !hid.Visible() {
-		obj = nil
 	}
 
 	if f.focused != nil {

--- a/internal/app/focus_manager.go
+++ b/internal/app/focus_manager.go
@@ -24,6 +24,18 @@ func NewFocusManager(c fyne.CanvasObject) *FocusManager {
 func (f *FocusManager) Focus(obj fyne.Focusable) {
 	f.Lock()
 	defer f.Unlock()
+	if obj != nil {
+		found := driver.WalkCompleteObjectTree(
+			f.content,
+			func(object fyne.CanvasObject, _, _ fyne.Position, _ fyne.Size) bool {
+				return object == obj.(fyne.CanvasObject)
+			},
+			nil,
+		)
+		if !found {
+			return
+		}
+	}
 	f.focus(obj)
 }
 

--- a/internal/app/focus_manager.go
+++ b/internal/app/focus_manager.go
@@ -73,6 +73,10 @@ func (f *FocusManager) focus(obj fyne.Focusable) {
 		obj = nil
 	}
 
+	if hid, ok := obj.(fyne.CanvasObject); ok && !hid.Visible() {
+		obj = nil
+	}
+
 	if f.focused != nil {
 		f.focused.FocusLost()
 	}

--- a/internal/app/focus_manager_test.go
+++ b/internal/app/focus_manager_test.go
@@ -12,17 +12,7 @@ import (
 )
 
 func TestFocusManager_Focus(t *testing.T) {
-	entry1 := &focusable{}
-	hidden := widget.NewCheck("test", func(bool) {})
-	hidden.Hide()
-	entry2 := &focusable{}
-	disabled := widget.NewCheck("test", func(bool) {})
-	disabled.Disable()
-	entry3 := &focusable{}
-	c := widget.NewVBox(entry1, hidden, entry2, disabled, entry3)
-
-	manager := app.NewFocusManager(c)
-	assert.Nil(t, manager.Focused())
+	manager, entry1, _, entry2, _, entry3 := setupFocusManager(t)
 
 	manager.Focus(entry2)
 	assert.Equal(t, entry2, manager.Focused())
@@ -44,12 +34,8 @@ func TestFocusManager_Focus(t *testing.T) {
 }
 
 func TestFocusManager_FocusLost_FocusGained(t *testing.T) {
-	entry1 := &focusable{}
-	entry2 := &focusable{}
-	entry3 := &focusable{}
-	c := widget.NewVBox(entry1, entry2, entry3)
+	manager, entry1, _, entry2, _, _ := setupFocusManager(t)
 
-	manager := app.NewFocusManager(c)
 	manager.Focus(entry2)
 	require.Equal(t, entry2, manager.Focused())
 	require.False(t, entry1.focused)
@@ -67,17 +53,7 @@ func TestFocusManager_FocusLost_FocusGained(t *testing.T) {
 }
 
 func TestFocusManager_FocusNext(t *testing.T) {
-	entry1 := &focusable{}
-	hidden := widget.NewCheck("test", func(bool) {})
-	hidden.Hide()
-	entry2 := &focusable{}
-	disabled := widget.NewCheck("test", func(bool) {})
-	disabled.Disable()
-	entry3 := &focusable{}
-	c := widget.NewVBox(entry1, hidden, entry2, disabled, entry3)
-
-	manager := app.NewFocusManager(c)
-	assert.Nil(t, manager.Focused())
+	manager, entry1, _, entry2, _, entry3 := setupFocusManager(t)
 
 	manager.FocusNext()
 	assert.Equal(t, entry1, manager.Focused())
@@ -100,17 +76,7 @@ func TestFocusManager_FocusNext(t *testing.T) {
 }
 
 func TestFocusManager_FocusPrevious(t *testing.T) {
-	entry1 := &focusable{}
-	hidden := widget.NewCheck("test", func(bool) {})
-	hidden.Hide()
-	entry2 := &focusable{}
-	disabled := widget.NewCheck("test", func(bool) {})
-	disabled.Disable()
-	entry3 := &focusable{}
-	c := widget.NewVBox(entry1, hidden, entry2, disabled, entry3)
-
-	manager := app.NewFocusManager(c)
-	assert.Nil(t, manager.Focused())
+	manager, entry1, _, entry2, _, entry3 := setupFocusManager(t)
 
 	manager.FocusPrevious()
 	assert.Equal(t, entry3, manager.Focused())
@@ -146,4 +112,17 @@ func (f *focusable) FocusGained() {
 
 func (f *focusable) FocusLost() {
 	f.focused = false
+}
+
+func setupFocusManager(t *testing.T) (m *app.FocusManager, entry1, hidden, entry2, disabled, entry3 *focusable) {
+	entry1 = &focusable{}
+	hidden = &focusable{}
+	hidden.Hide()
+	entry2 = &focusable{}
+	disabled = &focusable{}
+	disabled.Disable()
+	entry3 = &focusable{}
+	m = app.NewFocusManager(widget.NewVBox(entry1, hidden, entry2, disabled, entry3))
+	assert.Nil(t, m.Focused())
+	return
 }

--- a/internal/app/focus_manager_test.go
+++ b/internal/app/focus_manager_test.go
@@ -12,25 +12,42 @@ import (
 )
 
 func TestFocusManager_Focus(t *testing.T) {
-	manager, entry1, _, entry2, _, entry3 := setupFocusManager(t)
+	t.Run("focusing and unfocusing", func(t *testing.T) {
+		manager, entry1, _, entry2, _, entry3 := setupFocusManager(t)
 
-	manager.Focus(entry2)
-	assert.Equal(t, entry2, manager.Focused())
-	assert.True(t, entry2.focused)
+		manager.Focus(entry2)
+		assert.Equal(t, entry2, manager.Focused())
+		assert.True(t, entry2.focused)
 
-	manager.Focus(entry1)
-	assert.Equal(t, entry1, manager.Focused())
-	assert.True(t, entry1.focused)
-	assert.False(t, entry2.focused)
+		manager.Focus(entry1)
+		assert.Equal(t, entry1, manager.Focused())
+		assert.True(t, entry1.focused)
+		assert.False(t, entry2.focused)
 
-	manager.Focus(entry3)
-	assert.Equal(t, entry3, manager.Focused())
-	assert.True(t, entry3.focused)
-	assert.False(t, entry1.focused)
+		manager.Focus(entry3)
+		assert.Equal(t, entry3, manager.Focused())
+		assert.True(t, entry3.focused)
+		assert.False(t, entry1.focused)
 
-	manager.Focus(nil)
-	assert.Nil(t, manager.Focused())
-	assert.False(t, entry3.focused)
+		manager.Focus(nil)
+		assert.Nil(t, manager.Focused())
+		assert.False(t, entry3.focused)
+	})
+
+	t.Run("focus disabled", func(t *testing.T) {
+		manager, entry1, _, _, disabled, _ := setupFocusManager(t)
+
+		manager.Focus(disabled)
+		assert.Nil(t, manager.Focused())
+		assert.False(t, disabled.focused)
+
+		manager.Focus(entry1)
+		require.True(t, entry1.focused)
+		manager.Focus(disabled)
+		assert.Nil(t, manager.Focused())
+		assert.False(t, disabled.focused)
+		assert.False(t, entry1.focused)
+	})
 }
 
 func TestFocusManager_FocusLost_FocusGained(t *testing.T) {

--- a/internal/app/focus_manager_test.go
+++ b/internal/app/focus_manager_test.go
@@ -33,44 +33,34 @@ func TestFocusManager_Focus(t *testing.T) {
 		assert.False(t, entry3.focused)
 	})
 
-	itBehavesLikeUnfocus := func(manager *app.FocusManager, notFocusableObj *focusable, focusableObj *focusable) {
+	itBehavesLikeDoingNothing := func(t *testing.T, manager *app.FocusManager, notFocusableObj *focusable, focusableObj *focusable) {
 		manager.Focus(notFocusableObj)
 		assert.Nil(t, manager.Focused())
 		assert.False(t, notFocusableObj.focused)
 
 		manager.Focus(focusableObj)
+		require.Equal(t, focusableObj, manager.Focused())
 		require.True(t, focusableObj.focused)
 		manager.Focus(notFocusableObj)
-		assert.Nil(t, manager.Focused())
 		assert.False(t, notFocusableObj.focused)
-		assert.False(t, focusableObj.focused)
+		assert.Equal(t, focusableObj, manager.Focused())
+		assert.True(t, focusableObj.focused)
 	}
 
 	t.Run("focus disabled", func(t *testing.T) {
 		manager, entry1, _, _, disabled, _ := setupFocusManager(t)
-		itBehavesLikeUnfocus(manager, disabled, entry1)
+		itBehavesLikeDoingNothing(t, manager, disabled, entry1)
 	})
 
 	t.Run("focus hidden", func(t *testing.T) {
 		manager, entry1, hidden, _, _, _ := setupFocusManager(t)
-		itBehavesLikeUnfocus(manager, hidden, entry1)
+		itBehavesLikeDoingNothing(t, manager, hidden, entry1)
 	})
 
 	t.Run("focus foreign", func(t *testing.T) {
 		manager, entry1, _, _, _, _ := setupFocusManager(t)
 		foreigner := &focusable{}
-
-		manager.Focus(foreigner)
-		assert.Nil(t, manager.Focused())
-		assert.False(t, foreigner.focused)
-
-		manager.Focus(entry1)
-		require.Equal(t, entry1, manager.Focused())
-		require.True(t, entry1.focused)
-		manager.Focus(foreigner)
-		assert.False(t, foreigner.focused)
-		assert.Equal(t, entry1, manager.Focused())
-		assert.True(t, entry1.focused)
+		itBehavesLikeDoingNothing(t, manager, foreigner, entry1)
 	})
 }
 

--- a/internal/app/focus_manager_test.go
+++ b/internal/app/focus_manager_test.go
@@ -34,19 +34,27 @@ func TestFocusManager_Focus(t *testing.T) {
 		assert.False(t, entry3.focused)
 	})
 
+	itBehavesLikeUnfocus := func(manager *app.FocusManager, notFocusableObj *focusable, focusableObj *focusable) {
+		manager.Focus(notFocusableObj)
+		assert.Nil(t, manager.Focused())
+		assert.False(t, notFocusableObj.focused)
+
+		manager.Focus(focusableObj)
+		require.True(t, focusableObj.focused)
+		manager.Focus(notFocusableObj)
+		assert.Nil(t, manager.Focused())
+		assert.False(t, notFocusableObj.focused)
+		assert.False(t, focusableObj.focused)
+	}
+
 	t.Run("focus disabled", func(t *testing.T) {
 		manager, entry1, _, _, disabled, _ := setupFocusManager(t)
+		itBehavesLikeUnfocus(manager, disabled, entry1)
+	})
 
-		manager.Focus(disabled)
-		assert.Nil(t, manager.Focused())
-		assert.False(t, disabled.focused)
-
-		manager.Focus(entry1)
-		require.True(t, entry1.focused)
-		manager.Focus(disabled)
-		assert.Nil(t, manager.Focused())
-		assert.False(t, disabled.focused)
-		assert.False(t, entry1.focused)
+	t.Run("focus hidden", func(t *testing.T) {
+		manager, entry1, hidden, _, _, _ := setupFocusManager(t)
+		itBehavesLikeUnfocus(manager, hidden, entry1)
 	})
 }
 

--- a/internal/app/focus_manager_test.go
+++ b/internal/app/focus_manager_test.go
@@ -3,12 +3,11 @@ package app_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"fyne.io/fyne/internal/app"
 	"fyne.io/fyne/widget"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFocusManager_Focus(t *testing.T) {
@@ -55,6 +54,23 @@ func TestFocusManager_Focus(t *testing.T) {
 	t.Run("focus hidden", func(t *testing.T) {
 		manager, entry1, hidden, _, _, _ := setupFocusManager(t)
 		itBehavesLikeUnfocus(manager, hidden, entry1)
+	})
+
+	t.Run("focus foreign", func(t *testing.T) {
+		manager, entry1, _, _, _, _ := setupFocusManager(t)
+		foreigner := &focusable{}
+
+		manager.Focus(foreigner)
+		assert.Nil(t, manager.Focused())
+		assert.False(t, foreigner.focused)
+
+		manager.Focus(entry1)
+		require.Equal(t, entry1, manager.Focused())
+		require.True(t, entry1.focused)
+		manager.Focus(foreigner)
+		assert.False(t, foreigner.focused)
+		assert.Equal(t, entry1, manager.Focused())
+		assert.True(t, entry1.focused)
 	})
 }
 

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -144,6 +144,9 @@ func walkObjectTree(
 	afterChildren func(fyne.CanvasObject, fyne.CanvasObject),
 	requireVisible bool,
 ) bool {
+	if obj == nil {
+		return false
+	}
 	if requireVisible && !obj.Visible() {
 		return false
 	}

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -289,10 +289,15 @@ func TestEntry_DoubleTapped(t *testing.T) {
 func TestEntry_DoubleTapped_AfterCol(t *testing.T) {
 	entry := widget.NewEntry()
 	entry.SetText("A\nB\n")
-	c := fyne.CurrentApp().Driver().CanvasForObject(entry)
+	window := test.NewWindow(entry)
+	defer window.Close()
+	window.SetPadded(false)
+	window.Resize(entry.MinSize())
+	entry.Resize(entry.MinSize())
+	c := window.Canvas()
 
 	test.Tap(entry)
-	assert.Equal(t, c.Focused(), entry)
+	assert.Equal(t, entry, c.Focused())
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(testCharSize, testCharSize*4) // tap below rows
@@ -389,7 +394,7 @@ func TestEntry_Focus(t *testing.T) {
 		</canvas>
 	`, c)
 
-	test.Canvas().Focus(entry)
+	window.Canvas().Focus(entry)
 	test.AssertRendersToMarkup(t, `
 		<canvas padded size="150x200">
 			<content>


### PR DESCRIPTION
### Description:

This PR
- ensures that disabled objects are not focusable (was already the case -> test only)
- implements the same for hidden objects
- fixes the focus manager to not focus objects that are not part of its content

This is part of the preparations for keyboard controllable menus.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.