### PR TITLE
fix #1811: some tests were missed on main menu keyboard control

### DIFF
--- a/internal/driver/glfw/canvas_other_test.go
+++ b/internal/driver/glfw/canvas_other_test.go
@@ -19,6 +19,7 @@ func TestGlCanvas_FocusHandlingWhenActivatingOrDeactivatingTheMenu(t *testing.T)
 	w.SetMainMenu(
 		fyne.NewMainMenu(
 			fyne.NewMenu("test", fyne.NewMenuItem("item", func() {})),
+			fyne.NewMenu("other", fyne.NewMenuItem("item", func() {})),
 		),
 	)
 	c := w.Canvas().(*glCanvas)
@@ -38,22 +39,20 @@ func TestGlCanvas_FocusHandlingWhenActivatingOrDeactivatingTheMenu(t *testing.T)
 
 	m.Items[0].(*menuBarItem).Tapped(&fyne.PointEvent{})
 	assert.True(t, m.IsActive())
-	ctxt := "activating the menu changes focus handler but does not remove focus from content"
+	ctxt := "activating the menu changes focus handler and focuses the menu bar item but does not remove focus from content"
 	assert.True(t, ce2.focused, ctxt)
-	assert.Nil(t, c.Focused(), ctxt)
+	assert.Equal(t, m.Items[0], c.Focused(), ctxt)
 
 	c.FocusNext()
-	// TODO: changes menu focus as soon as menu has focus support
 	ctxt = "changing focus with active menu does not affect content focus"
 	assert.True(t, ce2.focused, ctxt)
-	assert.Nil(t, c.Focused(), ctxt)
+	assert.Equal(t, m.Items[1], c.Focused(), ctxt)
 
 	m.Items[0].(*menuBarItem).Tapped(&fyne.PointEvent{})
 	assert.False(t, m.IsActive())
-	// TODO: does not remove focus from focused menu item as soon as menu has focus support
 	ctxt = "deactivating the menu restores focus handler from content"
 	assert.True(t, ce2.focused, ctxt)
-	assert.Equal(t, ce2, c.Focused())
+	assert.Equal(t, ce2, c.Focused(), ctxt)
 
 	c.FocusPrevious()
 	assert.Equal(t, ce1, c.Focused(), ctxt)


### PR DESCRIPTION
### Description:
I missed to adjust some tests due to not testing with `no_native_menus` tag when implementing the main menu keyboard control.
This PR fixes these.

Fixes #1811

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

