### PR TITLE
When window init fails we should quit the app

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -3,6 +3,7 @@
 package glfw
 
 import (
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -111,6 +112,16 @@ func (d *gLDriver) windowList() []fyne.Window {
 	d.windowLock.RLock()
 	defer d.windowLock.RUnlock()
 	return d.windows
+}
+
+func (d *gLDriver) initFailed(msg string, err error) {
+	fyne.LogError(msg, err)
+
+	if running() {
+		d.Quit()
+	} else {
+		os.Exit(1)
+	}
 }
 
 func goroutineID() int {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -57,6 +57,7 @@ type window struct {
 	cursor       desktop.Cursor
 	customCursor *glfw.Cursor
 	canvas       *glCanvas
+	driver       *gLDriver
 	title        string
 	icon         fyne.Resource
 	mainmenu     *fyne.MainMenu
@@ -446,7 +447,7 @@ func (w *window) Close() {
 
 func (w *window) ShowAndRun() {
 	w.Show()
-	fyne.CurrentApp().Driver().Run()
+	w.driver.Run()
 }
 
 // Clipboard returns the system clipboard
@@ -1265,7 +1266,7 @@ func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 	runOnMain(func() {
 		d.initGLFW()
 
-		ret = &window{title: title, decorate: decorate}
+		ret = &window{title: title, decorate: decorate, driver: d}
 		// This channel will be closed when the window is closed.
 		ret.eventQueue = make(chan func(), 1024)
 		go ret.runEventQueue()
@@ -1308,7 +1309,7 @@ func (w *window) create() {
 
 		win, err := glfw.CreateWindow(pixWidth, pixHeight, w.title, nil, nil)
 		if err != nil {
-			fyne.LogError("window creation error", err)
+			w.driver.initFailed("window creation error", err)
 			return
 		}
 


### PR DESCRIPTION
IIf the driver is running already then quit the app.
If not we can exit before it starts.

Fixes #1593 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
