### PR TITLE
Proper dot escape in vedoring regexp and performance improvement

### DIFF
--- a/cmd/fyne/vendor.go
+++ b/cmd/fyne/vendor.go
@@ -22,12 +22,15 @@ const (
 	goModFile = "go.mod"
 	// goModVendorFile is the vendor module file
 	goModVendorFile = "vendor/modules.txt"
-	// glfwModNew is the glfw module regexp for 3.3+
-	glfwModNew = `github\.com/go-gl/glfw/(v(\d+\.)?(\*|\d)?(\*|\d+))/glfw`
-	// glfwModOld is the glfw module regexp for 3.2
-	glfwModOld = "github.com/go-gl/glfw"
 	// glfwModSrcDir is the glfw dir containing the c source code to copy
 	glfwModSrcDir = "glfw"
+)
+
+var (
+	// glfwModNew is the glfw module regexp for 3.3+
+	glfwModNew = regexp.MustCompile(`github\.com/go-gl/glfw/(v(\d+\.)?(\*|\d)?(\*|\d+))/glfw`)
+	// glfwModOld is the glfw module regexp for 3.2
+	glfwModOld = regexp.MustCompile(`github\.com/go-gl/glfw`)
 )
 
 // Declare conformity to command interface
@@ -122,13 +125,11 @@ func cacheModPath(r io.Reader) (string, string, error) {
 			continue
 		}
 
-		r, _ := regexp.Compile(glfwModNew)
-		if r.Match([]byte(s[1])) {
+		if glfwModNew.MatchString(s[1]) {
 			return filepath.Join(build.Default.GOPATH, "pkg/mod", s[1]+"@"+s[2]), s[1], nil
 		}
 
-		r, _ = regexp.Compile(glfwModOld)
-		if r.Match([]byte(s[1])) {
+		if glfwModOld.MatchString(s[1]) {
 			extra := "/v3.2/glfw"
 			return filepath.Join(build.Default.GOPATH, "pkg/mod", s[1]+"@"+s[2]+extra), s[1] + extra, nil
 		}

--- a/cmd/fyne/vendor_test.go
+++ b/cmd/fyne/vendor_test.go
@@ -9,19 +9,28 @@ import (
 )
 
 func Test_pkgModPath(t *testing.T) {
-	const mockModulesTxtMissing = `# github.com/go-gl/gl v0.0.0-20181026044259-55b76b7df9d2
-github.com/go-gl/gl/v3.2-core/gl
-# github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
-`
-	const mockModulesTxtMatch = `# github.com/go-gl/gl v0.0.0-20181026044259-55b76b7df9d2
-github.com/go-gl/gl/v3.2-core/gl
-# github.com/go-gl/glfw/v3.3/glfw v0.0.0-20181213070059-819e8ce5125f
-github.com/go-gl/glfw/v3.3/glfw
-# github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
-`
-	const mockModulesTxtOld = `# github.com/go-gl/glfw v0.0.0-20181213070059-819e8ce5125f
-github.com/go-gl/glfw/v3.2/glfw
-`
+	const (
+		mockModulesTxtMissing = `# github.com/go-gl/gl v0.0.0-20181026044259-55b76b7df9d2
+		github.com/go-gl/gl/v3.2-core/gl
+		# github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
+		`
+		mockModulesTxtMatch = `# github.com/go-gl/gl v0.0.0-20181026044259-55b76b7df9d2
+		github.com/go-gl/gl/v3.2-core/gl
+		# github.com/go-gl/glfw/v3.3/glfw v0.0.0-20181213070059-819e8ce5125f
+		github.com/go-gl/glfw/v3.3/glfw
+		# github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
+		`
+
+		mockModulesTxtOld = `# github.com/go-gl/glfw v0.0.0-20181213070059-819e8ce5125f
+		github.com/go-gl/glfw/v3.2/glfw
+		`
+
+		// Make sure to test correct escape for dots in regexp
+		mockModulesOldMalicious = `# github\com/go-gl/glfw v0.0.0-20181213070059-819e8ce5125f
+		github.com/go-gl/glfw/v3.2/glfw
+		`
+	)
+
 	type args struct {
 		r io.Reader
 	}
@@ -56,6 +65,14 @@ github.com/go-gl/glfw/v3.2/glfw
 			},
 			want:    filepath.Join(build.Default.GOPATH, "pkg/mod/github.com/go-gl/glfw@v0.0.0-20181213070059-819e8ce5125f/v3.2/glfw"),
 			target:  "github.com/go-gl/glfw/v3.2/glfw",
+			wantErr: false,
+		},
+		{
+			name: "No match (malicious)",
+			args: args{
+				r: strings.NewReader(mockModulesOldMalicious),
+			},
+			want:    "",
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This fixes a potential security vulnerability where the vendor command could accept a maliciously crafted path.
It also simplifies and improves the performance by only compiling regexp once not for each iteration in the for-loop and uses MatchString() instead of converting to []byte for each match.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### To reviewer:
- Please test to make sure that the `fyne vendor` command works on your machine.