### PR TITLE
Don't crash if keyboard controls are invoked too soon

### DIFF
--- a/internal/driver/gomobile/keyboard.go
+++ b/internal/driver/gomobile/keyboard.go
@@ -8,12 +8,21 @@ import (
 
 func showVirtualKeyboard(keyboard mobile.KeyboardType) {
 	if driver, ok := fyne.CurrentApp().Driver().(*mobileDriver); ok {
+		if driver.app == nil { // not yet running
+			fyne.LogError("Cannot show keyboard before app is running", nil)
+			return
+		}
+
 		driver.app.ShowVirtualKeyboard(app.KeyboardType(keyboard))
 	}
 }
 
 func hideVirtualKeyboard() {
 	if driver, ok := fyne.CurrentApp().Driver().(*mobileDriver); ok {
+		if driver.app == nil { // not yet running
+			return
+		}
+
 		driver.app.HideVirtualKeyboard()
 	}
 }


### PR DESCRIPTION
Fixes #1896

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- there is no way to currently test the driver of a mobile app. Am working to figure that out separately
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
