### PR TITLE
Add support for building on DragonflyBSD

### DIFF
--- a/app/app_other.go
+++ b/app/app_other.go
@@ -1,4 +1,4 @@
-// +build ci !linux,!darwin,!windows,!freebsd,!openbsd,!netbsd
+// +build ci !linux,!darwin,!windows,!freebsd,!openbsd,!netbsd,!dragonfly
 
 package app
 

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -1,6 +1,6 @@
 // +build !ci
 
-// +build linux openbsd freebsd netbsd
+// +build linux openbsd freebsd netbsd dragonfly
 // +build !android
 
 package app

--- a/cmd/fyne/commands/install.go
+++ b/cmd/fyne/commands/install.go
@@ -77,7 +77,7 @@ func (i *installer) install() error {
 		switch p.os {
 		case "darwin":
 			i.installDir = "/Applications"
-		case "linux", "openbsd", "freebsd", "netbsd":
+		case "linux", "openbsd", "freebsd", "netbsd", "dragonfly":
 			i.installDir = "/" // the tarball contains the structure starting at usr/local
 		case "windows":
 			i.installDir = filepath.Join(os.Getenv("ProgramFiles"), p.name)

--- a/cmd/fyne/commands/package.go
+++ b/cmd/fyne/commands/package.go
@@ -40,7 +40,7 @@ func NewPackager() Command {
 }
 
 func (p *packager) AddFlags() {
-	flag.StringVar(&p.os, "os", "", "The operating system to target (android, android/arm, android/arm64, android/amd64, android/386, darwin, freebsd, ios, linux, netbsd, openbsd, windows)")
+	flag.StringVar(&p.os, "os", "", "The operating system to target (android, android/arm, android/arm64, android/amd64, android/386, darwin, dragonfly, freebsd, ios, linux, netbsd, openbsd, windows)")
 	flag.StringVar(&p.exe, "executable", "", "The path to the executable, default is the current dir main binary")
 	flag.StringVar(&p.srcDir, "sourceDir", "", "The directory to package, if executable is not set")
 	flag.StringVar(&p.name, "name", "", "The name of the application, default is the executable file name")
@@ -110,7 +110,7 @@ func (p *packager) doPackage() error {
 	switch p.os {
 	case "darwin":
 		return p.packageDarwin()
-	case "linux", "openbsd", "freebsd", "netbsd":
+	case "linux", "openbsd", "freebsd", "netbsd", "dragonfly":
 		return p.packageUNIX()
 	case "windows":
 		return p.packageWindows()

--- a/cmd/fyne/commands/release.go
+++ b/cmd/fyne/commands/release.go
@@ -45,7 +45,7 @@ func NewReleaser() Command {
 }
 
 func (r *releaser) AddFlags() {
-	flag.StringVar(&r.os, "os", "", "The operating system to target (android, android/arm, android/arm64, android/amd64, android/386, darwin, freebsd, ios, linux, netbsd, openbsd, windows)")
+	flag.StringVar(&r.os, "os", "", "The operating system to target (android, android/arm, android/arm64, android/amd64, android/386, darwin, dragonfly, freebsd, ios, linux, netbsd, openbsd, windows)")
 	flag.StringVar(&r.name, "name", "", "The name of the application, default is the executable file name")
 	flag.StringVar(&r.icon, "icon", "Icon.png", "The name of the application icon file")
 	flag.StringVar(&r.appID, "appID", "", "For ios or darwin targets an appID is required, for ios this must \nmatch a valid provisioning profile")

--- a/dialog/file_xdg.go
+++ b/dialog/file_xdg.go
@@ -1,4 +1,4 @@
-// +build linux openbsd freebsd netbsd
+// +build linux openbsd freebsd netbsd dragonfly
 // +build !android
 
 package dialog

--- a/dialog/file_xdg_test.go
+++ b/dialog/file_xdg_test.go
@@ -1,4 +1,4 @@
-// +build linux openbsd freebsd netbsd
+// +build linux openbsd freebsd netbsd dragonfly
 // +build !android
 
 package dialog


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

My idea with this is to have it be merged before #1858  to be able to backport to the 2.0.1 release. This isn't really as much of a new feature as it is just the adding necessary build flags to make compilation work on DragonflyBSD.

NOTE: The GOOS value is `dragonfly` and not `dragonflybsd`.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
