### PR TITLE
Start fixing scrolling containing entries

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -158,13 +158,21 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 	// initialise
 	e.textProvider()
 	e.placeholderProvider()
+	scrolling := e.Wrapping != fyne.TextWrapOff
 
 	box := canvas.NewRectangle(theme.InputBackgroundColor())
 	line := canvas.NewRectangle(theme.ShadowColor())
 
 	e.content = &entryContent{entry: e}
-	e.scroll = widget.NewScroll(e.content)
-	objects := []fyne.CanvasObject{box, line, e.scroll}
+	e.scroll = &widget.Scroll{}
+	objects := []fyne.CanvasObject{box, line}
+	if scrolling {
+		e.scroll.Content = e.content
+		objects = append(objects, e.scroll)
+	} else {
+		e.scroll.Hide()
+		objects = append(objects, e.content)
+	}
 	e.content.scroll = e.scroll
 
 	if e.Password && e.ActionItem == nil {
@@ -1117,8 +1125,13 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 
 	entrySize := size.Subtract(fyne.NewSize(xInset, theme.InputBorderSize()*2))
 	entryPos := fyne.NewPos(0, theme.InputBorderSize())
-	r.scroll.Resize(entrySize)
-	r.scroll.Move(entryPos)
+	if r.entry.Wrapping == fyne.TextWrapOff {
+		r.entry.content.Resize(entrySize)
+		r.entry.content.Move(entryPos)
+	} else {
+		r.scroll.Resize(entrySize)
+		r.scroll.Move(entryPos)
+	}
 }
 
 // MinSize calculates the minimum size of an entry widget.
@@ -1126,7 +1139,7 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 // If MultiLine is true then we will reserve space for at leasts 3 lines
 func (r *entryRenderer) MinSize() fyne.Size {
 	if r.scroll.Direction == widget.ScrollNone {
-		return r.scroll.MinSize().Add(fyne.NewSize(0, theme.InputBorderSize()*2))
+		return r.entry.content.MinSize().Add(fyne.NewSize(0, theme.InputBorderSize()*2))
 	}
 
 	minSize := r.entry.placeholderProvider().charMinSize().Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2))
@@ -1193,7 +1206,7 @@ func (r *entryRenderer) Refresh() {
 		r.entry.validationStatus.Hide()
 	}
 
-	cache.Renderer(r.scroll.Content.(*entryContent)).Refresh()
+	cache.Renderer(r.entry.content).Refresh()
 	canvas.Refresh(r.entry.super())
 }
 
@@ -1453,8 +1466,10 @@ func (r *entryContentRenderer) ensureCursorVisible() {
 	} else if cy2 >= offset.X+size.Height {
 		move.DY += cy2 - (offset.Y + size.Height)
 	}
-	r.content.scroll.Offset = r.content.scroll.Offset.Add(move)
-	r.content.scroll.Refresh()
+	if r.content.scroll.Content != nil {
+		r.content.scroll.Offset = r.content.scroll.Offset.Add(move)
+		r.content.scroll.Refresh()
+	}
 }
 
 func (r *entryContentRenderer) moveCursor() {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -158,7 +158,6 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 	// initialise
 	e.textProvider()
 	e.placeholderProvider()
-	scrolling := e.Wrapping != fyne.TextWrapOff
 
 	box := canvas.NewRectangle(theme.InputBackgroundColor())
 	line := canvas.NewRectangle(theme.ShadowColor())
@@ -166,7 +165,7 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 	e.content = &entryContent{entry: e}
 	e.scroll = &widget.Scroll{}
 	objects := []fyne.CanvasObject{box, line}
-	if scrolling {
+	if e.Wrapping != fyne.TextWrapOff {
 		e.scroll.Content = e.content
 		objects = append(objects, e.scroll)
 	} else {
@@ -1091,6 +1090,24 @@ type entryRenderer struct {
 func (r *entryRenderer) Destroy() {
 }
 
+func (r *entryRenderer) trailingInset() float32 {
+	xInset := float32(0)
+
+	if r.entry.ActionItem != nil {
+		xInset = theme.IconInlineSize() + 2*theme.Padding()
+	}
+
+	if r.entry.Validator != nil {
+		if r.entry.ActionItem == nil {
+			xInset = theme.IconInlineSize() + 2*theme.Padding()
+		} else {
+			xInset += theme.IconInlineSize() + theme.Padding()
+		}
+	}
+
+	return xInset
+}
+
 func (r *entryRenderer) Layout(size fyne.Size) {
 	r.line.Resize(fyne.NewSize(size.Width, theme.InputBorderSize()))
 	r.line.Move(fyne.NewPos(0, size.Height-theme.InputBorderSize()))
@@ -1098,10 +1115,8 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 	r.box.Move(fyne.NewPos(0, theme.InputBorderSize()))
 
 	actionIconSize := fyne.NewSize(0, 0)
-	xInset := float32(0)
 	if r.entry.ActionItem != nil {
 		actionIconSize = fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
-		xInset = theme.IconInlineSize() + 2*theme.Padding()
 
 		r.entry.ActionItem.Resize(actionIconSize)
 		r.entry.ActionItem.Move(fyne.NewPos(size.Width-actionIconSize.Width-2*theme.Padding(), theme.Padding()*2))
@@ -1116,14 +1131,12 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 
 		if r.entry.ActionItem == nil {
 			r.entry.validationStatus.Move(fyne.NewPos(size.Width-validatorIconSize.Width-2*theme.Padding(), theme.Padding()*2))
-			xInset = theme.IconInlineSize() + 2*theme.Padding()
 		} else {
 			r.entry.validationStatus.Move(fyne.NewPos(size.Width-validatorIconSize.Width-actionIconSize.Width-3*theme.Padding(), theme.Padding()*2))
-			xInset += theme.IconInlineSize() + theme.Padding()
 		}
 	}
 
-	entrySize := size.Subtract(fyne.NewSize(xInset, theme.InputBorderSize()*2))
+	entrySize := size.Subtract(fyne.NewSize(r.trailingInset(), theme.InputBorderSize()*2))
 	entryPos := fyne.NewPos(0, theme.InputBorderSize())
 	if r.entry.Wrapping == fyne.TextWrapOff {
 		r.entry.content.Resize(entrySize)
@@ -1163,12 +1176,44 @@ func (r *entryRenderer) Objects() []fyne.CanvasObject {
 func (r *entryRenderer) Refresh() {
 	r.entry.propertyLock.RLock()
 	provider := r.entry.textProvider()
-	content := r.entry.Text
+	text := r.entry.Text
+	content := r.entry.content
 	focused := r.entry.focused
+	size := r.entry.size
+	wrapping := r.entry.Wrapping
 	r.entry.propertyLock.RUnlock()
 
-	if content != string(provider.buffer) {
-		r.entry.SetText(content)
+	// correct our scroll wrappers if the wrap mode changed
+	entrySize := size.Subtract(fyne.NewSize(r.trailingInset(), theme.InputBorderSize()*2))
+	if wrapping == fyne.TextWrapOff && r.scroll.Content != nil {
+		r.scroll.Hide()
+		r.scroll.Content = nil
+		content.Move(fyne.NewPos(0, theme.InputBorderSize()))
+		content.Resize(entrySize)
+
+		for i, o := range r.objects {
+			if o == r.scroll {
+				r.objects[i] = content
+				break
+			}
+		}
+	} else if wrapping != fyne.TextWrapOff && r.scroll.Content == nil {
+		r.scroll.Content = content
+		content.Move(fyne.NewPos(0, 0))
+		r.scroll.Move(fyne.NewPos(0, theme.InputBorderSize()))
+		r.scroll.Resize(entrySize)
+		r.scroll.Show()
+
+		for i, o := range r.objects {
+			if o == content {
+				r.objects[i] = r.scroll
+				break
+			}
+		}
+	}
+
+	if text != string(provider.buffer) {
+		r.entry.SetText(text)
 		return
 	}
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1567,8 +1567,7 @@ func TestPasswordEntry_Reveal(t *testing.T) {
 	// the Password field is set to true.
 	// In this case the action item will be set when the renderer is created.
 	t.Run("Entry with Password field", func(t *testing.T) {
-		entry := &widget.Entry{}
-		entry.Password = true
+		entry := &widget.Entry{Password: true, Wrapping: fyne.TextWrapWord}
 		entry.Refresh()
 		window := test.NewWindow(entry)
 		defer window.Close()
@@ -1657,7 +1656,12 @@ func checkNewlineIgnored(t *testing.T, entry *widget.Entry) {
 func setupImageTest(t *testing.T, multiLine bool) (*widget.Entry, fyne.Window) {
 	test.NewApp()
 
-	entry := &widget.Entry{MultiLine: multiLine}
+	var entry *widget.Entry
+	if multiLine {
+		entry = &widget.Entry{MultiLine: true, Wrapping: fyne.TextWrapWord}
+	} else {
+		entry = &widget.Entry{Wrapping: fyne.TextWrapOff}
+	}
 	w := test.NewWindow(entry)
 	w.Resize(fyne.NewSize(150, 200))
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1392,20 +1392,19 @@ func TestEntry_TextWrap(t *testing.T) {
 		"single line WrapOff": {
 			want: "entry/wrap_single_line_off.xml",
 		},
-		// Disallowed - fallback to TextWrapOff
 		"single line Truncate": {
 			wrap: fyne.TextTruncate,
-			want: "entry/wrap_single_line_off.xml",
+			want: "entry/wrap_single_line_truncate.xml",
 		},
-		// Disallowed - fallback to TextWrapOff
+		// Disallowed - fallback to TextWrapTruncate (horizontal)
 		"single line WrapBreak": {
 			wrap: fyne.TextWrapBreak,
-			want: "entry/wrap_single_line_off.xml",
+			want: "entry/wrap_single_line_truncate.xml",
 		},
-		// Disallowed - fallback to TextWrapOff
+		// Disallowed - fallback to TextWrapTruncate (horizontal)
 		"single line WrapWord": {
 			wrap: fyne.TextWrapWord,
-			want: "entry/wrap_single_line_off.xml",
+			want: "entry/wrap_single_line_truncate.xml",
 		},
 		"multi line WrapOff": {
 			multiLine: true,
@@ -1415,7 +1414,7 @@ func TestEntry_TextWrap(t *testing.T) {
 		"multi line Truncate": {
 			multiLine: true,
 			wrap:      fyne.TextTruncate,
-			want:      "entry/wrap_multi_line_off.xml",
+			want:      "entry/wrap_multi_line_truncate.xml",
 		},
 		"multi line WrapBreak": {
 			multiLine: true,
@@ -1443,6 +1442,25 @@ func TestEntry_TextWrap(t *testing.T) {
 			test.AssertRendersToMarkup(t, tt.want, c)
 		})
 	}
+}
+
+func TestEntry_TextWrap_Changed(t *testing.T) {
+	e, window := setupImageTest(t, false)
+	defer teardownImageTest(window)
+	c := window.Canvas()
+
+	c.Focus(e)
+	e.Wrapping = fyne.TextWrapOff
+	e.SetText("Testing Wrapping")
+	test.AssertRendersToMarkup(t, "entry/wrap_single_line_off.xml", c)
+
+	e.Wrapping = fyne.TextTruncate
+	e.Refresh()
+	test.AssertRendersToMarkup(t, "entry/wrap_single_line_truncate.xml", c)
+
+	e.Wrapping = fyne.TextWrapOff
+	e.Refresh()
+	test.AssertRendersToMarkup(t, "entry/wrap_single_line_off.xml", c)
 }
 
 func TestMultiLineEntry_MinSize(t *testing.T) {

--- a/widget/select_entry.go
+++ b/widget/select_entry.go
@@ -17,6 +17,7 @@ type SelectEntry struct {
 func NewSelectEntry(options []string) *SelectEntry {
 	e := &SelectEntry{}
 	e.ExtendBaseWidget(e)
+	e.Wrapping = fyne.TextTruncate
 	e.options = options
 	return e
 }

--- a/widget/testdata/entry/disableable_disabled_custom_value.xml
+++ b/widget/testdata/entry/disableable_disabled_custom_value.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="disabled" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21">Hello</text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21">Hello</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/disableable_disabled_empty.xml
+++ b/widget/testdata/entry/disableable_disabled_empty.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="disabled" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/disableable_disabled_placeholder.xml
+++ b/widget/testdata/entry/disableable_disabled_placeholder.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="disabled" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21">Type!</text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21">Type!</text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/disableable_enabled_custom_value.xml
+++ b/widget/testdata/entry/disableable_enabled_custom_value.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Hello</text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Hello</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/disableable_enabled_empty.xml
+++ b/widget/testdata/entry/disableable_enabled_empty.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/disableable_enabled_placeholder.xml
+++ b/widget/testdata/entry/disableable_enabled_placeholder.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21">Type!</text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21">Type!</text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/focus_gained.xml
+++ b/widget/testdata/entry/focus_gained.xml
@@ -3,16 +3,14 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
 				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
+				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/focus_lost.xml
+++ b/widget/testdata/entry/focus_lost.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/focus_with_popup_dismissed.xml
+++ b/widget/testdata/entry/focus_with_popup_dismissed.xml
@@ -3,16 +3,14 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
 				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
+				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/focus_with_popup_entry_selected.xml
+++ b/widget/testdata/entry/focus_with_popup_entry_selected.xml
@@ -3,16 +3,14 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
 				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
+				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/focus_with_popup_initial.xml
+++ b/widget/testdata/entry/focus_with_popup_initial.xml
@@ -3,16 +3,14 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
 				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
+				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/focused_disabled.xml
+++ b/widget/testdata/entry/focused_disabled.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="disabled" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/focused_enabled.xml
+++ b/widget/testdata/entry/focused_enabled.xml
@@ -3,16 +3,14 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
 				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
+				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/initial.xml
+++ b/widget/testdata/entry/initial.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/placeholder_with_text.xml
+++ b/widget/testdata/entry/placeholder_with_text.xml
@@ -3,11 +3,9 @@
 		<widget pos="4,4" size="38x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="38x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="38x2"/>
-			<widget pos="0,2" size="38x33" type="*widget.Scroll">
-				<widget size="38x33" type="*widget.entryContent">
-					<widget size="38x33" type="*widget.textProvider">
-						<text pos="8,6" size="30x21">Text</text>
-					</widget>
+			<widget pos="0,2" size="38x33" type="*widget.entryContent">
+				<widget size="38x33" type="*widget.textProvider">
+					<text pos="8,6" size="30x21">Text</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/placeholder_without_text.xml
+++ b/widget/testdata/entry/placeholder_without_text.xml
@@ -3,14 +3,12 @@
 		<widget pos="4,4" size="38x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="38x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="38x2"/>
-			<widget pos="0,2" size="38x33" type="*widget.Scroll">
-				<widget size="38x33" type="*widget.entryContent">
-					<widget size="38x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="30x21">Placehold</text>
-					</widget>
-					<widget size="38x33" type="*widget.textProvider">
-						<text pos="8,6" size="30x21"></text>
-					</widget>
+			<widget pos="0,2" size="38x33" type="*widget.entryContent">
+				<widget size="38x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="30x21">Placehold</text>
+				</widget>
+				<widget size="38x33" type="*widget.textProvider">
+					<text pos="8,6" size="30x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/select_add_selection.xml
+++ b/widget/testdata/entry/select_add_selection.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<rectangle fillColor="primary" pos="16,6" size="22x21"/>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="37,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<rectangle fillColor="primary" pos="16,6" size="22x21"/>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="37,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/select_initial.xml
+++ b/widget/testdata/entry/select_initial.xml
@@ -3,13 +3,11 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/select_move_wo_shift.xml
+++ b/widget/testdata/entry/select_move_wo_shift.xml
@@ -3,13 +3,11 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="37,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="37,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/select_select_left.xml
+++ b/widget/testdata/entry/select_select_left.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<rectangle fillColor="primary" pos="24,6" size="14x21"/>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="24,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<rectangle fillColor="primary" pos="24,6" size="14x21"/>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="24,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/select_selected.xml
+++ b/widget/testdata/entry/select_selected.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<rectangle fillColor="primary" pos="16,6" size="17x21"/>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="32,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<rectangle fillColor="primary" pos="16,6" size="17x21"/>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="32,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/select_single_line_pagedown.xml
+++ b/widget/testdata/entry/select_single_line_pagedown.xml
@@ -3,13 +3,11 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="60,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="60,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/select_single_line_shift_pagedown.xml
+++ b/widget/testdata/entry/select_single_line_shift_pagedown.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<rectangle fillColor="primary" pos="16,6" size="45x21"/>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="60,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<rectangle fillColor="primary" pos="16,6" size="45x21"/>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="60,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/select_single_line_shift_pageup.xml
+++ b/widget/testdata/entry/select_single_line_shift_pageup.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<rectangle fillColor="primary" pos="7,6" size="10x21"/>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing</text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<rectangle fillColor="primary" pos="7,6" size="10x21"/>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing</text>
 				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/set_placeholder_replaced.xml
+++ b/widget/testdata/entry/set_placeholder_replaced.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Hi</text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Hi</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/set_placeholder_set.xml
+++ b/widget/testdata/entry/set_placeholder_set.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21">Test</text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21">Test</text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/set_text_changed.xml
+++ b/widget/testdata/entry/set_text_changed.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Test</text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Test</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/set_text_style_bold.xml
+++ b/widget/testdata/entry/set_text_style_bold.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text bold pos="8,6" size="112x21">Styled Text</text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text bold pos="8,6" size="112x21">Styled Text</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/set_text_style_italic.xml
+++ b/widget/testdata/entry/set_text_style_italic.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text italic pos="8,6" size="112x21">Styled Text</text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text italic pos="8,6" size="112x21">Styled Text</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/set_text_style_monospace.xml
+++ b/widget/testdata/entry/set_text_style_monospace.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text monospace pos="8,6" size="112x18">Styled Text</text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text monospace pos="8,6" size="112x18">Styled Text</text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/tapped_secondary_full_menu.xml
+++ b/widget/testdata/entry/tapped_secondary_full_menu.xml
@@ -3,16 +3,14 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
 				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
+				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/tapped_secondary_no_password_menu.xml
+++ b/widget/testdata/entry/tapped_secondary_no_password_menu.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="disabled" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/tapped_secondary_password_menu.xml
+++ b/widget/testdata/entry/tapped_secondary_password_menu.xml
@@ -3,16 +3,14 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
 				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
+				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/tapped_secondary_read_menu.xml
+++ b/widget/testdata/entry/tapped_secondary_read_menu.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="disabled" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="disabled" pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="disabled" pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/validate_initial.xml
+++ b/widget/testdata/entry/validate_initial.xml
@@ -3,14 +3,12 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="shadow" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text color="placeholder" pos="8,6" size="112x21"></text>
-					</widget>
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21"></text>
-					</widget>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text color="placeholder" pos="8,6" size="112x21"></text>
+				</widget>
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21"></text>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/validate_invalid.xml
+++ b/widget/testdata/entry/validate_invalid.xml
@@ -3,11 +3,9 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="error" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="92x33" type="*widget.Scroll">
-				<widget size="92x33" type="*widget.entryContent">
-					<widget size="92x33" type="*widget.textProvider">
-						<text pos="8,6" size="84x21">2020-02</text>
-					</widget>
+			<widget pos="0,2" size="92x33" type="*widget.entryContent">
+				<widget size="92x33" type="*widget.textProvider">
+					<text pos="8,6" size="84x21">2020-02</text>
 				</widget>
 			</widget>
 			<widget pos="92,8" size="20x20" type="*widget.validationStatus">

--- a/widget/testdata/entry/validate_valid.xml
+++ b/widget/testdata/entry/validate_valid.xml
@@ -3,13 +3,11 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="92x33" type="*widget.Scroll">
-				<widget size="92x33" type="*widget.entryContent">
-					<widget size="92x33" type="*widget.textProvider">
-						<text pos="8,6" size="84x21">2020-02-12</text>
-					</widget>
-					<rectangle fillColor="primary" pos="87,6" size="2x21"/>
+			<widget pos="0,2" size="92x33" type="*widget.entryContent">
+				<widget size="92x33" type="*widget.textProvider">
+					<text pos="8,6" size="84x21">2020-02-12</text>
 				</widget>
+				<rectangle fillColor="primary" pos="87,6" size="2x21"/>
 			</widget>
 			<widget pos="92,8" size="20x20" type="*widget.validationStatus">
 				<image rsc="confirmIcon" size="iconInlineSize"/>

--- a/widget/testdata/entry/wrap_multi_line_off.xml
+++ b/widget/testdata/entry/wrap_multi_line_off.xml
@@ -3,13 +3,11 @@
 		<widget pos="10,10" size="120x100" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x96"/>
 			<rectangle fillColor="primary" pos="0,98" size="120x2"/>
-			<widget pos="0,2" size="120x96" type="*widget.Scroll">
-				<widget size="120x96" type="*widget.entryContent">
-					<widget size="120x96" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">A long text on short words w/o NLs or LFs.</text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x96" type="*widget.entryContent">
+				<widget size="120x96" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">A long text on short words w/o NLs or LFs.</text>
 				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/wrap_multi_line_truncate.xml
+++ b/widget/testdata/entry/wrap_multi_line_truncate.xml
@@ -1,0 +1,16 @@
+<canvas padded size="150x200">
+	<content>
+		<widget pos="10,10" size="120x100" type="*widget.Entry">
+			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x96"/>
+			<rectangle fillColor="primary" pos="0,98" size="120x2"/>
+			<widget pos="0,2" size="120x96" type="*widget.Scroll">
+				<widget size="120x96" type="*widget.entryContent">
+					<widget size="120x96" type="*widget.textProvider">
+						<text pos="8,6" size="112x21">A long text on short words w/o NLs or LFs.</text>
+					</widget>
+					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+				</widget>
+			</widget>
+		</widget>
+	</content>
+</canvas>

--- a/widget/testdata/entry/wrap_single_line_off.xml
+++ b/widget/testdata/entry/wrap_single_line_off.xml
@@ -3,13 +3,11 @@
 		<widget pos="10,10" size="120x37" type="*widget.Entry">
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
 			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
-			<widget pos="0,2" size="120x33" type="*widget.Scroll">
-				<widget size="120x33" type="*widget.entryContent">
-					<widget size="120x33" type="*widget.textProvider">
-						<text pos="8,6" size="112x21">Testing Wrapping</text>
-					</widget>
-					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+			<widget pos="0,2" size="120x33" type="*widget.entryContent">
+				<widget size="120x33" type="*widget.textProvider">
+					<text pos="8,6" size="112x21">Testing Wrapping</text>
 				</widget>
+				<rectangle fillColor="primary" pos="7,6" size="2x21"/>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/entry/wrap_single_line_truncate.xml
+++ b/widget/testdata/entry/wrap_single_line_truncate.xml
@@ -1,0 +1,16 @@
+<canvas padded size="150x200">
+	<content>
+		<widget pos="10,10" size="120x37" type="*widget.Entry">
+			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x33"/>
+			<rectangle fillColor="primary" pos="0,35" size="120x2"/>
+			<widget pos="0,2" size="120x33" type="*widget.Scroll">
+				<widget size="143x33" type="*widget.entryContent">
+					<widget size="143x33" type="*widget.textProvider">
+						<text pos="8,6" size="135x21">Testing Wrapping</text>
+					</widget>
+					<rectangle fillColor="primary" pos="7,6" size="2x21"/>
+				</widget>
+			</widget>
+		</widget>
+	</content>
+</canvas>


### PR DESCRIPTION
When setting up an entry do not expose a scroll container unless multiline or scrolling is specified.
This is the best we can do until a future version of event handling that can reflect on object state not existance.

Fixes #1939

TODO
- [x] Reconfigure if the wrap type changes

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

