### PR TITLE
sticking plaster fix for clipboard test failure

### DIFF
--- a/internal/driver/glfw/clipboard.go
+++ b/internal/driver/glfw/clipboard.go
@@ -1,6 +1,9 @@
 package glfw
 
 import (
+	"runtime"
+	"time"
+
 	"fyne.io/fyne"
 
 	"github.com/go-gl/glfw/v3.3/glfw"
@@ -16,6 +19,22 @@ type clipboard struct {
 
 // Content returns the clipboard content
 func (c *clipboard) Content() string {
+	// This retry logic is to work arround the "Access Denied" error often thrown in windows PR#1679
+	if runtime.GOOS != "windows" {
+		return c.content()
+	}
+	for i := 3; i > 0; i-- {
+		cb := c.content()
+		if cb != "" {
+			return cb
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	//can't log retry as it would alos log errors for an empty clipboard
+	return ""
+}
+
+func (c *clipboard) content() string {
 	content := ""
 	runOnMain(func() {
 		content = glfw.GetClipboardString()
@@ -25,6 +44,22 @@ func (c *clipboard) Content() string {
 
 // SetContent sets the clipboard content
 func (c *clipboard) SetContent(content string) {
+	// This retry logic is to work arround the "Access Denied" error often thrown in windows PR#1679
+	if runtime.GOOS != "windows" {
+		c.setContent(content)
+		return
+	}
+	for i := 3; i > 0; i-- {
+		c.setContent(content)
+		if c.content() == content {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	fyne.LogError("GLFW clipboard set failed", nil)
+}
+
+func (c *clipboard) setContent(content string) {
 	runOnMain(func() {
 		defer func() {
 			if r := recover(); r != nil {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -851,7 +851,7 @@ func TestWindow_Clipboard(t *testing.T) {
 	text := "My content from test window"
 	cb := w.Clipboard()
 
-	cliboardContent := cb.Content() // this sometimes fails but does not break the test, just means the CB is not restored at the end.
+	cliboardContent := cb.Content()
 	if cliboardContent != "" {
 		// Current environment has some content stored in clipboard,
 		// set temporary to an empty string to allow test and restore later.
@@ -860,19 +860,8 @@ func TestWindow_Clipboard(t *testing.T) {
 
 	assert.Empty(t, cb.Content())
 
-	cb.SetContent(text) // if this fails it will get caught by the retry
-
-	cbText := cb.Content() // if this fails it will get caught by the retry
-	i := 0
-	for cbText == "" && i < 3 { // retry sticking plaster fix for CB Access Denied error
-		t.Log("Clipboard Retry")
-		i++
-		time.Sleep(time.Duration(i*500) * time.Millisecond)
-		cb.SetContent(text)
-		cbText = cb.Content()
-	}
-
-	assert.Equal(t, text, cbText)
+	cb.SetContent(text)
+	assert.Equal(t, text, cb.Content())
 
 	// Restore clipboardContent, if any
 	cb.SetContent(cliboardContent) // this can fail but does not break the test, just means the CB is not restored.

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -851,14 +851,14 @@ func TestWindow_Clipboard(t *testing.T) {
 	text := "My content from test window"
 	cb := w.Clipboard()
 
-	cliboardContent := cb.Content() // this fails but does not break the test
+	cliboardContent := cb.Content() // this sometimes fails but does not break the test, just means the CB is not restored at the end.
 	if cliboardContent != "" {
 		// Current environment has some content stored in clipboard,
 		// set temporary to an empty string to allow test and restore later.
-		cb.SetContent("") // this fails but does not break the test
+		cb.SetContent("")
 	}
 
-	assert.Empty(t, cb.Content()) // this fails but does not break the test
+	assert.Empty(t, cb.Content())
 
 	cb.SetContent(text) // if this fails it will get caught by the retry
 
@@ -875,7 +875,7 @@ func TestWindow_Clipboard(t *testing.T) {
 	assert.Equal(t, text, cbText)
 
 	// Restore clipboardContent, if any
-	cb.SetContent(cliboardContent) // this fails but does not break the test
+	cb.SetContent(cliboardContent) // this can fail but does not break the test, just means the CB is not restored
 }
 
 func TestWindow_CloseInterception(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -864,7 +864,7 @@ func TestWindow_Clipboard(t *testing.T) {
 	assert.Equal(t, text, cb.Content())
 
 	// Restore clipboardContent, if any
-	cb.SetContent(cliboardContent) // this can fail but does not break the test, just means the CB is not restored.
+	cb.SetContent(cliboardContent)
 }
 
 func TestWindow_CloseInterception(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -851,20 +851,31 @@ func TestWindow_Clipboard(t *testing.T) {
 	text := "My content from test window"
 	cb := w.Clipboard()
 
-	cliboardContent := cb.Content()
+	cliboardContent := cb.Content() // this fails but does not break the test
 	if cliboardContent != "" {
 		// Current environment has some content stored in clipboard,
 		// set temporary to an empty string to allow test and restore later.
-		cb.SetContent("")
+		cb.SetContent("") // this fails but does not break the test
 	}
 
-	assert.Empty(t, cb.Content())
+	assert.Empty(t, cb.Content()) // this fails but does not break the test
 
-	cb.SetContent(text)
-	assert.Equal(t, text, cb.Content())
+	cb.SetContent(text) // if this fails it will get caught by the retry
+
+	cbText := cb.Content() // if this fails it will get caught by the retry
+	i := 0
+	for cbText == "" && i < 3 { // retry sticking plaster fix for CB Access Denied error
+		t.Log("Clipboard Retry")
+		i++
+		time.Sleep(time.Duration(i*500) * time.Millisecond)
+		cb.SetContent(text)
+		cbText = cb.Content()
+	}
+
+	assert.Equal(t, text, cbText)
 
 	// Restore clipboardContent, if any
-	cb.SetContent(cliboardContent)
+	cb.SetContent(cliboardContent) // this fails but does not break the test
 }
 
 func TestWindow_CloseInterception(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -875,7 +875,7 @@ func TestWindow_Clipboard(t *testing.T) {
 	assert.Equal(t, text, cbText)
 
 	// Restore clipboardContent, if any
-	cb.SetContent(cliboardContent) // this can fail but does not break the test, just means the CB is not restored
+	cb.SetContent(cliboardContent) // this can fail but does not break the test, just means the CB is not restored.
 }
 
 func TestWindow_CloseInterception(t *testing.T) {


### PR DESCRIPTION
### Description:
This is a sticking plaster fix for the Clipboard Access Denied error when running tests on windows.
Really the glfw should expose the error for correct retry handling, but this retry means at least the Fyne test will pass on windows. Most of the time it now passes with one retry but I have seen two.
I had to run the test 14 times before I could get an example output where the test passed without a retry.
`$ go clean -testcache ./... ; go test ./... -v | grep "Clipboard"
=== RUN   TestWindow_Clipboard
    window_test.go:868: Clipboard Retry
--- PASS: TestWindow_Clipboard (0.55s)

$ go clean -testcache ./... ; go test ./... -v | grep "Clipboard"
=== RUN   TestWindow_Clipboard
--- PASS: TestWindow_Clipboard (0.07s)`

Fixes #1679

### Checklist:
- [ N/A ] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
