### PR TITLE
Align size and position to closest pixel for crisp output

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -2,6 +2,7 @@ package gl
 
 import (
 	"image/color"
+	"math"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
@@ -117,6 +118,7 @@ func (p *glPainter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyn
 func (p *glPainter) rectCoords(size fyne.Size, pos fyne.Position, frame fyne.Size,
 	fill canvas.ImageFill, aspect float32, pad float32) []float32 {
 	size, pos = rectInnerCoords(size, pos, fill, aspect)
+	size, pos = roundToPixelCoords(size, pos, p.canvas.Scale()*p.texScale)
 
 	xPos := (pos.X - pad) / frame.Width
 	x1 := -1 + xPos*2
@@ -155,6 +157,23 @@ func rectInnerCoords(size fyne.Size, pos fyne.Position, fill canvas.ImageFill, a
 
 		return fyne.NewSize(newWidth, newHeight), fyne.NewPos(pos.X+widthPad, pos.Y+heightPad)
 	}
+
+	return size, pos
+}
+
+func roundToPixel(v float32, pixScale float32) float32 {
+	if pixScale == 1.0 {
+		return float32(math.Round(float64(v)))
+	}
+
+	return float32(math.Round(float64(v*pixScale))) / pixScale
+}
+
+func roundToPixelCoords(size fyne.Size, pos fyne.Position, pixScale float32) (fyne.Size, fyne.Position) {
+	size.Width = roundToPixel(size.Width, pixScale)
+	size.Height = roundToPixel(size.Height, pixScale)
+	pos.X = roundToPixel(pos.X, pixScale)
+	pos.Y = roundToPixel(pos.Y, pixScale)
 
 	return size, pos
 }

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -9,52 +9,6 @@ import (
 	"fyne.io/fyne/internal/painter"
 )
 
-func rectInnerCoords(size fyne.Size, pos fyne.Position, fill canvas.ImageFill, aspect float32) (fyne.Size, fyne.Position) {
-	if fill == canvas.ImageFillContain || fill == canvas.ImageFillOriginal {
-		// change pos and size accordingly
-
-		viewAspect := size.Width / size.Height
-
-		newWidth, newHeight := size.Width, size.Height
-		widthPad, heightPad := float32(0), float32(0)
-		if viewAspect > aspect {
-			newWidth = size.Height * aspect
-			widthPad = (size.Width - newWidth) / 2
-		} else if viewAspect < aspect {
-			newHeight = size.Width / aspect
-			heightPad = (size.Height - newHeight) / 2
-		}
-
-		return fyne.NewSize(newWidth, newHeight), fyne.NewPos(pos.X+widthPad, pos.Y+heightPad)
-	}
-
-	return size, pos
-}
-
-// rectCoords calculates the openGL coordinate space of a rectangle
-func (p *glPainter) rectCoords(size fyne.Size, pos fyne.Position, frame fyne.Size,
-	fill canvas.ImageFill, aspect float32, pad float32) []float32 {
-	size, pos = rectInnerCoords(size, pos, fill, aspect)
-
-	xPos := (pos.X - pad) / frame.Width
-	x1 := -1 + xPos*2
-	x2Pos := (pos.X + size.Width + pad) / frame.Width
-	x2 := -1 + x2Pos*2
-
-	yPos := (pos.Y - pad) / frame.Height
-	y1 := 1 - yPos*2
-	y2Pos := (pos.Y + size.Height + pad) / frame.Height
-	y2 := 1 - y2Pos*2
-
-	return []float32{
-		// coord x, y, z texture x, y
-		x1, y2, 0, 0.0, 1.0, // top left
-		x1, y1, 0, 0.0, 0.0, // bottom left
-		x2, y2, 0, 1.0, 1.0, // top right
-		x2, y1, 0, 1.0, 0.0, // bottom right
-	}
-}
-
 func (p *glPainter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canvasObject fyne.CanvasObject) Texture,
 	pos fyne.Position, size, frame fyne.Size, fill canvas.ImageFill, alpha float32, pad float32) {
 
@@ -157,4 +111,50 @@ func (p *glPainter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyn
 	case fyne.Widget:
 		p.drawWidget(obj, pos, frame)
 	}
+}
+
+// rectCoords calculates the openGL coordinate space of a rectangle
+func (p *glPainter) rectCoords(size fyne.Size, pos fyne.Position, frame fyne.Size,
+	fill canvas.ImageFill, aspect float32, pad float32) []float32 {
+	size, pos = rectInnerCoords(size, pos, fill, aspect)
+
+	xPos := (pos.X - pad) / frame.Width
+	x1 := -1 + xPos*2
+	x2Pos := (pos.X + size.Width + pad) / frame.Width
+	x2 := -1 + x2Pos*2
+
+	yPos := (pos.Y - pad) / frame.Height
+	y1 := 1 - yPos*2
+	y2Pos := (pos.Y + size.Height + pad) / frame.Height
+	y2 := 1 - y2Pos*2
+
+	return []float32{
+		// coord x, y, z texture x, y
+		x1, y2, 0, 0.0, 1.0, // top left
+		x1, y1, 0, 0.0, 0.0, // bottom left
+		x2, y2, 0, 1.0, 1.0, // top right
+		x2, y1, 0, 1.0, 0.0, // bottom right
+	}
+}
+
+func rectInnerCoords(size fyne.Size, pos fyne.Position, fill canvas.ImageFill, aspect float32) (fyne.Size, fyne.Position) {
+	if fill == canvas.ImageFillContain || fill == canvas.ImageFillOriginal {
+		// change pos and size accordingly
+
+		viewAspect := size.Width / size.Height
+
+		newWidth, newHeight := size.Width, size.Height
+		widthPad, heightPad := float32(0), float32(0)
+		if viewAspect > aspect {
+			newWidth = size.Height * aspect
+			widthPad = (size.Width - newWidth) / 2
+		} else if viewAspect < aspect {
+			newHeight = size.Width / aspect
+			heightPad = (size.Height - newHeight) / 2
+		}
+
+		return fyne.NewSize(newWidth, newHeight), fyne.NewPos(pos.X+widthPad, pos.Y+heightPad)
+	}
+
+	return size, pos
 }

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -118,7 +118,7 @@ func (p *glPainter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyn
 func (p *glPainter) rectCoords(size fyne.Size, pos fyne.Position, frame fyne.Size,
 	fill canvas.ImageFill, aspect float32, pad float32) []float32 {
 	size, pos = rectInnerCoords(size, pos, fill, aspect)
-	size, pos = roundToPixelCoords(size, pos, p.canvas.Scale()*p.texScale)
+	size, pos = roundToPixelCoords(size, pos, p.pixScale)
 
 	xPos := (pos.X - pad) / frame.Width
 	x1 := -1 + xPos*2

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -75,8 +75,9 @@ func (p *glPainter) Free(obj fyne.CanvasObject) {
 
 func (p *glPainter) textureScale(v float32) float32 {
 	if p.canvas.Scale() == 1.0 && p.texScale == 1.0 {
-		return v
+		return float32(math.Round(float64(v)))
 	}
+
 	return float32(math.Round(float64(v * p.canvas.Scale() * p.texScale)))
 }
 

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -41,10 +41,12 @@ type glPainter struct {
 	context  driver.WithContext
 	program  Program
 	texScale float32
+	pixScale float32 // pre-calculate scale*texScale for each draw
 }
 
 func (p *glPainter) SetFrameBufferScale(scale float32) {
 	p.texScale = scale
+	p.pixScale = p.canvas.Scale() * p.texScale
 }
 
 func (p *glPainter) Clear() {
@@ -74,11 +76,11 @@ func (p *glPainter) Free(obj fyne.CanvasObject) {
 }
 
 func (p *glPainter) textureScale(v float32) float32 {
-	if p.canvas.Scale() == 1.0 && p.texScale == 1.0 {
+	if p.pixScale == 1.0 {
 		return float32(math.Round(float64(v)))
 	}
 
-	return float32(math.Round(float64(v * p.canvas.Scale() * p.texScale)))
+	return float32(math.Round(float64(v * p.pixScale)))
 }
 
 var startCacheMonitor = &sync.Once{}
@@ -87,7 +89,7 @@ var startCacheMonitor = &sync.Once{}
 // If it is a master painter it will also initialise OpenGL
 func NewPainter(c fyne.Canvas, ctx driver.WithContext) Painter {
 	p := &glPainter{canvas: c, context: ctx}
-	p.texScale = 1.0
+	p.SetFrameBufferScale(1.0)
 
 	glInit()
 	startCacheMonitor.Do(func() {


### PR DESCRIPTION
This is most noticable on low resolution screens where the new floating-point position could look fuzzy (most notably text, but also lines etc).
Not only does it now look as crisp as when we used integers I think that on a HiDPI this now looks exceptional :)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- GL only, just look at any app and see that the text is clear
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
