### PR TITLE
Move the binding and preferences to 64bit int for consistency

### DIFF
--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -43,7 +43,7 @@ func TestPreferences_Load(t *testing.T) {
 	p.loadFromFile(filepath.Join("testdata", "preferences.json"))
 
 	assert.Equal(t, "value", p.String("keyString"))
-	assert.Equal(t, 4, p.Int("keyInt"))
+	assert.Equal(t, int64(4), p.Int("keyInt"))
 	assert.Equal(t, 3.5, p.Float("keyFloat"))
 	assert.Equal(t, true, p.Bool("keyBool"))
 }

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -111,27 +111,27 @@ func (b *boundFloat) Set(val float64) {
 	b.trigger()
 }
 
-// Int supports binding a int value.
+// Int supports binding a int64 value.
 //
 // Since: 2.0.0
 type Int interface {
 	DataItem
-	Get() int
-	Set(int)
+	Get() int64
+	Set(int64)
 }
 
-// NewInt returns a bindable int value that is managed internally.
+// NewInt returns a bindable int64 value that is managed internally.
 //
 // Since: 2.0.0
 func NewInt() Int {
-	blank := 0
+	blank := int64(0)
 	return &boundInt{val: &blank}
 }
 
-// BindInt returns a new bindable value that controls the contents of the provided int variable.
+// BindInt returns a new bindable value that controls the contents of the provided int64 variable.
 //
 // Since: 2.0.0
-func BindInt(v *int) Int {
+func BindInt(v *int64) Int {
 	if v == nil {
 		return NewInt() // never allow a nil value pointer
 	}
@@ -142,17 +142,17 @@ func BindInt(v *int) Int {
 type boundInt struct {
 	base
 
-	val *int
+	val *int64
 }
 
-func (b *boundInt) Get() int {
+func (b *boundInt) Get() int64 {
 	if b.val == nil {
-		return 0
+		return int64(0)
 	}
 	return *b.val
 }
 
-func (b *boundInt) Set(val int) {
+func (b *boundInt) Set(val int64) {
 	if *b.val == val {
 		return
 	}

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -163,29 +163,29 @@ func (l *boundFloatList) Set(i int, v float64) {
 	l.GetItem(i).(Float).Set(v)
 }
 
-// IntList supports binding a list of int values.
+// IntList supports binding a list of int64 values.
 //
 // Since: 2.0.0
 type IntList interface {
 	DataList
 
-	Append(int)
-	Get(int) int
-	Prepend(int)
-	Set(int, int)
+	Append(int64)
+	Get(int) int64
+	Prepend(int64)
+	Set(int, int64)
 }
 
-// NewIntList returns a bindable list of int values.
+// NewIntList returns a bindable list of int64 values.
 //
 // Since: 2.0.0
 func NewIntList() IntList {
 	return &boundIntList{}
 }
 
-// BindIntList returns a bound list of int values, based on the contents of the passed slice.
+// BindIntList returns a bound list of int64 values, based on the contents of the passed slice.
 //
 // Since: 2.0.0
-func BindIntList(v *[]int) IntList {
+func BindIntList(v *[]int64) IntList {
 	if v == nil {
 		return NewIntList()
 	}
@@ -202,10 +202,10 @@ func BindIntList(v *[]int) IntList {
 type boundIntList struct {
 	listBase
 
-	val *[]int
+	val *[]int64
 }
 
-func (l *boundIntList) Append(val int) {
+func (l *boundIntList) Append(val int64) {
 	if l.val != nil {
 		*l.val = append(*l.val, val)
 	}
@@ -213,9 +213,9 @@ func (l *boundIntList) Append(val int) {
 	l.appendItem(BindInt(&val))
 }
 
-func (l *boundIntList) Get(i int) int {
+func (l *boundIntList) Get(i int) int64 {
 	if i < 0 || i > l.Length() {
-		return 0
+		return int64(0)
 	}
 	if l.val != nil {
 		return (*l.val)[i]
@@ -224,15 +224,15 @@ func (l *boundIntList) Get(i int) int {
 	return l.GetItem(i).(Int).Get()
 }
 
-func (l *boundIntList) Prepend(val int) {
+func (l *boundIntList) Prepend(val int64) {
 	if l.val != nil {
-		*l.val = append([]int{val}, *l.val...)
+		*l.val = append([]int64{val}, *l.val...)
 	}
 
 	l.prependItem(BindInt(&val))
 }
 
-func (l *boundIntList) Set(i int, v int) {
+func (l *boundIntList) Set(i int, v int64) {
 	if i > l.Length() {
 		return
 	}

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -147,7 +147,7 @@ func (s *stringFromInt) Get() string {
 }
 
 func (s *stringFromInt) Set(str string) {
-	var val int
+	var val int64
 	n, err := fmt.Sscanf(str, s.format, &val)
 	if err != nil || n != 1 {
 		fyne.LogError("int parse error", err)
@@ -309,23 +309,23 @@ func StringToIntWithFormat(str String, format string) Int {
 	return v
 }
 
-func (s *stringToInt) Get() int {
+func (s *stringToInt) Get() int64 {
 	str := s.from.Get()
 	if str == "" {
-		return 0
+		return int64(0)
 	}
 
-	var val int
+	var val int64
 	n, err := fmt.Sscanf(str, s.format, &val)
 	if err != nil || n != 1 {
 		fyne.LogError("int parse error", err)
-		return 0
+		return int64(0)
 	}
 
 	return val
 }
 
-func (s *stringToInt) Set(val int) {
+func (s *stringToInt) Set(val int64) {
 	str := fmt.Sprintf(s.format, val)
 	if str == s.from.Get() {
 		return

--- a/data/binding/convert_test.go
+++ b/data/binding/convert_test.go
@@ -63,7 +63,7 @@ func TestIntToString(t *testing.T) {
 	assert.Equal(t, "3", s.Get())
 
 	s.Set("5")
-	assert.Equal(t, 5, i.Get())
+	assert.Equal(t, int64(5), i.Get())
 }
 
 func TestIntToStringWithFormat(t *testing.T) {
@@ -75,7 +75,7 @@ func TestIntToStringWithFormat(t *testing.T) {
 	assert.Equal(t, "num3", s.Get())
 
 	s.Set("num5")
-	assert.Equal(t, 5, i.Get())
+	assert.Equal(t, int64(5), i.Get())
 }
 
 func TestStringToBool(t *testing.T) {
@@ -131,10 +131,10 @@ func TestStringToFloatWithFormat(t *testing.T) {
 func TestStringToInt(t *testing.T) {
 	s := NewString()
 	i := StringToInt(s)
-	assert.Equal(t, 0, i.Get())
+	assert.Equal(t, int64(0), i.Get())
 
 	s.Set("3")
-	assert.Equal(t, 3, i.Get())
+	assert.Equal(t, int64(3), i.Get())
 
 	i.Set(5)
 	assert.Equal(t, "5", s.Get())
@@ -144,10 +144,10 @@ func TestStringToIntWithFormat(t *testing.T) {
 	start := "num0"
 	s := BindString(&start)
 	i := StringToIntWithFormat(s, "num%d")
-	assert.Equal(t, 0, i.Get())
+	assert.Equal(t, int64(0), i.Get())
 
 	s.Set("num3")
-	assert.Equal(t, 3, i.Get())
+	assert.Equal(t, int64(3), i.Get())
 
 	i.Set(5)
 	assert.Equal(t, "num5", s.Get())

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -374,7 +374,7 @@ var prefBinds = make(map[string]DataItem)
 	binds := []bindValues{
 		bindValues{Name: "Bool", Type: "bool", Default: "false", Format: "%t", SupportsPreferences: true},
 		bindValues{Name: "Float", Type: "float64", Default: "0.0", Format: "%f", SupportsPreferences: true},
-		bindValues{Name: "Int", Type: "int", Default: "0", Format: "%d", SupportsPreferences: true},
+		bindValues{Name: "Int", Type: "int64", Default: "int64(0)", Format: "%d", SupportsPreferences: true},
 		bindValues{Name: "Rune", Type: "rune", Default: "rune(0)"},
 		bindValues{Name: "String", Type: "string", Default: "\"\"", SupportsPreferences: true},
 	}

--- a/data/binding/preference.go
+++ b/data/binding/preference.go
@@ -82,7 +82,7 @@ type prefBoundInt struct {
 	p   fyne.Preferences
 }
 
-// BindPreferenceInt returns a bindable int value that is managed by the application preferences.
+// BindPreferenceInt returns a bindable int64 value that is managed by the application preferences.
 // Changes to this value will be saved to application storage and when the app starts the previous values will be read.
 //
 // Since: 2.0.0
@@ -99,11 +99,11 @@ func BindPreferenceInt(key string, p fyne.Preferences) Int {
 	return listen
 }
 
-func (b *prefBoundInt) Get() int {
+func (b *prefBoundInt) Get() int64 {
 	return b.p.Int(b.key)
 }
 
-func (b *prefBoundInt) Set(v int) {
+func (b *prefBoundInt) Set(v int64) {
 	b.p.SetInt(b.key, v)
 
 	b.trigger()

--- a/data/binding/preference_test.go
+++ b/data/binding/preference_test.go
@@ -43,11 +43,11 @@ func TestBindPreferenceInt(t *testing.T) {
 
 	p.SetInt(key, 4)
 	bind := BindPreferenceInt(key, p)
-	assert.Equal(t, 4, bind.Get())
+	assert.Equal(t, int64(4), bind.Get())
 
 	bind.Set(7)
-	assert.Equal(t, 7, bind.Get())
-	assert.Equal(t, 7, p.Int(key))
+	assert.Equal(t, int64(7), bind.Get())
+	assert.Equal(t, int64(7), p.Int(key))
 }
 
 func TestBindPreferenceString(t *testing.T) {

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -105,30 +105,37 @@ func (p *InMemoryPreferences) SetFloat(key string, value float64) {
 }
 
 // Int looks up an integer value for the key
-func (p *InMemoryPreferences) Int(key string) int {
+func (p *InMemoryPreferences) Int(key string) int64 {
 	return p.IntWithFallback(key, 0)
 }
 
 // IntWithFallback looks up an integer value and returns the given fallback if not found
-func (p *InMemoryPreferences) IntWithFallback(key string, fallback int) int {
+func (p *InMemoryPreferences) IntWithFallback(key string, fallback int64) int64 {
 	value, ok := p.get(key)
 	if !ok {
 		return fallback
 	}
 
 	// integers can be de-serialised as floats, so support both
-	if intVal, ok := value.(int); ok {
+	if intVal, ok := value.(int64); ok {
 		return intVal
+	}
+	if intVal, ok := value.(int); ok {
+		return int64(intVal)
 	}
 	val, ok := value.(float64)
 	if !ok {
-		return 0
+		val2, ok := value.(float32)
+		if !ok {
+			return 0
+		}
+		val = float64(val2)
 	}
-	return int(val)
+	return int64(val)
 }
 
 // SetInt saves an integer value for the given key
-func (p *InMemoryPreferences) SetInt(key string, value int) {
+func (p *InMemoryPreferences) SetInt(key string, value int64) {
 	p.set(key, value)
 }
 

--- a/internal/preferences_test.go
+++ b/internal/preferences_test.go
@@ -66,28 +66,28 @@ func TestPrefs_SetInt(t *testing.T) {
 	p := NewInMemoryPreferences()
 	p.SetInt("testInt", 5)
 
-	assert.Equal(t, 5, p.Int("testInt"))
+	assert.Equal(t, int64(5), p.Int("testInt"))
 }
 
 func TestPrefs_Int(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values()["testInt"] = 5
+	p.Values()["testInt"] = int64(5)
 
-	assert.Equal(t, 5, p.Int("testInt"))
+	assert.Equal(t, int64(5), p.Int("testInt"))
 }
 
 func TestPrefs_IntWithFallback(t *testing.T) {
 	p := NewInMemoryPreferences()
 
-	assert.Equal(t, 2, p.IntWithFallback("testInt", 2))
-	p.Values()["testInt"] = 5
-	assert.Equal(t, 5, p.IntWithFallback("testInt", 2))
+	assert.Equal(t, int64(2), p.IntWithFallback("testInt", 2))
+	p.Values()["testInt"] = int64(5)
+	assert.Equal(t, int64(5), p.IntWithFallback("testInt", 2))
 }
 
 func TestPrefs_Int_Zero(t *testing.T) {
 	p := NewInMemoryPreferences()
 
-	assert.Equal(t, 0, p.Int("testInt"))
+	assert.Equal(t, int64(0), p.Int("testInt"))
 }
 
 func TestPrefs_SetString(t *testing.T) {
@@ -145,6 +145,6 @@ func TestRemoveValue(t *testing.T) {
 
 	assert.Equal(t, false, p.Bool("dummy"))
 	assert.Equal(t, float64(0), p.Float("pi"))
-	assert.Equal(t, 0, p.Int("number"))
+	assert.Equal(t, int64(0), p.Int("number"))
 	assert.Equal(t, "", p.String("month"))
 }

--- a/preferences.go
+++ b/preferences.go
@@ -17,11 +17,11 @@ type Preferences interface {
 	SetFloat(key string, value float64)
 
 	// Int looks up an integer value for the key
-	Int(key string) int
+	Int(key string) int64
 	// IntWithFallback looks up an integer value and returns the given fallback if not found
-	IntWithFallback(key string, fallback int) int
+	IntWithFallback(key string, fallback int64) int64
 	// SetInt saves an integer value for the given key
-	SetInt(key string, value int)
+	SetInt(key string, value int64)
 
 	// String looks up a string value for the key
 	String(key string) string


### PR DESCRIPTION
This PR moves the data binding, and preferences API from `int` to `int64`.
After discovering that `int` could be 32 bit on some systems this makes it more consistent.

However the Go tour recommends to use `int` unless there is a reason not to.
This is a breaking change for Preferences, but not for the data binding which is not yet public.

I am considering that this change is not desirable after all... Thoughts?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [ ] Any breaking changes have a deprecation path or have been discussed.
