### PR TITLE
Fix/structmapbindissues

### DIFF
--- a/data/binding/mapbinding.go
+++ b/data/binding/mapbinding.go
@@ -49,12 +49,21 @@ func BindUntypedMap(d *map[string]interface{}) UntypedMap {
 	return m
 }
 
+// Struct is the base interface for a bound struct type.
+//
+// Since: 2.0.0
+type Struct interface {
+	DataMap
+	Get(string) (interface{}, error)
+	Set(string, interface{}) error
+}
+
 // BindStruct creates a new map binding of string to interface{} using the struct passed as data.
 // The key for each item is a string representation of each exported field with the value set as an interface{}.
 // Only exported fields are included.
 //
 // Since: 2.0.0
-func BindStruct(i interface{}) DataMap {
+func BindStruct(i interface{}) Struct {
 	if i == nil {
 		return NewUntypedMap()
 	}

--- a/data/binding/mapbinding_test.go
+++ b/data/binding/mapbinding_test.go
@@ -115,7 +115,7 @@ func TestUntypedMap_Delete(t *testing.T) {
 	b.Delete("foo")
 	assert.Equal(t, 1, len(b.Keys()))
 	v, err = b.Get("foo")
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	assert.Equal(t, nil, v)
 	v, err = b.Get("val")
 	assert.Nil(t, err)


### PR DESCRIPTION
Two realisations came to me in finishing the chapter on data binding:
1) Structs did not have Get/Set exported
2) The map setter was not working in all cases

This PR addresses both of those concerns.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included. <- fixed broken test
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
