### PR TITLE
fix: making gl thing to compile and work on apple silicon

### DIFF
--- a/internal/driver/glfw/glfw_core.go
+++ b/internal/driver/glfw/glfw_core.go
@@ -1,4 +1,4 @@
-// +build !gles,!arm,!arm64
+// +build !gles,!arm,!arm64 arm64,darwin
 
 package glfw
 

--- a/internal/driver/glfw/glfw_core.go
+++ b/internal/driver/glfw/glfw_core.go
@@ -1,4 +1,4 @@
-// +build !gles,!arm,!arm64 arm64,darwin
+// +build !gles,!arm,!arm64 darwin
 
 package glfw
 

--- a/internal/driver/glfw/glfw_es.go
+++ b/internal/driver/glfw/glfw_es.go
@@ -1,5 +1,5 @@
 // +build gles arm arm64
-// +build !arm64,!darwin
+// +build !arm64,darwin arm64,!darwin
 
 package glfw
 

--- a/internal/driver/glfw/glfw_es.go
+++ b/internal/driver/glfw/glfw_es.go
@@ -1,5 +1,5 @@
 // +build gles arm arm64
-// +build !arm64,darwin arm64,!darwin
+// +build !darwin
 
 package glfw
 

--- a/internal/driver/glfw/glfw_es.go
+++ b/internal/driver/glfw/glfw_es.go
@@ -1,4 +1,5 @@
 // +build gles arm arm64
+// +build !arm64,!darwin
 
 package glfw
 

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -1,4 +1,4 @@
-// +build !gles,!arm,!arm64,!android,!ios,!mobile arm64,darwin
+// +build !gles,!arm,!arm64,!android,!ios,!mobile darwin
 
 package gl
 

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -1,4 +1,4 @@
-// +build !gles,!arm,!android,!ios,!mobile amr64,darwin
+// +build !gles,!arm,!arm64,!android,!ios,!mobile arm64,darwin
 
 package gl
 

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -1,4 +1,4 @@
-// +build !gles,!arm,!arm64,!android,!ios,!mobile
+// +build !gles,!arm,!android,!ios,!mobile amr64,darwin
 
 package gl
 

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -1,6 +1,6 @@
 // +build gles arm arm64
 // +build !android,!ios,!mobile
-// +build !arm64,darwin arm64,!darwin
+// +build !darwin
 
 package gl
 

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -1,4 +1,4 @@
-// +build gles arm arm64
+// +build gles arm arm64,!darwin
 // +build !android,!ios,!mobile
 
 package gl

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -1,5 +1,6 @@
-// +build gles arm arm64,!darwin
+// +build gles arm arm64
 // +build !android,!ios,!mobile
+// +build !arm64,darwin arm64,!darwin
 
 package gl
 


### PR DESCRIPTION
### Description:

Changes to make fyne to compile and work on Apple Silicon. It is based on recent changes in Go, where GOOS for iPhones and iPads was changed to ios and GOOS=darwin now only refers to MacOS. https://github.com/golang/go/issues/42100

Fixes #1739

PS This is not a final solution, rather show a way of workable configuration to build for Apple Silicon.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

