### PR TITLE
markdownlint / minor typographical fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,22 +9,25 @@ assignees: ''
 
 <!-- Please search for open issues that relate to the same problem before opening a new one. -->
 
-### Describe the bug:
+### Bug Description
+
 <!-- A clear and concise description about the bug. -->
 
+### Reproduction
 
-### To Reproduce:
 Steps to reproduce the behaviour:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-### Screenshots:
+### Screenshot(s)
+
 <!-- If applicable, add screenshots or gifs to help explain your problem. -->
 
+### Example Code
 
-### Example code:
 <!-- If applicable, add a short code snippet to help explain and simplify reproduction of the problem. -->
 <!-- Please write the code inside a code block with go syntax, like this:
 ```go
@@ -32,9 +35,9 @@ Write your code here.
 ```
 -->
 
+### Device (please complete the following information)
 
-### Device (please complete the following information):
- - **OS:** <!-- [e.g. Linux, MacOS or iOS] -->
- - **Version:** <!-- [e.g. 5.10.2, 10.13 High Sierra or 14.2] -->
- - **Go version:** <!-- [e.g. 1.12.3] -->
- - **Fyne version:** <!-- [e.g. 1.4.2 or git SHA] -->
+- **OS:** <!-- [e.g. Linux, MacOS or iOS] -->
+- **Version:** <!-- [e.g. 5.10.2, 10.13 High Sierra or 14.2] -->
+- **Go version:** <!-- [e.g. 1.12.3] -->
+- **Fyne version:** <!-- [e.g. 1.4.2 or git SHA] -->


### PR DESCRIPTION
### Description:

I ran markdownlint against the project and applied simple typographical fixes as necessary.

|Code|Rule|Summary
|-|-|-
|MD007|ul-indent|Unordered list indentation
|MD012|no-multiple-blanks|Multiple consecutive blank lines
|MD022|blanks-around-headings|Headings should be surrounded by blank lines
|MD026|no-trailing-punctuation|Trailing punctuation in heading
|MD032|blanks-around-lists|Lists should be surrounded by blank lines

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [ ] Tests all pass.
