### PR TITLE
Add support for overriding standard icons in the new theme interface

### DIFF
--- a/app/app_darwin.go
+++ b/app/app_darwin.go
@@ -31,12 +31,12 @@ import (
 
 func defaultVariant() fyne.ThemeVariant {
 	if fyne.CurrentDevice().IsMobile() { // this is called in mobile simulate mode
-		return theme.Variants.Light
+		return theme.VariantNameLight
 	}
 	if C.isDarkMode() {
-		return theme.Variants.Dark
+		return theme.VariantNameDark
 	}
-	return theme.Variants.Light
+	return theme.VariantNameLight
 }
 
 func rootConfigDir() string {

--- a/app/app_other.go
+++ b/app/app_other.go
@@ -11,7 +11,7 @@ import (
 )
 
 func defaultVariant() fyne.ThemeVariant {
-	return theme.Variants.Dark
+	return theme.VariantNameDark
 }
 
 func rootConfigDir() string {

--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -51,9 +51,9 @@ func isDark() bool {
 
 func defaultVariant() fyne.ThemeVariant {
 	if isDark() {
-		return theme.Variants.Dark
+		return theme.VariantNameDark
 	}
-	return theme.Variants.Light
+	return theme.VariantNameLight
 }
 
 func rootConfigDir() string {

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -17,7 +17,7 @@ import (
 )
 
 func defaultVariant() fyne.ThemeVariant {
-	return theme.Variants.Dark
+	return theme.VariantNameDark
 }
 
 func (app *fyneApp) OpenURL(url *url.URL) error {

--- a/app/settings.go
+++ b/app/settings.go
@@ -146,9 +146,9 @@ func (s *settings) setupTheme() {
 	}
 
 	if name == "light" {
-		s.applyTheme(theme.LightTheme(), theme.Variants.Light)
+		s.applyTheme(theme.LightTheme(), theme.VariantNameLight)
 	} else if name == "dark" {
-		s.applyTheme(theme.DarkTheme(), theme.Variants.Dark)
+		s.applyTheme(theme.DarkTheme(), theme.VariantNameDark)
 	} else {
 		s.applyTheme(theme.DefaultTheme(), defaultVariant())
 	}

--- a/app/settings_desktop_test.go
+++ b/app/settings_desktop_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestDefaultTheme(t *testing.T) {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" { // system defines default for macOS and Windows
-		assert.Equal(t, theme.Variants.Dark, defaultVariant())
+		assert.Equal(t, theme.VariantNameDark, defaultVariant())
 	}
 }
 

--- a/cmd/fyne_demo/tutorials/icons.go
+++ b/cmd/fyne_demo/tutorials/icons.go
@@ -11,26 +11,33 @@ import (
 	"fyne.io/fyne/widget"
 )
 
+type iconInfo struct {
+	name string
+	icon fyne.Resource
+}
+
 type browser struct {
 	current int
+	icons   []iconInfo
 
 	name *widget.Select
 	icon *widget.Icon
 }
 
 func (b *browser) setIcon(index int) {
-	if index < 0 || index > len(icons)-1 {
+	if index < 0 || index > len(b.icons)-1 {
 		return
 	}
 	b.current = index
 
-	b.name.SetSelected(icons[index].name)
-	b.icon.SetResource(icons[index].icon)
+	b.name.SetSelected(b.icons[index].name)
+	b.icon.SetResource(b.icons[index].icon)
 }
 
 // iconScreen loads a panel that shows the various icons available in Fyne
 func iconScreen(_ fyne.Window) fyne.CanvasObject {
 	b := &browser{}
+	b.icons = loadIcons()
 
 	prev := widget.NewButtonWithIcon("", theme.NavigateBackIcon(), func() {
 		b.setIcon(b.current - 1)
@@ -38,8 +45,8 @@ func iconScreen(_ fyne.Window) fyne.CanvasObject {
 	next := widget.NewButtonWithIcon("", theme.NavigateNextIcon(), func() {
 		b.setIcon(b.current + 1)
 	})
-	b.name = widget.NewSelect(iconList(), func(name string) {
-		for i, icon := range icons {
+	b.name = widget.NewSelect(iconList(b.icons), func(name string) {
+		for i, icon := range b.icons {
 			if icon.name == name {
 				if b.current != i {
 					b.setIcon(i)
@@ -48,13 +55,13 @@ func iconScreen(_ fyne.Window) fyne.CanvasObject {
 			}
 		}
 	})
-	b.name.SetSelected(icons[b.current].name)
+	b.name.SetSelected(b.icons[b.current].name)
 	buttons := container.NewHBox(prev, next)
 	bar := container.NewBorder(nil, nil, buttons, nil, b.name)
 
 	background := canvas.NewRasterWithPixels(checkerPattern)
 	background.SetMinSize(fyne.NewSize(280, 280))
-	b.icon = widget.NewIcon(icons[b.current].icon)
+	b.icon = widget.NewIcon(b.icons[b.current].icon)
 
 	return fyne.NewContainerWithLayout(layout.NewBorderLayout(
 		bar, nil, nil, nil), bar, background, b.icon)
@@ -71,7 +78,7 @@ func checkerPattern(x, y, _, _ int) color.Color {
 	return theme.ShadowColor()
 }
 
-func iconList() []string {
+func iconList(icons []iconInfo) []string {
 	ret := make([]string, len(icons))
 	for i, icon := range icons {
 		ret[i] = icon.name
@@ -80,100 +87,99 @@ func iconList() []string {
 	return ret
 }
 
-var icons = []struct {
-	name string
-	icon fyne.Resource
-}{
-	{"CancelIcon", theme.CancelIcon()},
-	{"ConfirmIcon", theme.ConfirmIcon()},
-	{"DeleteIcon", theme.DeleteIcon()},
-	{"SearchIcon", theme.SearchIcon()},
-	{"SearchReplaceIcon", theme.SearchReplaceIcon()},
+func loadIcons() []iconInfo {
+	return []iconInfo{
+		{"CancelIcon", theme.CancelIcon()},
+		{"ConfirmIcon", theme.ConfirmIcon()},
+		{"DeleteIcon", theme.DeleteIcon()},
+		{"SearchIcon", theme.SearchIcon()},
+		{"SearchReplaceIcon", theme.SearchReplaceIcon()},
 
-	{"CheckButtonIcon", theme.CheckButtonIcon()},
-	{"CheckButtonCheckedIcon", theme.CheckButtonCheckedIcon()},
-	{"RadioButtonIcon", theme.RadioButtonIcon()},
-	{"RadioButtonCheckedIcon", theme.RadioButtonCheckedIcon()},
+		{"CheckButtonIcon", theme.CheckButtonIcon()},
+		{"CheckButtonCheckedIcon", theme.CheckButtonCheckedIcon()},
+		{"RadioButtonIcon", theme.RadioButtonIcon()},
+		{"RadioButtonCheckedIcon", theme.RadioButtonCheckedIcon()},
 
-	{"ColorAchromaticIcon", theme.ColorAchromaticIcon()},
-	{"ColorChromaticIcon", theme.ColorChromaticIcon()},
-	{"ColorPaletteIcon", theme.ColorPaletteIcon()},
+		{"ColorAchromaticIcon", theme.ColorAchromaticIcon()},
+		{"ColorChromaticIcon", theme.ColorChromaticIcon()},
+		{"ColorPaletteIcon", theme.ColorPaletteIcon()},
 
-	{"ContentAddIcon", theme.ContentAddIcon()},
-	{"ContentRemoveIcon", theme.ContentRemoveIcon()},
-	{"ContentClearIcon", theme.ContentClearIcon()},
-	{"ContentCutIcon", theme.ContentCutIcon()},
-	{"ContentCopyIcon", theme.ContentCopyIcon()},
-	{"ContentPasteIcon", theme.ContentPasteIcon()},
-	{"ContentRedoIcon", theme.ContentRedoIcon()},
-	{"ContentUndoIcon", theme.ContentUndoIcon()},
+		{"ContentAddIcon", theme.ContentAddIcon()},
+		{"ContentRemoveIcon", theme.ContentRemoveIcon()},
+		{"ContentClearIcon", theme.ContentClearIcon()},
+		{"ContentCutIcon", theme.ContentCutIcon()},
+		{"ContentCopyIcon", theme.ContentCopyIcon()},
+		{"ContentPasteIcon", theme.ContentPasteIcon()},
+		{"ContentRedoIcon", theme.ContentRedoIcon()},
+		{"ContentUndoIcon", theme.ContentUndoIcon()},
 
-	{"InfoIcon", theme.InfoIcon()},
-	{"ErrorIcon", theme.ErrorIcon()},
-	{"QuestionIcon", theme.QuestionIcon()},
-	{"WarningIcon", theme.WarningIcon()},
+		{"InfoIcon", theme.InfoIcon()},
+		{"ErrorIcon", theme.ErrorIcon()},
+		{"QuestionIcon", theme.QuestionIcon()},
+		{"WarningIcon", theme.WarningIcon()},
 
-	{"DocumentIcon", theme.DocumentIcon()},
-	{"DocumentCreateIcon", theme.DocumentCreateIcon()},
-	{"DocumentPrintIcon", theme.DocumentPrintIcon()},
-	{"DocumentSaveIcon", theme.DocumentSaveIcon()},
+		{"DocumentIcon", theme.DocumentIcon()},
+		{"DocumentCreateIcon", theme.DocumentCreateIcon()},
+		{"DocumentPrintIcon", theme.DocumentPrintIcon()},
+		{"DocumentSaveIcon", theme.DocumentSaveIcon()},
 
-	{"FileIcon", theme.FileIcon()},
-	{"FileApplicationIcon", theme.FileApplicationIcon()},
-	{"FileAudioIcon", theme.FileAudioIcon()},
-	{"FileImageIcon", theme.FileImageIcon()},
-	{"FileTextIcon", theme.FileTextIcon()},
-	{"FileVideoIcon", theme.FileVideoIcon()},
-	{"FolderIcon", theme.FolderIcon()},
-	{"FolderNewIcon", theme.FolderNewIcon()},
-	{"FolderOpenIcon", theme.FolderOpenIcon()},
-	{"ComputerIcon", theme.ComputerIcon()},
-	{"HomeIcon", theme.HomeIcon()},
-	{"HelpIcon", theme.HelpIcon()},
-	{"HistoryIcon", theme.HistoryIcon()},
-	{"SettingsIcon", theme.SettingsIcon()},
-	{"StorageIcon", theme.StorageIcon()},
-	{"DownloadIcon", theme.DownloadIcon()},
-	{"UploadIcon", theme.UploadIcon()},
+		{"FileIcon", theme.FileIcon()},
+		{"FileApplicationIcon", theme.FileApplicationIcon()},
+		{"FileAudioIcon", theme.FileAudioIcon()},
+		{"FileImageIcon", theme.FileImageIcon()},
+		{"FileTextIcon", theme.FileTextIcon()},
+		{"FileVideoIcon", theme.FileVideoIcon()},
+		{"FolderIcon", theme.FolderIcon()},
+		{"FolderNewIcon", theme.FolderNewIcon()},
+		{"FolderOpenIcon", theme.FolderOpenIcon()},
+		{"ComputerIcon", theme.ComputerIcon()},
+		{"HomeIcon", theme.HomeIcon()},
+		{"HelpIcon", theme.HelpIcon()},
+		{"HistoryIcon", theme.HistoryIcon()},
+		{"SettingsIcon", theme.SettingsIcon()},
+		{"StorageIcon", theme.StorageIcon()},
+		{"DownloadIcon", theme.DownloadIcon()},
+		{"UploadIcon", theme.UploadIcon()},
 
-	{"ViewFullScreenIcon", theme.ViewFullScreenIcon()},
-	{"ViewRestoreIcon", theme.ViewRestoreIcon()},
-	{"ViewRefreshIcon", theme.ViewRefreshIcon()},
-	{"VisibilityIcon", theme.VisibilityIcon()},
-	{"VisibilityOffIcon", theme.VisibilityOffIcon()},
-	{"ZoomFitIcon", theme.ZoomFitIcon()},
-	{"ZoomInIcon", theme.ZoomInIcon()},
-	{"ZoomOutIcon", theme.ZoomOutIcon()},
+		{"ViewFullScreenIcon", theme.ViewFullScreenIcon()},
+		{"ViewRestoreIcon", theme.ViewRestoreIcon()},
+		{"ViewRefreshIcon", theme.ViewRefreshIcon()},
+		{"VisibilityIcon", theme.VisibilityIcon()},
+		{"VisibilityOffIcon", theme.VisibilityOffIcon()},
+		{"ZoomFitIcon", theme.ZoomFitIcon()},
+		{"ZoomInIcon", theme.ZoomInIcon()},
+		{"ZoomOutIcon", theme.ZoomOutIcon()},
 
-	{"MoveDownIcon", theme.MoveDownIcon()},
-	{"MoveUpIcon", theme.MoveUpIcon()},
+		{"MoveDownIcon", theme.MoveDownIcon()},
+		{"MoveUpIcon", theme.MoveUpIcon()},
 
-	{"NavigateBackIcon", theme.NavigateBackIcon()},
-	{"NavigateNextIcon", theme.NavigateNextIcon()},
+		{"NavigateBackIcon", theme.NavigateBackIcon()},
+		{"NavigateNextIcon", theme.NavigateNextIcon()},
 
-	{"Menu", theme.MenuIcon()},
-	{"MenuExpand", theme.MenuExpandIcon()},
-	{"MenuDropDown", theme.MenuDropDownIcon()},
-	{"MenuDropUp", theme.MenuDropUpIcon()},
+		{"Menu", theme.MenuIcon()},
+		{"MenuExpand", theme.MenuExpandIcon()},
+		{"MenuDropDown", theme.MenuDropDownIcon()},
+		{"MenuDropUp", theme.MenuDropUpIcon()},
 
-	{"MailAttachmentIcon", theme.MailAttachmentIcon()},
-	{"MailComposeIcon", theme.MailComposeIcon()},
-	{"MailForwardIcon", theme.MailForwardIcon()},
-	{"MailReplyIcon", theme.MailReplyIcon()},
-	{"MailReplyAllIcon", theme.MailReplyAllIcon()},
-	{"MailSendIcon", theme.MailSendIcon()},
+		{"MailAttachmentIcon", theme.MailAttachmentIcon()},
+		{"MailComposeIcon", theme.MailComposeIcon()},
+		{"MailForwardIcon", theme.MailForwardIcon()},
+		{"MailReplyIcon", theme.MailReplyIcon()},
+		{"MailReplyAllIcon", theme.MailReplyAllIcon()},
+		{"MailSendIcon", theme.MailSendIcon()},
 
-	{"MediaFastForward", theme.MediaFastForwardIcon()},
-	{"MediaFastRewind", theme.MediaFastRewindIcon()},
-	{"MediaPause", theme.MediaPauseIcon()},
-	{"MediaPlay", theme.MediaPlayIcon()},
-	{"MediaStop", theme.MediaStopIcon()},
-	{"MediaRecord", theme.MediaRecordIcon()},
-	{"MediaReplay", theme.MediaReplayIcon()},
-	{"MediaSkipNext", theme.MediaSkipNextIcon()},
-	{"MediaSkipPrevious", theme.MediaSkipPreviousIcon()},
+		{"MediaFastForward", theme.MediaFastForwardIcon()},
+		{"MediaFastRewind", theme.MediaFastRewindIcon()},
+		{"MediaPause", theme.MediaPauseIcon()},
+		{"MediaPlay", theme.MediaPlayIcon()},
+		{"MediaStop", theme.MediaStopIcon()},
+		{"MediaRecord", theme.MediaRecordIcon()},
+		{"MediaReplay", theme.MediaReplayIcon()},
+		{"MediaSkipNext", theme.MediaSkipNextIcon()},
+		{"MediaSkipPrevious", theme.MediaSkipPreviousIcon()},
 
-	{"VolumeDown", theme.VolumeDownIcon()},
-	{"VolumeMute", theme.VolumeMuteIcon()},
-	{"VolumeUp", theme.VolumeUpIcon()},
+		{"VolumeDown", theme.VolumeDownIcon()},
+		{"VolumeMute", theme.VolumeMuteIcon()},
+		{"VolumeUp", theme.VolumeUpIcon()},
+	}
 }

--- a/cmd/fyne_demo/tutorials/theme.go
+++ b/cmd/fyne_demo/tutorials/theme.go
@@ -38,6 +38,10 @@ func (customTheme) Font(style fyne.TextStyle) fyne.Resource {
 	return theme.DarkTheme().Font(style)
 }
 
+func (customTheme) Icon(n fyne.ThemeIconName) fyne.Resource {
+	return theme.DefaultTheme().Icon(n)
+}
+
 func (customTheme) Size(s fyne.ThemeSizeName) int {
 	switch s {
 	case theme.Sizes.Padding:

--- a/cmd/fyne_demo/tutorials/theme.go
+++ b/cmd/fyne_demo/tutorials/theme.go
@@ -34,6 +34,10 @@ func (customTheme) Color(c fyne.ThemeColorName, _ fyne.ThemeVariant) color.Color
 	}
 }
 
+func (customTheme) Font(style fyne.TextStyle) fyne.Resource {
+	return theme.DarkTheme().Font(style)
+}
+
 func (customTheme) Size(s fyne.ThemeSizeName) int {
 	switch s {
 	case theme.Sizes.Padding:
@@ -49,10 +53,6 @@ func (customTheme) Size(s fyne.ThemeSizeName) int {
 	default:
 		return 0
 	}
-}
-
-func (customTheme) Font(style fyne.TextStyle) fyne.Resource {
-	return theme.DarkTheme().Font(style)
 }
 
 func newCustomTheme() fyne.Theme {

--- a/cmd/fyne_demo/tutorials/theme.go
+++ b/cmd/fyne_demo/tutorials/theme.go
@@ -19,15 +19,15 @@ type customTheme struct {
 
 func (customTheme) Color(c fyne.ThemeColorName, _ fyne.ThemeVariant) color.Color {
 	switch c {
-	case theme.Colors.Background:
+	case theme.ColorNameBackground:
 		return purple
-	case theme.Colors.Button, theme.Colors.Disabled:
+	case theme.ColorNameButton, theme.ColorNameDisabled:
 		return color.Black
-	case theme.Colors.PlaceHolder, theme.Colors.ScrollBar:
+	case theme.ColorNamePlaceHolder, theme.ColorNameScrollBar:
 		return grey
-	case theme.Colors.Primary, theme.Colors.Hover, theme.Colors.Focus:
+	case theme.ColorNamePrimary, theme.ColorNameHover, theme.ColorNameFocus:
 		return orange
-	case theme.Colors.Shadow:
+	case theme.ColorNameShadow:
 		return &color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xcc}
 	default:
 		return color.White
@@ -44,15 +44,15 @@ func (customTheme) Icon(n fyne.ThemeIconName) fyne.Resource {
 
 func (customTheme) Size(s fyne.ThemeSizeName) int {
 	switch s {
-	case theme.Sizes.Padding:
+	case theme.SizeNamePadding:
 		return 10
-	case theme.Sizes.InlineIcon:
+	case theme.SizeNameInlineIcon:
 		return 20
-	case theme.Sizes.ScrollBar:
+	case theme.SizeNameScrollBar:
 		return 10
-	case theme.Sizes.ScrollBarSmall:
+	case theme.SizeNameScrollBarSmall:
 		return 5
-	case theme.Sizes.Text:
+	case theme.SizeNameText:
 		return 12
 	default:
 		return 0

--- a/test/testtheme.go
+++ b/test/testtheme.go
@@ -17,17 +17,17 @@ var (
 func NewTheme() fyne.Theme {
 	return &configurableTheme{
 		colors: map[fyne.ThemeColorName]color.Color{
-			theme.Colors.Background:     red,
-			theme.Colors.Button:         color.Black,
-			theme.Colors.Disabled:       color.Black,
-			theme.Colors.DisabledButton: color.White,
-			theme.Colors.Focus:          green,
-			theme.Colors.Foreground:     color.White,
-			theme.Colors.Hover:          green,
-			theme.Colors.PlaceHolder:    blue,
-			theme.Colors.Primary:        green,
-			theme.Colors.ScrollBar:      blue,
-			theme.Colors.Shadow:         blue,
+			theme.ColorNameBackground:     red,
+			theme.ColorNameButton:         color.Black,
+			theme.ColorNameDisabled:       color.Black,
+			theme.ColorNameDisabledButton: color.White,
+			theme.ColorNameFocus:          green,
+			theme.ColorNameForeground:     color.White,
+			theme.ColorNameHover:          green,
+			theme.ColorNamePlaceHolder:    blue,
+			theme.ColorNamePrimary:        green,
+			theme.ColorNameScrollBar:      blue,
+			theme.ColorNameShadow:         blue,
 		},
 		fonts: map[fyne.TextStyle]fyne.Resource{
 			fyne.TextStyle{}:                         theme.DefaultTextBoldFont(),
@@ -37,11 +37,11 @@ func NewTheme() fyne.Theme {
 			fyne.TextStyle{Monospace: true}:          theme.DefaultTextFont(),
 		},
 		sizes: map[fyne.ThemeSizeName]int{
-			theme.Sizes.InlineIcon:     24,
-			theme.Sizes.Padding:        10,
-			theme.Sizes.ScrollBar:      10,
-			theme.Sizes.ScrollBarSmall: 2,
-			theme.Sizes.Text:           18,
+			theme.SizeNameInlineIcon:     24,
+			theme.SizeNamePadding:        10,
+			theme.SizeNameScrollBar:      10,
+			theme.SizeNameScrollBarSmall: 2,
+			theme.SizeNameText:           18,
 		},
 	}
 }

--- a/test/theme.go
+++ b/test/theme.go
@@ -22,17 +22,17 @@ func Theme() fyne.Theme {
 	if defaultTheme == nil {
 		defaultTheme = &configurableTheme{
 			colors: map[fyne.ThemeColorName]color.Color{
-				theme.Colors.Background:     color.NRGBA{R: 0x44, G: 0x44, B: 0x44, A: 0xff},
-				theme.Colors.Button:         color.NRGBA{R: 0x33, G: 0x33, B: 0x33, A: 0xff},
-				theme.Colors.Disabled:       color.NRGBA{R: 0x88, G: 0x88, B: 0x88, A: 0xff},
-				theme.Colors.DisabledButton: color.NRGBA{R: 0x22, G: 0x22, B: 0x22, A: 0xff},
-				theme.Colors.Focus:          color.NRGBA{R: 0x81, G: 0xc7, B: 0x84, A: 0xff},
-				theme.Colors.Foreground:     color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff},
-				theme.Colors.Hover:          color.NRGBA{R: 0x88, G: 0xff, B: 0xff, A: 0x22},
-				theme.Colors.PlaceHolder:    color.NRGBA{R: 0xaa, G: 0xaa, B: 0xaa, A: 0xff},
-				theme.Colors.Primary:        color.NRGBA{R: 0xff, G: 0xcc, B: 0x80, A: 0xff},
-				theme.Colors.ScrollBar:      color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0xaa},
-				theme.Colors.Shadow:         color.NRGBA{A: 0x88},
+				theme.ColorNameBackground:     color.NRGBA{R: 0x44, G: 0x44, B: 0x44, A: 0xff},
+				theme.ColorNameButton:         color.NRGBA{R: 0x33, G: 0x33, B: 0x33, A: 0xff},
+				theme.ColorNameDisabled:       color.NRGBA{R: 0x88, G: 0x88, B: 0x88, A: 0xff},
+				theme.ColorNameDisabledButton: color.NRGBA{R: 0x22, G: 0x22, B: 0x22, A: 0xff},
+				theme.ColorNameFocus:          color.NRGBA{R: 0x81, G: 0xc7, B: 0x84, A: 0xff},
+				theme.ColorNameForeground:     color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff},
+				theme.ColorNameHover:          color.NRGBA{R: 0x88, G: 0xff, B: 0xff, A: 0x22},
+				theme.ColorNamePlaceHolder:    color.NRGBA{R: 0xaa, G: 0xaa, B: 0xaa, A: 0xff},
+				theme.ColorNamePrimary:        color.NRGBA{R: 0xff, G: 0xcc, B: 0x80, A: 0xff},
+				theme.ColorNameScrollBar:      color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0xaa},
+				theme.ColorNameShadow:         color.NRGBA{A: 0x88},
 			},
 			fonts: map[fyne.TextStyle]fyne.Resource{
 				fyne.TextStyle{}:                         theme.DefaultTextFont(),
@@ -42,11 +42,11 @@ func Theme() fyne.Theme {
 				fyne.TextStyle{Monospace: true}:          theme.DefaultTextMonospaceFont(),
 			},
 			sizes: map[fyne.ThemeSizeName]int{
-				theme.Sizes.InlineIcon:     20,
-				theme.Sizes.Padding:        4,
-				theme.Sizes.ScrollBar:      16,
-				theme.Sizes.ScrollBarSmall: 3,
-				theme.Sizes.Text:           14,
+				theme.SizeNameInlineIcon:     20,
+				theme.SizeNamePadding:        4,
+				theme.SizeNameScrollBar:      16,
+				theme.SizeNameScrollBarSmall: 3,
+				theme.SizeNameText:           14,
 			},
 		}
 	}

--- a/test/theme.go
+++ b/test/theme.go
@@ -61,6 +61,10 @@ func (t *configurableTheme) Font(style fyne.TextStyle) fyne.Resource {
 	return t.fonts[style]
 }
 
+func (t *configurableTheme) Icon(n fyne.ThemeIconName) fyne.Resource {
+	return theme.DefaultTheme().Icon(n)
+}
+
 func (t *configurableTheme) Size(s fyne.ThemeSizeName) int {
 	return t.sizes[s]
 }

--- a/theme.go
+++ b/theme.go
@@ -22,8 +22,8 @@ type ThemeSizeName string
 // Since 2.0.0
 type Theme interface {
 	Color(ThemeColorName, ThemeVariant) color.Color
-	Size(ThemeSizeName) int
 	Font(TextStyle) Resource
+	Size(ThemeSizeName) int
 }
 
 // LegacyTheme defines the requirements of any Fyne theme.

--- a/theme.go
+++ b/theme.go
@@ -7,12 +7,17 @@ import "image/color"
 // Since 2.0.0
 type ThemeVariant uint
 
-// ThemeColorName is used to look up a colour based on it's name.
+// ThemeColorName is used to look up a colour based on its name.
 //
 // Since 2.0.0
 type ThemeColorName string
 
-// ThemeSizeName is used to look up a size based on it's name.
+// ThemeIconName is used to look up an icon based on its name.
+//
+// Since 2.0.0
+type ThemeIconName string
+
+// ThemeSizeName is used to look up a size based on its name.
 //
 // Since 2.0.0
 type ThemeSizeName string
@@ -23,6 +28,7 @@ type ThemeSizeName string
 type Theme interface {
 	Color(ThemeColorName, ThemeVariant) color.Color
 	Font(TextStyle) Resource
+	Icon(ThemeIconName) Resource
 	Size(ThemeSizeName) int
 }
 

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -9,6 +9,142 @@ import (
 	"fyne.io/fyne"
 )
 
+var (
+	// Icons specifies each of the known icon names that a theme can contain.
+	//
+	// Since 2.0.0
+	Icons = struct {
+		Cancel, Confirm, Delete, Search, SearchReplace, Menu, MenuExpand                fyne.ThemeIconName
+		CheckButtonChecked, CheckButton, RadioButton, RadioButtonChecked                fyne.ThemeIconName
+		ColorAchromatic, ColorChromatic, ColorPalette                                   fyne.ThemeIconName
+		ContentAdd, ContentRemove, ContentCut, ContentCopy, ContentPaste                fyne.ThemeIconName
+		ContentClear, ContentRedo, ContentUndo, Info, Question, Warning, Error          fyne.ThemeIconName
+		Document, DocumentCreate, DocumentPrint, DocumentSave                           fyne.ThemeIconName
+		MailAttachment, MailCompose, MailForward, MailReply, MailReplyAll, MailSend     fyne.ThemeIconName
+		MediaFastForward, MediaFastRewind, MediaPause, MediaPlay                        fyne.ThemeIconName
+		MediaRecord, MediaReplay, MediaSkipNext, MediaSkipPrevious, MediaStop           fyne.ThemeIconName
+		NavigateBack, MoveDown, NavigateNext, MoveUp, ArrowDropDown, ArrowDropUp        fyne.ThemeIconName
+		File, FileApplication, FileAudio, FileImage, FileText, FileVideo                fyne.ThemeIconName
+		Folder, FolderNew, FolderOpen, Help, History, Home, Settings, Storage, Upload   fyne.ThemeIconName
+		ViewFullScreen, ViewRefresh, ViewZoomFit, ViewZoomIn, ViewZoomOut, ViewRestore  fyne.ThemeIconName
+		Visibility, VisibilityOff, VolumeDown, VolumeMute, VolumeUp, Download, Computer fyne.ThemeIconName
+	}{
+		"cancel", "confirm", "delete", "search", "searchReplace", "menu", "menuExpand",
+		"checked", "unchecked", "radioButton", "radioButtonChecked",
+		"colorAchromatic", "colorChromatic", "colorPalette",
+		"contentAdd", "contentRemove", "contentCut", "contentCopy", "contentPaste",
+		"contentClear", "contentRedo", "contentUndo", "info", "question", "warning", "errori",
+		"document", "documentCreate", "documentPrint", "documentSave",
+		"mailAttachment", "mailCompose", "mailForward", "mailReply", "mailReplyAll", "mailSend",
+		"mediaFastForward", "mediaFastRewind", "mediaPause", "mediaPlay",
+		"mediaRecord", "mediaReplay", "mediaSkipNext", "mediaSkipPrevious", "mediaStop",
+		"arrowBack", "arrowDown", "arrowForward", "arrowUp", "arrowDropDown", "arrowDropUp",
+		"file", "fileApplication", "fileAudio", "fileImage", "fileText", "fileVideo",
+		"folder", "folderNew", "folderOpen", "help", "history", "home", "settings", "storage", "upload",
+		"viewFullScreen", "viewRefresh", "viewZoomFit", "viewZoomIn", "viewZoomOut", "viewRestore",
+		"visibility", "visibilityOff", "volumeDown", "volumeMute", "volumeUp", "download", "computer",
+	}
+
+	icons = map[fyne.ThemeIconName]fyne.Resource{
+		Icons.Cancel:        NewThemedResource(cancelIconRes),
+		Icons.Confirm:       NewThemedResource(checkIconRes),
+		Icons.Delete:        NewThemedResource(deleteIconRes),
+		Icons.Search:        NewThemedResource(searchIconRes),
+		Icons.SearchReplace: NewThemedResource(searchreplaceIconRes),
+		Icons.Menu:          NewThemedResource(menuIconRes),
+		Icons.MenuExpand:    NewThemedResource(menuexpandIconRes),
+
+		Icons.CheckButton:        NewThemedResource(checkboxblankIconRes),
+		Icons.CheckButtonChecked: NewThemedResource(checkboxIconRes),
+		Icons.RadioButton:        NewThemedResource(radiobuttonIconRes),
+		Icons.RadioButtonChecked: NewThemedResource(radiobuttoncheckedIconRes),
+
+		Icons.ContentAdd:    NewThemedResource(contentaddIconRes),
+		Icons.ContentClear:  NewThemedResource(cancelIconRes),
+		Icons.ContentRemove: NewThemedResource(contentremoveIconRes),
+		Icons.ContentCut:    NewThemedResource(contentcutIconRes),
+		Icons.ContentCopy:   NewThemedResource(contentcopyIconRes),
+		Icons.ContentPaste:  NewThemedResource(contentpasteIconRes),
+		Icons.ContentRedo:   NewThemedResource(contentredoIconRes),
+		Icons.ContentUndo:   NewThemedResource(contentundoIconRes),
+
+		Icons.ColorAchromatic: NewThemedResource(colorachromaticIconRes),
+		Icons.ColorChromatic:  NewThemedResource(colorchromaticIconRes),
+		Icons.ColorPalette:    NewThemedResource(colorpaletteIconRes),
+
+		Icons.Document:       NewThemedResource(documentIconRes),
+		Icons.DocumentCreate: NewThemedResource(documentcreateIconRes),
+		Icons.DocumentPrint:  NewThemedResource(documentprintIconRes),
+		Icons.DocumentSave:   NewThemedResource(documentsaveIconRes),
+
+		Icons.Info:     NewThemedResource(infoIconRes),
+		Icons.Question: NewThemedResource(questionIconRes),
+		Icons.Warning:  NewThemedResource(warningIconRes),
+		Icons.Error:    NewThemedResource(errorIconRes),
+
+		Icons.MailAttachment: NewThemedResource(mailattachmentIconRes),
+		Icons.MailCompose:    NewThemedResource(mailcomposeIconRes),
+		Icons.MailForward:    NewThemedResource(mailforwardIconRes),
+		Icons.MailReply:      NewThemedResource(mailreplyIconRes),
+		Icons.MailReplyAll:   NewThemedResource(mailreplyallIconRes),
+		Icons.MailSend:       NewThemedResource(mailsendIconRes),
+
+		Icons.MediaFastForward:  NewThemedResource(mediafastforwardIconRes),
+		Icons.MediaFastRewind:   NewThemedResource(mediafastrewindIconRes),
+		Icons.MediaPause:        NewThemedResource(mediapauseIconRes),
+		Icons.MediaPlay:         NewThemedResource(mediaplayIconRes),
+		Icons.MediaRecord:       NewThemedResource(mediarecordIconRes),
+		Icons.MediaReplay:       NewThemedResource(mediareplayIconRes),
+		Icons.MediaSkipNext:     NewThemedResource(mediaskipnextIconRes),
+		Icons.MediaSkipPrevious: NewThemedResource(mediaskippreviousIconRes),
+		Icons.MediaStop:         NewThemedResource(mediastopIconRes),
+
+		Icons.NavigateBack:  NewThemedResource(arrowbackIconRes),
+		Icons.MoveDown:      NewThemedResource(arrowdownIconRes),
+		Icons.NavigateNext:  NewThemedResource(arrowforwardIconRes),
+		Icons.MoveUp:        NewThemedResource(arrowupIconRes),
+		Icons.ArrowDropDown: NewThemedResource(arrowdropdownIconRes),
+		Icons.ArrowDropUp:   NewThemedResource(arrowdropupIconRes),
+
+		Icons.File:            NewThemedResource(fileIconRes),
+		Icons.FileApplication: NewThemedResource(fileapplicationIconRes),
+		Icons.FileAudio:       NewThemedResource(fileaudioIconRes),
+		Icons.FileImage:       NewThemedResource(fileimageIconRes),
+		Icons.FileText:        NewThemedResource(filetextIconRes),
+		Icons.FileVideo:       NewThemedResource(filevideoIconRes),
+		Icons.Folder:          NewThemedResource(folderIconRes),
+		Icons.FolderNew:       NewThemedResource(foldernewIconRes),
+		Icons.FolderOpen:      NewThemedResource(folderopenIconRes),
+		Icons.Help:            NewThemedResource(helpIconRes),
+		Icons.History:         NewThemedResource(historyIconRes),
+		Icons.Home:            NewThemedResource(homeIconRes),
+		Icons.Settings:        NewThemedResource(settingsIconRes),
+
+		Icons.ViewFullScreen: NewThemedResource(viewfullscreenIconRes),
+		Icons.ViewRefresh:    NewThemedResource(viewrefreshIconRes),
+		Icons.ViewRestore:    NewThemedResource(viewzoomfitIconRes),
+		Icons.ViewZoomFit:    NewThemedResource(viewzoomfitIconRes),
+		Icons.ViewZoomIn:     NewThemedResource(viewzoominIconRes),
+		Icons.ViewZoomOut:    NewThemedResource(viewzoomoutIconRes),
+
+		Icons.Visibility:    NewThemedResource(visibilityIconRes),
+		Icons.VisibilityOff: NewThemedResource(visibilityoffIconRes),
+
+		Icons.VolumeDown: NewThemedResource(volumedownIconRes),
+		Icons.VolumeMute: NewThemedResource(volumemuteIconRes),
+		Icons.VolumeUp:   NewThemedResource(volumeupIconRes),
+
+		Icons.Download: NewThemedResource(downloadIconRes),
+		Icons.Computer: NewThemedResource(computerIconRes),
+		Icons.Storage:  NewThemedResource(storageIconRes),
+		Icons.Upload:   NewThemedResource(uploadIconRes),
+	}
+)
+
+func (t *builtinTheme) Icon(n fyne.ThemeIconName) fyne.Resource {
+	return icons[n]
+}
+
 // ThemedResource is a resource wrapper that will return a version of the resource with the main color changed
 // for the currently selected theme.
 type ThemedResource struct {
@@ -164,118 +300,6 @@ func colorizeResource(res fyne.Resource, clr color.Color) []byte {
 	return b
 }
 
-var (
-	cancel, confirm, delete, search, searchReplace, menu, menuExpand                *ThemedResource
-	checked, unchecked, radioButton, radioButtonChecked                             *ThemedResource
-	colorAchromatic, colorChromatic, colorPalette                                   *ThemedResource
-	contentAdd, contentRemove, contentCut, contentCopy, contentPaste                *ThemedResource
-	contentClear, contentRedo, contentUndo, info, question, warning, errori         *ThemedResource
-	document, documentCreate, documentPrint, documentSave                           *ThemedResource
-	mailAttachment, mailCompose, mailForward, mailReply, mailReplyAll, mailSend     *ThemedResource
-	mediaFastForward, mediaFastRewind, mediaPause, mediaPlay                        *ThemedResource
-	mediaRecord, mediaReplay, mediaSkipNext, mediaSkipPrevious, mediaStop           *ThemedResource
-	arrowBack, arrowDown, arrowForward, arrowUp, arrowDropDown, arrowDropUp         *ThemedResource
-	file, fileApplication, fileAudio, fileImage, fileText, fileVideo                *ThemedResource
-	folder, folderNew, folderOpen, help, history, home, settings, storage, upload   *ThemedResource
-	viewFullScreen, viewRefresh, viewZoomFit, viewZoomIn, viewZoomOut, viewRestore  *ThemedResource
-	visibility, visibilityOff, volumeDown, volumeMute, volumeUp, download, computer *ThemedResource
-)
-
-func init() {
-	cancel = NewThemedResource(cancelIconRes)
-	confirm = NewThemedResource(checkIconRes)
-	delete = NewThemedResource(deleteIconRes)
-	search = NewThemedResource(searchIconRes)
-	searchReplace = NewThemedResource(searchreplaceIconRes)
-	menu = NewThemedResource(menuIconRes)
-	menuExpand = NewThemedResource(menuexpandIconRes)
-
-	checked = NewThemedResource(checkboxIconRes)
-	unchecked = NewThemedResource(checkboxblankIconRes)
-	radioButton = NewThemedResource(radiobuttonIconRes)
-	radioButtonChecked = NewThemedResource(radiobuttoncheckedIconRes)
-
-	contentAdd = NewThemedResource(contentaddIconRes)
-	contentClear = NewThemedResource(cancelIconRes)
-	contentRemove = NewThemedResource(contentremoveIconRes)
-	contentCut = NewThemedResource(contentcutIconRes)
-	contentCopy = NewThemedResource(contentcopyIconRes)
-	contentPaste = NewThemedResource(contentpasteIconRes)
-	contentRedo = NewThemedResource(contentredoIconRes)
-	contentUndo = NewThemedResource(contentundoIconRes)
-
-	colorAchromatic = NewThemedResource(colorachromaticIconRes)
-	colorChromatic = NewThemedResource(colorchromaticIconRes)
-	colorPalette = NewThemedResource(colorpaletteIconRes)
-
-	document = NewThemedResource(documentIconRes)
-	documentCreate = NewThemedResource(documentcreateIconRes)
-	documentPrint = NewThemedResource(documentprintIconRes)
-	documentSave = NewThemedResource(documentsaveIconRes)
-
-	info = NewThemedResource(infoIconRes)
-	question = NewThemedResource(questionIconRes)
-	warning = NewThemedResource(warningIconRes)
-	errori = NewThemedResource(errorIconRes)
-
-	mailAttachment = NewThemedResource(mailattachmentIconRes)
-	mailCompose = NewThemedResource(mailcomposeIconRes)
-	mailForward = NewThemedResource(mailforwardIconRes)
-	mailReply = NewThemedResource(mailreplyIconRes)
-	mailReplyAll = NewThemedResource(mailreplyallIconRes)
-	mailSend = NewThemedResource(mailsendIconRes)
-
-	mediaFastForward = NewThemedResource(mediafastforwardIconRes)
-	mediaFastRewind = NewThemedResource(mediafastrewindIconRes)
-	mediaPause = NewThemedResource(mediapauseIconRes)
-	mediaPlay = NewThemedResource(mediaplayIconRes)
-	mediaRecord = NewThemedResource(mediarecordIconRes)
-	mediaReplay = NewThemedResource(mediareplayIconRes)
-	mediaSkipNext = NewThemedResource(mediaskipnextIconRes)
-	mediaSkipPrevious = NewThemedResource(mediaskippreviousIconRes)
-	mediaStop = NewThemedResource(mediastopIconRes)
-
-	arrowBack = NewThemedResource(arrowbackIconRes)
-	arrowDown = NewThemedResource(arrowdownIconRes)
-	arrowForward = NewThemedResource(arrowforwardIconRes)
-	arrowUp = NewThemedResource(arrowupIconRes)
-	arrowDropDown = NewThemedResource(arrowdropdownIconRes)
-	arrowDropUp = NewThemedResource(arrowdropupIconRes)
-
-	file = NewThemedResource(fileIconRes)
-	fileApplication = NewThemedResource(fileapplicationIconRes)
-	fileAudio = NewThemedResource(fileaudioIconRes)
-	fileImage = NewThemedResource(fileimageIconRes)
-	fileText = NewThemedResource(filetextIconRes)
-	fileVideo = NewThemedResource(filevideoIconRes)
-	folder = NewThemedResource(folderIconRes)
-	folderNew = NewThemedResource(foldernewIconRes)
-	folderOpen = NewThemedResource(folderopenIconRes)
-	help = NewThemedResource(helpIconRes)
-	history = NewThemedResource(historyIconRes)
-	home = NewThemedResource(homeIconRes)
-	settings = NewThemedResource(settingsIconRes)
-
-	viewFullScreen = NewThemedResource(viewfullscreenIconRes)
-	viewRefresh = NewThemedResource(viewrefreshIconRes)
-	viewRestore = NewThemedResource(viewzoomfitIconRes)
-	viewZoomFit = NewThemedResource(viewzoomfitIconRes)
-	viewZoomIn = NewThemedResource(viewzoominIconRes)
-	viewZoomOut = NewThemedResource(viewzoomoutIconRes)
-
-	visibility = NewThemedResource(visibilityIconRes)
-	visibilityOff = NewThemedResource(visibilityoffIconRes)
-
-	volumeDown = NewThemedResource(volumedownIconRes)
-	volumeMute = NewThemedResource(volumemuteIconRes)
-	volumeUp = NewThemedResource(volumeupIconRes)
-
-	download = NewThemedResource(downloadIconRes)
-	computer = NewThemedResource(computerIconRes)
-	storage = NewThemedResource(storageIconRes)
-	upload = NewThemedResource(uploadIconRes)
-}
-
 // FyneLogo returns a resource containing the Fyne logo
 func FyneLogo() fyne.Resource {
 	return fynelogo
@@ -283,395 +307,395 @@ func FyneLogo() fyne.Resource {
 
 // CancelIcon returns a resource containing the standard cancel icon for the current theme
 func CancelIcon() fyne.Resource {
-	return cancel
+	return current().Icon(Icons.Cancel)
 }
 
 // ConfirmIcon returns a resource containing the standard confirm icon for the current theme
 func ConfirmIcon() fyne.Resource {
-	return confirm
+	return current().Icon(Icons.Confirm)
 }
 
 // DeleteIcon returns a resource containing the standard delete icon for the current theme
 func DeleteIcon() fyne.Resource {
-	return delete
+	return current().Icon(Icons.Delete)
 }
 
 // SearchIcon returns a resource containing the standard search icon for the current theme
 func SearchIcon() fyne.Resource {
-	return search
+	return current().Icon(Icons.Search)
 }
 
 // SearchReplaceIcon returns a resource containing the standard search and replace icon for the current theme
 func SearchReplaceIcon() fyne.Resource {
-	return searchReplace
+	return current().Icon(Icons.SearchReplace)
 }
 
 // MenuIcon returns a resource containing the standard (mobile) menu icon for the current theme
 func MenuIcon() fyne.Resource {
-	return menu
+	return current().Icon(Icons.Menu)
 }
 
 // MenuExpandIcon returns a resource containing the standard (mobile) expand "submenu icon for the current theme
 func MenuExpandIcon() fyne.Resource {
-	return menuExpand
+	return current().Icon(Icons.MenuExpand)
 }
 
 // CheckButtonIcon returns a resource containing the standard checkbox icon for the current theme
 func CheckButtonIcon() fyne.Resource {
-	return unchecked
+	return current().Icon(Icons.CheckButton)
 }
 
 // CheckButtonCheckedIcon returns a resource containing the standard checkbox checked icon for the current theme
 func CheckButtonCheckedIcon() fyne.Resource {
-	return checked
+	return current().Icon(Icons.CheckButtonChecked)
 }
 
 // RadioButtonIcon returns a resource containing the standard radio button icon for the current theme
 func RadioButtonIcon() fyne.Resource {
-	return radioButton
+	return current().Icon(Icons.RadioButton)
 }
 
 // RadioButtonCheckedIcon returns a resource containing the standard radio button checked icon for the current theme
 func RadioButtonCheckedIcon() fyne.Resource {
-	return radioButtonChecked
+	return current().Icon(Icons.RadioButtonChecked)
 }
 
 // ContentAddIcon returns a resource containing the standard content add icon for the current theme
 func ContentAddIcon() fyne.Resource {
-	return contentAdd
+	return current().Icon(Icons.ContentAdd)
 }
 
 // ContentRemoveIcon returns a resource containing the standard content remove icon for the current theme
 func ContentRemoveIcon() fyne.Resource {
-	return contentRemove
+	return current().Icon(Icons.ContentRemove)
 }
 
 // ContentClearIcon returns a resource containing the standard content clear icon for the current theme
 func ContentClearIcon() fyne.Resource {
-	return contentClear
+	return current().Icon(Icons.ContentClear)
 }
 
 // ContentCutIcon returns a resource containing the standard content cut icon for the current theme
 func ContentCutIcon() fyne.Resource {
-	return contentCut
+	return current().Icon(Icons.ContentCut)
 }
 
 // ContentCopyIcon returns a resource containing the standard content copy icon for the current theme
 func ContentCopyIcon() fyne.Resource {
-	return contentCopy
+	return current().Icon(Icons.ContentCopy)
 }
 
 // ContentPasteIcon returns a resource containing the standard content paste icon for the current theme
 func ContentPasteIcon() fyne.Resource {
-	return contentPaste
+	return current().Icon(Icons.ContentPaste)
 }
 
 // ContentRedoIcon returns a resource containing the standard content redo icon for the current theme
 func ContentRedoIcon() fyne.Resource {
-	return contentRedo
+	return current().Icon(Icons.ContentRedo)
 }
 
 // ContentUndoIcon returns a resource containing the standard content undo icon for the current theme
 func ContentUndoIcon() fyne.Resource {
-	return contentUndo
+	return current().Icon(Icons.ContentUndo)
 }
 
 // ColorAchromaticIcon returns a resource containing the standard achromatic color icon for the current theme
 func ColorAchromaticIcon() fyne.Resource {
-	return colorAchromatic
+	return current().Icon(Icons.ColorAchromatic)
 }
 
 // ColorChromaticIcon returns a resource containing the standard chromatic color icon for the current theme
 func ColorChromaticIcon() fyne.Resource {
-	return colorChromatic
+	return current().Icon(Icons.ColorChromatic)
 }
 
 // ColorPaletteIcon returns a resource containing the standard color palette icon for the current theme
 func ColorPaletteIcon() fyne.Resource {
-	return colorPalette
+	return current().Icon(Icons.ColorPalette)
 }
 
 // DocumentIcon returns a resource containing the standard document icon for the current theme
 func DocumentIcon() fyne.Resource {
-	return document
+	return current().Icon(Icons.Document)
 }
 
 // DocumentCreateIcon returns a resource containing the standard document create icon for the current theme
 func DocumentCreateIcon() fyne.Resource {
-	return documentCreate
+	return current().Icon(Icons.DocumentCreate)
 }
 
 // DocumentPrintIcon returns a resource containing the standard document print icon for the current theme
 func DocumentPrintIcon() fyne.Resource {
-	return documentPrint
+	return current().Icon(Icons.DocumentPrint)
 }
 
 // DocumentSaveIcon returns a resource containing the standard document save icon for the current theme
 func DocumentSaveIcon() fyne.Resource {
-	return documentSave
+	return current().Icon(Icons.DocumentSave)
 }
 
 // InfoIcon returns a resource containing the standard dialog info icon for the current theme
 func InfoIcon() fyne.Resource {
-	return info
+	return current().Icon(Icons.Info)
 }
 
 // QuestionIcon returns a resource containing the standard dialog question icon for the current theme
 func QuestionIcon() fyne.Resource {
-	return question
+	return current().Icon(Icons.Question)
 }
 
 // WarningIcon returns a resource containing the standard dialog warning icon for the current theme
 func WarningIcon() fyne.Resource {
-	return warning
+	return current().Icon(Icons.Warning)
 }
 
 // ErrorIcon returns a resource containing the standard dialog error icon for the current theme
 func ErrorIcon() fyne.Resource {
-	return errori
+	return current().Icon(Icons.Error)
 }
 
 // FileIcon returns a resource containing the appropriate file icon for the current theme
 func FileIcon() fyne.Resource {
-	return file
+	return current().Icon(Icons.File)
 }
 
 // FileApplicationIcon returns a resource containing the file icon representing application files for the current theme
 func FileApplicationIcon() fyne.Resource {
-	return fileApplication
+	return current().Icon(Icons.FileApplication)
 }
 
 // FileAudioIcon returns a resource containing the file icon representing audio files for the current theme
 func FileAudioIcon() fyne.Resource {
-	return fileAudio
+	return current().Icon(Icons.FileAudio)
 }
 
 // FileImageIcon returns a resource containing the file icon representing image files for the current theme
 func FileImageIcon() fyne.Resource {
-	return fileImage
+	return current().Icon(Icons.FileImage)
 }
 
 // FileTextIcon returns a resource containing the file icon representing text files for the current theme
 func FileTextIcon() fyne.Resource {
-	return fileText
+	return current().Icon(Icons.FileText)
 }
 
 // FileVideoIcon returns a resource containing the file icon representing video files for the current theme
 func FileVideoIcon() fyne.Resource {
-	return fileVideo
+	return current().Icon(Icons.FileVideo)
 }
 
 // FolderIcon returns a resource containing the standard folder icon for the current theme
 func FolderIcon() fyne.Resource {
-	return folder
+	return current().Icon(Icons.Folder)
 }
 
 // FolderNewIcon returns a resource containing the standard folder creation icon for the current theme
 func FolderNewIcon() fyne.Resource {
-	return folderNew
+	return current().Icon(Icons.FolderNew)
 }
 
 // FolderOpenIcon returns a resource containing the standard folder open icon for the current theme
 func FolderOpenIcon() fyne.Resource {
-	return folderOpen
+	return current().Icon(Icons.FolderOpen)
 }
 
 // HelpIcon returns a resource containing the standard help icon for the current theme
 func HelpIcon() fyne.Resource {
-	return help
+	return current().Icon(Icons.Help)
 }
 
 // HistoryIcon returns a resource containing the standard history icon for the current theme
 func HistoryIcon() fyne.Resource {
-	return history
+	return current().Icon(Icons.History)
 }
 
 // HomeIcon returns a resource containing the standard home folder icon for the current theme
 func HomeIcon() fyne.Resource {
-	return home
+	return current().Icon(Icons.Home)
 }
 
 // SettingsIcon returns a resource containing the standard settings icon for the current theme
 func SettingsIcon() fyne.Resource {
-	return settings
+	return current().Icon(Icons.Settings)
 }
 
 // MailAttachmentIcon returns a resource containing the standard mail attachment icon for the current theme
 func MailAttachmentIcon() fyne.Resource {
-	return mailAttachment
+	return current().Icon(Icons.MailAttachment)
 }
 
 // MailComposeIcon returns a resource containing the standard mail compose icon for the current theme
 func MailComposeIcon() fyne.Resource {
-	return mailCompose
+	return current().Icon(Icons.MailCompose)
 }
 
 // MailForwardIcon returns a resource containing the standard mail forward icon for the current theme
 func MailForwardIcon() fyne.Resource {
-	return mailForward
+	return current().Icon(Icons.MailForward)
 }
 
 // MailReplyIcon returns a resource containing the standard mail reply icon for the current theme
 func MailReplyIcon() fyne.Resource {
-	return mailReply
+	return current().Icon(Icons.MailReply)
 }
 
 // MailReplyAllIcon returns a resource containing the standard mail reply all icon for the current theme
 func MailReplyAllIcon() fyne.Resource {
-	return mailReplyAll
+	return current().Icon(Icons.MailReplyAll)
 }
 
 // MailSendIcon returns a resource containing the standard mail send icon for the current theme
 func MailSendIcon() fyne.Resource {
-	return mailSend
+	return current().Icon(Icons.MailSend)
 }
 
 // MediaFastForwardIcon returns a resource containing the standard media fast-forward icon for the current theme
 func MediaFastForwardIcon() fyne.Resource {
-	return mediaFastForward
+	return current().Icon(Icons.MediaFastForward)
 }
 
 // MediaFastRewindIcon returns a resource containing the standard media fast-rewind icon for the current theme
 func MediaFastRewindIcon() fyne.Resource {
-	return mediaFastRewind
+	return current().Icon(Icons.MediaFastRewind)
 }
 
 // MediaPauseIcon returns a resource containing the standard media pause icon for the current theme
 func MediaPauseIcon() fyne.Resource {
-	return mediaPause
+	return current().Icon(Icons.MediaPause)
 }
 
 // MediaPlayIcon returns a resource containing the standard media play icon for the current theme
 func MediaPlayIcon() fyne.Resource {
-	return mediaPlay
+	return current().Icon(Icons.MediaPlay)
 }
 
 // MediaRecordIcon returns a resource containing the standard media record icon for the current theme
 func MediaRecordIcon() fyne.Resource {
-	return mediaRecord
+	return current().Icon(Icons.MediaRecord)
 }
 
 // MediaReplayIcon returns a resource containing the standard media replay icon for the current theme
 func MediaReplayIcon() fyne.Resource {
-	return mediaReplay
+	return current().Icon(Icons.MediaReplay)
 }
 
 // MediaSkipNextIcon returns a resource containing the standard media skip next icon for the current theme
 func MediaSkipNextIcon() fyne.Resource {
-	return mediaSkipNext
+	return current().Icon(Icons.MediaSkipNext)
 }
 
 // MediaSkipPreviousIcon returns a resource containing the standard media skip previous icon for the current theme
 func MediaSkipPreviousIcon() fyne.Resource {
-	return mediaSkipPrevious
+	return current().Icon(Icons.MediaSkipPrevious)
 }
 
 // MediaStopIcon returns a resource containing the standard media stop icon for the current theme
 func MediaStopIcon() fyne.Resource {
-	return mediaStop
+	return current().Icon(Icons.MediaStop)
 }
 
 // MoveDownIcon returns a resource containing the standard down arrow icon for the current theme
 func MoveDownIcon() fyne.Resource {
-	return arrowDown
+	return current().Icon(Icons.MoveDown)
 }
 
 // MoveUpIcon returns a resource containing the standard up arrow icon for the current theme
 func MoveUpIcon() fyne.Resource {
-	return arrowUp
+	return current().Icon(Icons.MoveUp)
 }
 
 // NavigateBackIcon returns a resource containing the standard backward navigation icon for the current theme
 func NavigateBackIcon() fyne.Resource {
-	return arrowBack
+	return current().Icon(Icons.NavigateBack)
 }
 
 // NavigateNextIcon returns a resource containing the standard forward navigation icon for the current theme
 func NavigateNextIcon() fyne.Resource {
-	return arrowForward
+	return current().Icon(Icons.NavigateNext)
 }
 
 // MenuDropDownIcon returns a resource containing the standard menu drop down icon for the current theme
 func MenuDropDownIcon() fyne.Resource {
-	return arrowDropDown
+	return current().Icon(Icons.ArrowDropDown)
 }
 
 // MenuDropUpIcon returns a resource containing the standard menu drop up icon for the current theme
 func MenuDropUpIcon() fyne.Resource {
-	return arrowDropUp
+	return current().Icon(Icons.ArrowDropUp)
 }
 
 // ViewFullScreenIcon returns a resource containing the standard fullscreen icon for the current theme
 func ViewFullScreenIcon() fyne.Resource {
-	return viewFullScreen
+	return current().Icon(Icons.ViewFullScreen)
 }
 
 // ViewRestoreIcon returns a resource containing the standard exit fullscreen icon for the current theme
 func ViewRestoreIcon() fyne.Resource {
-	return viewRestore
+	return current().Icon(Icons.ViewRestore)
 }
 
 // ViewRefreshIcon returns a resource containing the standard refresh icon for the current theme
 func ViewRefreshIcon() fyne.Resource {
-	return viewRefresh
+	return current().Icon(Icons.ViewRefresh)
 }
 
 // ZoomFitIcon returns a resource containing the standard zoom fit icon for the current theme
 func ZoomFitIcon() fyne.Resource {
-	return viewZoomFit
+	return current().Icon(Icons.ViewZoomFit)
 }
 
 // ZoomInIcon returns a resource containing the standard zoom in icon for the current theme
 func ZoomInIcon() fyne.Resource {
-	return viewZoomIn
+	return current().Icon(Icons.ViewZoomIn)
 }
 
 // ZoomOutIcon returns a resource containing the standard zoom out icon for the current theme
 func ZoomOutIcon() fyne.Resource {
-	return viewZoomOut
+	return current().Icon(Icons.ViewZoomOut)
 }
 
 // VisibilityIcon returns a resource containing the standard visibity icon for the current theme
 func VisibilityIcon() fyne.Resource {
-	return visibility
+	return current().Icon(Icons.Visibility)
 }
 
 // VisibilityOffIcon returns a resource containing the standard visibity off icon for the current theme
 func VisibilityOffIcon() fyne.Resource {
-	return visibilityOff
+	return current().Icon(Icons.VisibilityOff)
 }
 
 // VolumeDownIcon returns a resource containing the standard volume down icon for the current theme
 func VolumeDownIcon() fyne.Resource {
-	return volumeDown
+	return current().Icon(Icons.VolumeDown)
 }
 
 // VolumeMuteIcon returns a resource containing the standard volume mute icon for the current theme
 func VolumeMuteIcon() fyne.Resource {
-	return volumeMute
+	return current().Icon(Icons.VolumeMute)
 }
 
 // VolumeUpIcon returns a resource containing the standard volume up icon for the current theme
 func VolumeUpIcon() fyne.Resource {
-	return volumeUp
+	return current().Icon(Icons.VolumeUp)
 }
 
 // ComputerIcon returns a resource containing the standard computer icon for the current theme
 func ComputerIcon() fyne.Resource {
-	return computer
+	return current().Icon(Icons.Computer)
 }
 
 // DownloadIcon returns a resource containing the standard download icon for the current theme
 func DownloadIcon() fyne.Resource {
-	return download
+	return current().Icon(Icons.Download)
 }
 
 // StorageIcon returns a resource containing the standard storage icon for the current theme
 func StorageIcon() fyne.Resource {
-	return storage
+	return current().Icon(Icons.Storage)
 }
 
 // UploadIcon returns a resource containing the standard upload icon for the current theme
 func UploadIcon() fyne.Resource {
-	return upload
+	return current().Icon(Icons.Upload)
 }

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -9,135 +9,497 @@ import (
 	"fyne.io/fyne"
 )
 
-var (
-	// Icons specifies each of the known icon names that a theme can contain.
+const (
+	// IconNameCancel is the name of theme lookup for cancel icon.
 	//
 	// Since 2.0.0
-	Icons = struct {
-		Cancel, Confirm, Delete, Search, SearchReplace, Menu, MenuExpand                fyne.ThemeIconName
-		CheckButtonChecked, CheckButton, RadioButton, RadioButtonChecked                fyne.ThemeIconName
-		ColorAchromatic, ColorChromatic, ColorPalette                                   fyne.ThemeIconName
-		ContentAdd, ContentRemove, ContentCut, ContentCopy, ContentPaste                fyne.ThemeIconName
-		ContentClear, ContentRedo, ContentUndo, Info, Question, Warning, Error          fyne.ThemeIconName
-		Document, DocumentCreate, DocumentPrint, DocumentSave                           fyne.ThemeIconName
-		MailAttachment, MailCompose, MailForward, MailReply, MailReplyAll, MailSend     fyne.ThemeIconName
-		MediaFastForward, MediaFastRewind, MediaPause, MediaPlay                        fyne.ThemeIconName
-		MediaRecord, MediaReplay, MediaSkipNext, MediaSkipPrevious, MediaStop           fyne.ThemeIconName
-		NavigateBack, MoveDown, NavigateNext, MoveUp, ArrowDropDown, ArrowDropUp        fyne.ThemeIconName
-		File, FileApplication, FileAudio, FileImage, FileText, FileVideo                fyne.ThemeIconName
-		Folder, FolderNew, FolderOpen, Help, History, Home, Settings, Storage, Upload   fyne.ThemeIconName
-		ViewFullScreen, ViewRefresh, ViewZoomFit, ViewZoomIn, ViewZoomOut, ViewRestore  fyne.ThemeIconName
-		Visibility, VisibilityOff, VolumeDown, VolumeMute, VolumeUp, Download, Computer fyne.ThemeIconName
-	}{
-		"cancel", "confirm", "delete", "search", "searchReplace", "menu", "menuExpand",
-		"checked", "unchecked", "radioButton", "radioButtonChecked",
-		"colorAchromatic", "colorChromatic", "colorPalette",
-		"contentAdd", "contentRemove", "contentCut", "contentCopy", "contentPaste",
-		"contentClear", "contentRedo", "contentUndo", "info", "question", "warning", "errori",
-		"document", "documentCreate", "documentPrint", "documentSave",
-		"mailAttachment", "mailCompose", "mailForward", "mailReply", "mailReplyAll", "mailSend",
-		"mediaFastForward", "mediaFastRewind", "mediaPause", "mediaPlay",
-		"mediaRecord", "mediaReplay", "mediaSkipNext", "mediaSkipPrevious", "mediaStop",
-		"arrowBack", "arrowDown", "arrowForward", "arrowUp", "arrowDropDown", "arrowDropUp",
-		"file", "fileApplication", "fileAudio", "fileImage", "fileText", "fileVideo",
-		"folder", "folderNew", "folderOpen", "help", "history", "home", "settings", "storage", "upload",
-		"viewFullScreen", "viewRefresh", "viewZoomFit", "viewZoomIn", "viewZoomOut", "viewRestore",
-		"visibility", "visibilityOff", "volumeDown", "volumeMute", "volumeUp", "download", "computer",
-	}
+	IconNameCancel fyne.ThemeIconName = "cancel"
 
+	// IconNameConfirm is the name of theme lookup for confirm icon.
+	//
+	// Since 2.0.0
+	IconNameConfirm fyne.ThemeIconName = "confirm"
+
+	// IconNameDelete is the name of theme lookup for delete icon.
+	//
+	// Since 2.0.0
+	IconNameDelete fyne.ThemeIconName = "delete"
+
+	// IconNameSearch is the name of theme lookup for search icon.
+	//
+	// Since 2.0.0
+	IconNameSearch fyne.ThemeIconName = "search"
+
+	// IconNameSearchReplace is the name of theme lookup for search and replace icon.
+	//
+	// Since 2.0.0
+	IconNameSearchReplace fyne.ThemeIconName = "searchReplace"
+
+	// IconNameMenu is the name of theme lookup for menu icon.
+	//
+	// Since 2.0.0
+	IconNameMenu fyne.ThemeIconName = "menu"
+
+	// IconNameMenuExpand is the name of theme lookup for menu expansion icon.
+	//
+	// Since 2.0.0
+	IconNameMenuExpand fyne.ThemeIconName = "menuExpand"
+
+	// IconNameCheckButtonChecked is the name of theme lookup for checked check button icon.
+	//
+	// Since 2.0.0
+	IconNameCheckButtonChecked fyne.ThemeIconName = "checked"
+
+	// IconNameCheckButton is the name of theme lookup for  unchecked check button icon.
+	//
+	// Since 2.0.0
+	IconNameCheckButton fyne.ThemeIconName = "unchecked"
+
+	// IconNameRadioButton is the name of theme lookup for radio button unchecked icon.
+	//
+	// Since 2.0.0
+	IconNameRadioButton fyne.ThemeIconName = "radioButton"
+
+	// IconNameRadioButtonChecked is the name of theme lookup for radio button checked icon.
+	//
+	// Since 2.0.0
+	IconNameRadioButtonChecked fyne.ThemeIconName = "radioButtonChecked"
+
+	// IconNameColorAchromatic is the name of theme lookup for greyscale color icon.
+	//
+	// Since 2.0.0
+	IconNameColorAchromatic fyne.ThemeIconName = "colorAchromatic"
+
+	// IconNameColorChromatic is the name of theme lookup for full color icon.
+	//
+	// Since 2.0.0
+	IconNameColorChromatic fyne.ThemeIconName = "colorChromatic"
+
+	// IconNameColorPalette is the name of theme lookup for color palette icon.
+	//
+	// Since 2.0.0
+	IconNameColorPalette fyne.ThemeIconName = "colorPalette"
+
+	// IconNameContentAdd is the name of theme lookup for content add icon.
+	//
+	// Since 2.0.0
+	IconNameContentAdd fyne.ThemeIconName = "contentAdd"
+
+	// IconNameContentRemove is the name of theme lookup for content remove icon.
+	//
+	// Since 2.0.0
+	IconNameContentRemove fyne.ThemeIconName = "contentRemove"
+
+	// IconNameContentCut is the name of theme lookup for content cut icon.
+	//
+	// Since 2.0.0
+	IconNameContentCut fyne.ThemeIconName = "contentCut"
+
+	// IconNameContentCopy is the name of theme lookup for content copy icon.
+	//
+	// Since 2.0.0
+	IconNameContentCopy fyne.ThemeIconName = "contentCopy"
+
+	// IconNameContentPaste is the name of theme lookup for content paste icon.
+	//
+	// Since 2.0.0
+	IconNameContentPaste fyne.ThemeIconName = "contentPaste"
+
+	// IconNameContentClear is the name of theme lookup for content clear icon.
+	//
+	// Since 2.0.0
+	IconNameContentClear fyne.ThemeIconName = "contentClear"
+
+	// IconNameContentRedo is the name of theme lookup for content redo icon.
+	//
+	// Since 2.0.0
+	IconNameContentRedo fyne.ThemeIconName = "contentRedo"
+
+	// IconNameContentUndo is the name of theme lookup for content undo icon.
+	//
+	// Since 2.0.0
+	IconNameContentUndo fyne.ThemeIconName = "contentUndo"
+
+	// IconNameInfo is the name of theme lookup for info icon.
+	//
+	// Since 2.0.0
+	IconNameInfo fyne.ThemeIconName = "info"
+
+	// IconNameQuestion is the name of theme lookup for question icon.
+	//
+	// Since 2.0.0
+	IconNameQuestion fyne.ThemeIconName = "question"
+
+	// IconNameWarning is the name of theme lookup for warning icon.
+	//
+	// Since 2.0.0
+	IconNameWarning fyne.ThemeIconName = "warning"
+
+	// IconNameError is the name of theme lookup for error icon.
+	//
+	// Since 2.0.0
+	IconNameError fyne.ThemeIconName = "error"
+
+	// IconNameDocument is the name of theme lookup for document icon.
+	//
+	// Since 2.0.0
+	IconNameDocument fyne.ThemeIconName = "document"
+
+	// IconNameDocumentCreate is the name of theme lookup for document create icon.
+	//
+	// Since 2.0.0
+	IconNameDocumentCreate fyne.ThemeIconName = "documentCreate"
+
+	// IconNameDocumentPrint is the name of theme lookup for document print icon.
+	//
+	// Since 2.0.0
+	IconNameDocumentPrint fyne.ThemeIconName = "documentPrint"
+
+	// IconNameDocumentSave is the name of theme lookup for document save icon.
+	//
+	// Since 2.0.0
+	IconNameDocumentSave fyne.ThemeIconName = "documentSave"
+
+	// IconNameMailAttachment is the name of theme lookup for mail attachment icon.
+	//
+	// Since 2.0.0
+	IconNameMailAttachment fyne.ThemeIconName = "mailAttachment"
+
+	// IconNameMailCompose is the name of theme lookup for mail compose icon.
+	//
+	// Since 2.0.0
+	IconNameMailCompose fyne.ThemeIconName = "mailCompose"
+
+	// IconNameMailForward is the name of theme lookup for mail forward icon.
+	//
+	// Since 2.0.0
+	IconNameMailForward fyne.ThemeIconName = "mailForward"
+
+	// IconNameMailReply is the name of theme lookup for mail reply icon.
+	//
+	// Since 2.0.0
+	IconNameMailReply fyne.ThemeIconName = "mailReply"
+
+	// IconNameMailReplyAll is the name of theme lookup for mail reply-all icon.
+	//
+	// Since 2.0.0
+	IconNameMailReplyAll fyne.ThemeIconName = "mailReplyAll"
+
+	// IconNameMailSend is the name of theme lookup for mail send icon.
+	//
+	// Since 2.0.0
+	IconNameMailSend fyne.ThemeIconName = "mailSend"
+
+	// IconNameMediaFastForward is the name of theme lookup for media fast-forward icon.
+	//
+	// Since 2.0.0
+	IconNameMediaFastForward fyne.ThemeIconName = "mediaFastForward"
+
+	// IconNameMediaFastRewind is the name of theme lookup for media fast-rewind icon.
+	//
+	// Since 2.0.0
+	IconNameMediaFastRewind fyne.ThemeIconName = "mediaFastRewind"
+
+	// IconNameMediaPause is the name of theme lookup for media pause icon.
+	//
+	// Since 2.0.0
+	IconNameMediaPause fyne.ThemeIconName = "mediaPause"
+
+	// IconNameMediaPlay is the name of theme lookup for media play icon.
+	//
+	// Since 2.0.0
+	IconNameMediaPlay fyne.ThemeIconName = "mediaPlay"
+
+	// IconNameMediaRecord is the name of theme lookup for media record icon.
+	//
+	// Since 2.0.0
+	IconNameMediaRecord fyne.ThemeIconName = "mediaRecord"
+
+	// IconNameMediaReplay is the name of theme lookup for media replay icon.
+	//
+	// Since 2.0.0
+	IconNameMediaReplay fyne.ThemeIconName = "mediaReplay"
+
+	// IconNameMediaSkipNext is the name of theme lookup for media skip next icon.
+	//
+	// Since 2.0.0
+	IconNameMediaSkipNext fyne.ThemeIconName = "mediaSkipNext"
+
+	// IconNameMediaSkipPrevious is the name of theme lookup for media skip previous icon.
+	//
+	// Since 2.0.0
+	IconNameMediaSkipPrevious fyne.ThemeIconName = "mediaSkipPrevious"
+
+	// IconNameMediaStop is the name of theme lookup for media stop icon.
+	//
+	// Since 2.0.0
+	IconNameMediaStop fyne.ThemeIconName = "mediaStop"
+
+	// IconNameMoveDown is the name of theme lookup for move down icon.
+	//
+	// Since 2.0.0
+	IconNameMoveDown fyne.ThemeIconName = "arrowDown"
+
+	// IconNameMoveUp is the name of theme lookup for move up icon.
+	//
+	// Since 2.0.0
+	IconNameMoveUp fyne.ThemeIconName = "arrowUp"
+
+	// IconNameNavigateBack is the name of theme lookup for navigate back icon.
+	//
+	// Since 2.0.0
+	IconNameNavigateBack fyne.ThemeIconName = "arrowBack"
+
+	// IconNameNavigateNext is the name of theme lookup for navigate next icon.
+	//
+	// Since 2.0.0
+	IconNameNavigateNext fyne.ThemeIconName = "arrowForward"
+
+	// IconNameArrowDropDown is the name of theme lookup for drop-down arrow icon.
+	//
+	// Since 2.0.0
+	IconNameArrowDropDown fyne.ThemeIconName = "arrowDropDown"
+
+	// IconNameArrowDropUp is the name of theme lookup for drop-up arrow icon.
+	//
+	// Since 2.0.0
+	IconNameArrowDropUp fyne.ThemeIconName = "arrowDropUp"
+
+	// IconNameFile is the name of theme lookup for file icon.
+	//
+	// Since 2.0.0
+	IconNameFile fyne.ThemeIconName = "file"
+
+	// IconNameFileApplication is the name of theme lookup for file application icon.
+	//
+	// Since 2.0.0
+	IconNameFileApplication fyne.ThemeIconName = "fileApplication"
+
+	// IconNameFileAudio is the name of theme lookup for file audio icon.
+	//
+	// Since 2.0.0
+	IconNameFileAudio fyne.ThemeIconName = "fileAudio"
+
+	// IconNameFileImage is the name of theme lookup for file image icon.
+	//
+	// Since 2.0.0
+	IconNameFileImage fyne.ThemeIconName = "fileImage"
+
+	// IconNameFileText is the name of theme lookup for file text icon.
+	//
+	// Since 2.0.0
+	IconNameFileText fyne.ThemeIconName = "fileText"
+
+	// IconNameFileVideo is the name of theme lookup for file video icon.
+	//
+	// Since 2.0.0
+	IconNameFileVideo fyne.ThemeIconName = "fileVideo"
+
+	// IconNameFolder is the name of theme lookup for folder icon.
+	//
+	// Since 2.0.0
+	IconNameFolder fyne.ThemeIconName = "folder"
+
+	// IconNameFolderNew is the name of theme lookup for folder new icon.
+	//
+	// Since 2.0.0
+	IconNameFolderNew fyne.ThemeIconName = "folderNew"
+
+	// IconNameFolderOpen is the name of theme lookup for folder open icon.
+	//
+	// Since 2.0.0
+	IconNameFolderOpen fyne.ThemeIconName = "folderOpen"
+
+	// IconNameHelp is the name of theme lookup for help icon.
+	//
+	// Since 2.0.0
+	IconNameHelp fyne.ThemeIconName = "help"
+
+	// IconNameHistory is the name of theme lookup for history icon.
+	//
+	// Since 2.0.0
+	IconNameHistory fyne.ThemeIconName = "history"
+
+	// IconNameHome is the name of theme lookup for home icon.
+	//
+	// Since 2.0.0
+	IconNameHome fyne.ThemeIconName = "home"
+
+	// IconNameSettings is the name of theme lookup for settings icon.
+	//
+	// Since 2.0.0
+	IconNameSettings fyne.ThemeIconName = "settings"
+
+	// IconNameStorage is the name of theme lookup for storage icon.
+	//
+	// Since 2.0.0
+	IconNameStorage fyne.ThemeIconName = "storage"
+
+	// IconNameUpload is the name of theme lookup for upload icon.
+	//
+	// Since 2.0.0
+	IconNameUpload fyne.ThemeIconName = "upload"
+
+	// IconNameViewFullScreen is the name of theme lookup for view fullscreen icon.
+	//
+	// Since 2.0.0
+	IconNameViewFullScreen fyne.ThemeIconName = "viewFullScreen"
+
+	// IconNameViewRefresh is the name of theme lookup for view refresh icon.
+	//
+	// Since 2.0.0
+	IconNameViewRefresh fyne.ThemeIconName = "viewRefresh"
+
+	// IconNameViewZoomFit is the name of theme lookup for view zoom fit icon.
+	//
+	// Since 2.0.0
+	IconNameViewZoomFit fyne.ThemeIconName = "viewZoomFit"
+
+	// IconNameViewZoomIn is the name of theme lookup for view zoom in icon.
+	//
+	// Since 2.0.0
+	IconNameViewZoomIn fyne.ThemeIconName = "viewZoomIn"
+
+	// IconNameViewZoomOut is the name of theme lookup for view zoom out icon.
+	//
+	// Since 2.0.0
+	IconNameViewZoomOut fyne.ThemeIconName = "viewZoomOut"
+
+	// IconNameViewRestore is the name of theme lookup for view restore icon.
+	//
+	// Since 2.0.0
+	IconNameViewRestore fyne.ThemeIconName = "viewRestore"
+
+	// IconNameVisibility is the name of theme lookup for visibility icon.
+	//
+	// Since 2.0.0
+	IconNameVisibility fyne.ThemeIconName = "visibility"
+
+	// IconNameVisibilityOff is the name of theme lookup for invisibility icon.
+	//
+	// Since 2.0.0
+	IconNameVisibilityOff fyne.ThemeIconName = "visibilityOff"
+
+	// IconNameVolumeDown is the name of theme lookup for volume down icon.
+	//
+	// Since 2.0.0
+	IconNameVolumeDown fyne.ThemeIconName = "volumeDown"
+
+	// IconNameVolumeMute is the name of theme lookup for volume mute icon.
+	//
+	// Since 2.0.0
+	IconNameVolumeMute fyne.ThemeIconName = "volumeMute"
+
+	// IconNameVolumeUp is the name of theme lookup for volume up icon.
+	//
+	// Since 2.0.0
+	IconNameVolumeUp fyne.ThemeIconName = "volumeUp"
+
+	// IconNameDownload is the name of theme lookup for download icon.
+	//
+	// Since 2.0.0
+	IconNameDownload fyne.ThemeIconName = "download"
+
+	// IconNameComputer is the name of theme lookup for computer icon.
+	//
+	// Since 2.0.0
+	IconNameComputer fyne.ThemeIconName = "computer"
+)
+
+var (
 	icons = map[fyne.ThemeIconName]fyne.Resource{
-		Icons.Cancel:        NewThemedResource(cancelIconRes),
-		Icons.Confirm:       NewThemedResource(checkIconRes),
-		Icons.Delete:        NewThemedResource(deleteIconRes),
-		Icons.Search:        NewThemedResource(searchIconRes),
-		Icons.SearchReplace: NewThemedResource(searchreplaceIconRes),
-		Icons.Menu:          NewThemedResource(menuIconRes),
-		Icons.MenuExpand:    NewThemedResource(menuexpandIconRes),
+		IconNameCancel:        NewThemedResource(cancelIconRes),
+		IconNameConfirm:       NewThemedResource(checkIconRes),
+		IconNameDelete:        NewThemedResource(deleteIconRes),
+		IconNameSearch:        NewThemedResource(searchIconRes),
+		IconNameSearchReplace: NewThemedResource(searchreplaceIconRes),
+		IconNameMenu:          NewThemedResource(menuIconRes),
+		IconNameMenuExpand:    NewThemedResource(menuexpandIconRes),
 
-		Icons.CheckButton:        NewThemedResource(checkboxblankIconRes),
-		Icons.CheckButtonChecked: NewThemedResource(checkboxIconRes),
-		Icons.RadioButton:        NewThemedResource(radiobuttonIconRes),
-		Icons.RadioButtonChecked: NewThemedResource(radiobuttoncheckedIconRes),
+		IconNameCheckButton:        NewThemedResource(checkboxblankIconRes),
+		IconNameCheckButtonChecked: NewThemedResource(checkboxIconRes),
+		IconNameRadioButton:        NewThemedResource(radiobuttonIconRes),
+		IconNameRadioButtonChecked: NewThemedResource(radiobuttoncheckedIconRes),
 
-		Icons.ContentAdd:    NewThemedResource(contentaddIconRes),
-		Icons.ContentClear:  NewThemedResource(cancelIconRes),
-		Icons.ContentRemove: NewThemedResource(contentremoveIconRes),
-		Icons.ContentCut:    NewThemedResource(contentcutIconRes),
-		Icons.ContentCopy:   NewThemedResource(contentcopyIconRes),
-		Icons.ContentPaste:  NewThemedResource(contentpasteIconRes),
-		Icons.ContentRedo:   NewThemedResource(contentredoIconRes),
-		Icons.ContentUndo:   NewThemedResource(contentundoIconRes),
+		IconNameContentAdd:    NewThemedResource(contentaddIconRes),
+		IconNameContentClear:  NewThemedResource(cancelIconRes),
+		IconNameContentRemove: NewThemedResource(contentremoveIconRes),
+		IconNameContentCut:    NewThemedResource(contentcutIconRes),
+		IconNameContentCopy:   NewThemedResource(contentcopyIconRes),
+		IconNameContentPaste:  NewThemedResource(contentpasteIconRes),
+		IconNameContentRedo:   NewThemedResource(contentredoIconRes),
+		IconNameContentUndo:   NewThemedResource(contentundoIconRes),
 
-		Icons.ColorAchromatic: NewThemedResource(colorachromaticIconRes),
-		Icons.ColorChromatic:  NewThemedResource(colorchromaticIconRes),
-		Icons.ColorPalette:    NewThemedResource(colorpaletteIconRes),
+		IconNameColorAchromatic: NewThemedResource(colorachromaticIconRes),
+		IconNameColorChromatic:  NewThemedResource(colorchromaticIconRes),
+		IconNameColorPalette:    NewThemedResource(colorpaletteIconRes),
 
-		Icons.Document:       NewThemedResource(documentIconRes),
-		Icons.DocumentCreate: NewThemedResource(documentcreateIconRes),
-		Icons.DocumentPrint:  NewThemedResource(documentprintIconRes),
-		Icons.DocumentSave:   NewThemedResource(documentsaveIconRes),
+		IconNameDocument:       NewThemedResource(documentIconRes),
+		IconNameDocumentCreate: NewThemedResource(documentcreateIconRes),
+		IconNameDocumentPrint:  NewThemedResource(documentprintIconRes),
+		IconNameDocumentSave:   NewThemedResource(documentsaveIconRes),
 
-		Icons.Info:     NewThemedResource(infoIconRes),
-		Icons.Question: NewThemedResource(questionIconRes),
-		Icons.Warning:  NewThemedResource(warningIconRes),
-		Icons.Error:    NewThemedResource(errorIconRes),
+		IconNameInfo:     NewThemedResource(infoIconRes),
+		IconNameQuestion: NewThemedResource(questionIconRes),
+		IconNameWarning:  NewThemedResource(warningIconRes),
+		IconNameError:    NewThemedResource(errorIconRes),
 
-		Icons.MailAttachment: NewThemedResource(mailattachmentIconRes),
-		Icons.MailCompose:    NewThemedResource(mailcomposeIconRes),
-		Icons.MailForward:    NewThemedResource(mailforwardIconRes),
-		Icons.MailReply:      NewThemedResource(mailreplyIconRes),
-		Icons.MailReplyAll:   NewThemedResource(mailreplyallIconRes),
-		Icons.MailSend:       NewThemedResource(mailsendIconRes),
+		IconNameMailAttachment: NewThemedResource(mailattachmentIconRes),
+		IconNameMailCompose:    NewThemedResource(mailcomposeIconRes),
+		IconNameMailForward:    NewThemedResource(mailforwardIconRes),
+		IconNameMailReply:      NewThemedResource(mailreplyIconRes),
+		IconNameMailReplyAll:   NewThemedResource(mailreplyallIconRes),
+		IconNameMailSend:       NewThemedResource(mailsendIconRes),
 
-		Icons.MediaFastForward:  NewThemedResource(mediafastforwardIconRes),
-		Icons.MediaFastRewind:   NewThemedResource(mediafastrewindIconRes),
-		Icons.MediaPause:        NewThemedResource(mediapauseIconRes),
-		Icons.MediaPlay:         NewThemedResource(mediaplayIconRes),
-		Icons.MediaRecord:       NewThemedResource(mediarecordIconRes),
-		Icons.MediaReplay:       NewThemedResource(mediareplayIconRes),
-		Icons.MediaSkipNext:     NewThemedResource(mediaskipnextIconRes),
-		Icons.MediaSkipPrevious: NewThemedResource(mediaskippreviousIconRes),
-		Icons.MediaStop:         NewThemedResource(mediastopIconRes),
+		IconNameMediaFastForward:  NewThemedResource(mediafastforwardIconRes),
+		IconNameMediaFastRewind:   NewThemedResource(mediafastrewindIconRes),
+		IconNameMediaPause:        NewThemedResource(mediapauseIconRes),
+		IconNameMediaPlay:         NewThemedResource(mediaplayIconRes),
+		IconNameMediaRecord:       NewThemedResource(mediarecordIconRes),
+		IconNameMediaReplay:       NewThemedResource(mediareplayIconRes),
+		IconNameMediaSkipNext:     NewThemedResource(mediaskipnextIconRes),
+		IconNameMediaSkipPrevious: NewThemedResource(mediaskippreviousIconRes),
+		IconNameMediaStop:         NewThemedResource(mediastopIconRes),
 
-		Icons.NavigateBack:  NewThemedResource(arrowbackIconRes),
-		Icons.MoveDown:      NewThemedResource(arrowdownIconRes),
-		Icons.NavigateNext:  NewThemedResource(arrowforwardIconRes),
-		Icons.MoveUp:        NewThemedResource(arrowupIconRes),
-		Icons.ArrowDropDown: NewThemedResource(arrowdropdownIconRes),
-		Icons.ArrowDropUp:   NewThemedResource(arrowdropupIconRes),
+		IconNameNavigateBack:  NewThemedResource(arrowbackIconRes),
+		IconNameMoveDown:      NewThemedResource(arrowdownIconRes),
+		IconNameNavigateNext:  NewThemedResource(arrowforwardIconRes),
+		IconNameMoveUp:        NewThemedResource(arrowupIconRes),
+		IconNameArrowDropDown: NewThemedResource(arrowdropdownIconRes),
+		IconNameArrowDropUp:   NewThemedResource(arrowdropupIconRes),
 
-		Icons.File:            NewThemedResource(fileIconRes),
-		Icons.FileApplication: NewThemedResource(fileapplicationIconRes),
-		Icons.FileAudio:       NewThemedResource(fileaudioIconRes),
-		Icons.FileImage:       NewThemedResource(fileimageIconRes),
-		Icons.FileText:        NewThemedResource(filetextIconRes),
-		Icons.FileVideo:       NewThemedResource(filevideoIconRes),
-		Icons.Folder:          NewThemedResource(folderIconRes),
-		Icons.FolderNew:       NewThemedResource(foldernewIconRes),
-		Icons.FolderOpen:      NewThemedResource(folderopenIconRes),
-		Icons.Help:            NewThemedResource(helpIconRes),
-		Icons.History:         NewThemedResource(historyIconRes),
-		Icons.Home:            NewThemedResource(homeIconRes),
-		Icons.Settings:        NewThemedResource(settingsIconRes),
+		IconNameFile:            NewThemedResource(fileIconRes),
+		IconNameFileApplication: NewThemedResource(fileapplicationIconRes),
+		IconNameFileAudio:       NewThemedResource(fileaudioIconRes),
+		IconNameFileImage:       NewThemedResource(fileimageIconRes),
+		IconNameFileText:        NewThemedResource(filetextIconRes),
+		IconNameFileVideo:       NewThemedResource(filevideoIconRes),
+		IconNameFolder:          NewThemedResource(folderIconRes),
+		IconNameFolderNew:       NewThemedResource(foldernewIconRes),
+		IconNameFolderOpen:      NewThemedResource(folderopenIconRes),
+		IconNameHelp:            NewThemedResource(helpIconRes),
+		IconNameHistory:         NewThemedResource(historyIconRes),
+		IconNameHome:            NewThemedResource(homeIconRes),
+		IconNameSettings:        NewThemedResource(settingsIconRes),
 
-		Icons.ViewFullScreen: NewThemedResource(viewfullscreenIconRes),
-		Icons.ViewRefresh:    NewThemedResource(viewrefreshIconRes),
-		Icons.ViewRestore:    NewThemedResource(viewzoomfitIconRes),
-		Icons.ViewZoomFit:    NewThemedResource(viewzoomfitIconRes),
-		Icons.ViewZoomIn:     NewThemedResource(viewzoominIconRes),
-		Icons.ViewZoomOut:    NewThemedResource(viewzoomoutIconRes),
+		IconNameViewFullScreen: NewThemedResource(viewfullscreenIconRes),
+		IconNameViewRefresh:    NewThemedResource(viewrefreshIconRes),
+		IconNameViewRestore:    NewThemedResource(viewzoomfitIconRes),
+		IconNameViewZoomFit:    NewThemedResource(viewzoomfitIconRes),
+		IconNameViewZoomIn:     NewThemedResource(viewzoominIconRes),
+		IconNameViewZoomOut:    NewThemedResource(viewzoomoutIconRes),
 
-		Icons.Visibility:    NewThemedResource(visibilityIconRes),
-		Icons.VisibilityOff: NewThemedResource(visibilityoffIconRes),
+		IconNameVisibility:    NewThemedResource(visibilityIconRes),
+		IconNameVisibilityOff: NewThemedResource(visibilityoffIconRes),
 
-		Icons.VolumeDown: NewThemedResource(volumedownIconRes),
-		Icons.VolumeMute: NewThemedResource(volumemuteIconRes),
-		Icons.VolumeUp:   NewThemedResource(volumeupIconRes),
+		IconNameVolumeDown: NewThemedResource(volumedownIconRes),
+		IconNameVolumeMute: NewThemedResource(volumemuteIconRes),
+		IconNameVolumeUp:   NewThemedResource(volumeupIconRes),
 
-		Icons.Download: NewThemedResource(downloadIconRes),
-		Icons.Computer: NewThemedResource(computerIconRes),
-		Icons.Storage:  NewThemedResource(storageIconRes),
-		Icons.Upload:   NewThemedResource(uploadIconRes),
+		IconNameDownload: NewThemedResource(downloadIconRes),
+		IconNameComputer: NewThemedResource(computerIconRes),
+		IconNameStorage:  NewThemedResource(storageIconRes),
+		IconNameUpload:   NewThemedResource(uploadIconRes),
 	}
 )
 
@@ -307,395 +669,395 @@ func FyneLogo() fyne.Resource {
 
 // CancelIcon returns a resource containing the standard cancel icon for the current theme
 func CancelIcon() fyne.Resource {
-	return current().Icon(Icons.Cancel)
+	return current().Icon(IconNameCancel)
 }
 
 // ConfirmIcon returns a resource containing the standard confirm icon for the current theme
 func ConfirmIcon() fyne.Resource {
-	return current().Icon(Icons.Confirm)
+	return current().Icon(IconNameConfirm)
 }
 
 // DeleteIcon returns a resource containing the standard delete icon for the current theme
 func DeleteIcon() fyne.Resource {
-	return current().Icon(Icons.Delete)
+	return current().Icon(IconNameDelete)
 }
 
 // SearchIcon returns a resource containing the standard search icon for the current theme
 func SearchIcon() fyne.Resource {
-	return current().Icon(Icons.Search)
+	return current().Icon(IconNameSearch)
 }
 
 // SearchReplaceIcon returns a resource containing the standard search and replace icon for the current theme
 func SearchReplaceIcon() fyne.Resource {
-	return current().Icon(Icons.SearchReplace)
+	return current().Icon(IconNameSearchReplace)
 }
 
 // MenuIcon returns a resource containing the standard (mobile) menu icon for the current theme
 func MenuIcon() fyne.Resource {
-	return current().Icon(Icons.Menu)
+	return current().Icon(IconNameMenu)
 }
 
 // MenuExpandIcon returns a resource containing the standard (mobile) expand "submenu icon for the current theme
 func MenuExpandIcon() fyne.Resource {
-	return current().Icon(Icons.MenuExpand)
+	return current().Icon(IconNameMenuExpand)
 }
 
 // CheckButtonIcon returns a resource containing the standard checkbox icon for the current theme
 func CheckButtonIcon() fyne.Resource {
-	return current().Icon(Icons.CheckButton)
+	return current().Icon(IconNameCheckButton)
 }
 
 // CheckButtonCheckedIcon returns a resource containing the standard checkbox checked icon for the current theme
 func CheckButtonCheckedIcon() fyne.Resource {
-	return current().Icon(Icons.CheckButtonChecked)
+	return current().Icon(IconNameCheckButtonChecked)
 }
 
 // RadioButtonIcon returns a resource containing the standard radio button icon for the current theme
 func RadioButtonIcon() fyne.Resource {
-	return current().Icon(Icons.RadioButton)
+	return current().Icon(IconNameRadioButton)
 }
 
 // RadioButtonCheckedIcon returns a resource containing the standard radio button checked icon for the current theme
 func RadioButtonCheckedIcon() fyne.Resource {
-	return current().Icon(Icons.RadioButtonChecked)
+	return current().Icon(IconNameRadioButtonChecked)
 }
 
 // ContentAddIcon returns a resource containing the standard content add icon for the current theme
 func ContentAddIcon() fyne.Resource {
-	return current().Icon(Icons.ContentAdd)
+	return current().Icon(IconNameContentAdd)
 }
 
 // ContentRemoveIcon returns a resource containing the standard content remove icon for the current theme
 func ContentRemoveIcon() fyne.Resource {
-	return current().Icon(Icons.ContentRemove)
+	return current().Icon(IconNameContentRemove)
 }
 
 // ContentClearIcon returns a resource containing the standard content clear icon for the current theme
 func ContentClearIcon() fyne.Resource {
-	return current().Icon(Icons.ContentClear)
+	return current().Icon(IconNameContentClear)
 }
 
 // ContentCutIcon returns a resource containing the standard content cut icon for the current theme
 func ContentCutIcon() fyne.Resource {
-	return current().Icon(Icons.ContentCut)
+	return current().Icon(IconNameContentCut)
 }
 
 // ContentCopyIcon returns a resource containing the standard content copy icon for the current theme
 func ContentCopyIcon() fyne.Resource {
-	return current().Icon(Icons.ContentCopy)
+	return current().Icon(IconNameContentCopy)
 }
 
 // ContentPasteIcon returns a resource containing the standard content paste icon for the current theme
 func ContentPasteIcon() fyne.Resource {
-	return current().Icon(Icons.ContentPaste)
+	return current().Icon(IconNameContentPaste)
 }
 
 // ContentRedoIcon returns a resource containing the standard content redo icon for the current theme
 func ContentRedoIcon() fyne.Resource {
-	return current().Icon(Icons.ContentRedo)
+	return current().Icon(IconNameContentRedo)
 }
 
 // ContentUndoIcon returns a resource containing the standard content undo icon for the current theme
 func ContentUndoIcon() fyne.Resource {
-	return current().Icon(Icons.ContentUndo)
+	return current().Icon(IconNameContentUndo)
 }
 
 // ColorAchromaticIcon returns a resource containing the standard achromatic color icon for the current theme
 func ColorAchromaticIcon() fyne.Resource {
-	return current().Icon(Icons.ColorAchromatic)
+	return current().Icon(IconNameColorAchromatic)
 }
 
 // ColorChromaticIcon returns a resource containing the standard chromatic color icon for the current theme
 func ColorChromaticIcon() fyne.Resource {
-	return current().Icon(Icons.ColorChromatic)
+	return current().Icon(IconNameColorChromatic)
 }
 
 // ColorPaletteIcon returns a resource containing the standard color palette icon for the current theme
 func ColorPaletteIcon() fyne.Resource {
-	return current().Icon(Icons.ColorPalette)
+	return current().Icon(IconNameColorPalette)
 }
 
 // DocumentIcon returns a resource containing the standard document icon for the current theme
 func DocumentIcon() fyne.Resource {
-	return current().Icon(Icons.Document)
+	return current().Icon(IconNameDocument)
 }
 
 // DocumentCreateIcon returns a resource containing the standard document create icon for the current theme
 func DocumentCreateIcon() fyne.Resource {
-	return current().Icon(Icons.DocumentCreate)
+	return current().Icon(IconNameDocumentCreate)
 }
 
 // DocumentPrintIcon returns a resource containing the standard document print icon for the current theme
 func DocumentPrintIcon() fyne.Resource {
-	return current().Icon(Icons.DocumentPrint)
+	return current().Icon(IconNameDocumentPrint)
 }
 
 // DocumentSaveIcon returns a resource containing the standard document save icon for the current theme
 func DocumentSaveIcon() fyne.Resource {
-	return current().Icon(Icons.DocumentSave)
+	return current().Icon(IconNameDocumentSave)
 }
 
 // InfoIcon returns a resource containing the standard dialog info icon for the current theme
 func InfoIcon() fyne.Resource {
-	return current().Icon(Icons.Info)
+	return current().Icon(IconNameInfo)
 }
 
 // QuestionIcon returns a resource containing the standard dialog question icon for the current theme
 func QuestionIcon() fyne.Resource {
-	return current().Icon(Icons.Question)
+	return current().Icon(IconNameQuestion)
 }
 
 // WarningIcon returns a resource containing the standard dialog warning icon for the current theme
 func WarningIcon() fyne.Resource {
-	return current().Icon(Icons.Warning)
+	return current().Icon(IconNameWarning)
 }
 
 // ErrorIcon returns a resource containing the standard dialog error icon for the current theme
 func ErrorIcon() fyne.Resource {
-	return current().Icon(Icons.Error)
+	return current().Icon(IconNameError)
 }
 
 // FileIcon returns a resource containing the appropriate file icon for the current theme
 func FileIcon() fyne.Resource {
-	return current().Icon(Icons.File)
+	return current().Icon(IconNameFile)
 }
 
 // FileApplicationIcon returns a resource containing the file icon representing application files for the current theme
 func FileApplicationIcon() fyne.Resource {
-	return current().Icon(Icons.FileApplication)
+	return current().Icon(IconNameFileApplication)
 }
 
 // FileAudioIcon returns a resource containing the file icon representing audio files for the current theme
 func FileAudioIcon() fyne.Resource {
-	return current().Icon(Icons.FileAudio)
+	return current().Icon(IconNameFileAudio)
 }
 
 // FileImageIcon returns a resource containing the file icon representing image files for the current theme
 func FileImageIcon() fyne.Resource {
-	return current().Icon(Icons.FileImage)
+	return current().Icon(IconNameFileImage)
 }
 
 // FileTextIcon returns a resource containing the file icon representing text files for the current theme
 func FileTextIcon() fyne.Resource {
-	return current().Icon(Icons.FileText)
+	return current().Icon(IconNameFileText)
 }
 
 // FileVideoIcon returns a resource containing the file icon representing video files for the current theme
 func FileVideoIcon() fyne.Resource {
-	return current().Icon(Icons.FileVideo)
+	return current().Icon(IconNameFileVideo)
 }
 
 // FolderIcon returns a resource containing the standard folder icon for the current theme
 func FolderIcon() fyne.Resource {
-	return current().Icon(Icons.Folder)
+	return current().Icon(IconNameFolder)
 }
 
 // FolderNewIcon returns a resource containing the standard folder creation icon for the current theme
 func FolderNewIcon() fyne.Resource {
-	return current().Icon(Icons.FolderNew)
+	return current().Icon(IconNameFolderNew)
 }
 
 // FolderOpenIcon returns a resource containing the standard folder open icon for the current theme
 func FolderOpenIcon() fyne.Resource {
-	return current().Icon(Icons.FolderOpen)
+	return current().Icon(IconNameFolderOpen)
 }
 
 // HelpIcon returns a resource containing the standard help icon for the current theme
 func HelpIcon() fyne.Resource {
-	return current().Icon(Icons.Help)
+	return current().Icon(IconNameHelp)
 }
 
 // HistoryIcon returns a resource containing the standard history icon for the current theme
 func HistoryIcon() fyne.Resource {
-	return current().Icon(Icons.History)
+	return current().Icon(IconNameHistory)
 }
 
 // HomeIcon returns a resource containing the standard home folder icon for the current theme
 func HomeIcon() fyne.Resource {
-	return current().Icon(Icons.Home)
+	return current().Icon(IconNameHome)
 }
 
 // SettingsIcon returns a resource containing the standard settings icon for the current theme
 func SettingsIcon() fyne.Resource {
-	return current().Icon(Icons.Settings)
+	return current().Icon(IconNameSettings)
 }
 
 // MailAttachmentIcon returns a resource containing the standard mail attachment icon for the current theme
 func MailAttachmentIcon() fyne.Resource {
-	return current().Icon(Icons.MailAttachment)
+	return current().Icon(IconNameMailAttachment)
 }
 
 // MailComposeIcon returns a resource containing the standard mail compose icon for the current theme
 func MailComposeIcon() fyne.Resource {
-	return current().Icon(Icons.MailCompose)
+	return current().Icon(IconNameMailCompose)
 }
 
 // MailForwardIcon returns a resource containing the standard mail forward icon for the current theme
 func MailForwardIcon() fyne.Resource {
-	return current().Icon(Icons.MailForward)
+	return current().Icon(IconNameMailForward)
 }
 
 // MailReplyIcon returns a resource containing the standard mail reply icon for the current theme
 func MailReplyIcon() fyne.Resource {
-	return current().Icon(Icons.MailReply)
+	return current().Icon(IconNameMailReply)
 }
 
 // MailReplyAllIcon returns a resource containing the standard mail reply all icon for the current theme
 func MailReplyAllIcon() fyne.Resource {
-	return current().Icon(Icons.MailReplyAll)
+	return current().Icon(IconNameMailReplyAll)
 }
 
 // MailSendIcon returns a resource containing the standard mail send icon for the current theme
 func MailSendIcon() fyne.Resource {
-	return current().Icon(Icons.MailSend)
+	return current().Icon(IconNameMailSend)
 }
 
 // MediaFastForwardIcon returns a resource containing the standard media fast-forward icon for the current theme
 func MediaFastForwardIcon() fyne.Resource {
-	return current().Icon(Icons.MediaFastForward)
+	return current().Icon(IconNameMediaFastForward)
 }
 
 // MediaFastRewindIcon returns a resource containing the standard media fast-rewind icon for the current theme
 func MediaFastRewindIcon() fyne.Resource {
-	return current().Icon(Icons.MediaFastRewind)
+	return current().Icon(IconNameMediaFastRewind)
 }
 
 // MediaPauseIcon returns a resource containing the standard media pause icon for the current theme
 func MediaPauseIcon() fyne.Resource {
-	return current().Icon(Icons.MediaPause)
+	return current().Icon(IconNameMediaPause)
 }
 
 // MediaPlayIcon returns a resource containing the standard media play icon for the current theme
 func MediaPlayIcon() fyne.Resource {
-	return current().Icon(Icons.MediaPlay)
+	return current().Icon(IconNameMediaPlay)
 }
 
 // MediaRecordIcon returns a resource containing the standard media record icon for the current theme
 func MediaRecordIcon() fyne.Resource {
-	return current().Icon(Icons.MediaRecord)
+	return current().Icon(IconNameMediaRecord)
 }
 
 // MediaReplayIcon returns a resource containing the standard media replay icon for the current theme
 func MediaReplayIcon() fyne.Resource {
-	return current().Icon(Icons.MediaReplay)
+	return current().Icon(IconNameMediaReplay)
 }
 
 // MediaSkipNextIcon returns a resource containing the standard media skip next icon for the current theme
 func MediaSkipNextIcon() fyne.Resource {
-	return current().Icon(Icons.MediaSkipNext)
+	return current().Icon(IconNameMediaSkipNext)
 }
 
 // MediaSkipPreviousIcon returns a resource containing the standard media skip previous icon for the current theme
 func MediaSkipPreviousIcon() fyne.Resource {
-	return current().Icon(Icons.MediaSkipPrevious)
+	return current().Icon(IconNameMediaSkipPrevious)
 }
 
 // MediaStopIcon returns a resource containing the standard media stop icon for the current theme
 func MediaStopIcon() fyne.Resource {
-	return current().Icon(Icons.MediaStop)
+	return current().Icon(IconNameMediaStop)
 }
 
 // MoveDownIcon returns a resource containing the standard down arrow icon for the current theme
 func MoveDownIcon() fyne.Resource {
-	return current().Icon(Icons.MoveDown)
+	return current().Icon(IconNameMoveDown)
 }
 
 // MoveUpIcon returns a resource containing the standard up arrow icon for the current theme
 func MoveUpIcon() fyne.Resource {
-	return current().Icon(Icons.MoveUp)
+	return current().Icon(IconNameMoveUp)
 }
 
 // NavigateBackIcon returns a resource containing the standard backward navigation icon for the current theme
 func NavigateBackIcon() fyne.Resource {
-	return current().Icon(Icons.NavigateBack)
+	return current().Icon(IconNameNavigateBack)
 }
 
 // NavigateNextIcon returns a resource containing the standard forward navigation icon for the current theme
 func NavigateNextIcon() fyne.Resource {
-	return current().Icon(Icons.NavigateNext)
+	return current().Icon(IconNameNavigateNext)
 }
 
 // MenuDropDownIcon returns a resource containing the standard menu drop down icon for the current theme
 func MenuDropDownIcon() fyne.Resource {
-	return current().Icon(Icons.ArrowDropDown)
+	return current().Icon(IconNameArrowDropDown)
 }
 
 // MenuDropUpIcon returns a resource containing the standard menu drop up icon for the current theme
 func MenuDropUpIcon() fyne.Resource {
-	return current().Icon(Icons.ArrowDropUp)
+	return current().Icon(IconNameArrowDropUp)
 }
 
 // ViewFullScreenIcon returns a resource containing the standard fullscreen icon for the current theme
 func ViewFullScreenIcon() fyne.Resource {
-	return current().Icon(Icons.ViewFullScreen)
+	return current().Icon(IconNameViewFullScreen)
 }
 
 // ViewRestoreIcon returns a resource containing the standard exit fullscreen icon for the current theme
 func ViewRestoreIcon() fyne.Resource {
-	return current().Icon(Icons.ViewRestore)
+	return current().Icon(IconNameViewRestore)
 }
 
 // ViewRefreshIcon returns a resource containing the standard refresh icon for the current theme
 func ViewRefreshIcon() fyne.Resource {
-	return current().Icon(Icons.ViewRefresh)
+	return current().Icon(IconNameViewRefresh)
 }
 
 // ZoomFitIcon returns a resource containing the standard zoom fit icon for the current theme
 func ZoomFitIcon() fyne.Resource {
-	return current().Icon(Icons.ViewZoomFit)
+	return current().Icon(IconNameViewZoomFit)
 }
 
 // ZoomInIcon returns a resource containing the standard zoom in icon for the current theme
 func ZoomInIcon() fyne.Resource {
-	return current().Icon(Icons.ViewZoomIn)
+	return current().Icon(IconNameViewZoomIn)
 }
 
 // ZoomOutIcon returns a resource containing the standard zoom out icon for the current theme
 func ZoomOutIcon() fyne.Resource {
-	return current().Icon(Icons.ViewZoomOut)
+	return current().Icon(IconNameViewZoomOut)
 }
 
 // VisibilityIcon returns a resource containing the standard visibity icon for the current theme
 func VisibilityIcon() fyne.Resource {
-	return current().Icon(Icons.Visibility)
+	return current().Icon(IconNameVisibility)
 }
 
 // VisibilityOffIcon returns a resource containing the standard visibity off icon for the current theme
 func VisibilityOffIcon() fyne.Resource {
-	return current().Icon(Icons.VisibilityOff)
+	return current().Icon(IconNameVisibilityOff)
 }
 
 // VolumeDownIcon returns a resource containing the standard volume down icon for the current theme
 func VolumeDownIcon() fyne.Resource {
-	return current().Icon(Icons.VolumeDown)
+	return current().Icon(IconNameVolumeDown)
 }
 
 // VolumeMuteIcon returns a resource containing the standard volume mute icon for the current theme
 func VolumeMuteIcon() fyne.Resource {
-	return current().Icon(Icons.VolumeMute)
+	return current().Icon(IconNameVolumeMute)
 }
 
 // VolumeUpIcon returns a resource containing the standard volume up icon for the current theme
 func VolumeUpIcon() fyne.Resource {
-	return current().Icon(Icons.VolumeUp)
+	return current().Icon(IconNameVolumeUp)
 }
 
 // ComputerIcon returns a resource containing the standard computer icon for the current theme
 func ComputerIcon() fyne.Resource {
-	return current().Icon(Icons.Computer)
+	return current().Icon(IconNameComputer)
 }
 
 // DownloadIcon returns a resource containing the standard download icon for the current theme
 func DownloadIcon() fyne.Resource {
-	return current().Icon(Icons.Download)
+	return current().Icon(IconNameDownload)
 }
 
 // StorageIcon returns a resource containing the standard storage icon for the current theme
 func StorageIcon() fyne.Resource {
-	return current().Icon(Icons.Storage)
+	return current().Icon(IconNameStorage)
 }
 
 // UploadIcon returns a resource containing the standard upload icon for the current theme
 func UploadIcon() fyne.Resource {
-	return current().Icon(Icons.Upload)
+	return current().Icon(IconNameUpload)
 }

--- a/theme/legacy.go
+++ b/theme/legacy.go
@@ -49,6 +49,22 @@ func (l *legacyWrapper) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.
 	}
 }
 
+func (l *legacyWrapper) Font(s fyne.TextStyle) fyne.Resource {
+	if s.Monospace {
+		return l.old.TextMonospaceFont()
+	}
+	if s.Bold {
+		if s.Italic {
+			return l.old.TextBoldItalicFont()
+		}
+		return l.old.TextBoldFont()
+	}
+	if s.Italic {
+		return l.old.TextItalicFont()
+	}
+	return l.old.TextFont()
+}
+
 func (l *legacyWrapper) Size(n fyne.ThemeSizeName) int {
 	switch n {
 	case Sizes.InlineIcon:
@@ -64,20 +80,4 @@ func (l *legacyWrapper) Size(n fyne.ThemeSizeName) int {
 	default:
 		return DefaultTheme().Size(n)
 	}
-}
-
-func (l *legacyWrapper) Font(s fyne.TextStyle) fyne.Resource {
-	if s.Monospace {
-		return l.old.TextMonospaceFont()
-	}
-	if s.Bold {
-		if s.Italic {
-			return l.old.TextBoldItalicFont()
-		}
-		return l.old.TextBoldFont()
-	}
-	if s.Italic {
-		return l.old.TextItalicFont()
-	}
-	return l.old.TextFont()
 }

--- a/theme/legacy.go
+++ b/theme/legacy.go
@@ -65,6 +65,10 @@ func (l *legacyWrapper) Font(s fyne.TextStyle) fyne.Resource {
 	return l.old.TextFont()
 }
 
+func (l *legacyWrapper) Icon(n fyne.ThemeIconName) fyne.Resource {
+	return DefaultTheme().Icon(n)
+}
+
 func (l *legacyWrapper) Size(n fyne.ThemeSizeName) int {
 	switch n {
 	case Sizes.InlineIcon:

--- a/theme/legacy.go
+++ b/theme/legacy.go
@@ -22,27 +22,27 @@ type legacyWrapper struct {
 
 func (l *legacyWrapper) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.Color {
 	switch n {
-	case Colors.Background:
+	case ColorNameBackground:
 		return l.old.BackgroundColor()
-	case Colors.Foreground:
+	case ColorNameForeground:
 		return l.old.TextColor()
-	case Colors.Button:
+	case ColorNameButton:
 		return l.old.ButtonColor()
-	case Colors.DisabledButton:
+	case ColorNameDisabledButton:
 		return l.old.DisabledButtonColor()
-	case Colors.Disabled:
+	case ColorNameDisabled:
 		return l.old.DisabledTextColor()
-	case Colors.Focus:
+	case ColorNameFocus:
 		return l.old.FocusColor()
-	case Colors.Hover:
+	case ColorNameHover:
 		return l.old.HoverColor()
-	case Colors.PlaceHolder:
+	case ColorNamePlaceHolder:
 		return l.old.PlaceHolderColor()
-	case Colors.Primary:
+	case ColorNamePrimary:
 		return l.old.PrimaryColor()
-	case Colors.ScrollBar:
+	case ColorNameScrollBar:
 		return l.old.ScrollBarColor()
-	case Colors.Shadow:
+	case ColorNameShadow:
 		return l.old.ShadowColor()
 	default:
 		return DefaultTheme().Color(n, v)
@@ -71,15 +71,15 @@ func (l *legacyWrapper) Icon(n fyne.ThemeIconName) fyne.Resource {
 
 func (l *legacyWrapper) Size(n fyne.ThemeSizeName) int {
 	switch n {
-	case Sizes.InlineIcon:
+	case SizeNameInlineIcon:
 		return l.old.IconInlineSize()
-	case Sizes.Padding:
+	case SizeNamePadding:
 		return l.old.Padding()
-	case Sizes.ScrollBar:
+	case SizeNameScrollBar:
 		return l.old.ScrollBarSize()
-	case Sizes.ScrollBarSmall:
+	case SizeNameScrollBarSmall:
 		return l.old.ScrollBarSmallSize()
-	case Sizes.Text:
+	case SizeNameText:
 		return l.old.TextSize()
 	default:
 		return DefaultTheme().Size(n)

--- a/theme/legacy_test.go
+++ b/theme/legacy_test.go
@@ -19,9 +19,9 @@ func TestFromLegacy(t *testing.T) {
 
 func TestLegacyWrapper_Color(t *testing.T) {
 	newTheme := FromLegacy(oldTheme)
-	assert.Equal(t, oldTheme.BackgroundColor(), newTheme.Color(Colors.Background, Variants.Light))
-	assert.Equal(t, oldTheme.ShadowColor(), newTheme.Color(Colors.Shadow, Variants.Light))
-	assert.Equal(t, oldTheme.TextColor(), newTheme.Color(Colors.Foreground, Variants.Light))
+	assert.Equal(t, oldTheme.BackgroundColor(), newTheme.Color(ColorNameBackground, VariantNameLight))
+	assert.Equal(t, oldTheme.ShadowColor(), newTheme.Color(ColorNameShadow, VariantNameLight))
+	assert.Equal(t, oldTheme.TextColor(), newTheme.Color(ColorNameForeground, VariantNameLight))
 }
 
 func TestLegacyWrapper_Font(t *testing.T) {
@@ -34,9 +34,9 @@ func TestLegacyWrapper_Font(t *testing.T) {
 
 func TestLegacyWrapper_Size(t *testing.T) {
 	newTheme := FromLegacy(oldTheme)
-	assert.Equal(t, oldTheme.IconInlineSize(), newTheme.Size(Sizes.InlineIcon))
-	assert.Equal(t, oldTheme.Padding(), newTheme.Size(Sizes.Padding))
-	assert.Equal(t, oldTheme.TextSize(), newTheme.Size(Sizes.Text))
+	assert.Equal(t, oldTheme.IconInlineSize(), newTheme.Size(SizeNameInlineIcon))
+	assert.Equal(t, oldTheme.Padding(), newTheme.Size(SizeNamePadding))
+	assert.Equal(t, oldTheme.TextSize(), newTheme.Size(SizeNameText))
 }
 
 var _ fyne.LegacyTheme = (*legacyTheme)(nil)

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -42,69 +42,102 @@ const (
 	//
 	// Since: 1.4.0
 	ColorGray = "gray"
+
+	// ColorNameBackground is the name of theme lookup for background color.
+	//
+	// Since 2.0.0
+	ColorNameBackground fyne.ThemeColorName = "background"
+
+	// ColorNameButton is the name of theme lookup for button color.
+	//
+	// Since 2.0.0
+	ColorNameButton fyne.ThemeColorName = "button"
+
+	// ColorNameDisabledButton is the name of theme lookup for disabled button color.
+	//
+	// Since 2.0.0
+	ColorNameDisabledButton fyne.ThemeColorName = "disabledButton"
+
+	// ColorNameDisabled is the name of theme lookup for disabled foreground color.
+	//
+	// Since 2.0.0
+	ColorNameDisabled fyne.ThemeColorName = "disabled"
+
+	// ColorNameFocus is the name of theme lookup for focus color.
+	//
+	// Since 2.0.0
+	ColorNameFocus fyne.ThemeColorName = "focus"
+
+	// ColorNameForeground is the name of theme lookup for foreground color.
+	//
+	// Since 2.0.0
+	ColorNameForeground fyne.ThemeColorName = "foreground"
+
+	// ColorNameHover is the name of theme lookup for hover color.
+	//
+	// Since 2.0.0
+	ColorNameHover fyne.ThemeColorName = "hover"
+
+	// ColorNamePlaceHolder is the name of theme lookup for placeholder text color.
+	//
+	// Since 2.0.0
+	ColorNamePlaceHolder fyne.ThemeColorName = "placeholder"
+
+	// ColorNamePrimary is the name of theme lookup for primary color.
+	//
+	// Since 2.0.0
+	ColorNamePrimary fyne.ThemeColorName = "primary"
+
+	// ColorNameScrollBar is the name of theme lookup for scrollbar color.
+	//
+	// Since 2.0.0
+	ColorNameScrollBar fyne.ThemeColorName = "scrollBar"
+
+	// ColorNameShadow is the name of theme lookup for shadow color.
+	//
+	// Since 2.0.0
+	ColorNameShadow fyne.ThemeColorName = "shadow"
+
+	// SizeNameInlineIcon is the name of theme lookup for inline icons size.
+	//
+	// Since 2.0.0
+	SizeNameInlineIcon fyne.ThemeSizeName = "iconInline"
+
+	// SizeNamePadding is the name of theme lookup for padding size.
+	//
+	// Since 2.0.0
+	SizeNamePadding fyne.ThemeSizeName = "padding"
+
+	// SizeNameScrollBar is the name of theme lookup for the scrollbar size.
+	//
+	// Since 2.0.0
+	SizeNameScrollBar fyne.ThemeSizeName = "scrollBar"
+
+	// SizeNameScrollBarSmall is the name of theme lookup for the shrunk scrollbar size.
+	//
+	// Since 2.0.0
+	SizeNameScrollBarSmall fyne.ThemeSizeName = "scrollBarSmall"
+
+	// SizeNameText is the name of theme lookup for text size.
+	//
+	// Since 2.0.0
+	SizeNameText fyne.ThemeSizeName = "text"
+
+	// VariantNameDark is the version of a theme that satisfies a user preference for a light look.
+	//
+	// Since 2.0.0
+	VariantNameDark fyne.ThemeVariant = 0
+
+	// VariantNameLight is the version of a theme that satisfies a user preference for a dark look.
+	//
+	// Since 2.0.0
+	VariantNameLight fyne.ThemeVariant = 1
+
+	// potential for adding theme types such as high visibility or monochrome...
+	variantNameUserPreference fyne.ThemeVariant = 2 // locally used in builtinTheme for backward compatibility
 )
 
 var (
-	// Colors specifies each of the known colour names that a theme can contain.
-	//
-	// Since 2.0.0
-	Colors = struct {
-		Background     fyne.ThemeColorName
-		Button         fyne.ThemeColorName
-		DisabledButton fyne.ThemeColorName
-		Disabled       fyne.ThemeColorName
-		Focus          fyne.ThemeColorName
-		Foreground     fyne.ThemeColorName
-		Hover          fyne.ThemeColorName
-		PlaceHolder    fyne.ThemeColorName
-		Primary        fyne.ThemeColorName
-		ScrollBar      fyne.ThemeColorName
-		Shadow         fyne.ThemeColorName
-	}{
-		"background",
-		"button",
-		"disabledButton",
-		"disabled",
-		"focus",
-		"foreground",
-		"hover",
-		"placeholder",
-		"primary",
-		"scrollBar",
-		"shadow",
-	}
-
-	// Sizes specifies each of the known size names that a theme can contain.
-	//
-	// Since 2.0.0
-	Sizes = struct {
-		InlineIcon     fyne.ThemeSizeName
-		Padding        fyne.ThemeSizeName
-		ScrollBar      fyne.ThemeSizeName
-		ScrollBarSmall fyne.ThemeSizeName
-		Text           fyne.ThemeSizeName
-	}{
-		"iconInline",
-		"padding",
-		"scrollBar",
-		"scrollBarSmall",
-		"text",
-	}
-
-	// Variants lists each of the known theme variants that can apply to a color lookup.
-	//
-	// Since 2.0.0
-	Variants = struct {
-		Dark  fyne.ThemeVariant
-		Light fyne.ThemeVariant
-		// potential for adding theme types such as high visibility or monochrome...
-		userPreference fyne.ThemeVariant // locally used in builtinTheme for backward compatibility
-	}{
-		0,
-		1,
-		2,
-	}
-
 	defaultTheme = setupDefaultTheme()
 
 	primaryColors = map[string]color.Color{
@@ -159,7 +192,7 @@ func DefaultTheme() fyne.Theme {
 
 // LightTheme defines the built in light theme colors and sizes
 func LightTheme() fyne.Theme {
-	theme := &builtinTheme{variant: Variants.Light}
+	theme := &builtinTheme{variant: VariantNameLight}
 
 	theme.initFonts()
 	return theme
@@ -167,7 +200,7 @@ func LightTheme() fyne.Theme {
 
 // DarkTheme defines the built in dark theme colors and sizes
 func DarkTheme() fyne.Theme {
-	theme := &builtinTheme{variant: Variants.Dark}
+	theme := &builtinTheme{variant: VariantNameDark}
 
 	theme.initFonts()
 	return theme
@@ -195,11 +228,11 @@ func (t *builtinTheme) initFonts() {
 
 func (t *builtinTheme) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.Color {
 	colors := darkPalette
-	if v == Variants.Light {
+	if v == VariantNameLight {
 		colors = lightPalette
 	}
 
-	if n == Colors.Primary || n == Colors.Focus { // TODO new focus color
+	if n == ColorNamePrimary || n == ColorNameFocus { // TODO new focus color
 		return PrimaryColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
 	}
 
@@ -228,15 +261,15 @@ func (t *builtinTheme) Font(style fyne.TextStyle) fyne.Resource {
 
 func (t *builtinTheme) Size(s fyne.ThemeSizeName) int {
 	switch s {
-	case Sizes.InlineIcon:
+	case SizeNameInlineIcon:
 		return 20
-	case Sizes.Padding:
+	case SizeNamePadding:
 		return 4
-	case Sizes.ScrollBar:
+	case SizeNameScrollBar:
 		return 16
-	case Sizes.ScrollBarSmall:
+	case SizeNameScrollBarSmall:
 		return 3
-	case Sizes.Text:
+	case SizeNameText:
 		return 14
 	default:
 		return 0
@@ -253,80 +286,80 @@ func current() fyne.Theme {
 
 // BackgroundColor returns the theme's background color
 func BackgroundColor() color.Color {
-	return current().Color(Colors.Background, currentVariant())
+	return current().Color(ColorNameBackground, currentVariant())
 }
 
 // ButtonColor returns the theme's standard button color.
 func ButtonColor() color.Color {
-	return current().Color(Colors.Button, currentVariant())
+	return current().Color(ColorNameButton, currentVariant())
 }
 
 // DisabledButtonColor returns the theme's disabled button color.
 func DisabledButtonColor() color.Color {
-	return current().Color(Colors.DisabledButton, currentVariant())
+	return current().Color(ColorNameDisabledButton, currentVariant())
 }
 
 // TextColor returns the theme's standard text color
 //
 // Deprecated: Use theme.Foreground colour instead
 func TextColor() color.Color {
-	return current().Color(Colors.Foreground, currentVariant())
+	return current().Color(ColorNameForeground, currentVariant())
 }
 
 // DisabledColor returns the foreground color for a disabled UI element
 //
 // Since: 2.0.0
 func DisabledColor() color.Color {
-	return current().Color(Colors.Disabled, currentVariant())
+	return current().Color(ColorNameDisabled, currentVariant())
 }
 
 // DisabledTextColor returns the color for a disabledIcon UI element
 //
 // Deprecated: Use DisabledColor() instead
 func DisabledTextColor() color.Color {
-	return current().Color(Colors.Disabled, currentVariant())
+	return current().Color(ColorNameDisabled, currentVariant())
 }
 
 // PlaceHolderColor returns the theme's standard text color
 func PlaceHolderColor() color.Color {
-	return current().Color(Colors.PlaceHolder, currentVariant())
+	return current().Color(ColorNamePlaceHolder, currentVariant())
 }
 
 // PrimaryColor returns the color used to highlight primary features
 func PrimaryColor() color.Color {
-	return current().Color(Colors.Primary, currentVariant())
+	return current().Color(ColorNamePrimary, currentVariant())
 }
 
 // HoverColor returns the color used to highlight interactive elements currently under a cursor
 func HoverColor() color.Color {
-	return current().Color(Colors.Hover, currentVariant())
+	return current().Color(ColorNameHover, currentVariant())
 }
 
 // FocusColor returns the color used to highlight a focused widget
 func FocusColor() color.Color {
-	return current().Color(Colors.Focus, currentVariant())
+	return current().Color(ColorNameFocus, currentVariant())
 }
 
 // ForegroundColor returns the theme's standard foreground color for text and icons
 //
 // Since: 2.0.0
 func ForegroundColor() color.Color {
-	return current().Color(Colors.Foreground, currentVariant())
+	return current().Color(ColorNameForeground, currentVariant())
 }
 
 // ScrollBarColor returns the color (and translucency) for a scrollBar
 func ScrollBarColor() color.Color {
-	return current().Color(Colors.ScrollBar, currentVariant())
+	return current().Color(ColorNameScrollBar, currentVariant())
 }
 
 // ShadowColor returns the color (and translucency) for shadows used for indicating elevation
 func ShadowColor() color.Color {
-	return current().Color(Colors.Shadow, currentVariant())
+	return current().Color(ColorNameShadow, currentVariant())
 }
 
 // TextSize returns the standard text size
 func TextSize() int {
-	return current().Size(Sizes.Text)
+	return current().Size(SizeNameText)
 }
 
 // TextFont returns the font resource for the regular font style
@@ -357,22 +390,22 @@ func TextMonospaceFont() fyne.Resource {
 // Padding is the standard gap between elements and the border around interface
 // elements
 func Padding() int {
-	return current().Size(Sizes.Padding)
+	return current().Size(SizeNamePadding)
 }
 
 // IconInlineSize is the standard size of icons which appear within buttons, labels etc.
 func IconInlineSize() int {
-	return current().Size(Sizes.InlineIcon)
+	return current().Size(SizeNameInlineIcon)
 }
 
 // ScrollBarSize is the width (or height) of the bars on a ScrollContainer
 func ScrollBarSize() int {
-	return current().Size(Sizes.ScrollBar)
+	return current().Size(SizeNameScrollBar)
 }
 
 // ScrollBarSmallSize is the width (or height) of the minimized bars on a ScrollContainer
 func ScrollBarSmallSize() int {
-	return current().Size(Sizes.ScrollBarSmall)
+	return current().Size(SizeNameScrollBarSmall)
 }
 
 // DefaultTextFont returns the font resource for the built-in regular font style
@@ -420,7 +453,7 @@ func PrimaryColorNamed(name string) color.Color {
 
 func currentVariant() fyne.ThemeVariant {
 	if std, ok := current().(*builtinTheme); ok {
-		if std.variant != Variants.userPreference {
+		if std.variant != variantNameUserPreference {
 			return std.variant // override if using the old LightTheme() or DarkTheme() constructor
 		}
 	}

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -106,15 +106,7 @@ var (
 	}
 
 	defaultTheme = setupDefaultTheme()
-)
 
-type builtinTheme struct {
-	variant fyne.ThemeVariant
-
-	regular, bold, italic, boldItalic, monospace fyne.Resource
-}
-
-var (
 	primaryColors = map[string]color.Color{
 		ColorRed:    color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff},
 		ColorOrange: color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff},
@@ -151,6 +143,12 @@ var (
 		"scrollBar":      color.NRGBA{0x0, 0x0, 0x0, 0x99},
 		"shadow":         color.NRGBA{0x0, 0x0, 0x0, 0x33}}
 )
+
+type builtinTheme struct {
+	variant fyne.ThemeVariant
+
+	regular, bold, italic, boldItalic, monospace fyne.Resource
+}
 
 // DefaultTheme returns a built-in theme that can adapt to the user preference of light or dark colors.
 //

--- a/theme/theme_test.go
+++ b/theme/theme_test.go
@@ -41,49 +41,49 @@ func TestBuiltinTheme_ShadowColor(t *testing.T) {
 func TestTheme_Dark_ReturnsCorrectBackground(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	bg := BackgroundColor()
-	assert.Equal(t, DarkTheme().Color(Colors.Background, Variants.Dark), bg, "wrong dark theme background color")
+	assert.Equal(t, DarkTheme().Color(ColorNameBackground, VariantNameDark), bg, "wrong dark theme background color")
 }
 
 func TestTheme_Light_ReturnsCorrectBackground(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(LightTheme())
 	bg := BackgroundColor()
-	assert.Equal(t, LightTheme().Color(Colors.Background, Variants.Light), bg, "wrong light theme background color")
+	assert.Equal(t, LightTheme().Color(ColorNameBackground, VariantNameLight), bg, "wrong light theme background color")
 }
 
 func Test_ButtonColor(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	c := ButtonColor()
-	assert.Equal(t, DarkTheme().Color(Colors.Button, Variants.Dark), c, "wrong button color")
+	assert.Equal(t, DarkTheme().Color(ColorNameButton, VariantNameDark), c, "wrong button color")
 }
 
 func Test_TextColor(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	c := ForegroundColor()
-	assert.Equal(t, DarkTheme().Color(Colors.Foreground, Variants.Dark), c, "wrong text color")
+	assert.Equal(t, DarkTheme().Color(ColorNameForeground, VariantNameDark), c, "wrong text color")
 }
 
 func Test_DisabledTextColor(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	c := DisabledColor()
-	assert.Equal(t, DarkTheme().Color(Colors.Disabled, Variants.Dark), c, "wrong disabled text color")
+	assert.Equal(t, DarkTheme().Color(ColorNameDisabled, VariantNameDark), c, "wrong disabled text color")
 }
 
 func Test_PlaceHolderColor(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	c := PlaceHolderColor()
-	assert.Equal(t, DarkTheme().Color(Colors.PlaceHolder, Variants.Dark), c, "wrong placeholder color")
+	assert.Equal(t, DarkTheme().Color(ColorNamePlaceHolder, VariantNameDark), c, "wrong placeholder color")
 }
 
 func Test_PrimaryColor(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	c := PrimaryColor()
-	assert.Equal(t, DarkTheme().Color(Colors.Primary, Variants.Dark), c, "wrong primary color")
+	assert.Equal(t, DarkTheme().Color(ColorNamePrimary, VariantNameDark), c, "wrong primary color")
 }
 
 func Test_HoverColor(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	c := HoverColor()
-	assert.Equal(t, DarkTheme().Color(Colors.Hover, Variants.Dark), c, "wrong hover color")
+	assert.Equal(t, DarkTheme().Color(ColorNameHover, VariantNameDark), c, "wrong hover color")
 }
 
 func Test_FocusColor(t *testing.T) {
@@ -95,12 +95,12 @@ func Test_FocusColor(t *testing.T) {
 func Test_ScrollBarColor(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	c := ScrollBarColor()
-	assert.Equal(t, DarkTheme().Color(Colors.ScrollBar, Variants.Dark), c, "wrong scrollbar color")
+	assert.Equal(t, DarkTheme().Color(ColorNameScrollBar, VariantNameDark), c, "wrong scrollbar color")
 }
 
 func Test_TextSize(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
-	assert.Equal(t, DarkTheme().Size(Sizes.Text), TextSize(), "wrong text size")
+	assert.Equal(t, DarkTheme().Size(SizeNameText), TextSize(), "wrong text size")
 }
 
 func Test_TextFont(t *testing.T) {
@@ -140,17 +140,17 @@ func Test_TextMonospaceFont(t *testing.T) {
 
 func Test_Padding(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
-	assert.Equal(t, DarkTheme().Size(Sizes.Padding), Padding(), "wrong padding")
+	assert.Equal(t, DarkTheme().Size(SizeNamePadding), Padding(), "wrong padding")
 }
 
 func Test_IconInlineSize(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
-	assert.Equal(t, DarkTheme().Size(Sizes.InlineIcon), IconInlineSize(), "wrong inline icon size")
+	assert.Equal(t, DarkTheme().Size(SizeNameInlineIcon), IconInlineSize(), "wrong inline icon size")
 }
 
 func Test_ScrollBarSize(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
-	assert.Equal(t, DarkTheme().Size(Sizes.ScrollBar), ScrollBarSize(), "wrong inline icon size")
+	assert.Equal(t, DarkTheme().Size(SizeNameScrollBar), ScrollBarSize(), "wrong inline icon size")
 }
 
 func Test_DefaultTextFont(t *testing.T) {

--- a/theme/themedtestapp.go
+++ b/theme/themedtestapp.go
@@ -73,7 +73,7 @@ func (t *themedApp) SetTheme(theme fyne.Theme) {
 }
 
 func (t *themedApp) ThemeVariant() fyne.ThemeVariant {
-	return Variants.Dark
+	return VariantNameDark
 }
 
 func (t *themedApp) Scale() float32 {


### PR DESCRIPTION
Makes for more flexibility as we start using specific icons in our more advanced widgets (like FileDialog for example).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

- [x] Public APIs match existing style.
