### PR TITLE
Reset dir to startingLocation on dismiss or save in file dialog

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -29,7 +29,10 @@ type fileDialog struct {
 
 	win      *widget.PopUp
 	selected *fileDialogItem
-	dir      fyne.ListableURI
+
+	dir              fyne.ListableURI
+	startingLocation fyne.ListableURI // To be able to change back when dismitting the dialog
+
 	// this will be the initial filename in a FileDialog in save mode
 	initialFileName string
 }
@@ -132,6 +135,10 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 			}
 			callback(f.dir, nil)
 		}
+
+		if f.dir != f.startingLocation {
+			f.setLocation(f.startingLocation)
+		}
 	})
 	f.open.Style = widget.PrimaryButton
 	f.open.Disable()
@@ -155,6 +162,10 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 			} else {
 				f.file.callback.(func(fyne.URIReadCloser, error))(nil, nil)
 			}
+		}
+
+		if f.dir != f.startingLocation {
+			f.setLocation(f.startingLocation)
 		}
 	})
 	buttons := widget.NewHBox(f.dismiss, f.open)
@@ -397,8 +408,8 @@ func showFile(file *FileDialog) *fileDialog {
 	d := &fileDialog{file: file, initialFileName: file.initialFileName}
 	ui := d.makeUI()
 
-	file.startingLocation = file.effectiveStartingDir() // To make sure that we always start at the starting location
-	d.setLocation(file.startingLocation)
+	d.startingLocation = file.effectiveStartingDir()
+	d.setLocation(d.startingLocation)
 
 	size := ui.MinSize().Add(fyne.NewSize(fileIconCellWidth*2+theme.Padding()*4,
 		(fileIconSize+fileTextSize)+theme.Padding()*4))
@@ -423,10 +434,6 @@ func (f *FileDialog) Show() {
 	}
 
 	if f.dialog != nil {
-		if f.dialog.dir != f.startingLocation { // Make sure to start at the starting location
-			f.dialog.setLocation(f.startingLocation)
-		}
-
 		f.dialog.win.Show()
 		return
 	}

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -397,7 +397,8 @@ func showFile(file *FileDialog) *fileDialog {
 	d := &fileDialog{file: file, initialFileName: file.initialFileName}
 	ui := d.makeUI()
 
-	d.setLocation(file.effectiveStartingDir())
+	file.startingLocation = file.effectiveStartingDir() // To make sure that we always start at the starting location
+	d.setLocation(file.startingLocation)
 
 	size := ui.MinSize().Add(fyne.NewSize(fileIconCellWidth*2+theme.Padding()*4,
 		(fileIconSize+fileTextSize)+theme.Padding()*4))
@@ -420,7 +421,12 @@ func (f *FileDialog) Show() {
 			return
 		}
 	}
+
 	if f.dialog != nil {
+		if f.dialog.dir != f.startingLocation { // Make sure to start at the starting location
+			f.dialog.setLocation(f.startingLocation)
+		}
+
 		f.dialog.win.Show()
 		return
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Saving a reference to the dialog and then reusing it be calling .Show() led to it being at the last used location.
This change makes sure that we return to the start directory on calling .Show().

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
