### PR TITLE
emit KeyDown/KeyUp for Tab key

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -977,19 +977,6 @@ func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action g
 	keyEvent := &fyne.KeyEvent{Name: keyName}
 	keyDesktopModifier := desktopModifier(mods)
 
-	if keyName == fyne.KeyTab {
-		if keyDesktopModifier == 0 {
-			if action != glfw.Release {
-				w.canvas.FocusNext()
-			}
-			return
-		} else if keyDesktopModifier == desktop.ShiftModifier {
-			if action != glfw.Release {
-				w.canvas.FocusPrevious()
-			}
-			return
-		}
-	}
 	if action == glfw.Press {
 		if w.canvas.Focused() != nil {
 			if focused, ok := w.canvas.Focused().(desktop.Keyable); ok {
@@ -1008,6 +995,20 @@ func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action g
 		}
 		return
 	} // key repeat will fall through to TypedKey and TypedShortcut
+
+	if keyName == fyne.KeyTab {
+		if keyDesktopModifier == 0 {
+			if action != glfw.Release {
+				w.canvas.FocusNext()
+			}
+			return
+		} else if keyDesktopModifier == desktop.ShiftModifier {
+			if action != glfw.Release {
+				w.canvas.FocusPrevious()
+			}
+			return
+		}
+	}
 
 	var shortcut fyne.Shortcut
 	ctrlMod := desktop.ControlModifier

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -997,15 +997,12 @@ func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action g
 	} // key repeat will fall through to TypedKey and TypedShortcut
 
 	if keyName == fyne.KeyTab {
+		// at this point we know action != glfw.Release
 		if keyDesktopModifier == 0 {
-			if action != glfw.Release {
-				w.canvas.FocusNext()
-			}
+			w.canvas.FocusNext()
 			return
 		} else if keyDesktopModifier == desktop.ShiftModifier {
-			if action != glfw.Release {
-				w.canvas.FocusPrevious()
-			}
+			w.canvas.FocusPrevious()
 			return
 		}
 	}


### PR DESCRIPTION
### Description:

KeyDown/KeyUp are not triggered for the Tab key. This fixes the issue by moving the processing of tab key to after KeyDown/KeyUp are triggered.

Note that the previous `if action == glfw.Release` (in KeyDown/KeyUp processing) will cause a return meaning the `if action != glfw.Release` in the Tab key handling will never be false, so I removed it and added a comment instead so the intent isn't lost.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
