### PR TITLE
Fix release builds not removing debug symbols

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -26,9 +26,9 @@ func (b *builder) build() error {
 
 	if goos == "windows" {
 		if b.release {
-			args = append(args, "-ldflags", "-s -w -H=windowsgui")
+			args = append(args, "-ldflags", `"-s -w -H=windowsgui"`)
 		} else {
-			args = append(args, "-ldflags", "-H=windowsgui")
+			args = append(args, "-ldflags", `"-H=windowsgui"`)
 		}
 	} else {
 		if goos == "darwin" {
@@ -36,7 +36,7 @@ func (b *builder) build() error {
 			env = append(env, "CGO_LDFLAGS=-mmacosx-version-min=10.11")
 		}
 		if b.release {
-			args = append(args, "-ldflags", "-s -w")
+			args = append(args, "-ldflags", `"-s -w"`)
 		}
 	}
 

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -21,8 +21,11 @@ func (b *builder) build() error {
 	}
 
 	args := []string{"build"}
-	env := os.Environ()
-	env = append(env, "CGO_ENABLED=1") // in case someone is trying to cross-compile...
+	env := append(os.Environ(), "CGO_ENABLED=1") // in case someone is trying to cross-compile...
+
+	if goos == "darwin" {
+		env = append(env, "CGO_CFLAGS=-mmacosx-version-min=10.11", "CGO_LDFLAGS=-mmacosx-version-min=10.11")
+	}
 
 	if goos == "windows" {
 		if b.release {
@@ -30,14 +33,8 @@ func (b *builder) build() error {
 		} else {
 			args = append(args, "-ldflags", `"-H=windowsgui"`)
 		}
-	} else {
-		if goos == "darwin" {
-			env = append(env, "CGO_CFLAGS=-mmacosx-version-min=10.11")
-			env = append(env, "CGO_LDFLAGS=-mmacosx-version-min=10.11")
-		}
-		if b.release {
-			args = append(args, "-ldflags", `"-s -w"`)
-		}
+	} else if b.release {
+		args = append(args, "-ldflags", `"-s -w"`)
 	}
 
 	// handle build tags


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I noticed on my linux computer that packaging and adding `--release` has no effect.
This change tidies up the code a bit and makes sure that the `-ldflags` call get the correct information.

I guess we might want this change for 2.0.1 as well, but that might not be possible to backport as is due to the changes after the cli rework.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

