### PR TITLE
Optimize the cost of calling on the main/draw threads

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -31,6 +31,9 @@ var drawFuncQueue = make(chan drawData)
 var runFlag = false
 var runMutex = &sync.Mutex{}
 var initOnce = &sync.Once{}
+var donePool = &sync.Pool{New: func() interface{} {
+	return make(chan struct{})
+}}
 
 // Arrange that main.main runs on main thread.
 func init() {
@@ -50,7 +53,8 @@ func runOnMain(f func()) {
 	if !running() {
 		f()
 	} else {
-		done := make(chan struct{})
+		done := donePool.Get().(chan struct{})
+		defer donePool.Put(done)
 
 		funcQueue <- funcData{f: f, done: done}
 		<-done
@@ -59,7 +63,8 @@ func runOnMain(f func()) {
 
 // force a function f to run on the draw thread
 func runOnDraw(w *window, f func()) {
-	done := make(chan struct{})
+	done := donePool.Get().(chan struct{})
+	defer donePool.Put(done)
 
 	drawFuncQueue <- drawData{f: f, win: w, done: done}
 	<-done

--- a/internal/driver/glfw/loop_test.go
+++ b/internal/driver/glfw/loop_test.go
@@ -1,0 +1,32 @@
+// +build !ci
+// +build !mobile
+
+package glfw
+
+import "testing"
+
+// BenchmarkRunOnMain measures the cost of calling a function
+// on the main thread.
+func BenchmarkRunOnMain(b *testing.B) {
+	f := func() {}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runOnMain(f)
+	}
+}
+
+// BenchmarkRunOnDraw measures the cost of calling a function
+// on the draw thread.
+func BenchmarkRunOnDraw(b *testing.B) {
+	f := func() {}
+	w := createWindow("Test").(*window)
+	w.create()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runOnDraw(w, f)
+	}
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

Calling a function on the main thread is a common operation
in Go's GUI programming. For instance, the runOnMain must
be called at each render loop.

Previously, the runOnMain allocates a done channel to wait
for a scheduled call on the main thread to complete and thus
can produce the amount of work and awake the garbage collector
quite often. Instead of allocating a channel for each call
on the main thread, this change uses a channel pool and
optimizes this particular case.

Aside, the calls on the draw thread can also be optimized and
use the same channel pool.

Benchmark results (benchstat):

```
$ go test -run=^$ -bench=. -count=10
```

```
goos: linux
goarch: amd64
pkg: fyne.io/fyne/internal/driver/glfw
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GH

name          old time/op     new time/op      delta
RunOnMain-16   5.26µs ±1%      5.02µs ±2%     -4.64%  (p=0.000 n=10+10)
RunOnDraw-16  44.5µs ±12%     43.2µs ±10%        ~    (p=0.393 n=10+10)

name          old alloc/op   new alloc/op      delta
RunOnMain-16    96.0B ±0%       0.0B        -100.00%  (p=0.000 n=10+10)
RunOnDraw-16     107B ±3%        10B ±33%    -90.15%  (p=0.000 n=10+10)

name          old allocs/op new allocs/op      delta
RunOnMain-16     1.00 ±0%      0.00         -100.00%  (p=0.000 n=10+10)
RunOnDraw-16     2.00 ±0%      1.00 ±0%      -50.00%  (p=0.000 n=10+10)
```

Trace visualization:

```
$ cd internal/driver/glfw
& go test -run=none -bench=Main -trace trace.out
```


Before

![image](https://user-images.githubusercontent.com/5498964/105199824-7fcada80-5b3f-11eb-999f-01c42b922181.png)

After:

![image](https://user-images.githubusercontent.com/5498964/105199841-86595200-5b3f-11eb-9fca-48a6edeccea4.png)

(explanation: no garbage!)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

