### PR TITLE
Use unique identifier for mac notifications instead of incremental integer

### DIFF
--- a/app/app_darwin.m
+++ b/app/app_darwin.m
@@ -22,8 +22,6 @@ extern void themeChanged();
 
 @end
 
-static int notifyNum = 0;
-
 void sendNSUserNotification(const char *, const char *);
 
 bool isBundled() {
@@ -40,10 +38,12 @@ void sendNotification(const char *title, const char *body) {
     if (center.delegate == nil) {
         center.delegate = [[FyneUserNotificationCenterDelegate new] autorelease];
     }
+
+    NSString *uuid = [[NSUUID UUID] UUIDString];
     NSUserNotification *notification = [[NSUserNotification new] autorelease];
     notification.title = [NSString stringWithUTF8String:title];
     notification.informativeText = [NSString stringWithUTF8String:body];
-    notification.identifier = [NSString stringWithFormat:@"%@-fyne-notify-%d", [[NSBundle mainBundle] bundleIdentifier], ++notifyNum];
+    notification.identifier = [NSString stringWithFormat:@"%@-fyne-notify-%@", [[NSBundle mainBundle] bundleIdentifier], uuid];
     [center scheduleNotification:notification];
 }
 


### PR DESCRIPTION
### Description:
On macOS, an incremental counter is used for notification identifier. So, notifications are not shown on subsequent app runs after the first run due to duplicate identifiers. Use unique identifiers instead of a counter to solve this.

Fixes #1699 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
