### PR TITLE
Allow custom Quit menu item

### DIFF
--- a/internal/driver/glfw/menu.go
+++ b/internal/driver/glfw/menu.go
@@ -9,16 +9,29 @@ func buildMenuOverlay(menus *fyne.MainMenu, c fyne.Canvas) fyne.CanvasObject {
 		fyne.LogError("Main menu must have at least one child menu", nil)
 		return nil
 	}
+
+	menus = addMissingQuit(menus)
+	return NewMenuBar(menus, c)
+}
+
+func addMissingQuit(menus *fyne.MainMenu) *fyne.MainMenu {
 	var firstItem *fyne.MenuItem
 	if len(menus.Items[0].Items) > 0 {
 		firstItem = menus.Items[0].Items[len(menus.Items[0].Items)-1]
+		if firstItem.Label == "Quit" {
+			firstItem.IsQuit = true
+		}
 	}
-	if firstItem == nil || firstItem.Label != "Quit" { // make sure the first menu always has a quit option
-		quitItem := fyne.NewMenuItem("Quit", func() {
-			fyne.CurrentApp().Quit()
-		})
+	if firstItem == nil || !firstItem.IsQuit { // make sure the first menu always has a quit option
+		quitItem := fyne.NewMenuItem("Quit", nil)
 		menus.Items[0].Items = append(menus.Items[0].Items, fyne.NewMenuItemSeparator(), quitItem)
 	}
-
-	return NewMenuBar(menus, c)
+	for _, item := range menus.Items[0].Items {
+		if item.IsQuit && item.Action == nil {
+			item.Action = func() {
+				fyne.CurrentApp().Quit()
+			}
+		}
+	}
+	return menus
 }

--- a/internal/driver/glfw/menu.go
+++ b/internal/driver/glfw/menu.go
@@ -15,14 +15,14 @@ func buildMenuOverlay(menus *fyne.MainMenu, c fyne.Canvas) fyne.CanvasObject {
 }
 
 func addMissingQuit(menus *fyne.MainMenu) *fyne.MainMenu {
-	var firstItem *fyne.MenuItem
+	var lastItem *fyne.MenuItem
 	if len(menus.Items[0].Items) > 0 {
-		firstItem = menus.Items[0].Items[len(menus.Items[0].Items)-1]
-		if firstItem.Label == "Quit" {
-			firstItem.IsQuit = true
+		lastItem = menus.Items[0].Items[len(menus.Items[0].Items)-1]
+		if lastItem.Label == "Quit" {
+			lastItem.IsQuit = true
 		}
 	}
-	if firstItem == nil || !firstItem.IsQuit { // make sure the first menu always has a quit option
+	if lastItem == nil || !lastItem.IsQuit { // make sure the first menu always has a quit option
 		quitItem := fyne.NewMenuItem("Quit", nil)
 		menus.Items[0].Items = append(menus.Items[0].Items, fyne.NewMenuItemSeparator(), quitItem)
 	}

--- a/internal/driver/glfw/menu_test.go
+++ b/internal/driver/glfw/menu_test.go
@@ -4,6 +4,7 @@
 package glfw
 
 import (
+	"reflect"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -28,9 +29,45 @@ func Test_Menu_AddsQuit(t *testing.T) {
 
 func Test_Menu_LeaveQuit(t *testing.T) {
 	w := createWindow("Menu Test").(*window)
-	mainMenu := fyne.NewMainMenu(fyne.NewMenu("File", fyne.NewMenuItem("Quit", nil)))
+	quitFunc := func() {}
+	mainMenu := fyne.NewMainMenu(fyne.NewMenu("File", fyne.NewMenuItem("Quit", quitFunc)))
 	bar := buildMenuOverlay(mainMenu, w.canvas)
 	assert.NotNil(t, bar)
 	assert.Equal(t, 1, len(mainMenu.Items[0].Items)) // no separator added
-	assert.Nil(t, mainMenu.Items[0].Items[0].Action) // no quit handler added
+	assert.Equal(t, reflect.ValueOf(quitFunc).Pointer(), reflect.ValueOf(mainMenu.Items[0].Items[0].Action).Pointer())
+}
+func Test_Menu_LeaveQuit_AddAction(t *testing.T) {
+	w := createWindow("Menu Test").(*window)
+	mainMenu := fyne.NewMainMenu(fyne.NewMenu("File", fyne.NewMenuItem("Quit", nil)))
+	bar := buildMenuOverlay(mainMenu, w.canvas)
+	assert.NotNil(t, bar)
+	assert.Equal(t, 1, len(mainMenu.Items[0].Items))    // no separator added
+	assert.NotNil(t, mainMenu.Items[0].Items[0].Action) // quit action was added
+}
+
+func Test_Menu_CustomQuit(t *testing.T) {
+	w := createWindow("Menu Test").(*window)
+
+	quitFunc := func() {}
+	quitItem := fyne.NewMenuItem("Beenden", quitFunc)
+	quitItem.IsQuit = true
+
+	mainMenu := fyne.NewMainMenu(fyne.NewMenu("File", quitItem))
+	bar := buildMenuOverlay(mainMenu, w.canvas)
+
+	assert.NotNil(t, bar)
+	assert.Equal(t, 1, len(mainMenu.Items[0].Items)) // no separator added
+	assert.Equal(t, reflect.ValueOf(quitFunc).Pointer(), reflect.ValueOf(mainMenu.Items[0].Items[0].Action).Pointer())
+}
+
+func Test_Menu_CustomQuit_NoAction(t *testing.T) {
+	w := createWindow("Menu Test").(*window)
+	quitItem := fyne.NewMenuItem("Beenden", nil)
+	quitItem.IsQuit = true
+	mainMenu := fyne.NewMainMenu(fyne.NewMenu("File", quitItem))
+	bar := buildMenuOverlay(mainMenu, w.canvas)
+
+	assert.NotNil(t, bar)
+	assert.Equal(t, 1, len(mainMenu.Items[0].Items))    // no separator added
+	assert.NotNil(t, mainMenu.Items[0].Items[0].Action) // quit action was added
 }

--- a/menu.go
+++ b/menu.go
@@ -15,10 +15,10 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
 	ChildMenu   *Menu
-	Label       string
 	IsSeparator bool
 	// Since: 2.1
 	IsQuit bool
+	Label  string
 	Action func()
 }
 

--- a/menu.go
+++ b/menu.go
@@ -15,8 +15,9 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
 	ChildMenu   *Menu
-	IsSeparator bool
 	Label       string
+	IsSeparator bool
+	IsQuit      bool
 	Action      func()
 }
 

--- a/menu.go
+++ b/menu.go
@@ -14,12 +14,12 @@ func NewMenu(label string, items ...*MenuItem) *Menu {
 
 // MenuItem is a single item within any menu, it contains a display Label and Action function that is called when tapped.
 type MenuItem struct {
-	ChildMenu   *Menu
-	IsSeparator bool
+	ChildMenu *Menu
 	// Since: 2.1
-	IsQuit bool
-	Label  string
-	Action func()
+	IsQuit      bool
+	IsSeparator bool
+	Label       string
+	Action      func()
 }
 
 // NewMenuItem creates a new menu item from the passed label and action parameters.

--- a/menu.go
+++ b/menu.go
@@ -17,8 +17,9 @@ type MenuItem struct {
 	ChildMenu   *Menu
 	Label       string
 	IsSeparator bool
-	IsQuit      bool
-	Action      func()
+	// Since: 2.1
+	IsQuit bool
+	Action func()
 }
 
 // NewMenuItem creates a new menu item from the passed label and action parameters.


### PR DESCRIPTION
### Description:
fyne automatically adds a Quit menu item if the last item in the first menu is not called "Quit". This does not work for e.g. other languages.

This PR adds an option to suppress that without breaking the previous behaviour.

It does change the behaviour slightly if no action is provided on the "Quit" item. Then it adds the quit action. Can be removed if you don't agree.

Thought I saw an issue for this, but can't find it any more.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
