### PR TITLE
Reorder some struct fields for memory savings

### DIFF
--- a/animation.go
+++ b/animation.go
@@ -22,11 +22,11 @@ var (
 // Animation represents an animated element within a Fyne canvas.
 // These animations may control individual objects or entire scenes.
 type Animation struct {
-	AutoReverse bool
 	Curve       AnimationCurve
 	Duration    time.Duration
-	Repeat      bool
 	Tick        func(float32)
+	AutoReverse bool
+	Repeat      bool
 }
 
 // NewAnimation creates a very basic animation where the callback function will be called for every

--- a/animation.go
+++ b/animation.go
@@ -21,7 +21,7 @@ var (
 
 // Animation represents an animated element within a Fyne canvas.
 // These animations may control individual objects or entire scenes.
-type Animation struct {
+type Animation struct { // NOTE: These structs are not in alphabetical order. They are structured using structslop to reduce padding and memory usage.
 	Curve       AnimationCurve
 	Duration    time.Duration
 	Tick        func(float32)

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -18,12 +18,11 @@ const (
 
 type fileDialogItem struct {
 	widget.BaseWidget
+	name      string
+	location  fyne.URI
 	picker    *fileDialog
 	isCurrent bool
-
-	name     string
-	location fyne.URI
-	dir      bool
+	dir       bool
 }
 
 func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -16,6 +16,7 @@ const (
 	fileIconCellWidth = fileIconSize * 1.25
 )
 
+// NOTE: These structs are not in alphabetical order. They are structured using structslop to reduce padding and memory usage.
 type fileDialogItem struct {
 	widget.BaseWidget
 	name      string


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This uses [structslop](https://github.com/orijtech/structslop) for specifying how structs should be laid out for best allocation efficiency. The animation struct is optimized for 33.3% memory savings and the fileitems in file dialog for 11.1% savings (the latter will be more noticeable with many files).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
