### PR TITLE
Preferences improvements, fix locking and watch file

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -113,8 +113,8 @@ func newAppWithDriver(d fyne.Driver, id string) fyne.App {
 	fyne.SetCurrentApp(newApp)
 
 	newApp.prefs = newPreferences(newApp)
-	if pref, ok := newApp.prefs.(interface{ load(string) }); ok && id != "" {
-		pref.load(id)
+	if pref, ok := newApp.prefs.(interface{ load() }); ok && id != "" {
+		pref.load()
 	}
 	newApp.settings = loadSettings()
 	newApp.storage = &store{a: newApp}

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -62,7 +62,6 @@ func (p *preferences) load() {
 
 func (p *preferences) loadFromFile(path string) error {
 	file, err := os.Open(path) // #nosec
-	defer file.Close()
 	if err != nil {
 		if os.IsNotExist(err) {
 			err := os.MkdirAll(filepath.Dir(path), 0700)
@@ -73,6 +72,7 @@ func (p *preferences) loadFromFile(path string) error {
 		}
 		return err
 	}
+	defer file.Close()
 	decode := json.NewDecoder(file)
 
 	p.InMemoryPreferences.WriteValues(func(values map[string]interface{}) {

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -40,8 +40,10 @@ func (p *preferences) saveToFile(path string) error {
 	}
 	encode := json.NewEncoder(file)
 
-	values := p.InMemoryPreferences.Values()
-	return encode.Encode(&values)
+	p.InMemoryPreferences.ReadValues(func(values map[string]interface{}) {
+		err = encode.Encode(&values)
+	})
+	return err
 }
 
 func (p *preferences) load(_ string) {
@@ -65,8 +67,10 @@ func (p *preferences) loadFromFile(path string) error {
 	}
 	decode := json.NewDecoder(file)
 
-	values := p.InMemoryPreferences.Values()
-	return decode.Decode(&values)
+	p.InMemoryPreferences.WriteValues(func(values map[string]interface{}) {
+		err = decode.Decode(&values)
+	})
+	return err
 }
 
 func newPreferences(app *fyneApp) *preferences {

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -53,7 +53,7 @@ func (p *preferences) saveToFile(path string) error {
 	return err
 }
 
-func (p *preferences) load(_ string) {
+func (p *preferences) load() {
 	err := p.loadFromFile(p.storagePath())
 	if err != nil {
 		fyne.LogError("Preferences load error:", err)

--- a/app/preferences_android.go
+++ b/app/preferences_android.go
@@ -14,3 +14,7 @@ func (p *preferences) storagePath() string {
 func (a *fyneApp) storageRoot() string {
 	return filepath.Join(rootConfigDir(), a.uniqueID)
 }
+
+func (p *preferences) watch() {
+	// no-op on mobile
+}

--- a/app/preferences_ios.go
+++ b/app/preferences_ios.go
@@ -17,3 +17,7 @@ func (p *preferences) storagePath() string {
 func (a *fyneApp) storageRoot() string {
 	return rootConfigDir() // we are in a sandbox, so no app ID added to this path
 }
+
+func (p *preferences) watch() {
+	// no-op on mobile
+}

--- a/app/preferences_other.go
+++ b/app/preferences_other.go
@@ -20,6 +20,6 @@ func (p *preferences) watch() {
 			return
 		}
 
-		p.load("") // path ignored
+		p.load()
 	})
 }

--- a/app/preferences_other.go
+++ b/app/preferences_other.go
@@ -13,3 +13,13 @@ func (p *preferences) storagePath() string {
 func (a *fyneApp) storageRoot() string {
 	return filepath.Join(rootConfigDir(), a.UniqueID())
 }
+
+func (p *preferences) watch() {
+	watchFile(p.storagePath(), func() {
+		if p.ignoreChange {
+			return
+		}
+
+		p.load("") // path ignored
+	})
+}

--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -11,7 +11,7 @@ import (
 
 func loadPreferences(id string) *preferences {
 	p := newPreferences(&fyneApp{uniqueID: id})
-	p.load(id)
+	p.load()
 
 	return p
 }

--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -18,10 +18,12 @@ func loadPreferences(id string) *preferences {
 
 func TestPreferences_Save(t *testing.T) {
 	p := loadPreferences("dummy")
-	p.Values()["keyString"] = "value"
-	p.Values()["keyInt"] = 4
-	p.Values()["keyFloat"] = 3.5
-	p.Values()["keyBool"] = true
+	p.WriteValues(func(val map[string]interface{}) {
+		val["keyString"] = "value"
+		val["keyInt"] = 4
+		val["keyFloat"] = 3.5
+		val["keyBool"] = true
+	})
 
 	path := filepath.Join(os.TempDir(), "fynePrefs.json")
 	defer os.Remove(path)

--- a/internal/preferences_test.go
+++ b/internal/preferences_test.go
@@ -16,7 +16,9 @@ func TestPrefs_SetBool(t *testing.T) {
 
 func TestPrefs_Bool(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values()["testBool"] = true
+	p.WriteValues(func(val map[string]interface{}) {
+		val["testBool"] = true
+	})
 
 	assert.Equal(t, true, p.Bool("testBool"))
 }
@@ -44,7 +46,9 @@ func TestPrefs_SetFloat(t *testing.T) {
 
 func TestPrefs_Float(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values()["testFloat"] = 1.2
+	p.WriteValues(func(val map[string]interface{}) {
+		val["testFloat"] = 1.2
+	})
 
 	assert.Equal(t, 1.2, p.Float("testFloat"))
 }
@@ -53,7 +57,9 @@ func TestPrefs_FloatWithFallback(t *testing.T) {
 	p := NewInMemoryPreferences()
 
 	assert.Equal(t, 1.0, p.FloatWithFallback("testFloat", 1.0))
-	p.Values()["testFloat"] = 1.2
+	p.WriteValues(func(val map[string]interface{}) {
+		val["testFloat"] = 1.2
+	})
 	assert.Equal(t, 1.2, p.FloatWithFallback("testFloat", 1.0))
 }
 
@@ -72,8 +78,9 @@ func TestPrefs_SetInt(t *testing.T) {
 
 func TestPrefs_Int(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values()["testInt"] = 5
-
+	p.WriteValues(func(val map[string]interface{}) {
+		val["testInt"] = 5
+	})
 	assert.Equal(t, 5, p.Int("testInt"))
 }
 
@@ -81,7 +88,9 @@ func TestPrefs_IntWithFallback(t *testing.T) {
 	p := NewInMemoryPreferences()
 
 	assert.Equal(t, 2, p.IntWithFallback("testInt", 2))
-	p.Values()["testInt"] = 5
+	p.WriteValues(func(val map[string]interface{}) {
+		val["testInt"] = 5
+	})
 	assert.Equal(t, 5, p.IntWithFallback("testInt", 2))
 }
 
@@ -100,7 +109,9 @@ func TestPrefs_SetString(t *testing.T) {
 
 func TestPrefs_String(t *testing.T) {
 	p := NewInMemoryPreferences()
-	p.Values()["test"] = "value"
+	p.WriteValues(func(val map[string]interface{}) {
+		val["test"] = "value"
+	})
 
 	assert.Equal(t, "value", p.String("test"))
 }
@@ -109,7 +120,9 @@ func TestPrefs_StringWithFallback(t *testing.T) {
 	p := NewInMemoryPreferences()
 
 	assert.Equal(t, "default", p.StringWithFallback("test", "default"))
-	p.Values()["test"] = "value"
+	p.WriteValues(func(val map[string]interface{}) {
+		val["test"] = "value"
+	})
 	assert.Equal(t, "value", p.StringWithFallback("test", "default"))
 }
 


### PR DESCRIPTION
Adds monitoring preference files for changes (re-using the settings code thankfully).
It hit the map concurrency issue so I resolved that as well.
The external looking APIs are all internal so the change is non-breaking.

Fixes #1718

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
