### PR TITLE
Fix location of mobile popups by fixing the absolute position lookup

### DIFF
--- a/internal/driver/gomobile/driver.go
+++ b/internal/driver/gomobile/driver.go
@@ -21,6 +21,7 @@ import (
 	"fyne.io/fyne/internal/painter"
 	pgl "fyne.io/fyne/internal/painter/gl"
 	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
 )
 
 const tapSecondaryDelay = 300 * time.Millisecond
@@ -83,7 +84,16 @@ func (d *mobileDriver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Posi
 	}
 
 	mc := c.(*mobileCanvas)
-	return driver.AbsolutePositionForObject(co, mc.objectTrees())
+	pos := driver.AbsolutePositionForObject(co, mc.objectTrees())
+	inset, _ := c.InteractiveArea()
+
+	if mc.windowHead != nil {
+		if len(mc.windowHead.(*widget.Box).Children) > 1 {
+			topHeight := mc.windowHead.MinSize().Height
+			pos = pos.Subtract(fyne.NewSize(0, topHeight))
+		}
+	}
+	return pos.Subtract(inset)
 }
 
 func (d *mobileDriver) Quit() {


### PR DESCRIPTION
We just were not adjusting for the mobile canvas details.

We need to check the InteractiveArea for the top window (see screenshot of menu).
For child windows we also need to check there is a window head that is more than just the menu button (second screenshot).

Fixes #1771

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- images attached until we improve mobile test infra
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

