### PR TITLE
Focus entry back after paste

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -794,6 +794,9 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 	}
 	e.updateText(provider.String())
 	e.Refresh()
+	impl := e.super()
+	// we need to propagate the focus, top level widget handles focus APIs
+	fyne.CurrentApp().Driver().CanvasForObject(impl).Focus(impl.(interface{}).(fyne.Focusable))
 }
 
 // placeholderProvider returns the placeholder text handler for this entry

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -716,6 +716,9 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 
 	e.copyToClipboard(clipboard)
 	e.eraseSelection()
+	impl := e.super()
+	// we need to propagate the focus, top level widget handles focus APIs
+	fyne.CurrentApp().Driver().CanvasForObject(impl).Focus(impl.(interface{}).(fyne.Focusable))
 }
 
 // eraseSelection removes the current selected region and moves the cursor


### PR DESCRIPTION
### Description:
Focus entry back after paste. This PR addresses the issue where the focus is out of the entry after a Paste. 

Fixes #1759

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
