### PR TITLE
enable custom TextStyle on Entry widget

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -33,6 +33,7 @@ type Entry struct {
 	DisableableWidget
 	shortcut    fyne.ShortcutHandler
 	Text        string
+	TextStyle   fyne.TextStyle
 	PlaceHolder string
 	OnChanged   func(string) `json:"-"`
 	Password    bool
@@ -950,7 +951,7 @@ func (e *Entry) textProvider() *textProvider {
 
 // textStyle tells the rendering textProvider our style
 func (e *Entry) textStyle() fyne.TextStyle {
-	return fyne.TextStyle{}
+	return e.TextStyle
 }
 
 // textWrap tells the rendering textProvider our wrapping


### PR DESCRIPTION
Enable setting a custom `TextStyle` on `Entry` widget. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
