### PR TITLE
Fix background colour not applying until theme change

### DIFF
--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -136,7 +136,7 @@ func (p *ProgressBar) CreateRenderer() fyne.WidgetRenderer {
 		p.Max = 1.0
 	}
 
-	background := canvas.NewRectangle(theme.ShadowColor())
+	background := canvas.NewRectangle(progressBackgroundColor())
 	bar := canvas.NewRectangle(theme.PrimaryColor())
 	label := canvas.NewText("0%", theme.ForegroundColor())
 	label.Alignment = fyne.TextAlignCenter


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The background colour of the progress bar did not change the background colour until the theme changed.
I would suggest having this change backported for the 2.0.1 release.

Without this change:
![wrong-progressbar-colour](https://user-images.githubusercontent.com/25466657/107125888-b6795280-68ac-11eb-9a9b-7b20918014e2.gif)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

