### PR TITLE
Allow Dialog.Resize(...) before Show()

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -31,9 +31,10 @@ type Dialog interface {
 var _ Dialog = (*dialog)(nil)
 
 type dialog struct {
-	callback func(bool)
-	title    string
-	icon     fyne.Resource
+	callback    func(bool)
+	title       string
+	icon        fyne.Resource
+	desiredSize fyne.Size
 
 	win            *widget.PopUp
 	bg             *canvas.Rectangle
@@ -99,6 +100,9 @@ func (d *dialog) Hide() {
 }
 
 func (d *dialog) Show() {
+	if !d.desiredSize.IsZero() {
+		d.win.Resize(d.desiredSize)
+	}
 	d.win.Show()
 }
 
@@ -141,6 +145,7 @@ func (d *dialog) Refresh() {
 
 // Resize dialog, call this function after dialog show
 func (d *dialog) Resize(size fyne.Size) {
+	d.desiredSize = size
 	maxSize := d.win.Size()
 	minSize := d.win.MinSize()
 	newWidth := size.Width

--- a/dialog/base_test.go
+++ b/dialog/base_test.go
@@ -4,9 +4,12 @@ import (
 	"image/color"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -27,4 +30,18 @@ func TestShowCustom_ApplyTheme(t *testing.T) {
 
 	test.ApplyTheme(t, test.NewTheme())
 	test.AssertImageMatches(t, "dialog-custom-ugly.png", w.Canvas().Capture())
+}
+
+func TestShowCustom_Resize(t *testing.T) {
+	w := test.NewWindow(canvas.NewRectangle(color.Transparent))
+	w.Resize(fyne.NewSize(300, 300))
+
+	label := widget.NewLabel("Content")
+	label.Alignment = fyne.TextAlignCenter
+	d := NewCustom("Title", "OK", label, w)
+
+	size := fyne.NewSize(200, 200)
+	d.Resize(size)
+	d.Show()
+	assert.Equal(t, size, d.(*dialog).win.Content.Size().Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
 }

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -47,7 +47,7 @@ type FileDialog struct {
 	parent           fyne.Window
 	dialog           *fileDialog
 	dismissText      string
-	desiredSize      *fyne.Size
+	desiredSize      fyne.Size
 	// this will be applied to dialog.dir when it's loaded
 	startingLocation fyne.ListableURI
 	// this will be the initial filename in a FileDialog in save mode
@@ -459,9 +459,8 @@ func (f *FileDialog) Show() {
 		return
 	}
 	f.dialog = showFile(f)
-	if f.desiredSize != nil {
-		f.Resize(*f.desiredSize)
-		f.desiredSize = nil
+	if !f.desiredSize.IsZero() {
+		f.Resize(f.desiredSize)
 	}
 }
 
@@ -470,10 +469,11 @@ func (f *FileDialog) Refresh() {
 	f.dialog.win.Refresh()
 }
 
-// Resize dialog, call this function after dialog show
+// Resize dialog to the requested size, if there is sufficient space.
+// If the parent window is not large enough then the size will be reduced to fit.
 func (f *FileDialog) Resize(size fyne.Size) {
+	f.desiredSize = size
 	if f.dialog == nil {
-		f.desiredSize = &size
 		return
 	}
 	maxSize := f.dialog.win.Size()


### PR DESCRIPTION
Basically matching what file dialog did, but without the pointer usage.

Fixes #1863

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
