### PR TITLE
Remove deprecated SetScale functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ These changes likely break some apps, please read the
 * The desktop.Cursor definition was renamed desktop.StandardCursor to make way for custom cursors
 
 * Dialogs no longer show when created, unless using the ShowXxx convenience methods
-* Removed deprecated types including dialog.FileIcon (now widget.FileIcon)
+* Removed deprecated types including:
+  - dialog.FileIcon (now widget.FileIcon)
+  - canvas.SetScale()
 * iOS apps preferences will be lost in this upgrade as we move to more advanced storage
 
 ### Added

--- a/canvas.go
+++ b/canvas.go
@@ -21,10 +21,6 @@ type Canvas interface {
 	// Scale returns the current scale (multiplication factor) this canvas uses to render
 	// The pixel size of a CanvasObject can be found by multiplying by this value.
 	Scale() float32
-	// SetScale sets ths scale for this canvas only, overriding system and user settings.
-	//
-	// Deprecated: Settings are now calculated solely on the user configuration and system setup.
-	SetScale(float32)
 
 	// Overlay returns the current overlay.
 	//

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -34,7 +34,6 @@ func ApplyThemeTo(content fyne.CanvasObject, canv fyne.Canvas) {
 func ApplySettings(set fyne.Settings, app fyne.App) {
 	for _, window := range app.Driver().AllWindows() {
 		ApplyThemeTo(window.Content(), window.Canvas())
-		window.Canvas().SetScale(set.Scale())
 
 		for _, overlay := range window.Canvas().Overlays().List() {
 			ApplyThemeTo(overlay, window.Canvas())

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -243,10 +243,7 @@ func (c *glCanvas) SetPadded(padded bool) {
 	c.content.Move(c.contentPos())
 }
 
-// SetScale sets the render scale for this specific canvas
-//
-// Deprecated: Settings are now calculated solely on the user configuration and system setup.
-func (c *glCanvas) SetScale(_ float32) {
+func (c *glCanvas) reloadScale() {
 	if !c.context.(*window).visible {
 		return
 	}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -193,6 +193,9 @@ func (d *gLDriver) startDrawThread() {
 				}
 			case <-settingsChange:
 				painter.ClearFontCache()
+				for _, win := range d.windowList() {
+					go win.Canvas().(*glCanvas).reloadScale()
+				}
 			case <-draw.C:
 				for _, win := range d.windowList() {
 					w := win.(*window)

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -520,7 +520,7 @@ func (w *window) moved(_ *glfw.Window, x, y int) {
 	}
 
 	w.canvas.detectedScale = w.detectScale()
-	go w.canvas.SetScale(fyne.SettingsScaleAuto) // scale is ignored
+	go w.canvas.reloadScale()
 }
 
 func (w *window) resized(_ *glfw.Window, width, height int) {

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -192,11 +192,6 @@ func (c *mobileCanvas) Scale() float32 {
 	return c.scale
 }
 
-// Deprecated: Settings are now calculated solely on the user configuration and system setup.
-func (c *mobileCanvas) SetScale(_ float32) {
-	c.scale = fyne.CurrentDevice().SystemScaleForWindow(nil) // we don't need a window parameter on mobile
-}
-
 func (c *mobileCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
 	return int(float32(pos.X) * c.scale), int(float32(pos.Y) * c.scale)
 }

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -131,7 +131,6 @@ func (d *mobileDriver) Run() {
 				dev.safeLeft = e.InsetLeftPx
 				dev.safeHeight = e.HeightPx - e.InsetTopPx - e.InsetBottomPx
 				dev.safeWidth = e.WidthPx - e.InsetLeftPx - e.InsetRightPx
-				canvas.SetScale(0) // value is ignored
 
 				// make sure that we paint on the next frame
 				canvas.Content().Refresh()

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -25,6 +25,7 @@ type WindowlessCanvas interface {
 	Padded() bool
 	Resize(fyne.Size)
 	SetPadded(bool)
+	SetScale(float32)
 }
 
 type testCanvas struct {


### PR DESCRIPTION
But keep it in WindowlessCanvas for test and playground usage

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included. <- this is just removing code, existing tests are perfect :)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

