### PR TITLE
The onConfirm callback should be called only when user click on 'Ok' of a EntryDialog dialog.

### DIFF
--- a/dialog/entry.go
+++ b/dialog/entry.go
@@ -49,9 +49,9 @@ func (i *EntryDialog) SetOnClosed(callback func()) {
 func NewEntryDialog(title, message string, onConfirm func(string), parent fyne.Window) *EntryDialog {
 	i := &EntryDialog{entry: widget.NewEntry()}
 	items := []*widget.FormItem{widget.NewFormItem(message, i.entry)}
-	i.formDialog = NewForm(title, "Ok", "Cancel", items, func(_ bool) {
+	i.formDialog = NewForm(title, "Ok", "Cancel", items, func(ok bool) {
 		// User has confirmed and entered an input
-		if onConfirm != nil {
+		if ok && onConfirm != nil {
 			onConfirm(i.entry.Text)
 		}
 

--- a/dialog/entry_test.go
+++ b/dialog/entry_test.go
@@ -1,0 +1,32 @@
+package dialog
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntryDialog_Confirm(t *testing.T) {
+	value := ""
+	ed := NewEntryDialog("Test", "message", func(v string) {
+		value = v
+	}, test.NewWindow(nil))
+	ed.Show()
+	test.Type(ed.entry, "123")
+	test.Tap(ed.confirm)
+
+	assert.Equal(t, value, "123", "Control form should be confirmed with no validation")
+}
+
+func TestEntryDialog_Dismiss(t *testing.T) {
+	value := "123"
+	ed := NewEntryDialog("Test", "message", func(v string) {
+		value = v
+	}, test.NewWindow(nil))
+	ed.Show()
+	test.Type(ed.entry, "XYZ")
+	test.Tap(ed.cancel)
+
+	assert.Equal(t, value, "123", "Control form should not change value on dismiss")
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
The onConfirm callback is getting called whether user click on Ok or Cancel button of the EntryDialog.
Such behavior doesn't allow to distinguish between Ok and Cancel actions.

The expected behavior is when onConfirm called only when use click on Ok button.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->
