### PR TITLE
Provide a way to inform the external variable based bindings that they should refresh state.

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -88,9 +88,6 @@ func (b *base) RemoveListener(l DataListener) {
 }
 
 func (b *base) trigger() {
-	b.lock.RLock()
-	defer b.lock.RUnlock()
-
 	for _, listen := range b.listeners {
 		queueItem(listen.DataChanged)
 	}

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -25,7 +25,7 @@ type ExternalBool interface {
 // Since: 2.0.0
 func NewBool() Bool {
 	blank := false
-	return &boundBool{val: &blank}
+	return &boundBool{val: &blank, old: blank}
 }
 
 // BindBool returns a new bindable value that controls the contents of the provided bool variable.
@@ -44,6 +44,7 @@ type boundBool struct {
 	base
 
 	val *bool
+	old bool 
 }
 
 func (b *boundBool) Get() (bool, error) {
@@ -54,8 +55,7 @@ func (b *boundBool) Get() (bool, error) {
 }
 
 func (b *boundBool) Reload() error {
-	b.trigger() // TODO we should cache the old value and compare
-	return nil
+	return b.setIfChanged(*b.val)
 }
 
 func (b *boundBool) Set(val bool) error {
@@ -67,6 +67,16 @@ func (b *boundBool) Set(val bool) error {
 	} else {
 		*b.val = val
 	}
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundBool) setIfChanged(val bool) error {
+	if val == b.old {
+		return nil
+	}
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -94,7 +104,7 @@ type ExternalFloat interface {
 // Since: 2.0.0
 func NewFloat() Float {
 	blank := 0.0
-	return &boundFloat{val: &blank}
+	return &boundFloat{val: &blank, old: blank}
 }
 
 // BindFloat returns a new bindable value that controls the contents of the provided float64 variable.
@@ -113,6 +123,7 @@ type boundFloat struct {
 	base
 
 	val *float64
+	old float64 
 }
 
 func (b *boundFloat) Get() (float64, error) {
@@ -123,8 +134,7 @@ func (b *boundFloat) Get() (float64, error) {
 }
 
 func (b *boundFloat) Reload() error {
-	b.trigger() // TODO we should cache the old value and compare
-	return nil
+	return b.setIfChanged(*b.val)
 }
 
 func (b *boundFloat) Set(val float64) error {
@@ -136,6 +146,16 @@ func (b *boundFloat) Set(val float64) error {
 	} else {
 		*b.val = val
 	}
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundFloat) setIfChanged(val float64) error {
+	if val == b.old {
+		return nil
+	}
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -163,7 +183,7 @@ type ExternalInt interface {
 // Since: 2.0.0
 func NewInt() Int {
 	blank := 0
-	return &boundInt{val: &blank}
+	return &boundInt{val: &blank, old: blank}
 }
 
 // BindInt returns a new bindable value that controls the contents of the provided int variable.
@@ -182,6 +202,7 @@ type boundInt struct {
 	base
 
 	val *int
+	old int 
 }
 
 func (b *boundInt) Get() (int, error) {
@@ -192,8 +213,7 @@ func (b *boundInt) Get() (int, error) {
 }
 
 func (b *boundInt) Reload() error {
-	b.trigger() // TODO we should cache the old value and compare
-	return nil
+	return b.setIfChanged(*b.val)
 }
 
 func (b *boundInt) Set(val int) error {
@@ -205,6 +225,16 @@ func (b *boundInt) Set(val int) error {
 	} else {
 		*b.val = val
 	}
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundInt) setIfChanged(val int) error {
+	if val == b.old {
+		return nil
+	}
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -232,7 +262,7 @@ type ExternalRune interface {
 // Since: 2.0.0
 func NewRune() Rune {
 	blank := rune(0)
-	return &boundRune{val: &blank}
+	return &boundRune{val: &blank, old: blank}
 }
 
 // BindRune returns a new bindable value that controls the contents of the provided rune variable.
@@ -251,6 +281,7 @@ type boundRune struct {
 	base
 
 	val *rune
+	old rune 
 }
 
 func (b *boundRune) Get() (rune, error) {
@@ -261,8 +292,7 @@ func (b *boundRune) Get() (rune, error) {
 }
 
 func (b *boundRune) Reload() error {
-	b.trigger() // TODO we should cache the old value and compare
-	return nil
+	return b.setIfChanged(*b.val)
 }
 
 func (b *boundRune) Set(val rune) error {
@@ -274,6 +304,16 @@ func (b *boundRune) Set(val rune) error {
 	} else {
 		*b.val = val
 	}
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundRune) setIfChanged(val rune) error {
+	if val == b.old {
+		return nil
+	}
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -301,7 +341,7 @@ type ExternalString interface {
 // Since: 2.0.0
 func NewString() String {
 	blank := ""
-	return &boundString{val: &blank}
+	return &boundString{val: &blank, old: blank}
 }
 
 // BindString returns a new bindable value that controls the contents of the provided string variable.
@@ -320,6 +360,7 @@ type boundString struct {
 	base
 
 	val *string
+	old string 
 }
 
 func (b *boundString) Get() (string, error) {
@@ -330,8 +371,7 @@ func (b *boundString) Get() (string, error) {
 }
 
 func (b *boundString) Reload() error {
-	b.trigger() // TODO we should cache the old value and compare
-	return nil
+	return b.setIfChanged(*b.val)
 }
 
 func (b *boundString) Set(val string) error {
@@ -343,6 +383,16 @@ func (b *boundString) Set(val string) error {
 	} else {
 		*b.val = val
 	}
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundString) setIfChanged(val string) error {
+	if val == b.old {
+		return nil
+	}
+	b.old = val
 
 	b.trigger()
 	return nil

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -25,7 +25,7 @@ type ExternalBool interface {
 // Since: 2.0.0
 func NewBool() Bool {
 	blank := false
-	return &boundBool{val: &blank, old: blank}
+	return &boundBool{val: &blank}
 }
 
 // BindBool returns a new bindable value that controls the contents of the provided bool variable.
@@ -44,7 +44,6 @@ type boundBool struct {
 	base
 
 	val *bool
-	old bool
 }
 
 func (b *boundBool) Get() (bool, error) {
@@ -92,7 +91,7 @@ type ExternalFloat interface {
 // Since: 2.0.0
 func NewFloat() Float {
 	blank := 0.0
-	return &boundFloat{val: &blank, old: blank}
+	return &boundFloat{val: &blank}
 }
 
 // BindFloat returns a new bindable value that controls the contents of the provided float64 variable.
@@ -111,7 +110,6 @@ type boundFloat struct {
 	base
 
 	val *float64
-	old float64
 }
 
 func (b *boundFloat) Get() (float64, error) {
@@ -159,7 +157,7 @@ type ExternalInt interface {
 // Since: 2.0.0
 func NewInt() Int {
 	blank := 0
-	return &boundInt{val: &blank, old: blank}
+	return &boundInt{val: &blank}
 }
 
 // BindInt returns a new bindable value that controls the contents of the provided int variable.
@@ -178,7 +176,6 @@ type boundInt struct {
 	base
 
 	val *int
-	old int
 }
 
 func (b *boundInt) Get() (int, error) {
@@ -226,7 +223,7 @@ type ExternalRune interface {
 // Since: 2.0.0
 func NewRune() Rune {
 	blank := rune(0)
-	return &boundRune{val: &blank, old: blank}
+	return &boundRune{val: &blank}
 }
 
 // BindRune returns a new bindable value that controls the contents of the provided rune variable.
@@ -245,7 +242,6 @@ type boundRune struct {
 	base
 
 	val *rune
-	old rune
 }
 
 func (b *boundRune) Get() (rune, error) {
@@ -293,7 +289,7 @@ type ExternalString interface {
 // Since: 2.0.0
 func NewString() String {
 	blank := ""
-	return &boundString{val: &blank, old: blank}
+	return &boundString{val: &blank}
 }
 
 // BindString returns a new bindable value that controls the contents of the provided string variable.
@@ -312,7 +308,6 @@ type boundString struct {
 	base
 
 	val *string
-	old string
 }
 
 func (b *boundString) Get() (string, error) {

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -58,34 +58,13 @@ func (b *boundBool) Get() (bool, error) {
 }
 
 func (b *boundBool) Reload() error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	return b.setIfChanged(*b.val)
+	return b.Set(*b.val)
 }
 
 func (b *boundBool) Set(val bool) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	if *b.val == val {
-		return nil
-	}
-	if b.val == nil { // was not initialized with a blank value, recover
-		b.val = &val
-	} else {
-		*b.val = val
-	}
-
-	b.trigger()
-	return nil
-}
-
-func (b *boundBool) setIfChanged(val bool) error {
-	if val == b.old {
-		return nil
-	}
-	b.old = val
+	*b.val = val
 
 	b.trigger()
 	return nil
@@ -146,34 +125,13 @@ func (b *boundFloat) Get() (float64, error) {
 }
 
 func (b *boundFloat) Reload() error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	return b.setIfChanged(*b.val)
+	return b.Set(*b.val)
 }
 
 func (b *boundFloat) Set(val float64) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	if *b.val == val {
-		return nil
-	}
-	if b.val == nil { // was not initialized with a blank value, recover
-		b.val = &val
-	} else {
-		*b.val = val
-	}
-
-	b.trigger()
-	return nil
-}
-
-func (b *boundFloat) setIfChanged(val float64) error {
-	if val == b.old {
-		return nil
-	}
-	b.old = val
+	*b.val = val
 
 	b.trigger()
 	return nil
@@ -234,34 +192,13 @@ func (b *boundInt) Get() (int, error) {
 }
 
 func (b *boundInt) Reload() error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	return b.setIfChanged(*b.val)
+	return b.Set(*b.val)
 }
 
 func (b *boundInt) Set(val int) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	if *b.val == val {
-		return nil
-	}
-	if b.val == nil { // was not initialized with a blank value, recover
-		b.val = &val
-	} else {
-		*b.val = val
-	}
-
-	b.trigger()
-	return nil
-}
-
-func (b *boundInt) setIfChanged(val int) error {
-	if val == b.old {
-		return nil
-	}
-	b.old = val
+	*b.val = val
 
 	b.trigger()
 	return nil
@@ -322,34 +259,13 @@ func (b *boundRune) Get() (rune, error) {
 }
 
 func (b *boundRune) Reload() error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	return b.setIfChanged(*b.val)
+	return b.Set(*b.val)
 }
 
 func (b *boundRune) Set(val rune) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	if *b.val == val {
-		return nil
-	}
-	if b.val == nil { // was not initialized with a blank value, recover
-		b.val = &val
-	} else {
-		*b.val = val
-	}
-
-	b.trigger()
-	return nil
-}
-
-func (b *boundRune) setIfChanged(val rune) error {
-	if val == b.old {
-		return nil
-	}
-	b.old = val
+	*b.val = val
 
 	b.trigger()
 	return nil
@@ -410,34 +326,13 @@ func (b *boundString) Get() (string, error) {
 }
 
 func (b *boundString) Reload() error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	return b.setIfChanged(*b.val)
+	return b.Set(*b.val)
 }
 
 func (b *boundString) Set(val string) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	if *b.val == val {
-		return nil
-	}
-	if b.val == nil { // was not initialized with a blank value, recover
-		b.val = &val
-	} else {
-		*b.val = val
-	}
-
-	b.trigger()
-	return nil
-}
-
-func (b *boundString) setIfChanged(val string) error {
-	if val == b.old {
-		return nil
-	}
-	b.old = val
+	*b.val = val
 
 	b.trigger()
 	return nil

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -12,6 +12,14 @@ type Bool interface {
 	Set(bool) error
 }
 
+// ExternalBool supports binding a bool value to an external value.
+//
+// Since: 2.0.0
+type ExternalBool interface {
+	Bool
+	Reload() error
+}
+
 // NewBool returns a bindable bool value that is managed internally.
 //
 // Since: 2.0.0
@@ -21,11 +29,12 @@ func NewBool() Bool {
 }
 
 // BindBool returns a new bindable value that controls the contents of the provided bool variable.
+// If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindBool(v *bool) Bool {
+func BindBool(v *bool) ExternalBool {
 	if v == nil {
-		return NewBool() // never allow a nil value pointer
+		return NewBool().(ExternalBool) // never allow a nil value pointer
 	}
 
 	return &boundBool{val: v}
@@ -42,6 +51,11 @@ func (b *boundBool) Get() (bool, error) {
 		return false, nil
 	}
 	return *b.val, nil
+}
+
+func (b *boundBool) Reload() error {
+	b.trigger() // TODO we should cache the old value and compare
+	return nil
 }
 
 func (b *boundBool) Set(val bool) error {
@@ -67,6 +81,14 @@ type Float interface {
 	Set(float64) error
 }
 
+// ExternalFloat supports binding a float64 value to an external value.
+//
+// Since: 2.0.0
+type ExternalFloat interface {
+	Float
+	Reload() error
+}
+
 // NewFloat returns a bindable float64 value that is managed internally.
 //
 // Since: 2.0.0
@@ -76,11 +98,12 @@ func NewFloat() Float {
 }
 
 // BindFloat returns a new bindable value that controls the contents of the provided float64 variable.
+// If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindFloat(v *float64) Float {
+func BindFloat(v *float64) ExternalFloat {
 	if v == nil {
-		return NewFloat() // never allow a nil value pointer
+		return NewFloat().(ExternalFloat) // never allow a nil value pointer
 	}
 
 	return &boundFloat{val: v}
@@ -97,6 +120,11 @@ func (b *boundFloat) Get() (float64, error) {
 		return 0.0, nil
 	}
 	return *b.val, nil
+}
+
+func (b *boundFloat) Reload() error {
+	b.trigger() // TODO we should cache the old value and compare
+	return nil
 }
 
 func (b *boundFloat) Set(val float64) error {
@@ -122,6 +150,14 @@ type Int interface {
 	Set(int) error
 }
 
+// ExternalInt supports binding a int value to an external value.
+//
+// Since: 2.0.0
+type ExternalInt interface {
+	Int
+	Reload() error
+}
+
 // NewInt returns a bindable int value that is managed internally.
 //
 // Since: 2.0.0
@@ -131,11 +167,12 @@ func NewInt() Int {
 }
 
 // BindInt returns a new bindable value that controls the contents of the provided int variable.
+// If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindInt(v *int) Int {
+func BindInt(v *int) ExternalInt {
 	if v == nil {
-		return NewInt() // never allow a nil value pointer
+		return NewInt().(ExternalInt) // never allow a nil value pointer
 	}
 
 	return &boundInt{val: v}
@@ -152,6 +189,11 @@ func (b *boundInt) Get() (int, error) {
 		return 0, nil
 	}
 	return *b.val, nil
+}
+
+func (b *boundInt) Reload() error {
+	b.trigger() // TODO we should cache the old value and compare
+	return nil
 }
 
 func (b *boundInt) Set(val int) error {
@@ -177,6 +219,14 @@ type Rune interface {
 	Set(rune) error
 }
 
+// ExternalRune supports binding a rune value to an external value.
+//
+// Since: 2.0.0
+type ExternalRune interface {
+	Rune
+	Reload() error
+}
+
 // NewRune returns a bindable rune value that is managed internally.
 //
 // Since: 2.0.0
@@ -186,11 +236,12 @@ func NewRune() Rune {
 }
 
 // BindRune returns a new bindable value that controls the contents of the provided rune variable.
+// If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindRune(v *rune) Rune {
+func BindRune(v *rune) ExternalRune {
 	if v == nil {
-		return NewRune() // never allow a nil value pointer
+		return NewRune().(ExternalRune) // never allow a nil value pointer
 	}
 
 	return &boundRune{val: v}
@@ -207,6 +258,11 @@ func (b *boundRune) Get() (rune, error) {
 		return rune(0), nil
 	}
 	return *b.val, nil
+}
+
+func (b *boundRune) Reload() error {
+	b.trigger() // TODO we should cache the old value and compare
+	return nil
 }
 
 func (b *boundRune) Set(val rune) error {
@@ -232,6 +288,14 @@ type String interface {
 	Set(string) error
 }
 
+// ExternalString supports binding a string value to an external value.
+//
+// Since: 2.0.0
+type ExternalString interface {
+	String
+	Reload() error
+}
+
 // NewString returns a bindable string value that is managed internally.
 //
 // Since: 2.0.0
@@ -241,11 +305,12 @@ func NewString() String {
 }
 
 // BindString returns a new bindable value that controls the contents of the provided string variable.
+// If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindString(v *string) String {
+func BindString(v *string) ExternalString {
 	if v == nil {
-		return NewString() // never allow a nil value pointer
+		return NewString().(ExternalString) // never allow a nil value pointer
 	}
 
 	return &boundString{val: v}
@@ -262,6 +327,11 @@ func (b *boundString) Get() (string, error) {
 		return "", nil
 	}
 	return *b.val, nil
+}
+
+func (b *boundString) Reload() error {
+	b.trigger() // TODO we should cache the old value and compare
+	return nil
 }
 
 func (b *boundString) Set(val string) error {

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -44,7 +44,7 @@ type boundBool struct {
 	base
 
 	val *bool
-	old bool 
+	old bool
 }
 
 func (b *boundBool) Get() (bool, error) {
@@ -123,7 +123,7 @@ type boundFloat struct {
 	base
 
 	val *float64
-	old float64 
+	old float64
 }
 
 func (b *boundFloat) Get() (float64, error) {
@@ -202,7 +202,7 @@ type boundInt struct {
 	base
 
 	val *int
-	old int 
+	old int
 }
 
 func (b *boundInt) Get() (int, error) {
@@ -281,7 +281,7 @@ type boundRune struct {
 	base
 
 	val *rune
-	old rune 
+	old rune
 }
 
 func (b *boundRune) Get() (rune, error) {
@@ -360,7 +360,7 @@ type boundString struct {
 	base
 
 	val *string
-	old string 
+	old string
 }
 
 func (b *boundString) Get() (string, error) {

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -48,6 +48,9 @@ type boundBool struct {
 }
 
 func (b *boundBool) Get() (bool, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
 	if b.val == nil {
 		return false, nil
 	}
@@ -55,10 +58,16 @@ func (b *boundBool) Get() (bool, error) {
 }
 
 func (b *boundBool) Reload() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return b.setIfChanged(*b.val)
 }
 
 func (b *boundBool) Set(val bool) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	if *b.val == val {
 		return nil
 	}
@@ -127,6 +136,9 @@ type boundFloat struct {
 }
 
 func (b *boundFloat) Get() (float64, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
 	if b.val == nil {
 		return 0.0, nil
 	}
@@ -134,10 +146,16 @@ func (b *boundFloat) Get() (float64, error) {
 }
 
 func (b *boundFloat) Reload() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return b.setIfChanged(*b.val)
 }
 
 func (b *boundFloat) Set(val float64) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	if *b.val == val {
 		return nil
 	}
@@ -206,6 +224,9 @@ type boundInt struct {
 }
 
 func (b *boundInt) Get() (int, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
 	if b.val == nil {
 		return 0, nil
 	}
@@ -213,10 +234,16 @@ func (b *boundInt) Get() (int, error) {
 }
 
 func (b *boundInt) Reload() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return b.setIfChanged(*b.val)
 }
 
 func (b *boundInt) Set(val int) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	if *b.val == val {
 		return nil
 	}
@@ -285,6 +312,9 @@ type boundRune struct {
 }
 
 func (b *boundRune) Get() (rune, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
 	if b.val == nil {
 		return rune(0), nil
 	}
@@ -292,10 +322,16 @@ func (b *boundRune) Get() (rune, error) {
 }
 
 func (b *boundRune) Reload() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return b.setIfChanged(*b.val)
 }
 
 func (b *boundRune) Set(val rune) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	if *b.val == val {
 		return nil
 	}
@@ -364,6 +400,9 @@ type boundString struct {
 }
 
 func (b *boundString) Get() (string, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
 	if b.val == nil {
 		return "", nil
 	}
@@ -371,10 +410,16 @@ func (b *boundString) Get() (string, error) {
 }
 
 func (b *boundString) Reload() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return b.setIfChanged(*b.val)
 }
 
 func (b *boundString) Set(val string) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	if *b.val == val {
 		return nil
 	}

--- a/data/binding/binditems_test.go
+++ b/data/binding/binditems_test.go
@@ -13,9 +13,29 @@ func TestBindFloat(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 0.5, v)
 
+	called := false
+	fn := NewDataListener(func() {
+		called = true
+	})
+	f.AddListener(fn)
+	waitForItems()
+	assert.True(t, called)
+
+	called = false
 	err = f.Set(0.3)
 	assert.Nil(t, err)
+	waitForItems()
 	assert.Equal(t, 0.3, val)
+	assert.True(t, called)
+
+	called = false
+	val = 1.2
+	f.Reload()
+	waitForItems()
+	assert.True(t, called)
+	v, err = f.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, 1.2, v)
 }
 
 func TestNewFloat(t *testing.T) {

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -58,12 +58,18 @@ type boundBoolList struct {
 }
 
 func (l *boundBoolList) Append(val bool) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	*l.val = append(*l.val, val)
 
 	return l.doReload()
 }
 
 func (l *boundBoolList) Get() ([]bool, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return *l.val, nil
 }
 
@@ -71,20 +77,30 @@ func (l *boundBoolList) GetValue(i int) (bool, error) {
 	if i < 0 || i >= l.Length() {
 		return false, errOutOfBounds
 	}
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return (*l.val)[i], nil
 }
 
 func (l *boundBoolList) Prepend(val bool) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = append([]bool{val}, *l.val...)
 
 	return l.doReload()
 }
 
 func (l *boundBoolList) Reload() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	return l.doReload()
 }
 
 func (l *boundBoolList) Set(v []bool) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = v
 
 	return l.doReload()
@@ -122,7 +138,10 @@ func (l *boundBoolList) SetValue(i int, v bool) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
+
+	l.lock.Lock()
 	(*l.val)[i] = v
+	l.lock.Unlock()
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -144,10 +163,16 @@ type boundBoolListItem struct {
 }
 
 func (b *boundBoolListItem) Get() (bool, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return (*b.val)[b.index], nil
 }
 
 func (b *boundBoolListItem) Set(val bool) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	(*b.val)[b.index] = val
 
 	b.trigger()
@@ -220,12 +245,18 @@ type boundFloatList struct {
 }
 
 func (l *boundFloatList) Append(val float64) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	*l.val = append(*l.val, val)
 
 	return l.doReload()
 }
 
 func (l *boundFloatList) Get() ([]float64, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return *l.val, nil
 }
 
@@ -233,20 +264,30 @@ func (l *boundFloatList) GetValue(i int) (float64, error) {
 	if i < 0 || i >= l.Length() {
 		return 0.0, errOutOfBounds
 	}
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return (*l.val)[i], nil
 }
 
 func (l *boundFloatList) Prepend(val float64) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = append([]float64{val}, *l.val...)
 
 	return l.doReload()
 }
 
 func (l *boundFloatList) Reload() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	return l.doReload()
 }
 
 func (l *boundFloatList) Set(v []float64) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = v
 
 	return l.doReload()
@@ -284,7 +325,10 @@ func (l *boundFloatList) SetValue(i int, v float64) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
+
+	l.lock.Lock()
 	(*l.val)[i] = v
+	l.lock.Unlock()
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -306,10 +350,16 @@ type boundFloatListItem struct {
 }
 
 func (b *boundFloatListItem) Get() (float64, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return (*b.val)[b.index], nil
 }
 
 func (b *boundFloatListItem) Set(val float64) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	(*b.val)[b.index] = val
 
 	b.trigger()
@@ -382,12 +432,18 @@ type boundIntList struct {
 }
 
 func (l *boundIntList) Append(val int) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	*l.val = append(*l.val, val)
 
 	return l.doReload()
 }
 
 func (l *boundIntList) Get() ([]int, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return *l.val, nil
 }
 
@@ -395,20 +451,30 @@ func (l *boundIntList) GetValue(i int) (int, error) {
 	if i < 0 || i >= l.Length() {
 		return 0, errOutOfBounds
 	}
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return (*l.val)[i], nil
 }
 
 func (l *boundIntList) Prepend(val int) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = append([]int{val}, *l.val...)
 
 	return l.doReload()
 }
 
 func (l *boundIntList) Reload() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	return l.doReload()
 }
 
 func (l *boundIntList) Set(v []int) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = v
 
 	return l.doReload()
@@ -446,7 +512,10 @@ func (l *boundIntList) SetValue(i int, v int) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
+
+	l.lock.Lock()
 	(*l.val)[i] = v
+	l.lock.Unlock()
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -468,10 +537,16 @@ type boundIntListItem struct {
 }
 
 func (b *boundIntListItem) Get() (int, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return (*b.val)[b.index], nil
 }
 
 func (b *boundIntListItem) Set(val int) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	(*b.val)[b.index] = val
 
 	b.trigger()
@@ -544,12 +619,18 @@ type boundRuneList struct {
 }
 
 func (l *boundRuneList) Append(val rune) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	*l.val = append(*l.val, val)
 
 	return l.doReload()
 }
 
 func (l *boundRuneList) Get() ([]rune, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return *l.val, nil
 }
 
@@ -557,20 +638,30 @@ func (l *boundRuneList) GetValue(i int) (rune, error) {
 	if i < 0 || i >= l.Length() {
 		return rune(0), errOutOfBounds
 	}
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return (*l.val)[i], nil
 }
 
 func (l *boundRuneList) Prepend(val rune) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = append([]rune{val}, *l.val...)
 
 	return l.doReload()
 }
 
 func (l *boundRuneList) Reload() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	return l.doReload()
 }
 
 func (l *boundRuneList) Set(v []rune) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = v
 
 	return l.doReload()
@@ -608,7 +699,10 @@ func (l *boundRuneList) SetValue(i int, v rune) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
+
+	l.lock.Lock()
 	(*l.val)[i] = v
+	l.lock.Unlock()
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -630,10 +724,16 @@ type boundRuneListItem struct {
 }
 
 func (b *boundRuneListItem) Get() (rune, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return (*b.val)[b.index], nil
 }
 
 func (b *boundRuneListItem) Set(val rune) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	(*b.val)[b.index] = val
 
 	b.trigger()
@@ -706,12 +806,18 @@ type boundStringList struct {
 }
 
 func (l *boundStringList) Append(val string) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	*l.val = append(*l.val, val)
 
 	return l.doReload()
 }
 
 func (l *boundStringList) Get() ([]string, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return *l.val, nil
 }
 
@@ -719,20 +825,30 @@ func (l *boundStringList) GetValue(i int) (string, error) {
 	if i < 0 || i >= l.Length() {
 		return "", errOutOfBounds
 	}
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	return (*l.val)[i], nil
 }
 
 func (l *boundStringList) Prepend(val string) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = append([]string{val}, *l.val...)
 
 	return l.doReload()
 }
 
 func (l *boundStringList) Reload() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	return l.doReload()
 }
 
 func (l *boundStringList) Set(v []string) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	*l.val = v
 
 	return l.doReload()
@@ -770,7 +886,10 @@ func (l *boundStringList) SetValue(i int, v string) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
+
+	l.lock.Lock()
 	(*l.val)[i] = v
+	l.lock.Unlock()
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -792,10 +911,16 @@ type boundStringListItem struct {
 }
 
 func (b *boundStringListItem) Get() (string, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	return (*b.val)[b.index], nil
 }
 
 func (b *boundStringListItem) Set(val string) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	(*b.val)[b.index] = val
 
 	b.trigger()

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -17,6 +17,15 @@ type BoolList interface {
 	SetValue(int, bool) error
 }
 
+// ExternalBoolList supports binding a list of bool values from an external variable.
+//
+// Since: 2.0.0
+type ExternalBoolList interface {
+	BoolList
+
+	Reload() error
+}
+
 // NewBoolList returns a bindable list of bool values.
 //
 // Since: 2.0.0
@@ -25,11 +34,12 @@ func NewBoolList() BoolList {
 }
 
 // BindBoolList returns a bound list of bool values, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindBoolList(v *[]bool) BoolList {
+func BindBoolList(v *[]bool) ExternalBoolList {
 	if v == nil {
-		return NewBoolList()
+		return NewBoolList().(ExternalBoolList)
 	}
 
 	b := &boundBoolList{val: v}
@@ -132,6 +142,15 @@ type FloatList interface {
 	SetValue(int, float64) error
 }
 
+// ExternalFloatList supports binding a list of float64 values from an external variable.
+//
+// Since: 2.0.0
+type ExternalFloatList interface {
+	FloatList
+
+	Reload() error
+}
+
 // NewFloatList returns a bindable list of float64 values.
 //
 // Since: 2.0.0
@@ -140,11 +159,12 @@ func NewFloatList() FloatList {
 }
 
 // BindFloatList returns a bound list of float64 values, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindFloatList(v *[]float64) FloatList {
+func BindFloatList(v *[]float64) ExternalFloatList {
 	if v == nil {
-		return NewFloatList()
+		return NewFloatList().(ExternalFloatList)
 	}
 
 	b := &boundFloatList{val: v}
@@ -247,6 +267,15 @@ type IntList interface {
 	SetValue(int, int) error
 }
 
+// ExternalIntList supports binding a list of int values from an external variable.
+//
+// Since: 2.0.0
+type ExternalIntList interface {
+	IntList
+
+	Reload() error
+}
+
 // NewIntList returns a bindable list of int values.
 //
 // Since: 2.0.0
@@ -255,11 +284,12 @@ func NewIntList() IntList {
 }
 
 // BindIntList returns a bound list of int values, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindIntList(v *[]int) IntList {
+func BindIntList(v *[]int) ExternalIntList {
 	if v == nil {
-		return NewIntList()
+		return NewIntList().(ExternalIntList)
 	}
 
 	b := &boundIntList{val: v}
@@ -362,6 +392,15 @@ type RuneList interface {
 	SetValue(int, rune) error
 }
 
+// ExternalRuneList supports binding a list of rune values from an external variable.
+//
+// Since: 2.0.0
+type ExternalRuneList interface {
+	RuneList
+
+	Reload() error
+}
+
 // NewRuneList returns a bindable list of rune values.
 //
 // Since: 2.0.0
@@ -370,11 +409,12 @@ func NewRuneList() RuneList {
 }
 
 // BindRuneList returns a bound list of rune values, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindRuneList(v *[]rune) RuneList {
+func BindRuneList(v *[]rune) ExternalRuneList {
 	if v == nil {
-		return NewRuneList()
+		return NewRuneList().(ExternalRuneList)
 	}
 
 	b := &boundRuneList{val: v}
@@ -477,6 +517,15 @@ type StringList interface {
 	SetValue(int, string) error
 }
 
+// ExternalStringList supports binding a list of string values from an external variable.
+//
+// Since: 2.0.0
+type ExternalStringList interface {
+	StringList
+
+	Reload() error
+}
+
 // NewStringList returns a bindable list of string values.
 //
 // Since: 2.0.0
@@ -485,11 +534,12 @@ func NewStringList() StringList {
 }
 
 // BindStringList returns a bound list of string values, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindStringList(v *[]string) StringList {
+func BindStringList(v *[]string) ExternalStringList {
 	if v == nil {
-		return NewStringList()
+		return NewStringList().(ExternalStringList)
 	}
 
 	b := &boundStringList{val: v}

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -21,7 +21,7 @@ type BoolList interface {
 //
 // Since: 2.0.0
 func NewBoolList() BoolList {
-	return &boundBoolList{}
+	return &boundBoolList{val: &[]bool{}}
 }
 
 // BindBoolList returns a bound list of bool values, based on the contents of the passed slice.
@@ -48,19 +48,13 @@ type boundBoolList struct {
 }
 
 func (l *boundBoolList) Append(val bool) error {
-	if l.val != nil {
-		*l.val = append(*l.val, val)
-	}
+	*l.val = append(*l.val, val)
 
 	l.appendItem(BindBool(&val))
 	return nil
 }
 
 func (l *boundBoolList) Get() ([]bool, error) {
-	if l.val == nil {
-		return []bool{}, nil
-	}
-
 	return *l.val, nil
 }
 
@@ -68,33 +62,17 @@ func (l *boundBoolList) GetValue(i int) (bool, error) {
 	if i < 0 || i >= l.Length() {
 		return false, errOutOfBounds
 	}
-	if l.val != nil {
-		return (*l.val)[i], nil
-	}
-
-	item, err := l.GetItem(i)
-	if err != nil {
-		return false, err
-	}
-	return item.(Bool).Get()
+	return (*l.val)[i], nil
 }
 
 func (l *boundBoolList) Prepend(val bool) error {
-	if l.val != nil {
-		*l.val = append([]bool{val}, *l.val...)
-	}
+	*l.val = append([]bool{val}, *l.val...)
 
 	l.prependItem(BindBool(&val))
 	return nil
 }
 
 func (l *boundBoolList) Set(v []bool) (retErr error) {
-	if l.val == nil { // was not initialized with a blank value, recover
-		l.val = &v
-		l.trigger()
-		return nil
-	}
-
 	oldLen := len(l.items)
 	*l.val = v
 	newLen := len(v)
@@ -131,9 +109,7 @@ func (l *boundBoolList) SetValue(i int, v bool) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
-	if l.val != nil {
-		(*l.val)[i] = v
-	}
+	(*l.val)[i] = v
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -160,7 +136,7 @@ type FloatList interface {
 //
 // Since: 2.0.0
 func NewFloatList() FloatList {
-	return &boundFloatList{}
+	return &boundFloatList{val: &[]float64{}}
 }
 
 // BindFloatList returns a bound list of float64 values, based on the contents of the passed slice.
@@ -187,19 +163,13 @@ type boundFloatList struct {
 }
 
 func (l *boundFloatList) Append(val float64) error {
-	if l.val != nil {
-		*l.val = append(*l.val, val)
-	}
+	*l.val = append(*l.val, val)
 
 	l.appendItem(BindFloat(&val))
 	return nil
 }
 
 func (l *boundFloatList) Get() ([]float64, error) {
-	if l.val == nil {
-		return []float64{}, nil
-	}
-
 	return *l.val, nil
 }
 
@@ -207,33 +177,17 @@ func (l *boundFloatList) GetValue(i int) (float64, error) {
 	if i < 0 || i >= l.Length() {
 		return 0.0, errOutOfBounds
 	}
-	if l.val != nil {
-		return (*l.val)[i], nil
-	}
-
-	item, err := l.GetItem(i)
-	if err != nil {
-		return 0.0, err
-	}
-	return item.(Float).Get()
+	return (*l.val)[i], nil
 }
 
 func (l *boundFloatList) Prepend(val float64) error {
-	if l.val != nil {
-		*l.val = append([]float64{val}, *l.val...)
-	}
+	*l.val = append([]float64{val}, *l.val...)
 
 	l.prependItem(BindFloat(&val))
 	return nil
 }
 
 func (l *boundFloatList) Set(v []float64) (retErr error) {
-	if l.val == nil { // was not initialized with a blank value, recover
-		l.val = &v
-		l.trigger()
-		return nil
-	}
-
 	oldLen := len(l.items)
 	*l.val = v
 	newLen := len(v)
@@ -270,9 +224,7 @@ func (l *boundFloatList) SetValue(i int, v float64) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
-	if l.val != nil {
-		(*l.val)[i] = v
-	}
+	(*l.val)[i] = v
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -299,7 +251,7 @@ type IntList interface {
 //
 // Since: 2.0.0
 func NewIntList() IntList {
-	return &boundIntList{}
+	return &boundIntList{val: &[]int{}}
 }
 
 // BindIntList returns a bound list of int values, based on the contents of the passed slice.
@@ -326,19 +278,13 @@ type boundIntList struct {
 }
 
 func (l *boundIntList) Append(val int) error {
-	if l.val != nil {
-		*l.val = append(*l.val, val)
-	}
+	*l.val = append(*l.val, val)
 
 	l.appendItem(BindInt(&val))
 	return nil
 }
 
 func (l *boundIntList) Get() ([]int, error) {
-	if l.val == nil {
-		return []int{}, nil
-	}
-
 	return *l.val, nil
 }
 
@@ -346,33 +292,17 @@ func (l *boundIntList) GetValue(i int) (int, error) {
 	if i < 0 || i >= l.Length() {
 		return 0, errOutOfBounds
 	}
-	if l.val != nil {
-		return (*l.val)[i], nil
-	}
-
-	item, err := l.GetItem(i)
-	if err != nil {
-		return 0, err
-	}
-	return item.(Int).Get()
+	return (*l.val)[i], nil
 }
 
 func (l *boundIntList) Prepend(val int) error {
-	if l.val != nil {
-		*l.val = append([]int{val}, *l.val...)
-	}
+	*l.val = append([]int{val}, *l.val...)
 
 	l.prependItem(BindInt(&val))
 	return nil
 }
 
 func (l *boundIntList) Set(v []int) (retErr error) {
-	if l.val == nil { // was not initialized with a blank value, recover
-		l.val = &v
-		l.trigger()
-		return nil
-	}
-
 	oldLen := len(l.items)
 	*l.val = v
 	newLen := len(v)
@@ -409,9 +339,7 @@ func (l *boundIntList) SetValue(i int, v int) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
-	if l.val != nil {
-		(*l.val)[i] = v
-	}
+	(*l.val)[i] = v
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -438,7 +366,7 @@ type RuneList interface {
 //
 // Since: 2.0.0
 func NewRuneList() RuneList {
-	return &boundRuneList{}
+	return &boundRuneList{val: &[]rune{}}
 }
 
 // BindRuneList returns a bound list of rune values, based on the contents of the passed slice.
@@ -465,19 +393,13 @@ type boundRuneList struct {
 }
 
 func (l *boundRuneList) Append(val rune) error {
-	if l.val != nil {
-		*l.val = append(*l.val, val)
-	}
+	*l.val = append(*l.val, val)
 
 	l.appendItem(BindRune(&val))
 	return nil
 }
 
 func (l *boundRuneList) Get() ([]rune, error) {
-	if l.val == nil {
-		return []rune{}, nil
-	}
-
 	return *l.val, nil
 }
 
@@ -485,33 +407,17 @@ func (l *boundRuneList) GetValue(i int) (rune, error) {
 	if i < 0 || i >= l.Length() {
 		return rune(0), errOutOfBounds
 	}
-	if l.val != nil {
-		return (*l.val)[i], nil
-	}
-
-	item, err := l.GetItem(i)
-	if err != nil {
-		return rune(0), err
-	}
-	return item.(Rune).Get()
+	return (*l.val)[i], nil
 }
 
 func (l *boundRuneList) Prepend(val rune) error {
-	if l.val != nil {
-		*l.val = append([]rune{val}, *l.val...)
-	}
+	*l.val = append([]rune{val}, *l.val...)
 
 	l.prependItem(BindRune(&val))
 	return nil
 }
 
 func (l *boundRuneList) Set(v []rune) (retErr error) {
-	if l.val == nil { // was not initialized with a blank value, recover
-		l.val = &v
-		l.trigger()
-		return nil
-	}
-
 	oldLen := len(l.items)
 	*l.val = v
 	newLen := len(v)
@@ -548,9 +454,7 @@ func (l *boundRuneList) SetValue(i int, v rune) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
-	if l.val != nil {
-		(*l.val)[i] = v
-	}
+	(*l.val)[i] = v
 
 	item, err := l.GetItem(i)
 	if err != nil {
@@ -577,7 +481,7 @@ type StringList interface {
 //
 // Since: 2.0.0
 func NewStringList() StringList {
-	return &boundStringList{}
+	return &boundStringList{val: &[]string{}}
 }
 
 // BindStringList returns a bound list of string values, based on the contents of the passed slice.
@@ -604,19 +508,13 @@ type boundStringList struct {
 }
 
 func (l *boundStringList) Append(val string) error {
-	if l.val != nil {
-		*l.val = append(*l.val, val)
-	}
+	*l.val = append(*l.val, val)
 
 	l.appendItem(BindString(&val))
 	return nil
 }
 
 func (l *boundStringList) Get() ([]string, error) {
-	if l.val == nil {
-		return []string{}, nil
-	}
-
 	return *l.val, nil
 }
 
@@ -624,33 +522,17 @@ func (l *boundStringList) GetValue(i int) (string, error) {
 	if i < 0 || i >= l.Length() {
 		return "", errOutOfBounds
 	}
-	if l.val != nil {
-		return (*l.val)[i], nil
-	}
-
-	item, err := l.GetItem(i)
-	if err != nil {
-		return "", err
-	}
-	return item.(String).Get()
+	return (*l.val)[i], nil
 }
 
 func (l *boundStringList) Prepend(val string) error {
-	if l.val != nil {
-		*l.val = append([]string{val}, *l.val...)
-	}
+	*l.val = append([]string{val}, *l.val...)
 
 	l.prependItem(BindString(&val))
 	return nil
 }
 
 func (l *boundStringList) Set(v []string) (retErr error) {
-	if l.val == nil { // was not initialized with a blank value, recover
-		l.val = &v
-		l.trigger()
-		return nil
-	}
-
 	oldLen := len(l.items)
 	*l.val = v
 	newLen := len(v)
@@ -687,9 +569,7 @@ func (l *boundStringList) SetValue(i int, v string) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
-	if l.val != nil {
-		(*l.val)[i] = v
-	}
+	(*l.val)[i] = v
 
 	item, err := l.GetItem(i)
 	if err != nil {

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -60,8 +60,7 @@ type boundBoolList struct {
 func (l *boundBoolList) Append(val bool) error {
 	*l.val = append(*l.val, val)
 
-	l.appendItem(BindBool(&val))
-	return nil
+	return l.doReload()
 }
 
 func (l *boundBoolList) Get() ([]bool, error) {
@@ -78,14 +77,22 @@ func (l *boundBoolList) GetValue(i int) (bool, error) {
 func (l *boundBoolList) Prepend(val bool) error {
 	*l.val = append([]bool{val}, *l.val...)
 
-	l.prependItem(BindBool(&val))
-	return nil
+	return l.doReload()
 }
 
-func (l *boundBoolList) Set(v []bool) (retErr error) {
-	oldLen := len(l.items)
+func (l *boundBoolList) Reload() error {
+	return l.doReload()
+}
+
+func (l *boundBoolList) Set(v []bool) error {
 	*l.val = v
-	newLen := len(v)
+
+	return l.doReload()
+}
+
+func (l *boundBoolList) doReload() (retErr error) {
+	oldLen := len(l.items)
+	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
@@ -103,14 +110,16 @@ func (l *boundBoolList) Set(v []bool) (retErr error) {
 			break
 		}
 
-		old, err := l.items[i].(Bool).Get()
-		val := (*(l.val))[i]
-		if err != nil || (*(l.val))[i] != old {
-			err = item.(*boundBool).Set(val)
-			if err != nil {
-				retErr = err
-			}
-		}
+// TODO cache values and do comparison - for now we just always trigger child elements
+//		old, err := l.items[i].(Bool).Get()
+//		val := (*(l.val))[i]
+//		if err != nil || (*(l.val))[i] != old {
+//			err = item.(*boundBool).Set(val)
+//			if err != nil {
+//				retErr = err
+//			}
+//		}
+		item.(*boundBoolListItem).trigger()
 	}
 	return
 }
@@ -185,8 +194,7 @@ type boundFloatList struct {
 func (l *boundFloatList) Append(val float64) error {
 	*l.val = append(*l.val, val)
 
-	l.appendItem(BindFloat(&val))
-	return nil
+	return l.doReload()
 }
 
 func (l *boundFloatList) Get() ([]float64, error) {
@@ -203,14 +211,22 @@ func (l *boundFloatList) GetValue(i int) (float64, error) {
 func (l *boundFloatList) Prepend(val float64) error {
 	*l.val = append([]float64{val}, *l.val...)
 
-	l.prependItem(BindFloat(&val))
-	return nil
+	return l.doReload()
 }
 
-func (l *boundFloatList) Set(v []float64) (retErr error) {
-	oldLen := len(l.items)
+func (l *boundFloatList) Reload() error {
+	return l.doReload()
+}
+
+func (l *boundFloatList) Set(v []float64) error {
 	*l.val = v
-	newLen := len(v)
+
+	return l.doReload()
+}
+
+func (l *boundFloatList) doReload() (retErr error) {
+	oldLen := len(l.items)
+	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
@@ -228,14 +244,16 @@ func (l *boundFloatList) Set(v []float64) (retErr error) {
 			break
 		}
 
-		old, err := l.items[i].(Float).Get()
-		val := (*(l.val))[i]
-		if err != nil || (*(l.val))[i] != old {
-			err = item.(*boundFloat).Set(val)
-			if err != nil {
-				retErr = err
-			}
-		}
+// TODO cache values and do comparison - for now we just always trigger child elements
+//		old, err := l.items[i].(Float).Get()
+//		val := (*(l.val))[i]
+//		if err != nil || (*(l.val))[i] != old {
+//			err = item.(*boundFloat).Set(val)
+//			if err != nil {
+//				retErr = err
+//			}
+//		}
+		item.(*boundFloatListItem).trigger()
 	}
 	return
 }
@@ -310,8 +328,7 @@ type boundIntList struct {
 func (l *boundIntList) Append(val int) error {
 	*l.val = append(*l.val, val)
 
-	l.appendItem(BindInt(&val))
-	return nil
+	return l.doReload()
 }
 
 func (l *boundIntList) Get() ([]int, error) {
@@ -328,14 +345,22 @@ func (l *boundIntList) GetValue(i int) (int, error) {
 func (l *boundIntList) Prepend(val int) error {
 	*l.val = append([]int{val}, *l.val...)
 
-	l.prependItem(BindInt(&val))
-	return nil
+	return l.doReload()
 }
 
-func (l *boundIntList) Set(v []int) (retErr error) {
-	oldLen := len(l.items)
+func (l *boundIntList) Reload() error {
+	return l.doReload()
+}
+
+func (l *boundIntList) Set(v []int) error {
 	*l.val = v
-	newLen := len(v)
+
+	return l.doReload()
+}
+
+func (l *boundIntList) doReload() (retErr error) {
+	oldLen := len(l.items)
+	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
@@ -353,14 +378,16 @@ func (l *boundIntList) Set(v []int) (retErr error) {
 			break
 		}
 
-		old, err := l.items[i].(Int).Get()
-		val := (*(l.val))[i]
-		if err != nil || (*(l.val))[i] != old {
-			err = item.(*boundInt).Set(val)
-			if err != nil {
-				retErr = err
-			}
-		}
+// TODO cache values and do comparison - for now we just always trigger child elements
+//		old, err := l.items[i].(Int).Get()
+//		val := (*(l.val))[i]
+//		if err != nil || (*(l.val))[i] != old {
+//			err = item.(*boundInt).Set(val)
+//			if err != nil {
+//				retErr = err
+//			}
+//		}
+		item.(*boundIntListItem).trigger()
 	}
 	return
 }
@@ -435,8 +462,7 @@ type boundRuneList struct {
 func (l *boundRuneList) Append(val rune) error {
 	*l.val = append(*l.val, val)
 
-	l.appendItem(BindRune(&val))
-	return nil
+	return l.doReload()
 }
 
 func (l *boundRuneList) Get() ([]rune, error) {
@@ -453,14 +479,22 @@ func (l *boundRuneList) GetValue(i int) (rune, error) {
 func (l *boundRuneList) Prepend(val rune) error {
 	*l.val = append([]rune{val}, *l.val...)
 
-	l.prependItem(BindRune(&val))
-	return nil
+	return l.doReload()
 }
 
-func (l *boundRuneList) Set(v []rune) (retErr error) {
-	oldLen := len(l.items)
+func (l *boundRuneList) Reload() error {
+	return l.doReload()
+}
+
+func (l *boundRuneList) Set(v []rune) error {
 	*l.val = v
-	newLen := len(v)
+
+	return l.doReload()
+}
+
+func (l *boundRuneList) doReload() (retErr error) {
+	oldLen := len(l.items)
+	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
@@ -478,14 +512,16 @@ func (l *boundRuneList) Set(v []rune) (retErr error) {
 			break
 		}
 
-		old, err := l.items[i].(Rune).Get()
-		val := (*(l.val))[i]
-		if err != nil || (*(l.val))[i] != old {
-			err = item.(*boundRune).Set(val)
-			if err != nil {
-				retErr = err
-			}
-		}
+// TODO cache values and do comparison - for now we just always trigger child elements
+//		old, err := l.items[i].(Rune).Get()
+//		val := (*(l.val))[i]
+//		if err != nil || (*(l.val))[i] != old {
+//			err = item.(*boundRune).Set(val)
+//			if err != nil {
+//				retErr = err
+//			}
+//		}
+		item.(*boundRuneListItem).trigger()
 	}
 	return
 }
@@ -560,8 +596,7 @@ type boundStringList struct {
 func (l *boundStringList) Append(val string) error {
 	*l.val = append(*l.val, val)
 
-	l.appendItem(BindString(&val))
-	return nil
+	return l.doReload()
 }
 
 func (l *boundStringList) Get() ([]string, error) {
@@ -578,14 +613,22 @@ func (l *boundStringList) GetValue(i int) (string, error) {
 func (l *boundStringList) Prepend(val string) error {
 	*l.val = append([]string{val}, *l.val...)
 
-	l.prependItem(BindString(&val))
-	return nil
+	return l.doReload()
 }
 
-func (l *boundStringList) Set(v []string) (retErr error) {
-	oldLen := len(l.items)
+func (l *boundStringList) Reload() error {
+	return l.doReload()
+}
+
+func (l *boundStringList) Set(v []string) error {
 	*l.val = v
-	newLen := len(v)
+
+	return l.doReload()
+}
+
+func (l *boundStringList) doReload() (retErr error) {
+	oldLen := len(l.items)
+	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
@@ -603,14 +646,16 @@ func (l *boundStringList) Set(v []string) (retErr error) {
 			break
 		}
 
-		old, err := l.items[i].(String).Get()
-		val := (*(l.val))[i]
-		if err != nil || (*(l.val))[i] != old {
-			err = item.(*boundString).Set(val)
-			if err != nil {
-				retErr = err
-			}
-		}
+// TODO cache values and do comparison - for now we just always trigger child elements
+//		old, err := l.items[i].(String).Get()
+//		val := (*(l.val))[i]
+//		if err != nil || (*(l.val))[i] != old {
+//			err = item.(*boundString).Set(val)
+//			if err != nil {
+//				retErr = err
+//			}
+//		}
+		item.(*boundStringListItem).trigger()
 	}
 	return
 }

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -110,15 +110,15 @@ func (l *boundBoolList) doReload() (retErr error) {
 			break
 		}
 
-// TODO cache values and do comparison - for now we just always trigger child elements
-//		old, err := l.items[i].(Bool).Get()
-//		val := (*(l.val))[i]
-//		if err != nil || (*(l.val))[i] != old {
-//			err = item.(*boundBool).Set(val)
-//			if err != nil {
-//				retErr = err
-//			}
-//		}
+		// TODO cache values and do comparison - for now we just always trigger child elements
+		//		old, err := l.items[i].(Bool).Get()
+		//		val := (*(l.val))[i]
+		//		if err != nil || (*(l.val))[i] != old {
+		//			err = item.(*boundBool).Set(val)
+		//			if err != nil {
+		//				retErr = err
+		//			}
+		//		}
 		item.(*boundBoolListItem).trigger()
 	}
 	return
@@ -145,7 +145,7 @@ type boundBoolListItem struct {
 	base
 
 	val   *[]bool
-    index int
+	index int
 }
 
 func (b *boundBoolListItem) Get() (bool, error) {
@@ -266,15 +266,15 @@ func (l *boundFloatList) doReload() (retErr error) {
 			break
 		}
 
-// TODO cache values and do comparison - for now we just always trigger child elements
-//		old, err := l.items[i].(Float).Get()
-//		val := (*(l.val))[i]
-//		if err != nil || (*(l.val))[i] != old {
-//			err = item.(*boundFloat).Set(val)
-//			if err != nil {
-//				retErr = err
-//			}
-//		}
+		// TODO cache values and do comparison - for now we just always trigger child elements
+		//		old, err := l.items[i].(Float).Get()
+		//		val := (*(l.val))[i]
+		//		if err != nil || (*(l.val))[i] != old {
+		//			err = item.(*boundFloat).Set(val)
+		//			if err != nil {
+		//				retErr = err
+		//			}
+		//		}
 		item.(*boundFloatListItem).trigger()
 	}
 	return
@@ -301,7 +301,7 @@ type boundFloatListItem struct {
 	base
 
 	val   *[]float64
-    index int
+	index int
 }
 
 func (b *boundFloatListItem) Get() (float64, error) {
@@ -422,15 +422,15 @@ func (l *boundIntList) doReload() (retErr error) {
 			break
 		}
 
-// TODO cache values and do comparison - for now we just always trigger child elements
-//		old, err := l.items[i].(Int).Get()
-//		val := (*(l.val))[i]
-//		if err != nil || (*(l.val))[i] != old {
-//			err = item.(*boundInt).Set(val)
-//			if err != nil {
-//				retErr = err
-//			}
-//		}
+		// TODO cache values and do comparison - for now we just always trigger child elements
+		//		old, err := l.items[i].(Int).Get()
+		//		val := (*(l.val))[i]
+		//		if err != nil || (*(l.val))[i] != old {
+		//			err = item.(*boundInt).Set(val)
+		//			if err != nil {
+		//				retErr = err
+		//			}
+		//		}
 		item.(*boundIntListItem).trigger()
 	}
 	return
@@ -457,7 +457,7 @@ type boundIntListItem struct {
 	base
 
 	val   *[]int
-    index int
+	index int
 }
 
 func (b *boundIntListItem) Get() (int, error) {
@@ -578,15 +578,15 @@ func (l *boundRuneList) doReload() (retErr error) {
 			break
 		}
 
-// TODO cache values and do comparison - for now we just always trigger child elements
-//		old, err := l.items[i].(Rune).Get()
-//		val := (*(l.val))[i]
-//		if err != nil || (*(l.val))[i] != old {
-//			err = item.(*boundRune).Set(val)
-//			if err != nil {
-//				retErr = err
-//			}
-//		}
+		// TODO cache values and do comparison - for now we just always trigger child elements
+		//		old, err := l.items[i].(Rune).Get()
+		//		val := (*(l.val))[i]
+		//		if err != nil || (*(l.val))[i] != old {
+		//			err = item.(*boundRune).Set(val)
+		//			if err != nil {
+		//				retErr = err
+		//			}
+		//		}
 		item.(*boundRuneListItem).trigger()
 	}
 	return
@@ -613,7 +613,7 @@ type boundRuneListItem struct {
 	base
 
 	val   *[]rune
-    index int
+	index int
 }
 
 func (b *boundRuneListItem) Get() (rune, error) {
@@ -734,15 +734,15 @@ func (l *boundStringList) doReload() (retErr error) {
 			break
 		}
 
-// TODO cache values and do comparison - for now we just always trigger child elements
-//		old, err := l.items[i].(String).Get()
-//		val := (*(l.val))[i]
-//		if err != nil || (*(l.val))[i] != old {
-//			err = item.(*boundString).Set(val)
-//			if err != nil {
-//				retErr = err
-//			}
-//		}
+		// TODO cache values and do comparison - for now we just always trigger child elements
+		//		old, err := l.items[i].(String).Get()
+		//		val := (*(l.val))[i]
+		//		if err != nil || (*(l.val))[i] != old {
+		//			err = item.(*boundString).Set(val)
+		//			if err != nil {
+		//				retErr = err
+		//			}
+		//		}
 		item.(*boundStringListItem).trigger()
 	}
 	return
@@ -769,7 +769,7 @@ type boundStringListItem struct {
 	base
 
 	val   *[]string
-    index int
+	index int
 }
 
 func (b *boundStringListItem) Get() (string, error) {

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -110,16 +110,10 @@ func (l *boundBoolList) doReload() (retErr error) {
 			break
 		}
 
-		// TODO cache values and do comparison - for now we just always trigger child elements
-		//		old, err := l.items[i].(Bool).Get()
-		//		val := (*(l.val))[i]
-		//		if err != nil || (*(l.val))[i] != old {
-		//			err = item.(*boundBool).Set(val)
-		//			if err != nil {
-		//				retErr = err
-		//			}
-		//		}
-		item.(*boundBoolListItem).trigger()
+		err := item.(*boundBoolListItem).setIfChanged((*l.val)[i])
+		if err != nil {
+			retErr = err
+		}
 	}
 	return
 }
@@ -138,7 +132,7 @@ func (l *boundBoolList) SetValue(i int, v bool) error {
 }
 
 func bindBoolListItem(v *[]bool, i int) Bool {
-	return &boundBoolListItem{val: v, index: i}
+	return &boundBoolListItem{val: v, index: i, old: (*v)[i]}
 }
 
 type boundBoolListItem struct {
@@ -146,6 +140,7 @@ type boundBoolListItem struct {
 
 	val   *[]bool
 	index int
+	old   bool
 }
 
 func (b *boundBoolListItem) Get() (bool, error) {
@@ -154,6 +149,17 @@ func (b *boundBoolListItem) Get() (bool, error) {
 
 func (b *boundBoolListItem) Set(val bool) error {
 	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundBoolListItem) setIfChanged(val bool) error {
+	if val == b.old {
+		return nil
+	}
+	(*b.val)[b.index] = val
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -266,16 +272,10 @@ func (l *boundFloatList) doReload() (retErr error) {
 			break
 		}
 
-		// TODO cache values and do comparison - for now we just always trigger child elements
-		//		old, err := l.items[i].(Float).Get()
-		//		val := (*(l.val))[i]
-		//		if err != nil || (*(l.val))[i] != old {
-		//			err = item.(*boundFloat).Set(val)
-		//			if err != nil {
-		//				retErr = err
-		//			}
-		//		}
-		item.(*boundFloatListItem).trigger()
+		err := item.(*boundFloatListItem).setIfChanged((*l.val)[i])
+		if err != nil {
+			retErr = err
+		}
 	}
 	return
 }
@@ -294,7 +294,7 @@ func (l *boundFloatList) SetValue(i int, v float64) error {
 }
 
 func bindFloatListItem(v *[]float64, i int) Float {
-	return &boundFloatListItem{val: v, index: i}
+	return &boundFloatListItem{val: v, index: i, old: (*v)[i]}
 }
 
 type boundFloatListItem struct {
@@ -302,6 +302,7 @@ type boundFloatListItem struct {
 
 	val   *[]float64
 	index int
+	old   float64
 }
 
 func (b *boundFloatListItem) Get() (float64, error) {
@@ -310,6 +311,17 @@ func (b *boundFloatListItem) Get() (float64, error) {
 
 func (b *boundFloatListItem) Set(val float64) error {
 	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundFloatListItem) setIfChanged(val float64) error {
+	if val == b.old {
+		return nil
+	}
+	(*b.val)[b.index] = val
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -422,16 +434,10 @@ func (l *boundIntList) doReload() (retErr error) {
 			break
 		}
 
-		// TODO cache values and do comparison - for now we just always trigger child elements
-		//		old, err := l.items[i].(Int).Get()
-		//		val := (*(l.val))[i]
-		//		if err != nil || (*(l.val))[i] != old {
-		//			err = item.(*boundInt).Set(val)
-		//			if err != nil {
-		//				retErr = err
-		//			}
-		//		}
-		item.(*boundIntListItem).trigger()
+		err := item.(*boundIntListItem).setIfChanged((*l.val)[i])
+		if err != nil {
+			retErr = err
+		}
 	}
 	return
 }
@@ -450,7 +456,7 @@ func (l *boundIntList) SetValue(i int, v int) error {
 }
 
 func bindIntListItem(v *[]int, i int) Int {
-	return &boundIntListItem{val: v, index: i}
+	return &boundIntListItem{val: v, index: i, old: (*v)[i]}
 }
 
 type boundIntListItem struct {
@@ -458,6 +464,7 @@ type boundIntListItem struct {
 
 	val   *[]int
 	index int
+	old   int
 }
 
 func (b *boundIntListItem) Get() (int, error) {
@@ -466,6 +473,17 @@ func (b *boundIntListItem) Get() (int, error) {
 
 func (b *boundIntListItem) Set(val int) error {
 	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundIntListItem) setIfChanged(val int) error {
+	if val == b.old {
+		return nil
+	}
+	(*b.val)[b.index] = val
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -578,16 +596,10 @@ func (l *boundRuneList) doReload() (retErr error) {
 			break
 		}
 
-		// TODO cache values and do comparison - for now we just always trigger child elements
-		//		old, err := l.items[i].(Rune).Get()
-		//		val := (*(l.val))[i]
-		//		if err != nil || (*(l.val))[i] != old {
-		//			err = item.(*boundRune).Set(val)
-		//			if err != nil {
-		//				retErr = err
-		//			}
-		//		}
-		item.(*boundRuneListItem).trigger()
+		err := item.(*boundRuneListItem).setIfChanged((*l.val)[i])
+		if err != nil {
+			retErr = err
+		}
 	}
 	return
 }
@@ -606,7 +618,7 @@ func (l *boundRuneList) SetValue(i int, v rune) error {
 }
 
 func bindRuneListItem(v *[]rune, i int) Rune {
-	return &boundRuneListItem{val: v, index: i}
+	return &boundRuneListItem{val: v, index: i, old: (*v)[i]}
 }
 
 type boundRuneListItem struct {
@@ -614,6 +626,7 @@ type boundRuneListItem struct {
 
 	val   *[]rune
 	index int
+	old   rune
 }
 
 func (b *boundRuneListItem) Get() (rune, error) {
@@ -622,6 +635,17 @@ func (b *boundRuneListItem) Get() (rune, error) {
 
 func (b *boundRuneListItem) Set(val rune) error {
 	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundRuneListItem) setIfChanged(val rune) error {
+	if val == b.old {
+		return nil
+	}
+	(*b.val)[b.index] = val
+	b.old = val
 
 	b.trigger()
 	return nil
@@ -734,16 +758,10 @@ func (l *boundStringList) doReload() (retErr error) {
 			break
 		}
 
-		// TODO cache values and do comparison - for now we just always trigger child elements
-		//		old, err := l.items[i].(String).Get()
-		//		val := (*(l.val))[i]
-		//		if err != nil || (*(l.val))[i] != old {
-		//			err = item.(*boundString).Set(val)
-		//			if err != nil {
-		//				retErr = err
-		//			}
-		//		}
-		item.(*boundStringListItem).trigger()
+		err := item.(*boundStringListItem).setIfChanged((*l.val)[i])
+		if err != nil {
+			retErr = err
+		}
 	}
 	return
 }
@@ -762,7 +780,7 @@ func (l *boundStringList) SetValue(i int, v string) error {
 }
 
 func bindStringListItem(v *[]string, i int) String {
-	return &boundStringListItem{val: v, index: i}
+	return &boundStringListItem{val: v, index: i, old: (*v)[i]}
 }
 
 type boundStringListItem struct {
@@ -770,6 +788,7 @@ type boundStringListItem struct {
 
 	val   *[]string
 	index int
+	old   string
 }
 
 func (b *boundStringListItem) Get() (string, error) {
@@ -778,6 +797,17 @@ func (b *boundStringListItem) Get() (string, error) {
 
 func (b *boundStringListItem) Set(val string) error {
 	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundStringListItem) setIfChanged(val string) error {
+	if val == b.old {
+		return nil
+	}
+	(*b.val)[b.index] = val
+	b.old = val
 
 	b.trigger()
 	return nil

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -45,7 +45,7 @@ func BindBoolList(v *[]bool) ExternalBoolList {
 	b := &boundBoolList{val: v}
 
 	for i := range *v {
-		b.appendItem(BindBool(&((*v)[i])))
+		b.appendItem(bindBoolListItem(v, i))
 	}
 
 	return b
@@ -100,7 +100,7 @@ func (l *boundBoolList) doReload() (retErr error) {
 		l.trigger()
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
-			l.appendItem(BindBool(&((*l.val)[i])))
+			l.appendItem(bindBoolListItem(l.val, i))
 		}
 		l.trigger()
 	}
@@ -135,6 +135,28 @@ func (l *boundBoolList) SetValue(i int, v bool) error {
 		return err
 	}
 	return item.(Bool).Set(v)
+}
+
+func bindBoolListItem(v *[]bool, i int) Bool {
+	return &boundBoolListItem{val: v, index: i}
+}
+
+type boundBoolListItem struct {
+	base
+
+	val   *[]bool
+    index int
+}
+
+func (b *boundBoolListItem) Get() (bool, error) {
+	return (*b.val)[b.index], nil
+}
+
+func (b *boundBoolListItem) Set(val bool) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
 }
 
 // FloatList supports binding a list of float64 values.
@@ -179,7 +201,7 @@ func BindFloatList(v *[]float64) ExternalFloatList {
 	b := &boundFloatList{val: v}
 
 	for i := range *v {
-		b.appendItem(BindFloat(&((*v)[i])))
+		b.appendItem(bindFloatListItem(v, i))
 	}
 
 	return b
@@ -234,7 +256,7 @@ func (l *boundFloatList) doReload() (retErr error) {
 		l.trigger()
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
-			l.appendItem(BindFloat(&((*l.val)[i])))
+			l.appendItem(bindFloatListItem(l.val, i))
 		}
 		l.trigger()
 	}
@@ -269,6 +291,28 @@ func (l *boundFloatList) SetValue(i int, v float64) error {
 		return err
 	}
 	return item.(Float).Set(v)
+}
+
+func bindFloatListItem(v *[]float64, i int) Float {
+	return &boundFloatListItem{val: v, index: i}
+}
+
+type boundFloatListItem struct {
+	base
+
+	val   *[]float64
+    index int
+}
+
+func (b *boundFloatListItem) Get() (float64, error) {
+	return (*b.val)[b.index], nil
+}
+
+func (b *boundFloatListItem) Set(val float64) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
 }
 
 // IntList supports binding a list of int values.
@@ -313,7 +357,7 @@ func BindIntList(v *[]int) ExternalIntList {
 	b := &boundIntList{val: v}
 
 	for i := range *v {
-		b.appendItem(BindInt(&((*v)[i])))
+		b.appendItem(bindIntListItem(v, i))
 	}
 
 	return b
@@ -368,7 +412,7 @@ func (l *boundIntList) doReload() (retErr error) {
 		l.trigger()
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
-			l.appendItem(BindInt(&((*l.val)[i])))
+			l.appendItem(bindIntListItem(l.val, i))
 		}
 		l.trigger()
 	}
@@ -403,6 +447,28 @@ func (l *boundIntList) SetValue(i int, v int) error {
 		return err
 	}
 	return item.(Int).Set(v)
+}
+
+func bindIntListItem(v *[]int, i int) Int {
+	return &boundIntListItem{val: v, index: i}
+}
+
+type boundIntListItem struct {
+	base
+
+	val   *[]int
+    index int
+}
+
+func (b *boundIntListItem) Get() (int, error) {
+	return (*b.val)[b.index], nil
+}
+
+func (b *boundIntListItem) Set(val int) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
 }
 
 // RuneList supports binding a list of rune values.
@@ -447,7 +513,7 @@ func BindRuneList(v *[]rune) ExternalRuneList {
 	b := &boundRuneList{val: v}
 
 	for i := range *v {
-		b.appendItem(BindRune(&((*v)[i])))
+		b.appendItem(bindRuneListItem(v, i))
 	}
 
 	return b
@@ -502,7 +568,7 @@ func (l *boundRuneList) doReload() (retErr error) {
 		l.trigger()
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
-			l.appendItem(BindRune(&((*l.val)[i])))
+			l.appendItem(bindRuneListItem(l.val, i))
 		}
 		l.trigger()
 	}
@@ -537,6 +603,28 @@ func (l *boundRuneList) SetValue(i int, v rune) error {
 		return err
 	}
 	return item.(Rune).Set(v)
+}
+
+func bindRuneListItem(v *[]rune, i int) Rune {
+	return &boundRuneListItem{val: v, index: i}
+}
+
+type boundRuneListItem struct {
+	base
+
+	val   *[]rune
+    index int
+}
+
+func (b *boundRuneListItem) Get() (rune, error) {
+	return (*b.val)[b.index], nil
+}
+
+func (b *boundRuneListItem) Set(val rune) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
 }
 
 // StringList supports binding a list of string values.
@@ -581,7 +669,7 @@ func BindStringList(v *[]string) ExternalStringList {
 	b := &boundStringList{val: v}
 
 	for i := range *v {
-		b.appendItem(BindString(&((*v)[i])))
+		b.appendItem(bindStringListItem(v, i))
 	}
 
 	return b
@@ -636,7 +724,7 @@ func (l *boundStringList) doReload() (retErr error) {
 		l.trigger()
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
-			l.appendItem(BindString(&((*l.val)[i])))
+			l.appendItem(bindStringListItem(l.val, i))
 		}
 		l.trigger()
 	}
@@ -671,4 +759,26 @@ func (l *boundStringList) SetValue(i int, v string) error {
 		return err
 	}
 	return item.(String).Set(v)
+}
+
+func bindStringListItem(v *[]string, i int) String {
+	return &boundStringListItem{val: v, index: i}
+}
+
+type boundStringListItem struct {
+	base
+
+	val   *[]string
+    index int
+}
+
+func (b *boundStringListItem) Get() (string, error) {
+	return (*b.val)[b.index], nil
+}
+
+func (b *boundStringListItem) Set(val string) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
 }

--- a/data/binding/bindlists_test.go
+++ b/data/binding/bindlists_test.go
@@ -71,6 +71,16 @@ func TestExternalFloatList_Reload(t *testing.T) {
 	assert.Equal(t, 4.2, v)
 	assert.True(t, calledList)
 	assert.True(t, calledChild)
+
+	calledList, calledChild = false, false
+	l = []float64{1.0, 4.2, 5.3}
+	f.Reload()
+	waitForItems()
+	v, err = f.GetValue(1)
+	assert.Nil(t, err)
+	assert.Equal(t, 4.2, v)
+	assert.True(t, calledList)
+	assert.False(t, calledChild)
 }
 
 func TestNewFloatList(t *testing.T) {

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -64,11 +64,13 @@ func (s *stringFromBool) Set(str string) error {
 		return err
 	}
 
-	s.trigger()
+	s.DataChanged()
 	return nil
 }
 
 func (s *stringFromBool) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -129,11 +131,13 @@ func (s *stringFromFloat) Set(str string) error {
 		return err
 	}
 
-	s.trigger()
+	s.DataChanged()
 	return nil
 }
 
 func (s *stringFromFloat) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -194,11 +198,13 @@ func (s *stringFromInt) Set(str string) error {
 		return err
 	}
 
-	s.trigger()
+	s.DataChanged()
 	return nil
 }
 
 func (s *stringFromInt) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -259,11 +265,13 @@ func (s *stringToBool) Set(val bool) error {
 		return err
 	}
 
-	s.trigger()
+	s.DataChanged()
 	return nil
 }
 
 func (s *stringToBool) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -324,11 +332,13 @@ func (s *stringToFloat) Set(val float64) error {
 		return err
 	}
 
-	s.trigger()
+	s.DataChanged()
 	return nil
 }
 
 func (s *stringToFloat) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -389,10 +399,12 @@ func (s *stringToInt) Set(val int) error {
 		return err
 	}
 
-	s.trigger()
+	s.DataChanged()
 	return nil
 }
 
 func (s *stringToInt) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	s.trigger()
 }

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -270,7 +270,7 @@ type {{ .Name }}List interface {
 //
 // Since: 2.0.0
 func New{{ .Name }}List() {{ .Name }}List {
-	return &bound{{ .Name }}List{}
+	return &bound{{ .Name }}List{val: &[]{{ .Type }}{}}
 }
 
 // Bind{{ .Name }}List returns a bound list of {{ .Type }} values, based on the contents of the passed slice.
@@ -297,19 +297,13 @@ type bound{{ .Name }}List struct {
 }
 
 func (l *bound{{ .Name }}List) Append(val {{ .Type }}) error {
-	if l.val != nil {
-		*l.val = append(*l.val, val)
-	}
+	*l.val = append(*l.val, val)
 
 	l.appendItem(Bind{{ .Name }}(&val))
 	return nil
 }
 
 func (l *bound{{ .Name }}List) Get() ([]{{ .Type }}, error) {
-	if l.val == nil {
-		return []{{ .Type }}{}, nil
-	}
-
 	return *l.val, nil
 }
 
@@ -317,33 +311,17 @@ func (l *bound{{ .Name }}List) GetValue(i int) ({{ .Type }}, error) {
 	if i < 0 || i >= l.Length() {
 		return {{ .Default }}, errOutOfBounds
 	}
-	if l.val != nil {
-		return (*l.val)[i], nil
-	}
-
-	item, err := l.GetItem(i)
-	if err != nil {
-		return {{ .Default }}, err
-	}
-	return item.({{ .Name }}).Get()
+	return (*l.val)[i], nil
 }
 
 func (l *bound{{ .Name }}List) Prepend(val {{ .Type }}) error {
-	if l.val != nil {
-		*l.val = append([]{{ .Type }}{val}, *l.val...)
-	}
+	*l.val = append([]{{ .Type }}{val}, *l.val...)
 
 	l.prependItem(Bind{{ .Name }}(&val))
 	return nil
 }
 
 func (l *bound{{ .Name }}List) Set(v []{{ .Type }}) (retErr error) {
-	if l.val == nil { // was not initialized with a blank value, recover
-		l.val = &v
-		l.trigger()
-		return nil
-	}
-
 	oldLen := len(l.items)
 	*l.val = v
 	newLen := len(v)
@@ -380,9 +358,7 @@ func (l *bound{{ .Name }}List) SetValue(i int, v {{ .Type }}) error {
 	if i < 0 || i >= l.Length() {
 		return errOutOfBounds
 	}
-	if l.val != nil {
-		(*l.val)[i] = v
-	}
+	(*l.val)[i] = v
 
 	item, err := l.GetItem(i)
 	if err != nil {

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -67,34 +67,13 @@ func (b *bound{{ .Name }}) Get() ({{ .Type }}, error) {
 }
 
 func (b *bound{{ .Name }}) Reload() error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	return b.setIfChanged(*b.val)
+	return b.Set(*b.val)
 }
 
 func (b *bound{{ .Name }}) Set(val {{ .Type }}) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	if *b.val == val {
-		return nil
-	}
-	if b.val == nil { // was not initialized with a blank value, recover
-		b.val = &val
-	} else {
-		*b.val = val
-	}
-
-	b.trigger()
-	return nil
-}
-
-func (b *bound{{ .Name }}) setIfChanged(val {{ .Type }}) error {
-	if val == b.old {
-		return nil
-	}
-	b.old = val
+	*b.val = val
 
 	b.trigger()
 	return nil

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -395,9 +395,13 @@ func (l *bound{{ .Name }}List) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
+			item.(*boundExternal{{ .Name }}ListItem).lock.Lock()
 			err = item.(*boundExternal{{ .Name }}ListItem).setIfChanged((*l.val)[i])
+			item.(*boundExternal{{ .Name }}ListItem).lock.Unlock()
 		} else {
+			item.(*bound{{ .Name }}ListItem).lock.Lock()
 			err = item.(*bound{{ .Name }}ListItem).doSet((*l.val)[i])
+			item.(*bound{{ .Name }}ListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -34,7 +34,7 @@ type External{{ .Name }} interface {
 // Since: 2.0.0
 func New{{ .Name }}() {{ .Name }} {
 	blank := {{ .Default }}
-	return &bound{{ .Name }}{val: &blank, old: blank}
+	return &bound{{ .Name }}{val: &blank}
 }
 
 // Bind{{ .Name }} returns a new bindable value that controls the contents of the provided {{ .Type }} variable.
@@ -53,7 +53,6 @@ type bound{{ .Name }} struct {
 	base
 
 	val *{{ .Type }}
-	old {{ .Type }}
 }
 
 func (b *bound{{ .Name }}) Get() ({{ .Type }}, error) {

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -53,7 +53,7 @@ type bound{{ .Name }} struct {
 	base
 
 	val *{{ .Type }}
-	old {{ .Type }} 
+	old {{ .Type }}
 }
 
 func (b *bound{{ .Name }}) Get() ({{ .Type }}, error) {

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -308,7 +308,7 @@ func Bind{{ .Name }}List(v *[]{{ .Type }}) External{{ .Name }}List {
 	b := &bound{{ .Name }}List{val: v}
 
 	for i := range *v {
-		b.appendItem(Bind{{ .Name }}(&((*v)[i])))
+		b.appendItem(bind{{ .Name }}ListItem(v, i))
 	}
 
 	return b
@@ -363,7 +363,7 @@ func (l *bound{{ .Name }}List) doReload() (retErr error) {
 		l.trigger()
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
-			l.appendItem(Bind{{ .Name }}(&((*l.val)[i])))
+			l.appendItem(bind{{ .Name }}ListItem(l.val, i))
 		}
 		l.trigger()
 	}
@@ -398,6 +398,28 @@ func (l *bound{{ .Name }}List) SetValue(i int, v {{ .Type }}) error {
 		return err
 	}
 	return item.({{ .Name }}).Set(v)
+}
+
+func bind{{ .Name }}ListItem(v *[]{{ .Type }}, i int) {{ .Name }} {
+	return &bound{{ .Name }}ListItem{val: v, index: i}
+}
+
+type bound{{ .Name }}ListItem struct {
+	base
+
+	val   *[]{{ .Type }}
+    index int
+}
+
+func (b *bound{{ .Name }}ListItem) Get() ({{ .Type }}, error) {
+	return (*b.val)[b.index], nil
+}
+
+func (b *bound{{ .Name }}ListItem) Set(val {{ .Type }}) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
 }
 `
 

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -373,15 +373,15 @@ func (l *bound{{ .Name }}List) doReload() (retErr error) {
 			break
 		}
 
-// TODO cache values and do comparison - for now we just always trigger child elements
-//		old, err := l.items[i].({{ .Name }}).Get()
-//		val := (*(l.val))[i]
-//		if err != nil || (*(l.val))[i] != old {
-//			err = item.(*bound{{ .Name }}).Set(val)
-//			if err != nil {
-//				retErr = err
-//			}
-//		}
+		// TODO cache values and do comparison - for now we just always trigger child elements
+		//		old, err := l.items[i].({{ .Name }}).Get()
+		//		val := (*(l.val))[i]
+		//		if err != nil || (*(l.val))[i] != old {
+		//			err = item.(*bound{{ .Name }}).Set(val)
+		//			if err != nil {
+		//				retErr = err
+		//			}
+		//		}
 		item.(*bound{{ .Name }}ListItem).trigger()
 	}
 	return
@@ -408,7 +408,7 @@ type bound{{ .Name }}ListItem struct {
 	base
 
 	val   *[]{{ .Type }}
-    index int
+	index int
 }
 
 func (b *bound{{ .Name }}ListItem) Get() ({{ .Type }}, error) {

--- a/data/binding/listbinding.go
+++ b/data/binding/listbinding.go
@@ -39,9 +39,3 @@ func (b *listBase) deleteItem(i int) {
 
 	b.trigger()
 }
-
-func (b *listBase) prependItem(i DataItem) {
-	b.items = append([]DataItem{i}, b.items...)
-
-	b.trigger()
-}

--- a/data/binding/mapbinding.go
+++ b/data/binding/mapbinding.go
@@ -116,10 +116,6 @@ type mapBase struct {
 	val   *map[string]interface{}
 }
 
-// GetItem returns the DataItem at the specified key.
-// It will return nil if the key was not found.
-//
-// Since: 2.0.0
 func (b *mapBase) GetItem(key string) (DataItem, error) {
 	if v, ok := b.items[key]; ok {
 		return v, nil
@@ -128,9 +124,6 @@ func (b *mapBase) GetItem(key string) (DataItem, error) {
 	return nil, errKeyNotFound
 }
 
-// Keys returns a list of all the keys in this data map.
-//
-// Since: 2.0.0
 func (b *mapBase) Keys() []string {
 	ret := make([]string, len(b.items))
 	// TODO lock
@@ -143,9 +136,6 @@ func (b *mapBase) Keys() []string {
 	return ret
 }
 
-// Delete removes the specified key and tha value associated with it.
-//
-// Since: 2.0.0
 func (b *mapBase) Delete(key string) {
 	delete(b.items, key)
 
@@ -160,9 +150,6 @@ func (b *mapBase) Get() (map[string]interface{}, error) {
 	return *b.val, nil
 }
 
-// Get returns the value stored at the specified key.
-//
-// Since: 2.0.0
 func (b *mapBase) GetValue(key string) (interface{}, error) {
 	if i, ok := b.items[key]; ok {
 		return i.(Untyped).get()
@@ -235,10 +222,6 @@ func (b *mapBase) doReload() (retErr error) {
 	return
 }
 
-// Set stores the value d at the specified key.
-// If the key is not present it will create a new binding internally.
-//
-// Since: 2.0.0
 func (b *mapBase) SetValue(key string, d interface{}) error {
 	if i, ok := b.items[key]; ok {
 		i.(Untyped).set(d)

--- a/data/binding/mapbinding.go
+++ b/data/binding/mapbinding.go
@@ -16,6 +16,14 @@ type DataMap interface {
 	Keys() []string
 }
 
+// ExternalUntypedMap is a map data binding with all values untyped (interface{}), connected to an external data source.
+//
+// Since: 2.0.0
+type ExternalUntypedMap interface {
+	UntypedMap
+	Reload() error
+}
+
 // UntypedMap is a map data binding with all values Untyped (interface{}).
 //
 // Since: 2.0.0
@@ -36,11 +44,12 @@ func NewUntypedMap() UntypedMap {
 }
 
 // BindUntypedMap creates a new map binding of string to interface{} based on the data passed.
+// If your code changes the content of the map this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0.0
-func BindUntypedMap(d *map[string]interface{}) UntypedMap {
+func BindUntypedMap(d *map[string]interface{}) ExternalUntypedMap {
 	if d == nil {
-		return NewUntypedMap()
+		return NewUntypedMap().(ExternalUntypedMap)
 	}
 	m := &mapBase{items: make(map[string]DataItem), val: d}
 
@@ -58,6 +67,7 @@ type Struct interface {
 	DataMap
 	GetValue(string) (interface{}, error)
 	SetValue(string, interface{}) error
+	Reload() error
 }
 
 // BindStruct creates a new map binding of string to interface{} using the struct passed as data.
@@ -67,13 +77,13 @@ type Struct interface {
 // Since: 2.0.0
 func BindStruct(i interface{}) Struct {
 	if i == nil {
-		return NewUntypedMap()
+		return NewUntypedMap().(Struct)
 	}
 	t := reflect.TypeOf(i)
 	if t.Kind() != reflect.Ptr ||
 		(reflect.TypeOf(reflect.ValueOf(i).Elem()).Kind() != reflect.Struct) {
 		fyne.LogError("Invalid type passed to BindStruct, must be pointer to struct", nil)
-		return NewUntypedMap()
+		return NewUntypedMap().(Struct)
 	}
 
 	m := &mapBase{items: make(map[string]DataItem)}

--- a/data/binding/mapbinding.go
+++ b/data/binding/mapbinding.go
@@ -248,7 +248,7 @@ func (b *mapBase) doReload() (retErr error) {
 	}
 
 	for k, item := range b.items {
-		err := item.(*boundUntyped).setIfChanged((*b.val)[k])
+		err := item.(*boundMapValue).setIfChanged((*b.val)[k])
 		if err != nil {
 			retErr = err
 		}
@@ -306,10 +306,10 @@ func (b *boundStruct) Reload() (retErr error) {
 }
 
 func bindUntypedMapValue(m *map[string]interface{}, k string) Untyped {
-	return &boundUntyped{val: m, key: k, old: (*m)[k]}
+	return &boundMapValue{val: m, key: k, old: (*m)[k]}
 }
 
-type boundUntyped struct {
+type boundMapValue struct {
 	base
 
 	val *map[string]interface{}
@@ -317,7 +317,7 @@ type boundUntyped struct {
 	old interface{}
 }
 
-func (b *boundUntyped) get() (interface{}, error) {
+func (b *boundMapValue) get() (interface{}, error) {
 	if v, ok := (*b.val)[b.key]; ok {
 		return v, nil
 	}
@@ -325,14 +325,14 @@ func (b *boundUntyped) get() (interface{}, error) {
 	return nil, errKeyNotFound
 }
 
-func (b *boundUntyped) set(val interface{}) error {
+func (b *boundMapValue) set(val interface{}) error {
 	(*b.val)[b.key] = val
 
 	b.trigger()
 	return nil
 }
 
-func (b *boundUntyped) setIfChanged(val interface{}) error {
+func (b *boundMapValue) setIfChanged(val interface{}) error {
 	if val == b.old {
 		return nil
 	}

--- a/data/binding/mapbinding_test.go
+++ b/data/binding/mapbinding_test.go
@@ -147,6 +147,20 @@ func TestExternalUntypedMap_Reload(t *testing.T) {
 	assert.Equal(t, "bar", v)
 	assert.True(t, calledMap)
 	assert.True(t, calledChild)
+
+	calledMap, calledChild = false, false
+	m = map[string]interface{}{
+		"foo": "bar",
+		"val": 5,
+		"new": "longer",
+	}
+	b.Reload()
+	waitForItems()
+	v, err = b.GetValue("foo")
+	assert.Nil(t, err)
+	assert.Equal(t, "bar", v)
+	assert.True(t, calledMap)
+	assert.False(t, calledChild)
 }
 
 func TestUntypedMap_Delete(t *testing.T) {

--- a/data/binding/preference.go
+++ b/data/binding/preference.go
@@ -42,6 +42,8 @@ func (b *prefBoundBool) Get() (bool, error) {
 func (b *prefBoundBool) Set(v bool) error {
 	b.p.SetBool(b.key, v)
 
+	b.lock.RLock()
+	defer b.lock.RUnlock()
 	b.trigger()
 	return nil
 }
@@ -89,6 +91,8 @@ func (b *prefBoundFloat) Get() (float64, error) {
 func (b *prefBoundFloat) Set(v float64) error {
 	b.p.SetFloat(b.key, v)
 
+	b.lock.RLock()
+	defer b.lock.RUnlock()
 	b.trigger()
 	return nil
 }
@@ -136,6 +140,8 @@ func (b *prefBoundInt) Get() (int, error) {
 func (b *prefBoundInt) Set(v int) error {
 	b.p.SetInt(b.key, v)
 
+	b.lock.RLock()
+	defer b.lock.RUnlock()
 	b.trigger()
 	return nil
 }
@@ -183,6 +189,8 @@ func (b *prefBoundString) Get() (string, error) {
 func (b *prefBoundString) Set(v string) error {
 	b.p.SetString(b.key, v)
 
+	b.lock.RLock()
+	defer b.lock.RUnlock()
 	b.trigger()
 	return nil
 }


### PR DESCRIPTION
OK, primarily this is about adding `Reload` to external data types where that is required.
This is BindXxx (not NewXxx) BindXxxList (not NewXxxList), BindUntypedMap (not NewUntypedMap) and BindStruct.
These interfaces can be ignored by anybody not using external variable binding, so to widgets, converters, validators etc this completely transparent.

During this development I also found that our set tests were a little lacking in map and list - re-using the same variable had unintended consequences. These are now fixed as well and all the tests pass.

To be finished
- [x] Calling `Reload` when the value has not changed should not trigger on primitive types
- [x] Calling `Reload` on a list/map/struct should not trigger the child element callbacks if the value has not changed

Fixes #1645

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
