### PR TITLE
correct error in fyne.io example

### DIFF
--- a/fyne.go
+++ b/fyne.go
@@ -9,13 +9,14 @@
 //
 //   import "fyne.io/fyne/v2/app"
 //   import "fyne.io/fyne/v2/widget"
+//   import "fyne.io/fyne/v2/container"
 //
 //   func main() {
 //   	a := app.New()
 //   	w := a.NewWindow("Hello")
 //
 //   	hello := widget.NewLabel("Hello Fyne!")
-//   	w.SetContent(widget.NewVBox(
+//   	w.SetContent(container.NewVBox(
 //   		hello,
 //   		widget.NewButton("Hi!", func() {
 //   			hello.SetText("Welcome :)")

--- a/fyne.go
+++ b/fyne.go
@@ -8,8 +8,8 @@
 //   package main
 //
 //   import "fyne.io/fyne/v2/app"
-//   import "fyne.io/fyne/v2/widget"
 //   import "fyne.io/fyne/v2/container"
+//   import "fyne.io/fyne/v2/widget"
 //
 //   func main() {
 //   	a := app.New()


### PR DESCRIPTION
### Description:
Fix error in fyne example code provided if file `fine.go`.
Replaced `widget` by `container` in `SetContent`. 

No associated issue. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
