### PR TITLE
Fix lots of Entry issues by making the content less smart

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -677,7 +677,7 @@ func (w *window) mouseOut() {
 func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.Action, mods glfw.ModifierKey) {
 	co, pos, _ := w.findObjectAtPositionMatching(w.canvas, w.mousePos, func(object fyne.CanvasObject) bool {
 		switch object.(type) {
-		case fyne.Tappable, fyne.SecondaryTappable, fyne.DoubleTappable, fyne.Focusable, fyne.Draggable, desktop.Mouseable, desktop.Hoverable:
+		case fyne.Tappable, fyne.SecondaryTappable, fyne.DoubleTappable, fyne.Focusable, desktop.Mouseable, desktop.Hoverable:
 			return true
 		}
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -24,11 +24,11 @@ const (
 
 // Declare conformity with interfaces
 var _ fyne.Disableable = (*Entry)(nil)
-var _ fyne.Draggable = (*entryContent)(nil)
+var _ fyne.Draggable = (*Entry)(nil)
 var _ fyne.Focusable = (*Entry)(nil)
-var _ fyne.Tappable = (*entryContent)(nil)
+var _ fyne.Tappable = (*Entry)(nil)
 var _ fyne.Widget = (*Entry)(nil)
-var _ desktop.Mouseable = (*entryContent)(nil)
+var _ desktop.Mouseable = (*Entry)(nil)
 var _ desktop.Keyable = (*Entry)(nil)
 var _ mobile.Keyboardable = (*Entry)(nil)
 
@@ -181,11 +181,9 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 
 // Cursor returns the cursor type of this widget
 //
-// Deprecated: This wraps inner behavior for compatibility and may be removed in a future release
-//
 // Implements: desktop.Cursorable
 func (e *Entry) Cursor() desktop.Cursor {
-	return e.content.Cursor()
+	return desktop.TextCursor
 }
 
 // Disable this widget so that it cannot be interacted with, updating any style appropriately.
@@ -204,30 +202,46 @@ func (e *Entry) Disabled() bool {
 
 // DoubleTapped is called when this entry has been double tapped so we should select text below the pointer
 //
-// Deprecated: This wraps inner behavior for compatibility and may be removed in a future release
-//
 // Implements: fyne.DoubleTappable
 func (e *Entry) DoubleTapped(p *fyne.PointEvent) {
-	e.content.DoubleTapped(p)
+	row := e.textProvider().row(e.CursorRow)
+	start, end := getTextWhitespaceRegion(row, e.CursorColumn)
+	if start == -1 || end == -1 {
+		return
+	}
+
+	e.setFieldsAndRefresh(func() {
+		if !e.selectKeyDown {
+			e.selectRow = e.CursorRow
+			e.selectColumn = start
+		}
+		// Always aim to maximise the selected region
+		if e.selectRow > e.CursorRow || (e.selectRow == e.CursorRow && e.selectColumn > e.CursorColumn) {
+			e.CursorColumn = start
+		} else {
+			e.CursorColumn = end
+		}
+		e.selecting = true
+	})
 }
 
 // DragEnd is called at end of a drag event. It does nothing.
 //
-// Deprecated: This wraps inner behavior for compatibility and may be removed in a future release
-//
 // Implements: fyne.Draggable
 func (e *Entry) DragEnd() {
-	e.content.DragEnd()
 }
 
 // Dragged is called when the pointer moves while a button is held down.
 // It updates the selection accordingly.
 //
-// Deprecated: This wraps inner behavior for compatibility and may be removed in a future release
-//
 // Implements: fyne.Draggable
 func (e *Entry) Dragged(d *fyne.DragEvent) {
-	e.content.Dragged(d)
+	if !e.selecting {
+		e.selectRow, e.selectColumn = e.getRowCol(&d.PointEvent)
+
+		e.selecting = true
+	}
+	e.updateMousePointer(&d.PointEvent, false)
 }
 
 // Enable this widget, updating any style or features appropriately.
@@ -343,22 +357,33 @@ func (e *Entry) MinSize() fyne.Size {
 // MouseDown called on mouse click, this triggers a mouse click which can move the cursor,
 // update the existing selection (if shift is held), or start a selection dragging operation.
 //
-// Deprecated: This wraps inner behavior for compatibility and may be removed in a future release
-//
 // Implements: desktop.Mouseable
 func (e *Entry) MouseDown(m *desktop.MouseEvent) {
-	e.content.MouseDown(m)
+	e.propertyLock.Lock()
+	if e.selectKeyDown {
+		e.selecting = true
+	}
+	if e.selecting && !e.selectKeyDown && m.Button == desktop.MouseButtonPrimary {
+		e.selecting = false
+	}
+	e.propertyLock.Unlock()
+
+	e.updateMousePointer(&m.PointEvent, m.Button == desktop.MouseButtonSecondary)
 }
 
 // MouseUp called on mouse release
 // If a mouse drag event has completed then check to see if it has resulted in an empty selection,
 // if so, and if a text select key isn't held, then disable selecting
 //
-// Deprecated: This wraps inner behavior for compatibility and may be removed in a future release
-//
 // Implements: desktop.Mouseable
 func (e *Entry) MouseUp(m *desktop.MouseEvent) {
-	e.content.MouseUp(m)
+	start, _ := e.selection()
+
+	e.propertyLock.Lock()
+	defer e.propertyLock.Unlock()
+	if start == -1 && e.selecting && !e.selectKeyDown {
+		e.selecting = false
+	}
 }
 
 // SelectedText returns the text currently selected in this Entry.
@@ -411,11 +436,12 @@ func (e *Entry) SetText(text string) {
 
 // Tapped is called when this entry has been tapped so we should update the cursor position.
 //
-// Deprecated: This wraps inner behavior for compatibility and may be removed in a future release
-//
 // Implements: fyne.Tappable
 func (e *Entry) Tapped(ev *fyne.PointEvent) {
-	e.content.Tapped(ev)
+	if fyne.CurrentDevice().IsMobile() && e.selecting {
+		e.selecting = false
+	}
+	e.updateMousePointer(ev, false)
 }
 
 // TappedSecondary is called when right or alternative tap is invoked.
@@ -1003,7 +1029,7 @@ func (e *Entry) textWrap() fyne.TextWrap {
 
 func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
 	if !e.focused && !e.Disabled() {
-		e.FocusGained()
+		e.focused = true
 	}
 
 	row, col := e.getRowCol(ev)
@@ -1200,113 +1226,6 @@ func (e *entryContent) CreateRenderer() fyne.WidgetRenderer {
 		provider, placeholder, e}
 	r.Layout(e.size)
 	return r
-}
-
-func (e *entryContent) Cursor() desktop.Cursor {
-	return desktop.TextCursor
-}
-
-// DoubleTapped is called when this entry has been double tapped so we should select text below the pointer
-//
-// Implements: fyne.DoubleTappable
-func (e *entryContent) DoubleTapped(_ *fyne.PointEvent) {
-	impl := e.entry.super()
-	// we need to propagate the focus, top level widget handles focus APIs
-	fyne.CurrentApp().Driver().CanvasForObject(impl).Focus(impl.(interface{}).(fyne.Focusable))
-
-	row := e.entry.textProvider().row(e.entry.CursorRow)
-	start, end := getTextWhitespaceRegion(row, e.entry.CursorColumn)
-	if start == -1 || end == -1 {
-		return
-	}
-
-	e.setFieldsAndRefresh(func() {
-		if !e.entry.selectKeyDown {
-			e.entry.selectRow = e.entry.CursorRow
-			e.entry.selectColumn = start
-		}
-		// Always aim to maximise the selected region
-		if e.entry.selectRow > e.entry.CursorRow || (e.entry.selectRow == e.entry.CursorRow && e.entry.selectColumn > e.entry.CursorColumn) {
-			e.entry.CursorColumn = start
-		} else {
-			e.entry.CursorColumn = end
-		}
-		e.entry.selecting = true
-	})
-}
-
-// DragEnd is called at end of a drag event. It does nothing.
-//
-// Implements: fyne.Draggable
-func (e *entryContent) DragEnd() {
-}
-
-// Dragged is called when the pointer moves while a button is held down.
-// It updates the selection accordingly.
-//
-// Implements: fyne.Draggable
-func (e *entryContent) Dragged(d *fyne.DragEvent) {
-	if !e.entry.selecting {
-		e.entry.selectRow, e.entry.selectColumn = e.entry.getRowCol(&d.PointEvent)
-
-		e.entry.selecting = true
-	}
-	e.entry.updateMousePointer(&d.PointEvent, false)
-}
-
-// MouseDown called on mouse click, this triggers a mouse click which can move the cursor,
-// update the existing selection (if shift is held), or start a selection dragging operation.
-//
-// Implements: desktop.Mouseable
-func (e *entryContent) MouseDown(m *desktop.MouseEvent) {
-	e.propertyLock.Lock()
-	if e.entry.selectKeyDown {
-		e.entry.selecting = true
-	}
-	if e.entry.selecting && !e.entry.selectKeyDown && m.Button == desktop.MouseButtonPrimary {
-		e.entry.selecting = false
-	}
-	e.propertyLock.Unlock()
-
-	e.entry.updateMousePointer(&m.PointEvent, m.Button == desktop.MouseButtonSecondary)
-}
-
-// MouseUp called on mouse release
-// If a mouse drag event has completed then check to see if it has resulted in an empty selection,
-// if so, and if a text select key isn't held, then disable selecting
-//
-// Implements: desktop.Mouseable
-func (e *entryContent) MouseUp(_ *desktop.MouseEvent) {
-	start, _ := e.entry.selection()
-
-	e.propertyLock.Lock()
-	defer e.propertyLock.Unlock()
-	if start == -1 && e.entry.selecting && !e.entry.selectKeyDown {
-		e.entry.selecting = false
-	}
-}
-
-// Tapped is called when this entry has been tapped so we should update the cursor position.
-//
-// Implements: fyne.Tappable
-func (e *entryContent) Tapped(ev *fyne.PointEvent) {
-	impl := e.entry.super()
-	// we need to propagate the focus, top level widget handles focus APIs
-	fyne.CurrentApp().Driver().CanvasForObject(impl).Focus(impl.(interface{}).(fyne.Focusable))
-
-	if fyne.CurrentDevice().IsMobile() && e.entry.selecting {
-		e.entry.selecting = false
-	}
-	e.entry.updateMousePointer(ev, false)
-}
-
-// TappedSecondary is called when right or alternative tap is invoked in the entry content.
-//
-// Opens the PopUpMenu in the main entry.
-//
-// Implements: fyne.SecondaryTappable
-func (e *entryContent) TappedSecondary(pe *fyne.PointEvent) {
-	e.entry.TappedSecondary(pe)
 }
 
 var _ fyne.WidgetRenderer = (*entryContentRenderer)(nil)

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -14,40 +14,37 @@ import (
 
 func TestEntry_Cursor(t *testing.T) {
 	entry := NewEntry()
-	content := cache.Renderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
-	assert.Equal(t, desktop.TextCursor, content.Cursor())
+	assert.Equal(t, desktop.TextCursor, entry.Cursor())
 }
 
 func TestEntry_DoubleTapped(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("The quick brown fox\njumped    over the lazy dog\n")
-	content := cache.Renderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
 
 	// select the word 'quick'
 	ev := getClickPosition("The qui", 0)
-	content.Tapped(ev)
-	content.DoubleTapped(ev)
+	entry.Tapped(ev)
+	entry.DoubleTapped(ev)
 	assert.Equal(t, "quick", entry.SelectedText())
 
 	// select the whitespace after 'quick'
 	ev = getClickPosition("The quick", 0)
 	// add half a ' ' character
 	ev.Position.X += fyne.MeasureText(" ", theme.TextSize(), fyne.TextStyle{}).Width / 2
-	content.Tapped(ev)
-	content.DoubleTapped(ev)
+	entry.Tapped(ev)
+	entry.DoubleTapped(ev)
 	assert.Equal(t, " ", entry.SelectedText())
 
 	// select all whitespace after 'jumped'
 	ev = getClickPosition("jumped  ", 1)
-	content.Tapped(ev)
-	content.DoubleTapped(ev)
+	entry.Tapped(ev)
+	entry.DoubleTapped(ev)
 	assert.Equal(t, "    ", entry.SelectedText())
 }
 
 func TestEntry_DoubleTapped_AfterCol(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("A\nB\n")
-	content := cache.Renderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
 
 	window := test.NewWindow(entry)
 	defer window.Close()
@@ -56,14 +53,14 @@ func TestEntry_DoubleTapped_AfterCol(t *testing.T) {
 	entry.Resize(entry.MinSize())
 	c := window.Canvas()
 
-	test.Tap(content)
+	test.Tap(entry)
 	assert.Equal(t, entry, c.Focused())
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(testCharSize, testCharSize*4) // tap below rows
 	ev := &fyne.PointEvent{Position: pos}
-	content.Tapped(ev)
-	content.DoubleTapped(ev)
+	entry.Tapped(ev)
+	entry.DoubleTapped(ev)
 
 	assert.Equal(t, "", entry.SelectedText())
 }
@@ -71,7 +68,6 @@ func TestEntry_DoubleTapped_AfterCol(t *testing.T) {
 func TestEntry_DragSelect(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("The quick brown fox jumped\nover the lazy dog\nThe quick\nbrown fox\njumped over the lazy dog\n")
-	content := cache.Renderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
 
 	// get position after the letter 'e' on the second row
 	ev1 := getClickPosition("ove", 1)
@@ -82,13 +78,13 @@ func TestEntry_DragSelect(t *testing.T) {
 
 	// mouse down and drag from 'r' to 'z'
 	me := &desktop.MouseEvent{PointEvent: *ev1, Button: desktop.MouseButtonPrimary}
-	content.MouseDown(me)
+	entry.MouseDown(me)
 	for ; ev1.Position.X < ev2.Position.X; ev1.Position.X++ {
 		de := &fyne.DragEvent{PointEvent: *ev1, Dragged: fyne.NewDelta(1, 0)}
-		content.Dragged(de)
+		entry.Dragged(de)
 	}
 	me = &desktop.MouseEvent{PointEvent: *ev1, Button: desktop.MouseButtonPrimary}
-	content.MouseUp(me)
+	entry.MouseUp(me)
 
 	assert.Equal(t, "r the laz", entry.SelectedText())
 }
@@ -182,17 +178,16 @@ func TestEntry_EraseSelection(t *testing.T) {
 func TestEntry_MouseClickAndDragOutsideText(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("A\nB\n")
-	content := cache.Renderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(testCharSize, testCharSize*4) // tap below rows
 	ev := &fyne.PointEvent{Position: pos}
 
 	me := &desktop.MouseEvent{PointEvent: *ev, Button: desktop.MouseButtonPrimary}
-	content.MouseDown(me)
+	entry.MouseDown(me)
 	de := &fyne.DragEvent{PointEvent: *ev, Dragged: fyne.NewDelta(1, 0)}
-	content.Dragged(de)
-	content.MouseUp(me)
+	entry.Dragged(de)
+	entry.MouseUp(me)
 	assert.False(t, entry.selecting)
 }
 
@@ -200,21 +195,20 @@ func TestEntry_MouseDownOnSelect(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("Ahnj\nBuki\n")
 	entry.TypedShortcut(&fyne.ShortcutSelectAll{})
-	content := cache.Renderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
 
 	testCharSize := theme.TextSize()
 	pos := fyne.NewPos(testCharSize, testCharSize*4) // tap below rows
 	ev := &fyne.PointEvent{Position: pos}
 
 	me := &desktop.MouseEvent{PointEvent: *ev, Button: desktop.MouseButtonSecondary}
-	content.MouseDown(me)
-	content.MouseUp(me)
+	entry.MouseDown(me)
+	entry.MouseUp(me)
 
 	assert.Equal(t, entry.SelectedText(), "Ahnj\nBuki\n")
 
 	me = &desktop.MouseEvent{PointEvent: *ev, Button: desktop.MouseButtonPrimary}
-	content.MouseDown(me)
-	content.MouseUp(me)
+	entry.MouseDown(me)
+	entry.MouseUp(me)
 
 	assert.Equal(t, entry.SelectedText(), "")
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1308,7 +1308,7 @@ func TestEntry_Tapped(t *testing.T) {
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 1, entry.CursorColumn)
 
-	pos = fyne.NewPos(entryOffset+theme.Padding()+theme.Padding()+testCharSize*2.5, entryOffset+theme.Padding()+testCharSize/2) // tap in the middle of the 3rd "M"
+	pos = fyne.NewPos(entryOffset+theme.Padding()+testCharSize*2.5, entryOffset+theme.Padding()+testCharSize/2) // tap in the middle of the 3rd "M"
 	test.TapCanvas(window.Canvas(), pos)
 	test.AssertRendersToMarkup(t, "entry/tapped_tapped_3rd_m.xml", c)
 	assert.Equal(t, 0, entry.CursorRow)


### PR DESCRIPTION
Made possible by fixing a bug in GLFW code.
An object being Draggable should not have been swallowing tap / focus events, fixed.

Fixes #1774, #1780, #1759

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

