### PR TITLE
fix driver utils to apply clipping to any scrollable

### DIFF
--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -155,11 +155,11 @@ func walkObjectTree(
 		children = co.Objects
 	case fyne.Widget:
 		children = cache.Renderer(co).Objects()
+	}
 
-		if _, ok := obj.(fyne.Scrollable); ok {
-			clipPos = pos
-			clipSize = obj.Size()
-		}
+	if _, ok := obj.(fyne.Scrollable); ok {
+		clipPos = pos
+		clipSize = obj.Size()
 	}
 
 	if beforeChildren != nil {


### PR DESCRIPTION
### Description:

This PR fixes the driver utils to apply clipping for all `fyne.Scrollable`s instead of scrollable `fyne.Widget` only.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
