### PR TITLE
When setting tab index make sure we start a new animation

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -380,24 +380,28 @@ func (r *appTabsRenderer) moveSelection() {
 	}
 
 	r.underline.Show()
-	if r.underline.Position().IsZero() || r.underline.Position() == underlinePos {
+	if r.underline.Position().IsZero() {
 		r.underline.Move(underlinePos)
 		r.underline.Resize(underlineSize)
-	} else if r.animation == nil {
-		r.animation = canvas.NewPositionAnimation(r.underline.Position(), underlinePos, canvas.DurationShort, func(p fyne.Position) {
-			r.underline.Move(p)
-			canvas.Refresh(r.underline)
-			if p == underlinePos {
-				r.animation = nil
-			}
-		})
-		r.animation.Start()
-
-		canvas.NewSizeAnimation(r.underline.Size(), underlineSize, canvas.DurationShort, func(s fyne.Size) {
-			r.underline.Resize(s)
-			canvas.Refresh(r.underline)
-		}).Start()
+		return
 	}
+
+	if r.animation != nil {
+		r.animation.Stop()
+	}
+	r.animation = canvas.NewPositionAnimation(r.underline.Position(), underlinePos, canvas.DurationShort, func(p fyne.Position) {
+		r.underline.Move(p)
+		canvas.Refresh(r.underline)
+		if p == underlinePos {
+			r.animation = nil
+		}
+	})
+	r.animation.Start()
+
+	canvas.NewSizeAnimation(r.underline.Size(), underlineSize, canvas.DurationShort, func(s fyne.Size) {
+		r.underline.Resize(s)
+		canvas.Refresh(r.underline)
+	}).Start()
 }
 
 func (r *appTabsRenderer) tabsInSync() bool {

--- a/container/apptabs_internal_test.go
+++ b/container/apptabs_internal_test.go
@@ -27,3 +27,21 @@ func Test_tabButtonRenderer_SetText(t *testing.T) {
 	renderer = cache.Renderer(button).(*tabButtonRenderer)
 	assert.Equal(t, "Replace", renderer.label.Text)
 }
+
+func Test_tabButtonRenderer_DeleteAdd(t *testing.T) {
+	item1 := &TabItem{Text: "Test", Content: widget.NewLabel("Content")}
+	item2 := &TabItem{Text: "Delete", Content: widget.NewLabel("Delete")}
+	tabs := NewAppTabs(item1, item2)
+	tabRenderer := cache.Renderer(tabs).(*appTabsRenderer)
+	underline := tabRenderer.underline
+
+	pos := underline.Position()
+	tabs.SelectTab(item2)
+	assert.NotEqual(t, pos, underline.Position())
+	pos = underline.Position()
+
+	tabs.Remove(item2)
+	tabs.Append(item2)
+	tabs.SelectTab(item2)
+	assert.Equal(t, pos, underline.Position())
+}


### PR DESCRIPTION
Issue was due to old animation overrwriting position and/or the "optimisation" not applying new position.

Fixes #1872

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
