### PR TITLE
Fix crash on extended password entry

### DIFF
--- a/widget/entry_password.go
+++ b/widget/entry_password.go
@@ -46,7 +46,7 @@ func (r *passwordRevealer) Tapped(*fyne.PointEvent) {
 	r.entry.setFieldsAndRefresh(func() {
 		r.entry.Password = !r.entry.Password
 	})
-	fyne.CurrentApp().Driver().CanvasForObject(r).Focus(r.entry)
+	fyne.CurrentApp().Driver().CanvasForObject(r).Focus(r.entry.super().(fyne.Focusable))
 }
 
 var _ fyne.WidgetRenderer = (*passwordRevealerRenderer)(nil)

--- a/widget/entry_password_extend_test.go
+++ b/widget/entry_password_extend_test.go
@@ -1,0 +1,31 @@
+package widget
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type extendEntry struct {
+	Entry
+}
+
+func TestEntry_Password_Extended_CreateRenderer(t *testing.T) {
+	entry := &extendEntry{}
+	entry.ExtendBaseWidget(entry)
+	entry.Password = true
+	entry.Wrapping = fyne.TextTruncate
+	assert.NotNil(t, test.WidgetRenderer(entry))
+	r := test.WidgetRenderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
+	p := test.WidgetRenderer(r).(*entryContentRenderer).provider
+	texts := test.WidgetRenderer(p).(*textRenderer).texts
+
+	test.Type(entry, "Pass")
+	assert.Equal(t, passwordChar+passwordChar+passwordChar+passwordChar, texts[0].Text)
+	assert.NotNil(t, entry.ActionItem)
+	test.Tap(entry.ActionItem.(*passwordRevealer))
+	assert.Equal(t, "Pass", texts[0].Text)
+}


### PR DESCRIPTION
Fixes #2036

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

