### PR TITLE
Enable setting a custom TextStyle on the Entry widget

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -34,8 +34,10 @@ var _ mobile.Keyboardable = (*Entry)(nil)
 // Entry widget allows simple text to be input when focused.
 type Entry struct {
 	DisableableWidget
-	shortcut    fyne.ShortcutHandler
-	Text        string
+	shortcut fyne.ShortcutHandler
+	Text     string
+	// Since: 2.0.0
+	TextStyle   fyne.TextStyle
 	PlaceHolder string
 	OnChanged   func(string) `json:"-"`
 	Password    bool
@@ -973,7 +975,7 @@ func (e *Entry) textProvider() *textProvider {
 
 // textStyle tells the rendering textProvider our style
 func (e *Entry) textStyle() fyne.TextStyle {
-	return fyne.TextStyle{}
+	return e.TextStyle
 }
 
 // textWrap tells the rendering textProvider our wrapping

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -2352,6 +2352,58 @@ func TestEntry_SetText_Underflow(t *testing.T) {
 	assert.Equal(t, "", entry.Text)
 }
 
+func TestEntry_SetTextStyle(t *testing.T) {
+	entry, window := setupImageTest(t, false)
+	defer teardownImageTest(window)
+	c := window.Canvas()
+
+	entry.Text = "Styled Text"
+	entry.TextStyle = fyne.TextStyle{Bold: true}
+	entry.Refresh()
+	test.AssertRendersToMarkup(t, `
+	<canvas padded size="150x200">
+		<content>
+			<widget pos="10,10" size="120x37" type="*widget.Entry">
+				<rectangle fillColor="shadow" pos="0,33" size="120x4"/>
+				<widget pos="4,4" size="112x29" type="*widget.textProvider">
+					<text bold pos="4,4" size="104x21">Styled Text</text>
+				</widget>
+			</widget>
+		</content>
+	</canvas>
+	`, c)
+
+	entry.TextStyle = fyne.TextStyle{Monospace: true}
+	entry.Refresh()
+	test.AssertRendersToMarkup(t, `
+	<canvas padded size="150x200">
+		<content>
+			<widget pos="10,10" size="120x37" type="*widget.Entry">
+				<rectangle fillColor="shadow" pos="0,33" size="120x4"/>
+				<widget pos="4,4" size="112x29" type="*widget.textProvider">
+					<text monospace pos="4,4" size="104x18">Styled Text</text>
+				</widget>
+			</widget>
+		</content>
+	</canvas>
+	`, c)
+
+	entry.TextStyle = fyne.TextStyle{Italic: true}
+	entry.Refresh()
+	test.AssertRendersToMarkup(t, `
+	<canvas padded size="150x200">
+		<content>
+			<widget pos="10,10" size="120x37" type="*widget.Entry">
+				<rectangle fillColor="shadow" pos="0,33" size="120x4"/>
+				<widget pos="4,4" size="112x29" type="*widget.textProvider">
+					<text italic pos="4,4" size="104x21">Styled Text</text>
+				</widget>
+			</widget>
+		</content>
+	</canvas>
+	`, c)
+}
+
 func TestEntry_Tapped(t *testing.T) {
 	entry, window := setupImageTest(t, true)
 	defer teardownImageTest(window)


### PR DESCRIPTION
### Description:
This enables setting a custom `TextStyle` on the `Entry` widget.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
