### PR TITLE
Fix/1809 - toolbar refresh on icon change

### DIFF
--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -137,11 +137,9 @@ func (r *toolbarRenderer) Refresh() {
 }
 
 func (r *toolbarRenderer) resetObjects() {
-	if len(r.items) != len(r.toolbar.Items) {
-		r.items = make([]fyne.CanvasObject, 0, len(r.toolbar.Items))
-		for _, item := range r.toolbar.Items {
-			r.items = append(r.items, item.ToolbarObject())
-		}
+	r.items = make([]fyne.CanvasObject, 0, len(r.toolbar.Items))
+	for _, item := range r.toolbar.Items {
+		r.items = append(r.items, item.ToolbarObject())
 	}
 	r.SetObjects(append([]fyne.CanvasObject{r.background}, r.items...))
 }

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -72,8 +72,7 @@ type Toolbar struct {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *Toolbar) CreateRenderer() fyne.WidgetRenderer {
 	t.ExtendBaseWidget(t)
-	background := canvas.NewRectangle(theme.ButtonColor())
-	r := &toolbarRenderer{toolbar: t, background: background, layout: layout.NewHBoxLayout()}
+	r := &toolbarRenderer{toolbar: t, layout: layout.NewHBoxLayout()}
 	r.resetObjects()
 	return r
 }
@@ -107,10 +106,9 @@ func NewToolbar(items ...ToolbarItem) *Toolbar {
 
 type toolbarRenderer struct {
 	widget.BaseRenderer
-	background *canvas.Rectangle
-	layout     fyne.Layout
-	items      []fyne.CanvasObject
-	toolbar    *Toolbar
+	layout  fyne.Layout
+	items   []fyne.CanvasObject
+	toolbar *Toolbar
 }
 
 func (r *toolbarRenderer) MinSize() fyne.Size {
@@ -118,13 +116,10 @@ func (r *toolbarRenderer) MinSize() fyne.Size {
 }
 
 func (r *toolbarRenderer) Layout(size fyne.Size) {
-	r.background.Resize(size)
 	r.layout.Layout(r.items, size)
 }
 
 func (r *toolbarRenderer) Refresh() {
-	r.background.FillColor = theme.ButtonColor()
-	r.background.Refresh()
 	r.resetObjects()
 	for i, item := range r.toolbar.Items {
 		if _, ok := item.(*ToolbarSeparator); ok {
@@ -141,5 +136,5 @@ func (r *toolbarRenderer) resetObjects() {
 	for _, item := range r.toolbar.Items {
 		r.items = append(r.items, item.ToolbarObject())
 	}
-	r.SetObjects(append([]fyne.CanvasObject{r.background}, r.items...))
+	r.SetObjects(r.items)
 }

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -40,11 +40,11 @@ func TestToolbar_Replace(t *testing.T) {
 	toolbar := NewToolbar(NewToolbarAction(icon, func() {}))
 	assert.Equal(t, 1, len(toolbar.Items))
 	render := test.WidgetRenderer(toolbar)
-	assert.Equal(t, icon, render.Objects()[1].(*Button).Icon)
+	assert.Equal(t, icon, render.Objects()[0].(*Button).Icon)
 
 	toolbar.Items[0] = NewToolbarAction(theme.HelpIcon(), func() {})
 	toolbar.Refresh()
-	assert.NotEqual(t, icon, render.Objects()[1].(*Button).Icon)
+	assert.NotEqual(t, icon, render.Objects()[0].(*Button).Icon)
 }
 
 func TestToolbar_ItemPositioning(t *testing.T) {

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -35,6 +35,18 @@ func TestToolbar_Prepend(t *testing.T) {
 	assert.Equal(t, prepend, toolbar.Items[0])
 }
 
+func TestToolbar_Replace(t *testing.T) {
+	icon := theme.ContentCutIcon()
+	toolbar := NewToolbar(NewToolbarAction(icon, func() {}))
+	assert.Equal(t, 1, len(toolbar.Items))
+	render := test.WidgetRenderer(toolbar)
+	assert.Equal(t, icon, render.Objects()[1].(*Button).Icon)
+
+	toolbar.Items[0] = NewToolbarAction(theme.HelpIcon(), func() {})
+	toolbar.Refresh()
+	assert.NotEqual(t, icon, render.Objects()[1].(*Button).Icon)
+}
+
 func TestToolbar_ItemPositioning(t *testing.T) {
 	toolbar := &Toolbar{
 		Items: []ToolbarItem{


### PR DESCRIPTION
We should refresh the whole toolbar if asked.
Since this optimisation was put in place we have better documented the potential expense of calling Refresh - and we have done a better job of avoiding it except when needed, like in this instance.

Also removed a rogue background rectangle folloing the BackgroundColor removal.

Fixes #1809

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
