### PR TITLE
Stop exiting early in GLFW tests

### DIFF
--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -45,6 +45,11 @@ func TestMain(m *testing.M) {
 		initMainMenu()
 		os.Exit(m.Run())
 	}()
+
+	master := d.CreateWindow("Master")
+	master.SetOnClosed(func() {
+		// we do not close, keeping the driver running
+	})
 	d.Run()
 }
 


### PR DESCRIPTION
As it says on the tin

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- just execution of others
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

