### PR TITLE
Fixes animation runner memory leak

### DIFF
--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -20,14 +20,13 @@ type anim struct {
 }
 
 func newAnim(a *fyne.Animation) *anim {
-	// TODO should we add a nil check here? (to avoid panic)
 	animate := &anim{a: a, start: time.Now(), end: time.Now().Add(a.Duration)}
 	animate.total = animate.end.Sub(animate.start).Nanoseconds() / 1000000 // TODO change this to Milliseconds() when we drop Go 1.12
 	animate.repeatsLeft = a.RepeatCount
 	return animate
 }
 
-func (a *anim) setStopFlag() {
+func (a *anim) setStopped() {
 	a.mu.Lock()
 	a.stopped = true
 	a.mu.Unlock()

--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -1,6 +1,7 @@
 package animation
 
 import (
+	"sync"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -13,11 +14,28 @@ type anim struct {
 	reverse     bool
 	start       time.Time
 	total       int64
+
+	mu      sync.RWMutex
+	stopped bool
 }
 
 func newAnim(a *fyne.Animation) *anim {
+	// TODO should we add a nil check here? (to avoid panic)
 	animate := &anim{a: a, start: time.Now(), end: time.Now().Add(a.Duration)}
 	animate.total = animate.end.Sub(animate.start).Nanoseconds() / 1000000 // TODO change this to Milliseconds() when we drop Go 1.12
 	animate.repeatsLeft = a.RepeatCount
 	return animate
+}
+
+func (a *anim) setStopFlag() {
+	a.mu.Lock()
+	a.stopped = true
+	a.mu.Unlock()
+}
+
+func (a *anim) isStopped() bool {
+	a.mu.RLock()
+	ret := a.stopped
+	a.mu.RUnlock()
+	return ret
 }

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -86,6 +86,8 @@ func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
 	run.Stop(c)
 
 	wg.Wait()
+	// animations stopped inside tick are really stopped in the next runner cycle
+	time.Sleep(time.Second/60 + 100*time.Millisecond)
 	run.animationMutex.RLock()
 	assert.Zero(t, len(run.animations))
 	run.animationMutex.RUnlock()

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -41,7 +41,7 @@ func (r *Runner) Stop(a *fyne.Animation) {
 		if item.a != a {
 			newList = append(newList, item)
 		} else {
-			item.setStopFlag()
+			item.setStopped()
 			stopped = true
 		}
 	}
@@ -55,7 +55,7 @@ func (r *Runner) Stop(a *fyne.Animation) {
 		if item.a != a {
 			newList = append(newList, item)
 		} else {
-			item.setStopFlag()
+			item.setStopped()
 		}
 	}
 	r.pendingAnimations = newList
@@ -72,7 +72,7 @@ func (r *Runner) runAnimations() {
 			r.animationMutex.Unlock()
 			newList := make([]*anim, 0, len(oldList))
 			for _, a := range oldList {
-				if r.tickAnimation(a) && !a.isStopped() {
+				if !a.isStopped() && r.tickAnimation(a) {
 					newList = append(newList, a)
 				}
 			}
@@ -115,6 +115,7 @@ func (r *Runner) tickAnimation(a *anim) bool {
 
 		a.start = time.Now()
 		a.end = a.start.Add(a.a.Duration)
+		return true
 	}
 
 	delta := time.Since(a.start).Nanoseconds() / 1000000 // TODO change this to Milliseconds() when we drop Go 1.12


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR will allow us to do the following actions without memory leak or crash:
1. Stop animation immediately after Start.
2. Stop animation inside animation tick function.

This PR also fixes the crash in AppTabs (#1952), however the performance (slow animation) can only be fixed by #1954.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
