### PR TITLE
remove hover from menus

### DIFF
--- a/internal/driver/glfw/menu_bar_item.go
+++ b/internal/driver/glfw/menu_bar_item.go
@@ -19,9 +19,8 @@ type menuBarItem struct {
 	Menu   *fyne.Menu
 	Parent *MenuBar
 
-	active  bool
-	child   *publicWidget.Menu
-	hovered bool
+	active bool
+	child  *publicWidget.Menu
 }
 
 func (i *menuBarItem) Child() *publicWidget.Menu {
@@ -82,19 +81,21 @@ func (i *menuBarItem) MinSize() fyne.Size {
 	return widget.MinSizeOf(i)
 }
 
-// MouseIn changes the item to be hovered and shows the menu if the bar is active.
+// MouseIn shows the menu if the bar is active.
 // The menu that was displayed before will be hidden.
 //
 // Implements: desktop.Hoverable
 func (i *menuBarItem) MouseIn(_ *desktop.MouseEvent) {
-	i.hovered = true
 	if i.Parent.active {
 		i.Parent.canvas.Focus(i)
 	}
-	i.Refresh()
 }
 
-// MouseMoved does nothing.
+// MouseMoved shows the menu if the bar is active.
+// The menu that was displayed before will be hidden.
+// This might have an effect when mouse and keyboard control are mixed.
+// Changing the active menu with the keyboard will make the hovered menu bar item inactive.
+// On the next mouse move the hovered item is activated again.
 //
 // Implements: desktop.Hoverable
 func (i *menuBarItem) MouseMoved(_ *desktop.MouseEvent) {
@@ -103,12 +104,10 @@ func (i *menuBarItem) MouseMoved(_ *desktop.MouseEvent) {
 	}
 }
 
-// MouseOut changes the item to not be hovered but has no effect on the visibility of the menu.
+// MouseOut does nothing.
 //
 // Implements: desktop.Hoverable
 func (i *menuBarItem) MouseOut() {
-	i.hovered = false
-	i.Refresh()
 }
 
 // Move sets the position of the widget relative to its parent.
@@ -194,9 +193,6 @@ func (r *menuBarItemRenderer) MinSize() fyne.Size {
 func (r *menuBarItemRenderer) Refresh() {
 	if r.i.active && r.i.Parent.active {
 		r.background.FillColor = theme.FocusColor()
-		r.background.Show()
-	} else if r.i.hovered {
-		r.background.FillColor = theme.HoverColor()
 		r.background.Show()
 	} else {
 		r.background.Hide()

--- a/internal/driver/glfw/menu_bar_item.go
+++ b/internal/driver/glfw/menu_bar_item.go
@@ -19,8 +19,9 @@ type menuBarItem struct {
 	Menu   *fyne.Menu
 	Parent *MenuBar
 
-	active bool
-	child  *publicWidget.Menu
+	active  bool
+	child   *publicWidget.Menu
+	hovered bool
 }
 
 func (i *menuBarItem) Child() *publicWidget.Menu {
@@ -81,21 +82,27 @@ func (i *menuBarItem) MinSize() fyne.Size {
 	return widget.MinSizeOf(i)
 }
 
-// MouseIn shows the menu if the bar is active.
+// MouseIn activates the item and shows the menu if the bar is active.
 // The menu that was displayed before will be hidden.
+//
+// If the bar is not active, the item will be hovered.
 //
 // Implements: desktop.Hoverable
 func (i *menuBarItem) MouseIn(_ *desktop.MouseEvent) {
+	i.hovered = true
 	if i.Parent.active {
 		i.Parent.canvas.Focus(i)
 	}
+	i.Refresh()
 }
 
-// MouseMoved shows the menu if the bar is active.
+// MouseMoved activates the item and shows the menu if the bar is active.
 // The menu that was displayed before will be hidden.
 // This might have an effect when mouse and keyboard control are mixed.
 // Changing the active menu with the keyboard will make the hovered menu bar item inactive.
 // On the next mouse move the hovered item is activated again.
+//
+// If the bar is not active, this will do nothing.
 //
 // Implements: desktop.Hoverable
 func (i *menuBarItem) MouseMoved(_ *desktop.MouseEvent) {
@@ -104,10 +111,14 @@ func (i *menuBarItem) MouseMoved(_ *desktop.MouseEvent) {
 	}
 }
 
-// MouseOut does nothing.
+// MouseOut does nothing if the bar is active.
+//
+// IF the bar is not active, it changes the item to not be hovered.
 //
 // Implements: desktop.Hoverable
 func (i *menuBarItem) MouseOut() {
+	i.hovered = false
+	i.Refresh()
 }
 
 // Move sets the position of the widget relative to its parent.
@@ -193,6 +204,9 @@ func (r *menuBarItemRenderer) MinSize() fyne.Size {
 func (r *menuBarItemRenderer) Refresh() {
 	if r.i.active && r.i.Parent.active {
 		r.background.FillColor = theme.FocusColor()
+		r.background.Show()
+	} else if r.i.hovered && !r.i.Parent.active {
+		r.background.FillColor = theme.HoverColor()
 		r.background.Show()
 	} else {
 		r.background.Hide()

--- a/widget/menu_item.go
+++ b/widget/menu_item.go
@@ -16,8 +16,7 @@ type menuItem struct {
 	Item   *fyne.MenuItem
 	Parent *Menu
 
-	child   *Menu
-	hovered bool
+	child *Menu
 }
 
 // newMenuItem creates a new menuItem.
@@ -71,14 +70,12 @@ func (i *menuItem) MinSize() fyne.Size {
 	return widget.MinSizeOf(i)
 }
 
-// MouseIn changes the item to be hovered and shows the submenu if the item has one.
+// MouseIn activates the item which shows the submenu if the item has one.
 // The submenu of any sibling of the item will be hidden.
 //
 // Implements: desktop.Hoverable
 func (i *menuItem) MouseIn(*desktop.MouseEvent) {
-	i.hovered = true
 	i.activate()
-	i.Refresh()
 }
 
 // MouseMoved does nothing.
@@ -87,15 +84,13 @@ func (i *menuItem) MouseIn(*desktop.MouseEvent) {
 func (i *menuItem) MouseMoved(*desktop.MouseEvent) {
 }
 
-// MouseOut changes the item to not be hovered but has no effect on the visibility of the item's submenu.
+// MouseOut deactivates the item unless it has an open submenu.
 //
 // Implements: desktop.Hoverable
 func (i *menuItem) MouseOut() {
-	i.hovered = false
 	if !i.isSubmenuOpen() {
 		i.deactivate()
 	}
-	i.Refresh()
 }
 
 // Move sets the position of the widget relative to its parent.
@@ -245,9 +240,6 @@ func (r *menuItemRenderer) Refresh() {
 		r.background.Hide()
 	} else if r.i.isActive() {
 		r.background.FillColor = theme.FocusColor()
-		r.background.Show()
-	} else if r.i.hovered {
-		r.background.FillColor = theme.HoverColor()
 		r.background.Show()
 	} else {
 		r.background.Hide()


### PR DESCRIPTION
### Description:
This removes the “hovered” state from `MenuItem` and `menuBarItem`.
Since the keyboard control implementation this state was mostly invisible because it was ruled out by the “active” state.
The hover emphasis was only visible when a menu was activated via mouse and then the active menu item was changed by keyboard.
Thus, the “hovered” state is not really useful and was removed. No tests were affected because the described behaviour is not a real use-case :).

### Checklist:
- [x] Tests included (the existing ones).
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
