### PR TITLE
create all desktop setting directories (#2023)

### DIFF
--- a/app/settings_desktop.go
+++ b/app/settings_desktop.go
@@ -25,7 +25,7 @@ func ensureDirExists(dir string) {
 		return
 	}
 
-	err := os.Mkdir(dir, 0700)
+	err := os.MkdirAll(dir, 0700)
 	if err != nil {
 		fyne.LogError("Unable to create settings storage:", err)
 	}


### PR DESCRIPTION
### Description:
Create all desktop setting directories

Avoids error if one of the directories in the path is missing (e.g. `.config/fyne`) on first execution.
This PR simply change os.Mkdir() into os.MkdirAll().

Fixes #2023

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
