### PR TITLE
Fix the release build flag for mobile

### DIFF
--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -321,6 +321,9 @@ func goCmdAt(at string, subcmd string, srcs []string, env []string, args ...stri
 	if targetOS == "darwin" {
 		tags = append(tags, "ios")
 	}
+	if buildRelease {
+		tags = append(tags, "release")
+	}
 	if len(tags) > 0 {
 		cmd.Args = append(cmd.Args, "-tags", strings.Join(tags, " "))
 	}


### PR DESCRIPTION
Release tag had been missed off mobile builds, oops

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- nothing around the mobile output package can be/is validated :(
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable: