### PR TITLE
Refactor: fixing (potential) bugs around closing

### DIFF
--- a/app/preferences.go
+++ b/app/preferences.go
@@ -64,19 +64,22 @@ func (p *preferences) load() {
 	}
 }
 
-func (p *preferences) loadFromFile(path string) error {
+func (p *preferences) loadFromFile(path string) (err error) {
 	file, err := os.Open(path) // #nosec
 	if err != nil {
 		if os.IsNotExist(err) {
-			err := os.MkdirAll(filepath.Dir(path), 0700)
-			if err != nil {
+			if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 				return err
 			}
 			return nil
 		}
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if r := file.Close(); r != nil {
+			err = r
+		}
+	}()
 	decode := json.NewDecoder(file)
 
 	p.InMemoryPreferences.WriteValues(func(values map[string]interface{}) {

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -76,7 +76,7 @@ func (p *preferences) loadFromFile(path string) (err error) {
 		return err
 	}
 	defer func() {
-		if r := file.Close(); r != nil {
+		if r := file.Close(); r != nil && err == nil {
 			err = r
 		}
 	}()

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -138,35 +138,23 @@ func (b *Bundler) Run(args []string) {
 	}
 }
 
-func (b *Bundler) bundleAction(ctx *cli.Context) error {
+func (b *Bundler) bundleAction(ctx *cli.Context) (err error) {
 	if ctx.Args().Len() != 1 {
 		return errors.New("missing required file or directory parameter after flags")
 	}
 
 	outFile := os.Stdout
 	if b.out != "" {
-		fileModes := os.O_RDWR | os.O_CREATE | os.O_TRUNC
-		if b.noheader {
-			fileModes = os.O_RDWR | os.O_APPEND
+		file, closeFile, err := getOutputFile(b.out, b.noheader)
+		if err != nil {
+			return err
 		}
-
-		f, err := os.OpenFile(b.out, fileModes, 0666)
-		if err == nil {
-			outFile = f
-		} else {
-			if os.IsNotExist(err) {
-				f, err = os.Create(b.out)
-				if err == nil {
-					outFile = f
-				} else {
-					fyne.LogError("Unable to read, or create, output file : "+b.out, err)
-					return err
-				}
-			} else {
-				fyne.LogError("Unable to open output file", err)
-				return err
+		defer func() {
+			if r := closeFile(); r != nil {
+				err = r
 			}
-		}
+		}()
+		outFile = file
 	}
 
 	arg := ctx.Args().First()
@@ -225,6 +213,32 @@ func (b *Bundler) doBundle(filepath string, out *os.File) {
 		b.name = sanitiseName(path.Base(filepath), b.prefix)
 	}
 	writeResource(filepath, b.name, out)
+}
+
+func getOutputFile(filePath string, noheader bool) (file *os.File, close func() error, err error) {
+	fileModes := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	if noheader {
+		fileModes = os.O_RDWR | os.O_APPEND
+	}
+
+	f, err := os.OpenFile(filePath, fileModes, 0666)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fyne.LogError("Unable to open output file", err)
+			return nil, nil, err
+		}
+
+		// try creating the file
+		f, err = os.Create(filePath)
+		if err != nil {
+			fyne.LogError("Unable to read, or create, output file : "+filePath, err)
+			return nil, nil, err
+		}
+	}
+
+	return f, func() error {
+		return f.Close()
+	}, nil
 }
 
 func sanitiseName(file, prefix string) string {

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -145,7 +145,7 @@ func (b *Bundler) bundleAction(ctx *cli.Context) (err error) {
 
 	outFile := os.Stdout
 	if b.out != "" {
-		file, closeFile, err := getOutputFile(b.out, b.noheader)
+		file, closeFile, err := openOutputFile(b.out, b.noheader)
 		if err != nil {
 			return err
 		}
@@ -215,7 +215,7 @@ func (b *Bundler) doBundle(filepath string, out *os.File) {
 	writeResource(filepath, b.name, out)
 }
 
-func getOutputFile(filePath string, noheader bool) (file *os.File, close func() error, err error) {
+func openOutputFile(filePath string, noheader bool) (file *os.File, close func() error, err error) {
 	fileModes := os.O_RDWR | os.O_CREATE | os.O_TRUNC
 	if noheader {
 		fileModes = os.O_RDWR | os.O_APPEND

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -236,7 +236,7 @@ func getOutputFile(filePath string, noheader bool) (file *os.File, close func() 
 		}
 	}
 
-	return f, f.Close(), nil
+	return f, f.Close, nil
 }
 
 func sanitiseName(file, prefix string) string {

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -236,9 +236,7 @@ func getOutputFile(filePath string, noheader bool) (file *os.File, close func() 
 		}
 	}
 
-	return f, func() error {
-		return f.Close()
-	}, nil
+	return f, f.Close(), nil
 }
 
 func sanitiseName(file, prefix string) string {

--- a/cmd/fyne/internal/commands/package-darwin.go
+++ b/cmd/fyne/internal/commands/package-darwin.go
@@ -31,7 +31,7 @@ func (p *Packager) packageDarwin() (err error) {
 		return errors.Wrap(err, "Failed to write plist template")
 	}
 	defer func() {
-		if r := infoFile.Close(); r != nil {
+		if r := infoFile.Close(); r != nil && err == nil {
 			err = r
 		}
 	}()
@@ -65,7 +65,7 @@ func (p *Packager) packageDarwin() (err error) {
 		return errors.Wrap(err, "Failed to open destination file")
 	}
 	defer func() {
-		if r := dest.Close(); r != nil {
+		if r := dest.Close(); r != nil && err == nil {
 			err = r
 		}
 	}()

--- a/cmd/fyne/internal/commands/package-darwin.go
+++ b/cmd/fyne/internal/commands/package-darwin.go
@@ -20,25 +20,31 @@ type darwinData struct {
 	Category      string
 }
 
-func (p *Packager) packageDarwin() error {
+func (p *Packager) packageDarwin() (err error) {
 	appDir := util.EnsureSubDir(p.dir, p.name+".app")
 	exeName := filepath.Base(p.exe)
 
 	contentsDir := util.EnsureSubDir(appDir, "Contents")
 	info := filepath.Join(contentsDir, "Info.plist")
-	infoFile, _ := os.Create(info)
+	infoFile, err := os.Create(info)
+	if err != nil {
+		return errors.Wrap(err, "Failed to write plist template")
+	}
+	defer func() {
+		if r := infoFile.Close(); r != nil {
+			err = r
+		}
+	}()
 
 	tplData := darwinData{Name: p.name, ExeName: exeName, AppID: p.appID, Version: p.appVersion, Build: p.appBuild,
 		Category: strings.ToLower(p.category)}
-	err := templates.InfoPlistDarwin.Execute(infoFile, tplData)
-	if err != nil {
+	if err := templates.InfoPlistDarwin.Execute(infoFile, tplData); err != nil {
 		return errors.Wrap(err, "Failed to write plist template")
 	}
 
 	macOSDir := util.EnsureSubDir(contentsDir, "MacOS")
 	binName := filepath.Join(macOSDir, exeName)
-	err = util.CopyExeFile(p.exe, binName)
-	if err != nil {
+	if err := util.CopyExeFile(p.exe, binName); err != nil {
 		return errors.Wrap(err, "Failed to copy exe file")
 	}
 
@@ -58,7 +64,11 @@ func (p *Packager) packageDarwin() error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to open destination file")
 	}
-	defer dest.Close()
+	defer func() {
+		if r := dest.Close(); r != nil {
+			err = r
+		}
+	}()
 	if err := icns.Encode(dest, srcImg); err != nil {
 		return errors.Wrap(err, "Failed to encode icns")
 	}

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -452,7 +452,7 @@ func (r *Releaser) writeEntitlements(tmpl *template.Template, entitlementData in
 		return nil, err
 	}
 	defer func() {
-		if r := entitlements.Close(); r != nil {
+		if r := entitlements.Close(); r != nil && err == nil {
 			err = r
 		}
 	}()

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -269,12 +269,14 @@ func (r *Releaser) packageIOSRelease() error {
 		return err
 	}
 
-	if _, err := r.writeEntitlements(templates.EntitlementsDarwinMobile, struct{ TeamID, AppID string }{
+	cleanup, err := r.writeEntitlements(templates.EntitlementsDarwinMobile, struct{ TeamID, AppID string }{
 		TeamID: team,
 		AppID:  r.appID,
-	}); err != nil {
+	})
+	if err != nil {
 		return errors.New("failed to write entitlements plist template")
 	}
+	defer cleanup()
 
 	cmd := exec.Command("codesign", "-f", "-vv", "-s", r.certificate, "--entitlements",
 		"entitlements.plist", "Payload/"+appName+"/")

--- a/cmd/fyne/internal/util/file.go
+++ b/cmd/fyne/internal/util/file.go
@@ -39,9 +39,8 @@ func EnsureSubDir(parent, name string) string {
 	return path
 }
 
-func copyFileMode(src, tgt string, perm os.FileMode) error {
-	_, err := os.Stat(src)
-	if err != nil {
+func copyFileMode(src, tgt string, perm os.FileMode) (err error) {
+	if _, err := os.Stat(src); err != nil {
 		return err
 	}
 
@@ -55,7 +54,11 @@ func copyFileMode(src, tgt string, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer target.Close()
+	defer func() {
+		if r := target.Close(); r != nil {
+			err = r
+		}
+	}()
 
 	_, err = io.Copy(target, source)
 	return err

--- a/cmd/fyne/internal/util/file.go
+++ b/cmd/fyne/internal/util/file.go
@@ -55,7 +55,7 @@ func copyFileMode(src, tgt string, perm os.FileMode) (err error) {
 		return err
 	}
 	defer func() {
-		if r := target.Close(); r != nil {
+		if r := target.Close(); r != nil && err == nil {
 			err = r
 		}
 	}()

--- a/resource.go
+++ b/resource.go
@@ -63,6 +63,7 @@ func LoadResourceFromURLString(urlStr string) (Resource, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	bytes, err := ioutil.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
### Description:
There was one http body close missing.

The other fixes resolve around ignoring the error on writable file handler closing (which should not be done). An error might be returned from `Close` that indicates a write failure. For more details see https://www.joeshaw.org/dont-defer-close-on-writable-files/

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
