### PR TITLE
fix typo ("data submiision") in fyne_demo

### DIFF
--- a/cmd/fyne_demo/tutorials/data.go
+++ b/cmd/fyne_demo/tutorials/data.go
@@ -78,7 +78,7 @@ var (
 			makeEntryTab,
 		},
 		"form": {"Form",
-			"Gathering input widgets for data submiission.",
+			"Gathering input widgets for data submission.",
 			makeFormTab,
 		},
 		"input": {"Input",


### PR DESCRIPTION
### Description:
The fyne_demo contains a typo ("submiision") in the widget/form tab.

Fixes #(issue)

simple... correct the typo 

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

