### PR TITLE
Capture on draw thread to avoid gl race

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -52,7 +52,7 @@ func (c *glCanvas) AddShortcut(shortcut fyne.Shortcut, handler func(shortcut fyn
 
 func (c *glCanvas) Capture() image.Image {
 	var img image.Image
-	runOnMain(func() {
+	runOnDraw(c.context.(*window), func() {
 		img = c.painter.Capture(c)
 	})
 	return img


### PR DESCRIPTION
### Description:
Right now the glfw canvas Capture will run on the main thread which can contend with the draw thread in its draw loop which can cause spurious sig aborts. Moving Capture over to the draw thread as well resolves this issue.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.