### PR TITLE
Fix unexpected call to os.Exit(0) during glfw tests

### DIFF
--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -475,8 +475,6 @@ func TestGlCanvas_ResizeWithModalPopUpOverlay(t *testing.T) {
 
 	winSize := fyne.NewSize(1000, 600)
 	w.Resize(winSize)
-	w.Show()
-	defer w.Close()
 
 	// get popup content padding dynamically
 	popupContentPadding := popup.MinSize().Subtract(popup.Content.MinSize())

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}()
 
-	master := d.CreateWindow("Master")
+	master := createWindow("Master")
 	master.SetOnClosed(func() {
 		// we do not close, keeping the driver running
 	})


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fix unexpected call to os.Exit(0) during glfw tests:
```
panic: unexpected call to os.Exit(0) during test

goroutine 1 [running, locked to thread]:
os.Exit(0x0)
        /usr/local/go/src/os/proc.go:68 +0x6d
main.main()
        _testmain.go:180 +0x252
FAIL    fyne.io/fyne/v2/internal/driver/glfw    0.400s
FAIL
```
### Checklist:
<!-- Please tick these as appropriate using [x] -->

~~- [ ] Tests included.~~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
