### PR TITLE
Improve mobile tap handling

### DIFF
--- a/internal/driver/gomobile/canvas.go
+++ b/internal/driver/gomobile/canvas.go
@@ -393,7 +393,7 @@ func (c *mobileCanvas) tapMove(pos fyne.Position, tapID int,
 	deltaX := pos.X - c.lastTapDownPos[tapID].X
 	deltaY := pos.Y - c.lastTapDownPos[tapID].Y
 
-	if math.Abs(float64(deltaX)) < 3 && math.Abs(float64(deltaY)) < 3 {
+	if c.dragging == nil && (math.Abs(float64(deltaX)) < tapMoveThreshold && math.Abs(float64(deltaY)) < tapMoveThreshold) {
 		return
 	}
 	c.lastTapDownPos[tapID] = pos
@@ -437,9 +437,10 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 	tapCallback func(fyne.Tappable, *fyne.PointEvent),
 	tapAltCallback func(fyne.SecondaryTappable, *fyne.PointEvent),
 	doubleTapCallback func(fyne.DoubleTappable, *fyne.PointEvent),
-	dragCallback func(fyne.Draggable, *fyne.DragEvent)) {
+	dragCallback func(fyne.Draggable)) {
+
 	if c.dragging != nil {
-		c.dragging.DragEnd()
+		dragCallback(c.dragging)
 
 		c.dragging = nil
 		return

--- a/internal/driver/gomobile/canvas_test.go
+++ b/internal/driver/gomobile/canvas_test.go
@@ -81,7 +81,7 @@ func TestCanvas_Tapped(t *testing.T) {
 		wid.TappedSecondary(ev)
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 		wid.DoubleTapped(ev)
-	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+	}, func(wid fyne.Draggable) {
 	})
 
 	assert.True(t, tapped, "tap primary")
@@ -111,7 +111,7 @@ func TestCanvas_Tapped_Multi(t *testing.T) {
 	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 		wid.DoubleTapped(ev)
-	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+	}, func(wid fyne.Draggable) {
 	})
 
 	assert.False(t, buttonTap, "button should not be tapped")
@@ -140,7 +140,7 @@ func TestCanvas_TappedSecondary(t *testing.T) {
 		wid.TappedSecondary(ev)
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 		wid.DoubleTapped(ev)
-	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+	}, func(wid fyne.Draggable) {
 	})
 
 	assert.False(t, obj.tap, "don't tap primary")
@@ -192,7 +192,7 @@ func TestCanvas_Tappable(t *testing.T) {
 	c.tapUp(fyne.NewPos(15, 15), 0, func(wid fyne.Tappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
-	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+	}, func(wid fyne.Draggable) {
 	})
 	assert.True(t, content.up)
 
@@ -336,6 +336,6 @@ func simulateTap(c *mobileCanvas) {
 	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 		wid.DoubleTapped(ev)
-	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+	}, func(wid fyne.Draggable) {
 	})
 }

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -23,7 +23,10 @@ import (
 	"fyne.io/fyne/theme"
 )
 
-const tapSecondaryDelay = 300 * time.Millisecond
+const (
+	tapMoveThreshold  = 4.0                    // how far can we move before it is a drag
+	tapSecondaryDelay = 300 * time.Millisecond // how long before secondary tap
+)
 
 type mobileDriver struct {
 	app   app.App
@@ -246,7 +249,7 @@ func (d *mobileDriver) tapUpCanvas(canvas *mobileCanvas, x, y float32, tapID tou
 		go wid.TappedSecondary(ev)
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 		go wid.DoubleTapped(ev)
-	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+	}, func(wid fyne.Draggable) {
 		go wid.DragEnd()
 	})
 }

--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -26,6 +26,7 @@ import (
 const (
 	tapMoveThreshold  = 4.0                    // how far can we move before it is a drag
 	tapSecondaryDelay = 300 * time.Millisecond // how long before secondary tap
+	tapYOffset        = -12.0                  // to compensate for how we hold our fingers on the device
 )
 
 type mobileDriver struct {
@@ -223,7 +224,7 @@ func (d *mobileDriver) paintWindow(window fyne.Window, size fyne.Size) {
 func (d *mobileDriver) tapDownCanvas(canvas *mobileCanvas, x, y float32, tapID touch.Sequence) {
 	tapX := internal.UnscaleInt(canvas, int(x))
 	tapY := internal.UnscaleInt(canvas, int(y))
-	pos := fyne.NewPos(tapX, tapY)
+	pos := fyne.NewPos(tapX, tapY+tapYOffset)
 
 	canvas.tapDown(pos, int(tapID))
 }
@@ -231,7 +232,7 @@ func (d *mobileDriver) tapDownCanvas(canvas *mobileCanvas, x, y float32, tapID t
 func (d *mobileDriver) tapMoveCanvas(canvas *mobileCanvas, x, y float32, tapID touch.Sequence) {
 	tapX := internal.UnscaleInt(canvas, int(x))
 	tapY := internal.UnscaleInt(canvas, int(y))
-	pos := fyne.NewPos(tapX, tapY)
+	pos := fyne.NewPos(tapX, tapY+tapYOffset)
 
 	canvas.tapMove(pos, int(tapID), func(wid fyne.Draggable, ev *fyne.DragEvent) {
 		go wid.Dragged(ev)
@@ -241,7 +242,7 @@ func (d *mobileDriver) tapMoveCanvas(canvas *mobileCanvas, x, y float32, tapID t
 func (d *mobileDriver) tapUpCanvas(canvas *mobileCanvas, x, y float32, tapID touch.Sequence) {
 	tapX := internal.UnscaleInt(canvas, int(x))
 	tapY := internal.UnscaleInt(canvas, int(y))
-	pos := fyne.NewPos(tapX, tapY)
+	pos := fyne.NewPos(tapX, tapY+tapYOffset)
 
 	canvas.tapUp(pos, int(tapID), func(wid fyne.Tappable, ev *fyne.PointEvent) {
 		go wid.Tapped(ev)


### PR DESCRIPTION
Once dragging starts be smooth.
When taps happen offset them up the screen to compensate for fat fingers. This is what iOS and others have done too.

Overall this makes mobile feel smoother and easier to handle.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

