### PR TITLE
Windows Test_listable_uri failing

### DIFF
--- a/internal/driver/glfw/file_test.go
+++ b/internal/driver/glfw/file_test.go
@@ -102,9 +102,9 @@ func Test_ListableURI(t *testing.T) {
 	}
 
 	expect := []string{
-		"file://" + filepath.Join(tempdir, "aaa"),
-		"file://" + filepath.Join(tempdir, "bbb"),
-		"file://" + filepath.Join(tempdir, "ccc"),
+		"file://" + filepath.ToSlash(filepath.Join(tempdir, "aaa")),
+		"file://" + filepath.ToSlash(filepath.Join(tempdir, "bbb")),
+		"file://" + filepath.ToSlash(filepath.Join(tempdir, "ccc")),
 	}
 
 	assert.ElementsMatch(t, listingStrings, expect)


### PR DESCRIPTION
### Description:
When running tests on windows the file_test.go fails due to a comparison of file URIs having backslashes instead of forward-slashes.

`2020/12/22 14:52:33 Fyne error:  Failed to focus object which is not part of the canvas’ content, menu or overlays.
2020/12/22 14:52:33   At: C:/Users/Adrian/go/src/github.com/adrianre12/fyne/internal/driver/glfw/canvas.go:85
--- FAIL: Test_ListableURI (0.01s)
    file_test.go:100: stringify URI file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/aaa to file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/aaa
    file_test.go:100: stringify URI file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/bbb to file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/bbb
    file_test.go:100: stringify URI file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/ccc to file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/ccc
    file_test.go:110:
                Error Trace:    file_test.go:110
                Error:          element file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/aaa appears more times in [file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/aaa file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/bbb file://C:/Users/Adrian/AppData/Local/Temp/file_test688170063/ccc] than in [file://C:\Users\Adrian\AppData\Local\Temp\file_test688170063\aaa file://C:\Users\Adrian\AppData\Local\Temp\file_test688170063\bbb file://C:\Users\Adrian\AppData\Local\Temp\file_test688170063\ccc]
                Test:           Test_ListableURI
2020/12/22 14:52:35 Fyne error:  Main menu must have at least one child menu
2020/12/22 14:52:35   At: C:/Users/Adrian/go/src/github.com/adrianre12/fyne/internal/driver/glfw/menu.go:9
FAIL
FAIL    fyne.io/fyne/internal/driver/glfw       15.139s
`
### Checklist:
- [x] Tests included.
- [ ] Lint and formatter run with no errors.
- [x ] Tests all pass.
