### PR TITLE
Validate appID contains a '.' as some OS require it

### DIFF
--- a/cmd/fyne/commands/package.go
+++ b/cmd/fyne/commands/package.go
@@ -159,13 +159,9 @@ func (p *packager) validate() error {
 		return errors.New("Missing application icon at \"" + p.icon + "\"")
 	}
 
-	// only used for iOS and macOS
-	if p.appID == "" {
-		if p.os == "darwin" {
-			p.appID = "com.example." + p.name
-		} else if p.os == "ios" || util.IsAndroid(p.os) || (p.os == "windows" && p.release) {
-			return errors.New("Missing appID parameter for package")
-		}
+	p.appID, err = validateAppID(p.appID, p.os, p.name, p.release)
+	if err != nil {
+		return err
 	}
 	if p.appVersion != "" && !isValidVersion(p.appVersion) {
 		return errors.New("invalid -appVersion parameter, integer and '.' characters only up to x.y.z")
@@ -185,4 +181,22 @@ func isValidVersion(ver string) bool {
 		}
 	}
 	return true
+}
+
+func validateAppID(appID, os, name string, release bool) (string, error) {
+	// old darwin compatibility
+	if os == "darwin" {
+		if appID == "" {
+			return "com.example." + name, nil
+		}
+	} else if os == "ios" || util.IsAndroid(os) || (os == "windows" && release) {
+		// all mobile, and for windows when releasing, needs a unique id - usually reverse DNS style
+		if appID == "" {
+			return "", errors.New("Missing appID parameter for package")
+		} else if !strings.Contains(appID, ".") {
+			return "", errors.New("appID must be globally unique and contain at least 1 '.'")
+		}
+	}
+
+	return appID, nil
 }

--- a/cmd/fyne/commands/package_test.go
+++ b/cmd/fyne/commands/package_test.go
@@ -42,16 +42,16 @@ func Test_validateAppID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "com.myApp", id)
 
-	id, err = validateAppID("", "ios", "myApp", false)
+	_, err = validateAppID("", "ios", "myApp", false)
 	assert.NotNil(t, err)
 
-	id, err = validateAppID("myApp", "ios", "myApp", false)
+	_, err = validateAppID("myApp", "ios", "myApp", false)
 	assert.NotNil(t, err)
 
 	id, err = validateAppID("com.myApp", "android", "myApp", true)
 	assert.Nil(t, err)
 	assert.Equal(t, "com.myApp", id)
 
-	id, err = validateAppID("myApp", "android", "myApp", true)
+	_, err = validateAppID("myApp", "android", "myApp", true)
 	assert.NotNil(t, err)
 }

--- a/cmd/fyne/commands/package_test.go
+++ b/cmd/fyne/commands/package_test.go
@@ -28,3 +28,30 @@ func Test_isValidVersion(t *testing.T) {
 	assert.False(t, isValidVersion("pre1"))
 	assert.False(t, isValidVersion("1..2"))
 }
+
+func Test_validateAppID(t *testing.T) {
+	id, err := validateAppID("myApp", "windows", "myApp", false)
+	assert.Nil(t, err)
+	assert.Equal(t, "myApp", id)
+
+	id, err = validateAppID("", "darwin", "myApp", true)
+	assert.Nil(t, err)
+	assert.Equal(t, "com.example.myApp", id) // this was in for compatibility
+
+	id, err = validateAppID("com.myApp", "darwin", "myApp", true)
+	assert.Nil(t, err)
+	assert.Equal(t, "com.myApp", id)
+
+	id, err = validateAppID("", "ios", "myApp", false)
+	assert.NotNil(t, err)
+
+	id, err = validateAppID("myApp", "ios", "myApp", false)
+	assert.NotNil(t, err)
+
+	id, err = validateAppID("com.myApp", "android", "myApp", true)
+	assert.Nil(t, err)
+	assert.Equal(t, "com.myApp", id)
+
+	id, err = validateAppID("myApp", "android", "myApp", true)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Ensure that mobile apps, and other usages of `appID` contain a "." as some require this.
We were getting build failures on Android when this was not present.

Relates to fyne-io/fyne-cross#25

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
