### PR TITLE
Update dialog.(New/Show)Error() docs with note about not passing nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ These changes likely break some apps, please read the
 * Coordinate system to float32
   * Size and Position units were changed from int to float32
   * `Text.TextSize` moved to float32 and `fyne.MeasureText` now takes a float32 size parameter
-  * Removed `Size.Union`
+  * Removed `Size.Union` (use `Size.Max` instead)
   * Added fyne.Delta for difference based X, Y representation
   * DraggedEvent.DraggedX and DraggedX (int, int) to DraggedEvent.Dragged (Delta)
   * ScrollEvent.DeltaX and DeltaY (int, int) moved to ScrollEvent.Scrolled (Delta)
@@ -30,12 +30,12 @@ These changes likely break some apps, please read the
 * Entry widget now contains scrolling so should no longer be wrapped in a scroll container
 
 * Removed deprecated types including:
-  - dialog.FileIcon (now widget.FileIcon)
-  - widget.Radio (now widget.RadioGroup)
-  - widget.AccordionContainer (now widget.Accordion)
-  - layout.NewFixedGridLayout() (now layout.NewGridWrapLayout())
-  - widget.ScrollContainer (now container.Scroll)
-  - widget.SplitContainer (now containerr.Spilt)
+  - `dialog.FileIcon` (now `widget.FileIcon`)
+  - `widget.Radio` (now `widget.RadioGroup`)
+  - `widget.AccordionContainer` (now `widget.Accordion`)
+  - `layout.NewFixedGridLayout()` (now `layout.NewGridWrapLayout()`)
+  - `widget.ScrollContainer` (now `container.Scroll`)
+  - `widget.SplitContainer` (now `containerr.Spilt`)
 
 ### Added
 

--- a/dialog/information.go
+++ b/dialog/information.go
@@ -24,21 +24,21 @@ func NewInformation(title, message string, parent fyne.Window) Dialog {
 	return createTextDialog(title, message, theme.InfoIcon(), parent)
 }
 
-// ShowInformation shows a dialog over the specified window for user
-// information. The title is used for the dialog window and message is the content.
+// ShowInformation shows a dialog over the specified window for user information.
+// The title is used for the dialog window and message is the content.
 func ShowInformation(title, message string, parent fyne.Window) {
 	NewInformation(title, message, parent).Show()
 }
 
-// NewError creates a dialog over the specified window for an application
-// error. The title and message are extracted from the provided error.
+// NewError creates a dialog over the specified window for an application error.
+// The message is extracted from the provided error (should not be nil).
 // After creation you should call Show().
 func NewError(err error, parent fyne.Window) Dialog {
 	return createTextDialog("Error", err.Error(), theme.ErrorIcon(), parent)
 }
 
-// ShowError shows a dialog over the specified window for an application
-// error. The title and message are extracted from the provided error.
+// ShowError shows a dialog over the specified window for an application error.
+// The message is extracted from the provided error (should not be nil).
 func ShowError(err error, parent fyne.Window) {
 	NewError(err, parent).Show()
 }


### PR DESCRIPTION
 ### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Adds a note about not passing nil to error dialog. I also improved the error dialog documentation to remove the comments about getting the title from the error (it is only the message that it gets).

Relates to [wormhole-gui#6](https://github.com/Jacalz/wormhole-gui/issues/6).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
