### PR TITLE
Fix implicit memory aliasing in list binding and fix file permissions

### DIFF
--- a/cmd/fyne/commands/bundle.go
+++ b/cmd/fyne/commands/bundle.go
@@ -58,7 +58,7 @@ func (b *bundler) Run(args []string) {
 			fileModes = os.O_RDWR | os.O_APPEND
 		}
 
-		f, err := os.OpenFile(b.out, fileModes, 0666)
+		f, err := os.OpenFile(b.out, fileModes, 0600)
 		if err == nil {
 			outFile = f
 		} else {

--- a/cmd/fyne/commands/package-mobile.go
+++ b/cmd/fyne/commands/package-mobile.go
@@ -31,7 +31,7 @@ func (p *packager) packageIOS() error {
     "author" : "xcode",
     "version" : 1
   }
-}`), 0644)
+}`), 0600)
 	if err != nil {
 		fyne.LogError("Content err", err)
 	}

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -171,7 +171,7 @@ func (s *Settings) saveToFile(path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, data, 0644)
+	return ioutil.WriteFile(path, data, 0600)
 }
 
 type colorButton struct {

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -32,8 +32,8 @@ func BindBoolList(v *[]bool) BoolList {
 
 	b := &boundBoolList{val: v}
 
-	for _, i := range *v {
-		b.appendItem(BindBool(&i))
+	for i := range *v {
+		b.appendItem(BindBool(&(*v)[i]))
 	}
 
 	return b
@@ -113,7 +113,7 @@ func BindFloatList(v *[]float64) FloatList {
 	b := &boundFloatList{val: v}
 
 	for i := range *v {
-		b.appendItem(BindFloat(&((*v)[i])))
+		b.appendItem(BindFloat(&(*v)[i]))
 	}
 
 	return b
@@ -192,8 +192,8 @@ func BindIntList(v *[]int) IntList {
 
 	b := &boundIntList{val: v}
 
-	for _, i := range *v {
-		b.appendItem(BindInt(&i))
+	for i := range *v {
+		b.appendItem(BindInt(&(*v)[i]))
 	}
 
 	return b
@@ -272,8 +272,8 @@ func BindRuneList(v *[]rune) RuneList {
 
 	b := &boundRuneList{val: v}
 
-	for _, i := range *v {
-		b.appendItem(BindRune(&i))
+	for i := range *v {
+		b.appendItem(BindRune(&(*v)[i]))
 	}
 
 	return b
@@ -352,8 +352,8 @@ func BindStringList(v *[]string) StringList {
 
 	b := &boundStringList{val: v}
 
-	for _, i := range *v {
-		b.appendItem(BindString(&i))
+	for i := range *v {
+		b.appendItem(BindString(&(*v)[i]))
 	}
 
 	return b

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -246,8 +246,8 @@ func Bind{{ .Name }}List(v *[]{{ .Type }}) {{ .Name }}List {
 
 	b := &bound{{ .Name }}List{val: v}
 
-	for _, i := range *v {
-		b.appendItem(Bind{{ .Name }}(&i))
+	for i := range *v {
+		b.appendItem(Bind{{ .Name }}(&(*v)[i]))
 	}
 
 	return b

--- a/internal/test/util.go
+++ b/internal/test/util.go
@@ -83,7 +83,7 @@ func pixelsForImage(t *testing.T, img image.Image) []uint8 {
 }
 
 func writeImage(path string, img image.Image) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return err
 	}
 	f, err := os.Create(path)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This fixes a potential security issue in the list bindings where it was acting on a pointer to a single variable. We now instead make sure to de-reference the pointer and grab the correct value at the position in the slice. See [this link](https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop#62486667) for more information. It also fixes some file and directory permissions that were too high.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
