### PR TITLE
Faster ci

### DIFF
--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: WillAbides/setup-go-faster@v1.5.0
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.12.x, 1.15.x]
+        go-version: [1.12.x, 1.16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -12,7 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: WillAbides/setup-go-faster@v1.5.0
+      id: setup-go-faster
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -44,6 +45,8 @@ jobs:
 
     - name: Update PR Coverage
       uses: shogo82148/actions-goveralls@v1
+      env:
+        GOROOT: ${{steps.setup-go-faster.outputs.GOROOT}}
       with:
         path-to-profile: coverage.out
       if: ${{ runner.os == 'Linux' && github.event_name == 'push' }}

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.12.x, 1.15.x]
+        go-version: [1.12.x, 1.16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The setup of each workflow run should now be about 3x faster thanks to using https://github.com/WillAbides/setup-go-faster.
This includes a workaround until WillAbides/setup-go-faster#11 is fixed.

This also makes sure that we run tests on the latest stable Go release (Go 1.16). It has the side-effect that the CI should be even faster: "Linking is 20-25% faster than 1.15 and requires 5-15% less memory on average for linux/amd64, with larger improvements for other architectures and OSes.".

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- ~[] Tests included.~
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.