### PR TITLE
Avoid unnecessary RenderTextSize calls

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -71,8 +71,8 @@ func (p *glPainter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Si
 		pos = fyne.NewPos(pos.X+(containerSize.Width-size.Width)/2, pos.Y)
 	}
 
-	if text.Size().Height > text.MinSize().Height {
-		pos = fyne.NewPos(pos.X, pos.Y+(text.Size().Height-text.MinSize().Height)/2)
+	if size.Height > containerSize.Height {
+		pos = fyne.NewPos(pos.X, pos.Y+(size.Height-containerSize.Height)/2)
 	}
 
 	p.drawTextureWithDetails(text, p.newGlTextTexture, pos, size, frame, canvas.ImageFillStretch, 1.0, 0)


### PR DESCRIPTION
### Description:
Reuse variables to avoid unnecessary RenderTextSize calls

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.