### PR TITLE
Ensure Collections calculate MinSize consistently

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -213,7 +213,7 @@ func (l *listRenderer) Layout(size fyne.Size) {
 }
 
 func (l *listRenderer) MinSize() fyne.Size {
-	return l.scroller.MinSize()
+	return l.scroller.MinSize().Max(l.list.itemMin)
 }
 
 func (l *listRenderer) Refresh() {

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -25,7 +25,7 @@ func TestNewList(t *testing.T) {
 
 	assert.Equal(t, 1000, list.Length())
 	assert.GreaterOrEqual(t, list.MinSize().Width, template.MinSize().Width)
-	assert.Equal(t, list.MinSize(), test.WidgetRenderer(list).(*listRenderer).scroller.MinSize())
+	assert.Equal(t, list.MinSize(), template.MinSize().Max(test.WidgetRenderer(list).(*listRenderer).scroller.MinSize()))
 	assert.Equal(t, 0, firstItemIndex)
 	assert.Equal(t, visibleCount, lastItemIndex-firstItemIndex+1)
 }

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -2,11 +2,13 @@ package widget
 
 import (
 	"fmt"
+	"image/color"
 	"math"
 	"testing"
 	"time"
 
 	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/layout"
 	"fyne.io/fyne/test"
@@ -28,6 +30,34 @@ func TestNewList(t *testing.T) {
 	assert.Equal(t, list.MinSize(), template.MinSize().Max(test.WidgetRenderer(list).(*listRenderer).scroller.MinSize()))
 	assert.Equal(t, 0, firstItemIndex)
 	assert.Equal(t, visibleCount, lastItemIndex-firstItemIndex+1)
+}
+
+func TestList_MinSize(t *testing.T) {
+	for name, tt := range map[string]struct {
+		cellSize        fyne.Size
+		expectedMinSize fyne.Size
+	}{
+		"small": {
+			fyne.NewSize(1, 1),
+			fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize),
+		},
+		"large": {
+			fyne.NewSize(100, 100),
+			fyne.NewSize(100+3*theme.Padding(), 100+2*theme.Padding()),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedMinSize, NewList(
+				func() int { return 5 },
+				func() fyne.CanvasObject {
+					r := canvas.NewRectangle(color.Black)
+					r.SetMinSize(tt.cellSize)
+					r.Resize(tt.cellSize)
+					return r
+				},
+				func(ListItemID, fyne.CanvasObject) {}).MinSize())
+		})
+	}
 }
 
 func TestList_Resize(t *testing.T) {

--- a/widget/table.go
+++ b/widget/table.go
@@ -244,7 +244,7 @@ func (t *tableRenderer) Layout(s fyne.Size) {
 }
 
 func (t *tableRenderer) MinSize() fyne.Size {
-	return t.t.scroll.MinSize().Max(t.cellSize)
+	return t.t.scroll.MinSize().Max(t.cellSize.Add(fyne.NewSize(theme.Padding(), 0)))
 }
 
 func (t *tableRenderer) Refresh() {

--- a/widget/table.go
+++ b/widget/table.go
@@ -244,7 +244,7 @@ func (t *tableRenderer) Layout(s fyne.Size) {
 }
 
 func (t *tableRenderer) MinSize() fyne.Size {
-	return t.cellSize
+	return t.t.scroll.MinSize().Max(t.cellSize)
 }
 
 func (t *tableRenderer) Refresh() {

--- a/widget/table.go
+++ b/widget/table.go
@@ -244,7 +244,7 @@ func (t *tableRenderer) Layout(s fyne.Size) {
 }
 
 func (t *tableRenderer) MinSize() fyne.Size {
-	return t.t.scroll.MinSize().Max(t.cellSize.Add(fyne.NewSize(theme.Padding(), 0)))
+	return t.t.scroll.MinSize().Max(t.cellSize.Add(fyne.NewSize(theme.Padding(), theme.Padding())))
 }
 
 func (t *tableRenderer) Refresh() {

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -112,7 +112,7 @@ func TestTable_MinSize(t *testing.T) {
 		},
 		"large": {
 			fyne.NewSize(100, 100),
-			fyne.NewSize(100+2*theme.Padding(), 100+2*theme.Padding()),
+			fyne.NewSize(100+3*theme.Padding(), 100+2*theme.Padding()),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -112,7 +112,7 @@ func TestTable_MinSize(t *testing.T) {
 		},
 		"large": {
 			fyne.NewSize(100, 100),
-			fyne.NewSize(100+3*theme.Padding(), 100+2*theme.Padding()),
+			fyne.NewSize(100+3*theme.Padding(), 100+3*theme.Padding()),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -101,6 +101,34 @@ func TestTable_Filled(t *testing.T) {
 	test.AssertImageMatches(t, "table/filled.png", w.Canvas().Capture())
 }
 
+func TestTable_MinSize(t *testing.T) {
+	for name, tt := range map[string]struct {
+		cellSize        fyne.Size
+		expectedMinSize fyne.Size
+	}{
+		"small": {
+			fyne.NewSize(1, 1),
+			fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize),
+		},
+		"large": {
+			fyne.NewSize(100, 100),
+			fyne.NewSize(100+2*theme.Padding(), 100+2*theme.Padding()),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedMinSize, NewTable(
+				func() (int, int) { return 5, 5 },
+				func() fyne.CanvasObject {
+					r := canvas.NewRectangle(color.Black)
+					r.SetMinSize(tt.cellSize)
+					r.Resize(tt.cellSize)
+					return r
+				},
+				func(TableCellID, fyne.CanvasObject) {}).MinSize())
+		})
+	}
+}
+
 func TestTable_Unselect(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()


### PR DESCRIPTION
### Description:
All three collections will not return the larger of a element's minsize and the scroller's minsize.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
