### PR TITLE
Add animation repeat count

### DIFF
--- a/animation.go
+++ b/animation.go
@@ -8,6 +8,9 @@ import "time"
 // A linear animation would return the same output value as is passed in.
 type AnimationCurve func(float32) float32
 
+// AnimationRepeatForever is an AnimationCount value that indicates it should not stop looping.
+const AnimationRepeatForever = -1
+
 var (
 	// AnimationEaseInOut is the default easing, it starts slowly, accelerates to the middle and slows to the end.
 	AnimationEaseInOut = animationEaseInOut
@@ -25,7 +28,7 @@ type Animation struct {
 	AutoReverse bool
 	Curve       AnimationCurve
 	Duration    time.Duration
-	Repeat      bool
+	RepeatCount int
 	Tick        func(float32)
 }
 

--- a/animation.go
+++ b/animation.go
@@ -9,21 +9,33 @@ import "time"
 type AnimationCurve func(float32) float32
 
 // AnimationRepeatForever is an AnimationCount value that indicates it should not stop looping.
+//
+// Since 2.0.0
 const AnimationRepeatForever = -1
 
 var (
 	// AnimationEaseInOut is the default easing, it starts slowly, accelerates to the middle and slows to the end.
+	//
+	// Since 2.0.0
 	AnimationEaseInOut = animationEaseInOut
 	// AnimationEaseIn starts slowly and accelerates to the end.
+	//
+	// Since 2.0.0
 	AnimationEaseIn = animationEaseIn
 	// AnimationEaseOut starts at speed and slows to the end.
+	//
+	// Since 2.0.0
 	AnimationEaseOut = animationEaseOut
 	// AnimationLinear is a linear mapping for animations that progress uniformly through their duration.
+	//
+	// Since 2.0.0
 	AnimationLinear = animationLinear
 )
 
 // Animation represents an animated element within a Fyne canvas.
 // These animations may control individual objects or entire scenes.
+//
+// Since 2.0.0
 type Animation struct {
 	AutoReverse bool
 	Curve       AnimationCurve
@@ -35,6 +47,8 @@ type Animation struct {
 // NewAnimation creates a very basic animation where the callback function will be called for every
 // rendered frame between time.Now() and the specified duration. The callback values start at 0.0 and
 // will be 1.0 when the animation completes.
+//
+// Since 2.0.0
 func NewAnimation(d time.Duration, fn func(float32)) *Animation {
 	return &Animation{Duration: d, Tick: fn}
 }

--- a/canvas/animation.go
+++ b/canvas/animation.go
@@ -9,8 +9,12 @@ import (
 
 const (
 	// DurationStandard is the time a standard interface animation will run.
+	//
+	// Since 2.0.0
 	DurationStandard = time.Millisecond * 300
 	// DurationShort is the time a subtle or small transition should use.
+	//
+	// Since 2.0.0
 	DurationShort = time.Millisecond * 150
 )
 
@@ -18,6 +22,8 @@ const (
 // the specified Duration. The colour transition will move linearly through the RGB colour space.
 // The content of fn should apply the color values to an object and refresh it.
 // You should call Start() on the returned animation to start it.
+//
+// Since 2.0.0
 func NewColorRGBAAnimation(start, stop color.Color, d time.Duration, fn func(color.Color)) *fyne.Animation {
 	r1, g1, b1, a1 := start.RGBA()
 	r2, g2, b2, a2 := stop.RGBA()
@@ -42,6 +48,8 @@ func NewColorRGBAAnimation(start, stop color.Color, d time.Duration, fn func(col
 // NewPositionAnimation sets up a new animation that will transition from the start to stop Position over
 // the specified Duration. The content of fn should apply the position value to an object for the change
 // to be visible. You should call Start() on the returned animation to start it.
+//
+// Since 2.0.0
 func NewPositionAnimation(start, stop fyne.Position, d time.Duration, fn func(fyne.Position)) *fyne.Animation {
 	xDelta := float32(stop.X - start.X)
 	yDelta := float32(stop.Y - start.Y)
@@ -56,6 +64,8 @@ func NewPositionAnimation(start, stop fyne.Position, d time.Duration, fn func(fy
 // NewSizeAnimation sets up a new animation that will transition from the start to stop Size over
 // the specified Duration. The content of fn should apply the size value to an object for the change
 // to be visible. You should call Start() on the returned animation to start it.
+//
+// Since 2.0.0
 func NewSizeAnimation(start, stop fyne.Size, d time.Duration, fn func(fyne.Size)) *fyne.Animation {
 	widthDelta := float32(stop.Width - start.Width)
 	heightDelta := float32(stop.Height - start.Height)

--- a/cmd/fyne_demo/tutorials/animation.go
+++ b/cmd/fyne_demo/tutorials/animation.go
@@ -25,7 +25,7 @@ func makeAnimationCanvas() fyne.CanvasObject {
 			rect.FillColor = c
 			canvas.Refresh(rect)
 		})
-	a.Repeat = true
+	a.RepeatCount = fyne.AnimationRepeatForever
 	a.AutoReverse = true
 	a.Start()
 
@@ -37,7 +37,7 @@ func makeAnimationCanvas() fyne.CanvasObject {
 		width := 10 + (p.X / 7)
 		i.Resize(fyne.NewSize(width, width))
 	})
-	a2.Repeat = true
+	a2.RepeatCount = fyne.AnimationRepeatForever
 	a2.AutoReverse = true
 	a2.Curve = fyne.AnimationLinear
 	a2.Start()
@@ -94,5 +94,7 @@ func makeAnimationCurveItem(label string, curve fyne.AnimationCurve, yOff float3
 			box.Refresh()
 		})
 	anim.Curve = curve
+	anim.AutoReverse = true
+	anim.RepeatCount = 1
 	return
 }

--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -7,15 +7,17 @@ import (
 )
 
 type anim struct {
-	a       *fyne.Animation
-	end     time.Time
-	reverse bool
-	start   time.Time
-	total   int64
+	a           *fyne.Animation
+	end         time.Time
+	repeatsLeft int
+	reverse     bool
+	start       time.Time
+	total       int64
 }
 
 func newAnim(a *fyne.Animation) *anim {
 	animate := &anim{a: a, start: time.Now(), end: time.Now().Add(a.Duration)}
 	animate.total = animate.end.Sub(animate.start).Nanoseconds() / 1000000 // TODO change this to Milliseconds() when we drop Go 1.12
+	animate.repeatsLeft = a.RepeatCount
 	return animate
 }

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -69,7 +69,7 @@ func (r *Runner) tickAnimation(a *anim) bool {
 	if time.Now().After(a.end) {
 		if a.reverse {
 			a.a.Tick(0.0)
-			if !a.a.Repeat {
+			if a.repeatsLeft == 0 {
 				return false
 			}
 			a.reverse = false
@@ -79,8 +79,13 @@ func (r *Runner) tickAnimation(a *anim) bool {
 				a.reverse = true
 			}
 		}
-		if !a.a.Repeat && !a.reverse {
-			return false
+		if !a.reverse {
+			if a.repeatsLeft == 0 {
+				return false
+			}
+			if a.repeatsLeft > 0 {
+				a.repeatsLeft--
+			}
 		}
 
 		a.start = time.Now()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1442,7 +1442,7 @@ func makeCursorAnimation(cursor *canvas.Rectangle) *fyne.Animation {
 		cursor.FillColor = c
 		cursor.Refresh()
 	})
-	anim.Repeat = true
+	anim.RepeatCount = fyne.AnimationRepeatForever
 	anim.AutoReverse = true
 
 	return anim


### PR DESCRIPTION
Moves `Repeat bool` to `RepeatCount int`. Adds special `AnimationRepeatForever` for un-ending repeat.

If an animation has `Reverse` set to `true` then the repeat count will be decremented after the reverse is complete.

Fixes #1578

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- I have included it in fyne_demo, the logic is in the internal runner and we have not figured out how to unit test that yet.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
