### PR TITLE
Fix issue with Focus call crashing

### DIFF
--- a/internal/app/focus_manager.go
+++ b/internal/app/focus_manager.go
@@ -59,6 +59,18 @@ func (f *FocusManager) Focus(obj fyne.Focusable) bool {
 	return true
 }
 
+// FocusBeforeAdded allows an object to be focused before it is added to the object tree.
+// This is typically used before a canvas is visible and should be used with care.
+func (f *FocusManager) FocusBeforeAdded(obj fyne.Focusable) {
+	f.RLock()
+	defer f.RUnlock()
+	if dis, ok := obj.(fyne.Disableable); ok && dis.Disabled() {
+		return
+	}
+
+	f.focus(obj)
+}
+
 // Focused returns the currently focused object or nil if none.
 func (f *FocusManager) Focused() fyne.Focusable {
 	f.RLock()

--- a/internal/app/focus_manager.go
+++ b/internal/app/focus_manager.go
@@ -59,18 +59,6 @@ func (f *FocusManager) Focus(obj fyne.Focusable) bool {
 	return true
 }
 
-// FocusBeforeAdded allows an object to be focused before it is added to the object tree.
-// This is typically used before a canvas is visible and should be used with care.
-func (f *FocusManager) FocusBeforeAdded(obj fyne.Focusable) {
-	f.RLock()
-	defer f.RUnlock()
-	if dis, ok := obj.(fyne.Disableable); ok && dis.Disabled() {
-		return
-	}
-
-	f.focus(obj)
-}
-
 // Focused returns the currently focused object or nil if none.
 func (f *FocusManager) Focused() fyne.Focusable {
 	f.RLock()

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -94,7 +94,7 @@ func (c *glCanvas) Focus(obj fyne.Focusable) {
 		}
 	}
 
-	c.contentFocusMgr.FocusBeforeAdded(obj) // not found yet assume we are preparing the UI
+	fyne.LogError("Failed to focus object which is not part of the canvas’ content, menu or overlays.", nil)
 }
 
 func (c *glCanvas) Focused() fyne.Focusable {

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -84,13 +84,17 @@ func (c *glCanvas) Focus(obj fyne.Focusable) {
 	c.RUnlock()
 
 	for _, mgr := range focusMgrs {
+		if mgr == nil {
+			continue
+		}
 		if focusMgr != mgr {
 			if mgr.Focus(obj) {
 				return
 			}
 		}
 	}
-	fyne.LogError("Failed to focus object which is not part of the canvas’ content, menu or overlays.", nil)
+
+	c.contentFocusMgr.FocusBeforeAdded(obj) // not found yet assume we are preparing the UI
 }
 
 func (c *glCanvas) Focused() fyne.Focusable {
@@ -452,7 +456,14 @@ func (c *glCanvas) paint(size fyne.Size) {
 func (c *glCanvas) setContent(content fyne.CanvasObject) {
 	c.content = content
 	c.contentTree = &renderCacheTree{root: &renderCacheNode{obj: c.content}}
+	var focused fyne.Focusable
+	if c.contentFocusMgr != nil {
+		focused = c.contentFocusMgr.Focused() // keep old focus if possible
+	}
 	c.contentFocusMgr = app.NewFocusManager(c.content)
+	if focused != nil {
+		c.contentFocusMgr.Focus(focused)
+	}
 }
 
 func (c *glCanvas) setDirty(dirty bool) {

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -216,12 +216,12 @@ func TestGlCanvas_Focus_SetContent(t *testing.T) {
 	w := createWindow("Test")
 	w.SetPadded(false)
 	e := widget.NewEntry()
-	w.SetContent(e)
+	w.SetContent(container.NewHBox(e))
 	c := w.Canvas().(*glCanvas)
 	c.Focus(e)
 	assert.Equal(t, e, c.Focused())
 
-	w.SetContent(e)
+	w.SetContent(container.NewVBox(e))
 	assert.Equal(t, e, c.Focused())
 }
 

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -210,9 +210,6 @@ func TestGlCanvas_Focus_BeforeVisible(t *testing.T) {
 	e := widget.NewEntry()
 	c := w.Canvas().(*glCanvas)
 	c.Focus(e) // this crashed in the past
-
-	w.SetContent(e)
-	assert.Equal(t, e, c.Focused(), "Item set to focus before SetContent was not focused after")
 }
 
 func TestGlCanvas_FocusHandlingWhenAddingAndRemovingOverlays(t *testing.T) {

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -212,6 +212,19 @@ func TestGlCanvas_Focus_BeforeVisible(t *testing.T) {
 	c.Focus(e) // this crashed in the past
 }
 
+func TestGlCanvas_Focus_SetContent(t *testing.T) {
+	w := createWindow("Test")
+	w.SetPadded(false)
+	e := widget.NewEntry()
+	w.SetContent(e)
+	c := w.Canvas().(*glCanvas)
+	c.Focus(e)
+	assert.Equal(t, e, c.Focused())
+
+	w.SetContent(e)
+	assert.Equal(t, e, c.Focused())
+}
+
 func TestGlCanvas_FocusHandlingWhenAddingAndRemovingOverlays(t *testing.T) {
 	w := createWindow("Test")
 	w.SetPadded(false)

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -204,6 +204,17 @@ func TestGlCanvas_Focus(t *testing.T) {
 	assert.True(t, o2e.focused)
 }
 
+func TestGlCanvas_Focus_BeforeVisible(t *testing.T) {
+	w := createWindow("Test")
+	w.SetPadded(false)
+	e := widget.NewEntry()
+	c := w.Canvas().(*glCanvas)
+	c.Focus(e) // this crashed in the past
+
+	w.SetContent(e)
+	assert.Equal(t, e, c.Focused(), "Item set to focus before SetContent was not focused after")
+}
+
 func TestGlCanvas_FocusHandlingWhenAddingAndRemovingOverlays(t *testing.T) {
 	w := createWindow("Test")
 	w.SetPadded(false)


### PR DESCRIPTION
Remove crash when calling Focus before canvas is visible.
Also fix issue where item focused before visible was not remembered (worked < 2.0.0).

Fixes #1893

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
