### PR TITLE
Multiple fixes around entry.SetValidationError()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ More detailed release notes can be found on the [releases page](https://github.c
 ### Changed
 
 * Run validation on content change instead of on each Refresh in widget.Entry
-* Run onValidationChanged() when calling entry.SetValidationError()
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ More detailed release notes can be found on the [releases page](https://github.c
 
 * [fyne-cli] Add support for passing custom build tags (#1538)
 
+### Changed
+
+* Run validation on content change instead of on each Refresh in widget.Entry
+* Run onValidationChanged() when calling entry.SetValidationError()
+
 ### Fixed
 
 * [fyne-cli] Android: allow to specify an inline password for the keystore
@@ -19,6 +24,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Support older macOS by default - back to 10.11 (#886)
 * Complete certification of macOS App Store releases (#1443)
 * Fix compilation errors for early stage Wayland testing
+* Fix entry.SetValidationError() not working correctly
 
 
 ## 1.4.1 - 20 November 2020

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1000,15 +1000,7 @@ func (e *Entry) updateText(text string) {
 	})
 
 	if validate := e.Validator; validate != nil {
-		if err := validate(text); err != e.validationError {
-			e.validationError = err
-
-			if f := e.onValidationChanged; f != nil {
-				f(err)
-			}
-		}
-
-		e.validationStatus.Refresh()
+		e.SetValidationError(validate(text))
 	}
 
 	if callback != nil {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -999,6 +999,18 @@ func (e *Entry) updateText(text string) {
 		}
 	})
 
+	if validate := e.Validator; validate != nil {
+		if err := validate(text); err != e.validationError {
+			e.validationError = err
+
+			if f := e.onValidationChanged; f != nil {
+				f(err)
+			}
+		}
+
+		e.validationStatus.Refresh()
+	}
+
 	if callback != nil {
 		callback(text)
 	}
@@ -1135,21 +1147,10 @@ func (r *entryRenderer) Refresh() {
 	}
 
 	if r.entry.Validator != nil {
-		err := r.entry.Validator(content)
-		if err != r.entry.validationError {
-			r.entry.validationError = err
-
-			if f := r.entry.onValidationChanged; f != nil {
-				f(err)
-			}
-		}
-
 		if !r.entry.focused && r.entry.Text != "" && r.entry.validationError != nil {
 			r.line.FillColor = &color.NRGBA{0xf4, 0x43, 0x36, 0xff} // TODO: Should be current().ErrorColor() in the future
 		}
-
 		r.ensureValidationSetup()
-
 		r.entry.validationStatus.Refresh()
 	} else if r.entry.validationStatus != nil {
 		r.entry.validationStatus.Hide()

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -29,10 +29,15 @@ func (e *Entry) SetOnValidationChanged(callback func(error)) {
 // SetValidationError manually updates the validation status until the next input change
 func (e *Entry) SetValidationError(err error) {
 	e.validationError = err
-
-	if e.Validator != nil {
-		e.validationStatus.Refresh()
+	if e.Validator == nil {
+		return
 	}
+
+	if err != e.validationError && e.onValidationChanged != nil {
+		e.onValidationChanged(err)
+	}
+
+	e.validationStatus.Refresh()
 }
 
 var _ fyne.Widget = (*validationStatus)(nil)
@@ -83,7 +88,6 @@ func (r *validationStatusRenderer) Refresh() {
 	defer r.entry.propertyLock.RUnlock()
 	if r.entry.Text == "" {
 		r.icon.Hide()
-		canvas.Refresh(r.icon)
 		return
 	}
 

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -15,7 +15,9 @@ func (e *Entry) Validate() error {
 		return nil
 	}
 
-	return e.Validator(e.Text)
+	err := e.Validator(e.Text)
+	e.SetValidationError(err)
+	return err
 }
 
 // SetOnValidationChanged is intended for parent widgets or containers to hook into the validation.
@@ -28,7 +30,6 @@ func (e *Entry) SetOnValidationChanged(callback func(error)) {
 
 // SetValidationError manually updates the validation status until the next input change
 func (e *Entry) SetValidationError(err error) {
-	e.validationError = err
 	if e.Validator == nil {
 		return
 	}
@@ -37,6 +38,7 @@ func (e *Entry) SetValidationError(err error) {
 		e.onValidationChanged(err)
 	}
 
+	e.validationError = err
 	e.validationStatus.Refresh()
 }
 


### PR DESCRIPTION
### Description:
This fixes `entry.SetValidationError()` that broke when moving validation to `.Refresh()`. We also stop validating on `.Refresh()` as that can be quite expensive with complex validators and a lot of text. It also makes sure to call `onValidationChanged()` if the validation did change.

@stuartmscott Please check that this works for you as you were the one to suggest moving validation to `.Refresh()`. I think calling `entry.SetValidationError()` should suffice. If not, we can easily make `.Validate()` update the status in the widget.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
