### PR TITLE
Fix/system scale deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ These changes likely break some apps, please read the
 * Removed deprecated types including:
   - dialog.FileIcon (now widget.FileIcon)
   - canvas.SetScale()
+  - device.SystemScale()
 * iOS apps preferences will be lost in this upgrade as we move to more advanced storage
 
 ### Added

--- a/app/settings.go
+++ b/app/settings.go
@@ -85,6 +85,9 @@ func (s *settings) applyTheme(theme fyne.Theme, variant fyne.ThemeVariant) {
 func (s *settings) Scale() float32 {
 	s.propertyLock.RLock()
 	defer s.propertyLock.RUnlock()
+	if s.schema.Scale < 0.0 {
+		return 1.0 // catching any really old data still using the `-1`  value for "auto" scale
+	}
 	return s.schema.Scale
 }
 

--- a/device.go
+++ b/device.go
@@ -30,9 +30,6 @@ type Device interface {
 	IsMobile() bool
 	HasKeyboard() bool
 	SystemScaleForWindow(Window) float32
-
-	// Deprecated: Use SystemScaleForWindow instead - system scale can vary depending on window placement
-	SystemScale() float32
 }
 
 // CurrentDevice returns the device information for the current hardware (via the driver)

--- a/internal/driver/glfw/device.go
+++ b/internal/driver/glfw/device.go
@@ -33,5 +33,5 @@ func (*glDevice) SystemScaleForWindow(w fyne.Window) float32 {
 		return xScale
 	}
 
-	return fyne.SettingsScaleAuto
+	return scaleAuto
 }

--- a/internal/driver/glfw/device.go
+++ b/internal/driver/glfw/device.go
@@ -24,15 +24,6 @@ func (*glDevice) HasKeyboard() bool {
 	return true // TODO actually check - we could be in tablet mode
 }
 
-// Deprecated: SystemScaleForWindow provides an accurate answer, this method may return incorrect results!
-func (d *glDevice) SystemScale() float32 {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		return 1.0
-	}
-
-	return fyne.SettingsScaleAuto
-}
-
 func (*glDevice) SystemScaleForWindow(w fyne.Window) float32 {
 	if runtime.GOOS == "darwin" {
 		return 1.0 // macOS scaling is done at the texture level

--- a/internal/driver/glfw/scale.go
+++ b/internal/driver/glfw/scale.go
@@ -11,6 +11,7 @@ import (
 const (
 	baselineDPI = 120.0
 	scaleEnvKey = "FYNE_SCALE"
+	scaleAuto   = float32(-1.0) // some platforms allow setting auto-scale (linux/BSD)
 )
 
 func calculateDetectedScale(widthMm, widthPx int) float32 {
@@ -27,11 +28,11 @@ func calculateDetectedScale(widthMm, widthPx int) float32 {
 }
 
 func calculateScale(user, system, detected float32) float32 {
-	if user == fyne.SettingsScaleAuto {
+	if user < 0 {
 		user = 1.0
 	}
 
-	if system == fyne.SettingsScaleAuto {
+	if system == scaleAuto {
 		system = detected
 	}
 
@@ -51,8 +52,7 @@ func userScale() float32 {
 	}
 
 	if env != "auto" {
-		setting := fyne.CurrentApp().Settings().Scale()
-		if setting != fyne.SettingsScaleAuto && setting != 0.0 {
+		if setting := fyne.CurrentApp().Settings().Scale(); setting > 0 {
 			return setting
 		}
 	}

--- a/internal/driver/glfw/scale_test.go
+++ b/internal/driver/glfw/scale_test.go
@@ -35,16 +35,10 @@ func TestCalculateScale(t *testing.T) {
 	smaller := calculateScale(0.8, 1.0, 1.0)
 	assert.Equal(t, float32(0.8), smaller)
 
-	auto := calculateScale(fyne.SettingsScaleAuto, fyne.SettingsScaleAuto, 1.1)
-	assert.Equal(t, float32(1.1), auto)
-
-	autoUser := calculateScale(fyne.SettingsScaleAuto, 1.0, 1.1)
-	assert.Equal(t, float32(1.0), autoUser)
-
 	hiDPI := calculateScale(0.8, 2.0, 1.0)
 	assert.Equal(t, float32(1.6), hiDPI)
 
-	hiDPIAuto := calculateScale(0.8, fyne.SettingsScaleAuto, 2.0)
+	hiDPIAuto := calculateScale(0.8, scaleAuto, 2.0)
 	assert.Equal(t, float32(1.6), hiDPIAuto)
 
 	large := calculateScale(1.5, 2.0, 2.0)

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -707,16 +707,13 @@ var scaleTests = []struct {
 	name                             string
 }{
 	{1.0, 1.0, 1.0, 1.0, "Windows with user setting 1.0"},
-	{fyne.SettingsScaleAuto, 1.0, 1.0, 1.0, "Windows with user legacy setting auto"},
 	{1.5, 1.0, 1.0, 1.5, "Windows with user setting 1.5"},
 
-	{1.0, fyne.SettingsScaleAuto, 1.0, 1.0, "Linux lowDPI with user setting 1.0"},
-	{fyne.SettingsScaleAuto, fyne.SettingsScaleAuto, 1.0, 1.0, "Linux lowDPI with user legacy setting auto"},
-	{1.5, fyne.SettingsScaleAuto, 1.0, 1.5, "Linux lowDPI with user setting 1.5"},
+	{1.0, scaleAuto, 1.0, 1.0, "Linux lowDPI with user setting 1.0"},
+	{1.5, scaleAuto, 1.0, 1.5, "Linux lowDPI with user setting 1.5"},
 
-	{1.0, fyne.SettingsScaleAuto, 2.0, 2.0, "Linux highDPI with user setting 1.0"},
-	{fyne.SettingsScaleAuto, fyne.SettingsScaleAuto, 2.0, 2.0, "Linux highDPI with user legacy setting auto"},
-	{1.5, fyne.SettingsScaleAuto, 2.0, 3.0, "Linux highDPI with user setting 1.5"},
+	{1.0, scaleAuto, 2.0, 2.0, "Linux highDPI with user setting 1.0"},
+	{1.5, scaleAuto, 2.0, 3.0, "Linux highDPI with user setting 1.5"},
 }
 
 func TestWindow_calculateScale(t *testing.T) {

--- a/internal/driver/gomobile/device.go
+++ b/internal/driver/gomobile/device.go
@@ -37,10 +37,6 @@ func (*device) HasKeyboard() bool {
 	return false
 }
 
-func (d *device) SystemScale() float32 {
-	return d.SystemScaleForWindow(nil)
-}
-
 func (*device) ShowVirtualKeyboard() {
 	showVirtualKeyboard(mobile.DefaultKeyboard)
 }

--- a/settings.go
+++ b/settings.go
@@ -1,11 +1,5 @@
 package fyne
 
-// SettingsScaleAuto is a specific scale value that indicates a canvas should
-// scale according to the DPI of the window that contains it.
-//
-// Deprecated: Automatic scaling is now handled in the drivers and is not a user setting.
-const SettingsScaleAuto = float32(-1.0)
-
 // BuildType defines different modes that an application can be built using.
 type BuildType int
 


### PR DESCRIPTION
Removal of more scale related code.
User cannot specify auto any more (since long ago). Move auto to an internal detail for per-system settings in GLFW.

Relates #1724

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Any breaking changes have a deprecation path or have been discussed.
