### PR TITLE
Improve detection of SVG from resources in case name was wrong

### DIFF
--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -28,9 +28,11 @@ func PaintImage(img *canvas.Image, c fyne.Canvas, width, height int) image.Image
 
 	switch {
 	case img.File != "" || img.Resource != nil:
-		var file io.Reader
-		var name string
-		isSVG := false
+		var (
+			file  io.Reader
+			name  string
+			isSVG bool
+		)
 		if img.Resource != nil {
 			name = img.Resource.Name()
 			file = bytes.NewReader(img.Resource.Content())
@@ -180,9 +182,9 @@ func isResourceSVG(res fyne.Resource) bool {
 		return false
 	}
 
-	switch strings.ToUpper(string(res.Content()[:5])) {
-		case "<!DOC", "<?xml", "<svg ":
-			return true
+	switch strings.ToLower(string(res.Content()[:5])) {
+	case "<!doc", "<?xml", "<svg ":
+		return true
 	}
 	return false
 }

--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -180,14 +180,9 @@ func isResourceSVG(res fyne.Resource) bool {
 		return false
 	}
 
-	if strings.ToUpper(string(res.Content()[:5])) == "<!DOC" {
-		return true
-	}
-	if strings.ToLower(string(res.Content()[:5])) == "<?xml" {
-		return true
-	}
-	if strings.ToLower(string(res.Content()[:5])) == "<svg " {
-		return true
+	switch strings.ToUpper(string(res.Content()[:5])) {
+		case "<!DOC", "<?xml", "<svg ":
+			return true
 	}
 	return false
 }

--- a/internal/painter/image_internal_test.go
+++ b/internal/painter/image_internal_test.go
@@ -1,0 +1,32 @@
+package painter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne"
+)
+
+func TestIsFileSVG(t *testing.T) {
+	assert.True(t, isFileSVG("test.svg"))
+	assert.True(t, isFileSVG("test.SVG"))
+	assert.False(t, isFileSVG("testsvg"))
+	assert.False(t, isFileSVG("test.png"))
+}
+
+func TestIsResourceSVG(t *testing.T) {
+	res, err := fyne.LoadResourceFromPath("./testdata/stroke.svg")
+	assert.Nil(t, err)
+	assert.True(t, isResourceSVG(res))
+
+	res.(*fyne.StaticResource).StaticName = "stroke"
+	assert.True(t, isResourceSVG(res))
+
+	svgString := "<svg version=\"1.1\"></svg>"
+	res.(*fyne.StaticResource).StaticContent = []byte(svgString)
+	assert.True(t, isResourceSVG(res))
+
+	res.(*fyne.StaticResource).StaticContent = []byte("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + svgString)
+	assert.True(t, isResourceSVG(res))
+}


### PR DESCRIPTION
Fixes a common case when someone names their svg resource "myImage".
We can't really do this for files as they are streamed off the filesystem. However in those cases it is likely named correctly.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
