### PR TITLE
Add URI binding

### DIFF
--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -337,7 +337,7 @@ func (b *boundString) Set(val string) error {
 
 // URI supports binding a fyne.URI value.
 //
-// Since: 2.0
+// Since: 2.1
 type URI interface {
 	DataItem
 	Get() (fyne.URI, error)
@@ -346,7 +346,7 @@ type URI interface {
 
 // ExternalURI supports binding a fyne.URI value to an external value.
 //
-// Since: 2.0
+// Since: 2.1
 type ExternalURI interface {
 	URI
 	Reload() error
@@ -354,7 +354,7 @@ type ExternalURI interface {
 
 // NewURI returns a bindable fyne.URI value that is managed internally.
 //
-// Since: 2.0
+// Since: 2.1
 func NewURI() URI {
 	blank := fyne.URI(nil)
 	return &boundURI{val: &blank}
@@ -363,7 +363,7 @@ func NewURI() URI {
 // BindURI returns a new bindable value that controls the contents of the provided fyne.URI variable.
 // If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
 //
-// Since: 2.0
+// Since: 2.1
 func BindURI(v *fyne.URI) ExternalURI {
 	if v == nil {
 		return NewURI().(ExternalURI) // never allow a nil value pointer

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -3,6 +3,8 @@
 
 package binding
 
+import "fyne.io/fyne/v2"
+
 // Bool supports binding a bool value.
 //
 // Since: 2.0
@@ -325,6 +327,72 @@ func (b *boundString) Reload() error {
 }
 
 func (b *boundString) Set(val string) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	*b.val = val
+
+	b.trigger()
+	return nil
+}
+
+// URI supports binding a fyne.URI value.
+//
+// Since: 2.0
+type URI interface {
+	DataItem
+	Get() (fyne.URI, error)
+	Set(fyne.URI) error
+}
+
+// ExternalURI supports binding a fyne.URI value to an external value.
+//
+// Since: 2.0
+type ExternalURI interface {
+	URI
+	Reload() error
+}
+
+// NewURI returns a bindable fyne.URI value that is managed internally.
+//
+// Since: 2.0
+func NewURI() URI {
+	blank := fyne.URI(nil)
+	return &boundURI{val: &blank}
+}
+
+// BindURI returns a new bindable value that controls the contents of the provided fyne.URI variable.
+// If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
+//
+// Since: 2.0
+func BindURI(v *fyne.URI) ExternalURI {
+	if v == nil {
+		return NewURI().(ExternalURI) // never allow a nil value pointer
+	}
+
+	return &boundURI{val: v}
+}
+
+type boundURI struct {
+	base
+
+	val *fyne.URI
+}
+
+func (b *boundURI) Get() (fyne.URI, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	if b.val == nil {
+		return fyne.URI(nil), nil
+	}
+	return *b.val, nil
+}
+
+func (b *boundURI) Reload() error {
+	return b.Set(*b.val)
+}
+
+func (b *boundURI) Set(val fyne.URI) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	*b.val = val

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -1072,7 +1072,7 @@ func (b *boundExternalStringListItem) setIfChanged(val string) error {
 
 // URIList supports binding a list of fyne.URI values.
 //
-// Since: 2.0
+// Since: 2.1
 type URIList interface {
 	DataList
 
@@ -1086,7 +1086,7 @@ type URIList interface {
 
 // ExternalURIList supports binding a list of fyne.URI values from an external variable.
 //
-// Since: 2.0
+// Since: 2.1
 type ExternalURIList interface {
 	URIList
 
@@ -1095,7 +1095,7 @@ type ExternalURIList interface {
 
 // NewURIList returns a bindable list of fyne.URI values.
 //
-// Since: 2.0
+// Since: 2.1
 func NewURIList() URIList {
 	return &boundURIList{val: &[]fyne.URI{}}
 }
@@ -1103,7 +1103,7 @@ func NewURIList() URIList {
 // BindURIList returns a bound list of fyne.URI values, based on the contents of the passed slice.
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
-// Since: 2.0
+// Since: 2.1
 func BindURIList(v *[]fyne.URI) ExternalURIList {
 	if v == nil {
 		return NewURIList().(ExternalURIList)

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -3,6 +3,8 @@
 
 package binding
 
+import "fyne.io/fyne/v2"
+
 // BoolList supports binding a list of bool values.
 //
 // Since: 2.0
@@ -1058,6 +1060,219 @@ type boundExternalStringListItem struct {
 }
 
 func (b *boundExternalStringListItem) setIfChanged(val string) error {
+	if val == b.old {
+		return nil
+	}
+	(*b.val)[b.index] = val
+	b.old = val
+
+	b.trigger()
+	return nil
+}
+
+// URIList supports binding a list of fyne.URI values.
+//
+// Since: 2.0
+type URIList interface {
+	DataList
+
+	Append(fyne.URI) error
+	Get() ([]fyne.URI, error)
+	GetValue(int) (fyne.URI, error)
+	Prepend(fyne.URI) error
+	Set([]fyne.URI) error
+	SetValue(int, fyne.URI) error
+}
+
+// ExternalURIList supports binding a list of fyne.URI values from an external variable.
+//
+// Since: 2.0
+type ExternalURIList interface {
+	URIList
+
+	Reload() error
+}
+
+// NewURIList returns a bindable list of fyne.URI values.
+//
+// Since: 2.0
+func NewURIList() URIList {
+	return &boundURIList{val: &[]fyne.URI{}}
+}
+
+// BindURIList returns a bound list of fyne.URI values, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
+//
+// Since: 2.0
+func BindURIList(v *[]fyne.URI) ExternalURIList {
+	if v == nil {
+		return NewURIList().(ExternalURIList)
+	}
+
+	b := &boundURIList{val: v, updateExternal: true}
+
+	for i := range *v {
+		b.appendItem(bindURIListItem(v, i, b.updateExternal))
+	}
+
+	return b
+}
+
+type boundURIList struct {
+	listBase
+
+	updateExternal bool
+	val            *[]fyne.URI
+}
+
+func (l *boundURIList) Append(val fyne.URI) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	*l.val = append(*l.val, val)
+
+	return l.doReload()
+}
+
+func (l *boundURIList) Get() ([]fyne.URI, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	return *l.val, nil
+}
+
+func (l *boundURIList) GetValue(i int) (fyne.URI, error) {
+	if i < 0 || i >= l.Length() {
+		return fyne.URI(nil), errOutOfBounds
+	}
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	return (*l.val)[i], nil
+}
+
+func (l *boundURIList) Prepend(val fyne.URI) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	*l.val = append([]fyne.URI{val}, *l.val...)
+
+	return l.doReload()
+}
+
+func (l *boundURIList) Reload() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	return l.doReload()
+}
+
+func (l *boundURIList) Set(v []fyne.URI) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	*l.val = v
+
+	return l.doReload()
+}
+
+func (l *boundURIList) doReload() (retErr error) {
+	oldLen := len(l.items)
+	newLen := len(*l.val)
+	if oldLen > newLen {
+		for i := oldLen - 1; i >= newLen; i-- {
+			l.deleteItem(i)
+		}
+		l.trigger()
+	} else if oldLen < newLen {
+		for i := oldLen; i < newLen; i++ {
+			l.appendItem(bindURIListItem(l.val, i, l.updateExternal))
+		}
+		l.trigger()
+	}
+
+	for i, item := range l.items {
+		if i > oldLen || i > newLen {
+			break
+		}
+
+		var err error
+		if l.updateExternal {
+			item.(*boundExternalURIListItem).lock.Lock()
+			err = item.(*boundExternalURIListItem).setIfChanged((*l.val)[i])
+			item.(*boundExternalURIListItem).lock.Unlock()
+		} else {
+			item.(*boundURIListItem).lock.Lock()
+			err = item.(*boundURIListItem).doSet((*l.val)[i])
+			item.(*boundURIListItem).lock.Unlock()
+		}
+		if err != nil {
+			retErr = err
+		}
+	}
+	return
+}
+
+func (l *boundURIList) SetValue(i int, v fyne.URI) error {
+	if i < 0 || i >= l.Length() {
+		return errOutOfBounds
+	}
+
+	l.lock.Lock()
+	(*l.val)[i] = v
+	l.lock.Unlock()
+
+	item, err := l.GetItem(i)
+	if err != nil {
+		return err
+	}
+	return item.(URI).Set(v)
+}
+
+func bindURIListItem(v *[]fyne.URI, i int, external bool) URI {
+	if external {
+		ret := &boundExternalURIListItem{old: (*v)[i]}
+		ret.val = v
+		ret.index = i
+		return ret
+	}
+
+	return &boundURIListItem{val: v, index: i}
+}
+
+type boundURIListItem struct {
+	base
+
+	val   *[]fyne.URI
+	index int
+}
+
+func (b *boundURIListItem) Get() (fyne.URI, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return (*b.val)[b.index], nil
+}
+
+func (b *boundURIListItem) Set(val fyne.URI) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return b.doSet(val)
+}
+
+func (b *boundURIListItem) doSet(val fyne.URI) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
+}
+
+type boundExternalURIListItem struct {
+	boundURIListItem
+
+	old fyne.URI
+}
+
+func (b *boundExternalURIListItem) setIfChanged(val fyne.URI) error {
 	if val == b.old {
 		return nil
 	}

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -23,9 +23,7 @@ type stringFromBool struct {
 //
 // Since: 2.0
 func BoolToString(v Bool) String {
-
 	return BoolToStringWithFormat(v, "%t")
-
 }
 
 // BoolToStringWithFormat creates a binding that connects a Bool data item to a String and is
@@ -46,11 +44,9 @@ func (s *stringFromBool) Get() (string, error) {
 	}
 
 	return fmt.Sprintf(s.format, val), nil
-
 }
 
 func (s *stringFromBool) Set(str string) error {
-
 	var val bool
 	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
 	if err != nil {
@@ -95,9 +91,7 @@ type stringFromFloat struct {
 //
 // Since: 2.0
 func FloatToString(v Float) String {
-
 	return FloatToStringWithFormat(v, "%f")
-
 }
 
 // FloatToStringWithFormat creates a binding that connects a Float data item to a String and is
@@ -118,11 +112,9 @@ func (s *stringFromFloat) Get() (string, error) {
 	}
 
 	return fmt.Sprintf(s.format, val), nil
-
 }
 
 func (s *stringFromFloat) Set(str string) error {
-
 	var val float64
 	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
 	if err != nil {
@@ -167,9 +159,7 @@ type stringFromInt struct {
 //
 // Since: 2.0
 func IntToString(v Int) String {
-
 	return IntToStringWithFormat(v, "%d")
-
 }
 
 // IntToStringWithFormat creates a binding that connects a Int data item to a String and is
@@ -190,11 +180,9 @@ func (s *stringFromInt) Get() (string, error) {
 	}
 
 	return fmt.Sprintf(s.format, val), nil
-
 }
 
 func (s *stringFromInt) Set(str string) error {
-
 	var val int
 	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
 	if err != nil {
@@ -237,11 +225,9 @@ type stringFromURI struct {
 //
 // Since: 2.0
 func URIToString(v URI) String {
-
 	str := &stringFromURI{from: v}
 	v.AddListener(str)
 	return str
-
 }
 
 func (s *stringFromURI) Get() (string, error) {
@@ -251,11 +237,9 @@ func (s *stringFromURI) Get() (string, error) {
 	}
 
 	return uriToString(val)
-
 }
 
 func (s *stringFromURI) Set(str string) error {
-
 	val, err := uriFromString(str)
 	if err != nil {
 		return err
@@ -296,9 +280,7 @@ type stringToBool struct {
 //
 // Since: 2.0
 func StringToBool(str String) Bool {
-
 	return StringToBoolWithFormat(str, "%t")
-
 }
 
 // StringToBoolWithFormat creates a binding that connects a String data item to a Bool and is
@@ -329,11 +311,9 @@ func (s *stringToBool) Get() (bool, error) {
 	}
 
 	return val, nil
-
 }
 
 func (s *stringToBool) Set(val bool) error {
-
 	str := fmt.Sprintf(s.format, val)
 
 	old, err := s.from.Get()
@@ -369,9 +349,7 @@ type stringToFloat struct {
 //
 // Since: 2.0
 func StringToFloat(str String) Float {
-
 	return StringToFloatWithFormat(str, "%f")
-
 }
 
 // StringToFloatWithFormat creates a binding that connects a String data item to a Float and is
@@ -402,11 +380,9 @@ func (s *stringToFloat) Get() (float64, error) {
 	}
 
 	return val, nil
-
 }
 
 func (s *stringToFloat) Set(val float64) error {
-
 	str := fmt.Sprintf(s.format, val)
 
 	old, err := s.from.Get()
@@ -442,9 +418,7 @@ type stringToInt struct {
 //
 // Since: 2.0
 func StringToInt(str String) Int {
-
 	return StringToIntWithFormat(str, "%d")
-
 }
 
 // StringToIntWithFormat creates a binding that connects a String data item to a Int and is
@@ -475,11 +449,9 @@ func (s *stringToInt) Get() (int, error) {
 	}
 
 	return val, nil
-
 }
 
 func (s *stringToInt) Set(val int) error {
-
 	str := fmt.Sprintf(s.format, val)
 
 	old, err := s.from.Get()
@@ -513,11 +485,9 @@ type stringToURI struct {
 //
 // Since: 2.0
 func StringToURI(str String) URI {
-
 	v := &stringToURI{from: str}
 	str.AddListener(v)
 	return v
-
 }
 
 func (s *stringToURI) Get() (fyne.URI, error) {
@@ -527,16 +497,13 @@ func (s *stringToURI) Get() (fyne.URI, error) {
 	}
 
 	return uriFromString(str)
-
 }
 
 func (s *stringToURI) Set(val fyne.URI) error {
-
 	str, err := uriToString(val)
 	if err != nil {
 		return err
 	}
-
 	old, err := s.from.Get()
 	if str == old {
 		return err

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -223,7 +223,7 @@ type stringFromURI struct {
 // Changes to the URI will be pushed to the String and setting the string will parse and set the
 // URI if the parse was successful.
 //
-// Since: 2.0
+// Since: 2.1
 func URIToString(v URI) String {
 	str := &stringFromURI{from: v}
 	v.AddListener(str)
@@ -483,7 +483,7 @@ type stringToURI struct {
 // Changes to the String will be parsed and pushed to the URI if the parse was successful, and setting
 // the URI update the String binding.
 //
-// Since: 2.0
+// Since: 2.1
 func StringToURI(str String) URI {
 	v := &stringToURI{from: str}
 	str.AddListener(v)

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -286,7 +286,8 @@ type stringToBool struct {
 	base
 
 	format string
-	from   String
+
+	from String
 }
 
 // StringToBool creates a binding that connects a String data item to a Bool.
@@ -358,7 +359,8 @@ type stringToFloat struct {
 	base
 
 	format string
-	from   String
+
+	from String
 }
 
 // StringToFloat creates a binding that connects a String data item to a Float.
@@ -430,7 +432,8 @@ type stringToInt struct {
 	base
 
 	format string
-	from   String
+
+	from String
 }
 
 // StringToInt creates a binding that connects a String data item to a Int.
@@ -501,8 +504,7 @@ func (s *stringToInt) DataChanged() {
 type stringToURI struct {
 	base
 
-	format string
-	from   String
+	from String
 }
 
 // StringToURI creates a binding that connects a String data item to a URI.

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -13,7 +13,8 @@ type stringFromBool struct {
 	base
 
 	format string
-	from   Bool
+
+	from Bool
 }
 
 // BoolToString creates a binding that connects a Bool data item to a String.
@@ -84,7 +85,8 @@ type stringFromFloat struct {
 	base
 
 	format string
-	from   Float
+
+	from Float
 }
 
 // FloatToString creates a binding that connects a Float data item to a String.
@@ -155,7 +157,8 @@ type stringFromInt struct {
 	base
 
 	format string
-	from   Int
+
+	from Int
 }
 
 // IntToString creates a binding that connects a Int data item to a String.
@@ -225,8 +228,7 @@ func (s *stringFromInt) DataChanged() {
 type stringFromURI struct {
 	base
 
-	format string
-	from   URI
+	from URI
 }
 
 // URIToString creates a binding that connects a URI data item to a String.

--- a/data/binding/convert_helper.go
+++ b/data/binding/convert_helper.go
@@ -1,0 +1,18 @@
+package binding
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/storage"
+)
+
+func uriFromString(in string) (fyne.URI, error) {
+	return storage.ParseURI(in)
+}
+
+func uriToString(in fyne.URI) (string, error) {
+	if in == nil {
+		return "", nil
+	}
+
+	return in.String(), nil
+}

--- a/data/binding/convert_helper_test.go
+++ b/data/binding/convert_helper_test.go
@@ -1,0 +1,29 @@
+package binding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2/storage"
+)
+
+func TestURIFromStringHelper(t *testing.T) {
+	str := "file:///tmp/test.txt"
+	u, err := uriFromString(str)
+
+	assert.Nil(t, err)
+	assert.Equal(t, str, u.String())
+}
+
+func TestURIToStringHelper(t *testing.T) {
+	u := storage.NewFileURI("/tmp/test.txt")
+	str, err := uriToString(u)
+
+	assert.Nil(t, err)
+	assert.Equal(t, u.String(), str)
+
+	str, err = uriToString(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, "", str)
+}

--- a/data/binding/convert_test.go
+++ b/data/binding/convert_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2/storage"
 )
 
 func TestBoolToString(t *testing.T) {
@@ -307,4 +309,57 @@ func TestStringToIntWithFormat(t *testing.T) {
 	v2, err := s.Get()
 	assert.Nil(t, err)
 	assert.Equal(t, "num5", v2)
+}
+
+func TestStringToURI(t *testing.T) {
+	s := NewString()
+	u := StringToURI(s)
+	v, err := u.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, nil, v)
+
+	err = s.Set("file:///tmp/test.txt")
+	assert.Nil(t, err)
+	v, err = u.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, "file:///tmp/test.txt", v.String())
+
+	// TODO fix issue in URI parser whereby "wrong" is a valid URI
+	//err = s.Set("wrong")
+	//assert.Nil(t, err)
+	//_, err = u.Get()
+	//assert.NotNil(t, err)
+
+	uri := storage.NewFileURI("/mydir/")
+	err = u.Set(uri)
+	assert.Nil(t, err)
+	v2, err := s.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, "file:///mydir/", v2)
+}
+
+func TestURIToString(t *testing.T) {
+	u := NewURI()
+	s := URIToString(u)
+	v, err := s.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, "", v)
+
+	err = u.Set(storage.NewFileURI("/tmp/test.txt"))
+	assert.Nil(t, err)
+	v, err = s.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, "file:///tmp/test.txt", v)
+
+	// TODO fix issue in URI parser whereby "wrong" is a valid URI
+	//err = s.Set("wrong")
+	//assert.NotNil(t, err)
+	//_, err = u.Get()
+	//assert.Nil(t, err)
+
+	err = s.Set("file:///tmp/test.txt")
+	assert.Nil(t, err)
+	v2, err := u.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, "file:///tmp/test.txt", v2.String())
 }

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -145,13 +145,13 @@ type stringFrom{{ .Name }} struct {
 //
 // Since: 2.0
 func {{ .Name }}ToString(v {{ .Name }}) String {
-{{ if .Format }}
+{{- if .Format }}
 	return {{ .Name }}ToStringWithFormat(v, "{{ .Format }}")
-{{ else }}
+{{- else }}
 	str := &stringFrom{{ .Name }}{from: v}
 	v.AddListener(str)
 	return str
-{{ end }}
+{{- end }}
 }
 {{ if .Format }}
 // {{ .Name }}ToStringWithFormat creates a binding that connects a {{ .Name }} data item to a String and is
@@ -172,13 +172,13 @@ func (s *stringFrom{{ .Name }}) Get() (string, error) {
 	}
 {{ if .ToString }}
 	return {{ .ToString }}(val)
-{{ else }}
+{{- else }}
 	return fmt.Sprintf(s.format, val), nil
-{{ end }}
+{{- end }}
 }
 
 func (s *stringFrom{{ .Name }}) Set(str string) error {
-{{ if .FromString }}
+{{- if .FromString }}
 	val, err := {{ .FromString }}(str)
 	if err != nil {
 		return err
@@ -230,13 +230,13 @@ type stringTo{{ .Name }} struct {
 //
 // Since: 2.0
 func StringTo{{ .Name }}(str String) {{ .Name }} {
-{{ if .Format }}
+{{- if .Format }}
 	return StringTo{{ .Name }}WithFormat(str, "{{ .Format }}")
-{{ else }}
+{{- else }}
 	v := &stringTo{{ .Name }}{from: str}
 	str.AddListener(v)
 	return v
-{{ end }}
+{{- end }}
 }
 {{ if .Format }}
 // StringTo{{ .Name }}WithFormat creates a binding that connects a String data item to a {{ .Name }} and is
@@ -258,7 +258,7 @@ func (s *stringTo{{ .Name }}) Get() ({{ .Type }}, error) {
 	}
 {{ if .FromString }}
 	return {{ .FromString }}(str)
-{{ else }}
+{{- else }}
 	var val {{ .Type }}
 	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
 	if err != nil {
@@ -269,16 +269,16 @@ func (s *stringTo{{ .Name }}) Get() ({{ .Type }}, error) {
 	}
 
 	return val, nil
-{{ end }}
+{{- end }}
 }
 
 func (s *stringTo{{ .Name }}) Set(val {{ .Type }}) error {
-{{ if .ToString }}
+{{- if .ToString }}
 	str, err := {{ .ToString }}(val)
 	if err != nil {
 		return err
 	}
-{{ else }}
+{{- else }}
 	str := fmt.Sprintf(s.format, val)
 {{ end }}
 	old, err := s.from.Get()

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -218,9 +218,10 @@ func (s *stringFrom{{ .Name }}) DataChanged() {
 const fromStringTemplate = `
 type stringTo{{ .Name }} struct {
 	base
-
+{{ if .Format }}
 	format string
-	from   String
+{{ end }}
+	from String
 }
 
 // StringTo{{ .Name }} creates a binding that connects a String data item to a {{ .Name }}.

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -133,9 +133,10 @@ func (b *prefBound{{ .Name }}) checkForChange() {
 const toStringTemplate = `
 type stringFrom{{ .Name }} struct {
 	base
-
+{{ if .Format }}
 	format string
-	from   {{ .Name }}
+{{ end }}
+	from {{ .Name }}
 }
 
 // {{ .Name }}ToString creates a binding that connects a {{ .Name }} data item to a String.

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -519,6 +519,9 @@ func main() {
 		return
 	}
 	defer itemFile.Close()
+	itemFile.WriteString(`
+import "fyne.io/fyne/v2"
+`)
 	convertFile, err := newFile("convert")
 	if err != nil {
 		return
@@ -545,6 +548,9 @@ const keyTypeMismatchError = "A previous preference binding exists with differen
 		return
 	}
 	defer listFile.Close()
+	listFile.WriteString(`
+import "fyne.io/fyne/v2"
+`)
 
 	item := template.Must(template.New("item").Parse(itemBindTemplate))
 	fromString := template.Must(template.New("fromString").Parse(fromStringTemplate))
@@ -557,6 +563,7 @@ const keyTypeMismatchError = "A previous preference binding exists with differen
 		bindValues{Name: "Int", Type: "int", Default: "0", Format: "%d", SupportsPreferences: true},
 		bindValues{Name: "Rune", Type: "rune", Default: "rune(0)"},
 		bindValues{Name: "String", Type: "string", Default: "\"\"", SupportsPreferences: true},
+		bindValues{Name: "URI", Type: "fyne.URI", Default: "fyne.URI(nil)"},
 	}
 	for _, b := range binds {
 		writeFile(itemFile, item, b)


### PR DESCRIPTION
Add fyne.URI to the types that can be bound.
Added string to/from as well, but not preferences, that can be done using the string conversion.

Fixes #1882

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
