### PR TITLE
replacing http.Get with context call

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -69,6 +69,8 @@ func LoadResourceFromURLString(urlStr string) (Resource, error) {
 	return LoadResourceFromURLStringWithCtx(ctx, urlStr)
 }
 
+// LoadResourceFromURLStringWithCtx creates a new StaticResource in memory using the body of the specified URL.
+// The provided context will be passed the the http request.
 func LoadResourceFromURLStringWithCtx(ctx context.Context, urlStr string) (Resource, error) {
 	req, err := http.NewRequest(http.MethodGet, urlStr, nil)
 	if err != nil {

--- a/resource.go
+++ b/resource.go
@@ -1,9 +1,11 @@
 package fyne
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
+	"time"
 )
 
 // Resource represents a single binary resource, such as an image or font.
@@ -59,7 +61,14 @@ func LoadResourceFromPath(path string) (Resource, error) {
 
 // LoadResourceFromURLString creates a new StaticResource in memory using the body of the specified URL.
 func LoadResourceFromURLString(urlStr string) (Resource, error) {
-	res, err := http.Get(urlStr)
+	req, err := http.NewRequest(http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	res, err := (&http.Client{}).Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/resource.go
+++ b/resource.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const httpReqTimeout = 60 * time.Second
+
 // Resource represents a single binary resource, such as an image or font.
 // A resource has an identifying name and byte array content.
 // The serialised path of a resource can be obtained which may result in a
@@ -61,12 +63,17 @@ func LoadResourceFromPath(path string) (Resource, error) {
 
 // LoadResourceFromURLString creates a new StaticResource in memory using the body of the specified URL.
 func LoadResourceFromURLString(urlStr string) (Resource, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), httpReqTimeout)
+	defer cancel()
+
+	return LoadResourceFromURLStringWithCtx(ctx, urlStr)
+}
+
+func LoadResourceFromURLStringWithCtx(ctx context.Context, urlStr string) (Resource, error) {
 	req, err := http.NewRequest(http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
 
 	res, err := (&http.Client{}).Do(req.WithContext(ctx))
 	if err != nil {


### PR DESCRIPTION
### Description:
http.Get without context is best not used any more.

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
