### PR TITLE
Proposal: Switch from gz to xz compression for unix packages

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -66,9 +66,8 @@ func (p *Packager) packageUNIX() error {
 			return errors.Wrap(err, "Failed to write Makefile string")
 		}
 
-		tarCmd := exec.Command("tar", "zcf", p.name+".tar.gz", "-C", tempDir, "usr", "Makefile")
-		err = tarCmd.Run()
-		if err != nil {
+		tarCmd := exec.Command("tar", "-Jcf", p.name+".tar.xz", "-C", tempDir, "usr", "Makefile")
+		if err = tarCmd.Run(); err != nil {
 			return errors.Wrap(err, "Failed to create archive with tar")
 		}
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Nowadays, `xz` compression should be available on default on most Linux and BSD systems.
Switching to `xz` gives, from my testing, roughly 20-30% smaller files at the expense of slightly longer compression time.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

