### PR TITLE
Fix/remove canvas deprecations

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -22,20 +22,8 @@ type Canvas interface {
 	// The pixel size of a CanvasObject can be found by multiplying by this value.
 	Scale() float32
 
-	// Overlay returns the current overlay.
-	//
-	// Deprecated: Overlays are stacked now.
-	// This method returns the top of the overlay stack.
-	// Use Overlays() instead.
-	Overlay() CanvasObject
 	// Overlays returns the overlay stack.
 	Overlays() OverlayStack
-	// SetOverlay sets the overlay for the canvas.
-	//
-	// Deprecated: Overlays are stacked now.
-	// This method replaces the whole stack by the given overlay.
-	// Use Overlays() instead.
-	SetOverlay(CanvasObject)
 
 	OnTypedRune() func(rune)
 	SetOnTypedRune(func(rune))

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -85,8 +85,6 @@ type Focusable interface {
 	FocusGained()
 	// FocusLost is a hook called by the focus handling logic after this object lost the focus.
 	FocusLost()
-	// Deprecated: this is an internal detail, canvas tracks current focused object
-	Focused() bool
 
 	// TypedRune is a hook called by the input handling logic on text input events if this object is focused.
 	TypedRune(rune)

--- a/internal/app/focus_manager_test.go
+++ b/internal/app/focus_manager_test.go
@@ -169,10 +169,6 @@ func (f *focusable) FocusLost() {
 	f.focused = false
 }
 
-func (f *focusable) Focused() bool {
-	return f.focused
-}
-
 func (f *focusable) TypedRune(_ rune) {
 }
 

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -574,19 +574,6 @@ func (o *overlayStack) remove(overlay fyne.CanvasObject) {
 	o.renderCaches = o.renderCaches[:overlayCount]
 }
 
-// concurrency safe implementation of deprecated c.SetOverlay
-func (o *overlayStack) setOverlay(overlay fyne.CanvasObject) {
-	o.propertyLock.Lock()
-	defer o.propertyLock.Unlock()
-
-	if len(o.List()) > 0 {
-		o.remove(o.List()[0])
-	}
-	if overlay != nil {
-		o.add(overlay)
-	}
-}
-
 type renderCacheNode struct {
 	// structural data
 	firstChild  *renderCacheNode

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -131,11 +131,6 @@ func (c *glCanvas) OnTypedRune() func(rune) {
 	return c.onTypedRune
 }
 
-// Deprecated: Use Overlays() instead.
-func (c *glCanvas) Overlay() fyne.CanvasObject {
-	return c.Overlays().Top()
-}
-
 func (c *glCanvas) Overlays() fyne.OverlayStack {
 	c.RLock()
 	defer c.RUnlock()
@@ -225,14 +220,6 @@ func (c *glCanvas) SetOnTypedKey(typed func(*fyne.KeyEvent)) {
 
 func (c *glCanvas) SetOnTypedRune(typed func(rune)) {
 	c.onTypedRune = typed
-}
-
-// Deprecated: Use Overlays() instead.
-func (c *glCanvas) SetOverlay(overlay fyne.CanvasObject) {
-	c.RLock()
-	o := c.overlays
-	c.RUnlock()
-	o.setOverlay(overlay)
 }
 
 func (c *glCanvas) SetPadded(padded bool) {

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -378,7 +378,7 @@ func TestGlCanvas_ResizeWithOtherOverlay(t *testing.T) {
 	content := widget.NewLabel("Content")
 	over := widget.NewLabel("Over")
 	w.SetContent(content)
-	w.Canvas().SetOverlay(over)
+	w.Canvas().Overlays().Add(over)
 	// TODO: address #707; overlays should always be canvas size
 	over.Resize(w.Canvas().Size())
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1075,10 +1075,6 @@ type focusable struct {
 	disabled       bool
 }
 
-func (f *focusable) Focused() bool {
-	panic("deprecated")
-}
-
 func (f *focusable) TypedRune(rune) {
 }
 

--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -71,21 +71,8 @@ func (c *mobileCanvas) SetContent(content fyne.CanvasObject) {
 	c.sizeContent(c.Size()) // fixed window size for mobile, cannot stretch to new content
 }
 
-// Deprecated: Use Overlays() instead.
-func (c *mobileCanvas) Overlay() fyne.CanvasObject {
-	return c.overlays.Top()
-}
-
 func (c *mobileCanvas) Overlays() fyne.OverlayStack {
 	return c.overlays
-}
-
-// Deprecated: Use Overlays() instead.
-func (c *mobileCanvas) SetOverlay(overlay fyne.CanvasObject) {
-	if len(c.overlays.List()) > 0 {
-		c.overlays.Remove(c.overlays.List()[0])
-	}
-	c.overlays.Add(overlay)
 }
 
 func (c *mobileCanvas) Refresh(obj fyne.CanvasObject) {

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -119,33 +119,33 @@ func TestFocusNext(t *testing.T) {
 	c.SetContent(fyne.NewContainerWithoutLayout(f1, f2, f3))
 
 	assert.Nil(t, c.Focused())
-	assert.False(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.False(t, f3.Focused())
+	assert.False(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.False(t, f3.focused)
 
 	test.FocusNext(c)
 	assert.Equal(t, f1, c.Focused())
-	assert.True(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.False(t, f3.Focused())
+	assert.True(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.False(t, f3.focused)
 
 	test.FocusNext(c)
 	assert.Equal(t, f2, c.Focused())
-	assert.False(t, f1.Focused())
-	assert.True(t, f2.Focused())
-	assert.False(t, f3.Focused())
+	assert.False(t, f1.focused)
+	assert.True(t, f2.focused)
+	assert.False(t, f3.focused)
 
 	test.FocusNext(c)
 	assert.Equal(t, f3, c.Focused())
-	assert.False(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.True(t, f3.Focused())
+	assert.False(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.True(t, f3.focused)
 
 	test.FocusNext(c)
 	assert.Equal(t, f1, c.Focused())
-	assert.True(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.False(t, f3.Focused())
+	assert.True(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.False(t, f3.focused)
 }
 
 func TestFocusPrevious(t *testing.T) {
@@ -156,33 +156,33 @@ func TestFocusPrevious(t *testing.T) {
 	c.SetContent(fyne.NewContainerWithoutLayout(f1, f2, f3))
 
 	assert.Nil(t, c.Focused())
-	assert.False(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.False(t, f3.Focused())
+	assert.False(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.False(t, f3.focused)
 
 	test.FocusPrevious(c)
 	assert.Equal(t, f3, c.Focused())
-	assert.False(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.True(t, f3.Focused())
+	assert.False(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.True(t, f3.focused)
 
 	test.FocusPrevious(c)
 	assert.Equal(t, f2, c.Focused())
-	assert.False(t, f1.Focused())
-	assert.True(t, f2.Focused())
-	assert.False(t, f3.Focused())
+	assert.False(t, f1.focused)
+	assert.True(t, f2.focused)
+	assert.False(t, f3.focused)
 
 	test.FocusPrevious(c)
 	assert.Equal(t, f1, c.Focused())
-	assert.True(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.False(t, f3.Focused())
+	assert.True(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.False(t, f3.focused)
 
 	test.FocusPrevious(c)
 	assert.Equal(t, f3, c.Focused())
-	assert.False(t, f1.Focused())
-	assert.False(t, f2.Focused())
-	assert.True(t, f3.Focused())
+	assert.False(t, f1.focused)
+	assert.False(t, f2.focused)
+	assert.True(t, f3.focused)
 }
 
 func TestScroll(t *testing.T) {
@@ -230,10 +230,6 @@ func (f *focusable) FocusGained() {
 
 func (f *focusable) FocusLost() {
 	f.focused = false
-}
-
-func (f *focusable) Focused() bool {
-	return f.focused
 }
 
 func (f *focusable) TypedKey(event *fyne.KeyEvent) {

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -129,11 +129,6 @@ func (c *testCanvas) OnTypedRune() func(rune) {
 	return c.onTypedRune
 }
 
-// Deprecated
-func (c *testCanvas) Overlay() fyne.CanvasObject {
-	panic("deprecated method should not be used")
-}
-
 func (c *testCanvas) Overlays() fyne.OverlayStack {
 	c.propertyLock.Lock()
 	defer c.propertyLock.Unlock()
@@ -216,11 +211,6 @@ func (c *testCanvas) SetOnTypedRune(handler func(rune)) {
 	defer c.propertyLock.Unlock()
 
 	c.onTypedRune = handler
-}
-
-// Deprecated
-func (c *testCanvas) SetOverlay(_ fyne.CanvasObject) {
-	panic("deprecated method should not be used")
 }
 
 func (c *testCanvas) SetPadded(padded bool) {

--- a/widget/check.go
+++ b/widget/check.go
@@ -261,16 +261,6 @@ func (c *Check) FocusLost() {
 	c.Refresh()
 }
 
-// Focused returns whether or not this Check has focus.
-//
-// Deprecated: this method will be removed as it is no longer required, widgets do not expose their focus state.
-func (c *Check) Focused() bool {
-	if c.Disabled() {
-		return false
-	}
-	return c.focused
-}
-
 // TypedRune receives text input events when the Check is focused.
 func (c *Check) TypedRune(r rune) {
 	if c.Disabled() {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -289,18 +289,6 @@ func (e *Entry) FocusLost() {
 	})
 }
 
-// Focused returns whether or not this Entry has focus.
-//
-// Implements: fyne.Focusable
-//
-// Deprecated: this method will be removed as it is no longer required, widgets do not expose their focus state.
-func (e *Entry) Focused() bool {
-	e.propertyLock.RLock()
-	defer e.propertyLock.RUnlock()
-
-	return e.focused
-}
-
 // Hide hides the entry.
 //
 // Implements: fyne.Widget
@@ -1038,7 +1026,7 @@ func (e *Entry) textWrap() fyne.TextWrap {
 }
 
 func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
-	if !e.Focused() && !e.Disabled() {
+	if !e.focused && !e.Disabled() {
 		e.FocusGained()
 	}
 

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -50,15 +50,6 @@ func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
 	return r
 }
 
-// Focused returns whether this item is focused or not.
-//
-// Implements: fyne.Focusable
-//
-// Deprecated: Use fyne.Canvas.Focused() instead.
-func (i *radioItem) Focused() bool {
-	return i.focused
-}
-
 // FocusGained is called when this item gained the focus.
 //
 // Implements: fyne.Focusable

--- a/widget/select.go
+++ b/widget/select.go
@@ -75,15 +75,6 @@ func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 	return r
 }
 
-// Focused returns whether this Select is focused or not.
-//
-// Implements: fyne.Focusable
-//
-// Deprecated: internal detail, don’t use
-func (s *Select) Focused() bool {
-	return s.focused
-}
-
 // FocusGained is called after this Select has gained focus.
 //
 // Implements: fyne.Focusable


### PR DESCRIPTION
Removing deprecated Focusable.Focused(), Canvas.Overlay and Canvas.SetOverlay.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Any breaking changes have a deprecation path or have been discussed.
