### PR TITLE
Use position to pixel coordinate mapping for gl Capture

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -198,12 +198,6 @@ func (c *glCanvas) Scale() float32 {
 	return c.scale
 }
 
-func (c *glCanvas) TextureScale() float32 {
-	c.RLock()
-	defer c.RUnlock()
-	return c.texScale
-}
-
 func (c *glCanvas) SetContent(content fyne.CanvasObject) {
 	c.Lock()
 	c.setContent(content)

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -198,6 +198,12 @@ func (c *glCanvas) Scale() float32 {
 	return c.scale
 }
 
+func (c *glCanvas) TextureScale() float32 {
+	c.RLock()
+	defer c.RUnlock()
+	return c.texScale
+}
+
 func (c *glCanvas) SetContent(content fyne.CanvasObject) {
 	c.Lock()
 	c.setContent(content)

--- a/internal/painter/gl/capture.go
+++ b/internal/painter/gl/capture.go
@@ -25,11 +25,6 @@ func (c *captureImage) At(x, y int) color.Color {
 	return color.RGBA{R: c.pix[start], G: c.pix[start+1], B: c.pix[start+2], A: c.pix[start+3]}
 }
 
-type glCanvas interface {
-	fyne.Canvas
-	TextureScale() float32
-}
-
 func (p *glPainter) Capture(c fyne.Canvas) image.Image {
 	pos := fyne.NewPos(c.Size().Width, c.Size().Height)
 	width, height := c.PixelCoordinateForPosition(pos)

--- a/internal/painter/gl/capture.go
+++ b/internal/painter/gl/capture.go
@@ -3,7 +3,6 @@ package gl
 import (
 	"image"
 	"image/color"
-	"runtime"
 
 	"fyne.io/fyne"
 )
@@ -32,12 +31,8 @@ type glCanvas interface {
 }
 
 func (p *glPainter) Capture(c fyne.Canvas) image.Image {
-	scale := c.Scale()
-	if gc, ok := c.(glCanvas); ok && runtime.GOOS == "darwin" { // macOS scaling is done at the texture level
-		scale = gc.TextureScale()
-	}
-	width := int(float32(c.Size().Width) * scale)
-	height := int(float32(c.Size().Height) * scale)
+	pos := fyne.NewPos(c.Size().Width, c.Size().Height)
+	width, height := c.PixelCoordinateForPosition(pos)
 	pixels := make([]uint8, width*height*4)
 
 	p.context.RunWithContext(func() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
On macOS retina screens, scaling is done at the texture level which can be 2.0. This change makes sure that ReadPixels ultimately captures the right amount of pixels from a canvas. I tested that this continues to work as a window is dragged back and forth between a retina and non-retina screen.

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
