### PR TITLE
Fix multiline entry cursor position when pasting content (with text wrap)

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -821,21 +821,10 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 	}
 	provider := e.textProvider()
 	runes := []rune(text)
-	provider.insertAt(e.cursorTextPos(), runes)
+	pos := e.cursorTextPos()
+	provider.insertAt(pos, runes)
+	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos + len(runes))
 
-	newlines := strings.Count(text, "\n")
-	if newlines == 0 {
-		e.CursorColumn += len(runes)
-	} else {
-		e.CursorRow += newlines
-		lastNewlineIndex := 0
-		for i, r := range runes {
-			if r == '\n' {
-				lastNewlineIndex = i
-			}
-		}
-		e.CursorColumn = len(runes) - lastNewlineIndex - 1
-	}
 	e.updateText(provider.String())
 	e.Refresh()
 }

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -255,6 +255,35 @@ func TestEntry_PasteFromClipboard(t *testing.T) {
 	assert.Equal(t, entry.Text, testContent)
 }
 
+func TestEntry_PasteFromClipboard_MultilineWrapping(t *testing.T) {
+	entry := NewMultiLineEntry()
+	entry.Wrapping = fyne.TextWrapWord
+
+	w := test.NewApp().NewWindow("")
+	w.SetContent(entry)
+	w.Resize(fyne.NewSize(100, 64))
+
+	test.Type(entry, "T")
+	assert.Equal(t, 0, entry.CursorRow)
+	assert.Equal(t, 1, entry.CursorColumn)
+
+	clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
+	clipboard.SetContent("esting entry")
+
+	entry.pasteFromClipboard(clipboard)
+
+	assert.Equal(t, entry.Text, "Testing entry")
+	assert.Equal(t, 1, entry.CursorRow)
+	assert.Equal(t, 5, entry.CursorColumn)
+
+	clipboard.SetContent(" paste\ncontent")
+	entry.pasteFromClipboard(clipboard)
+
+	assert.Equal(t, "Testing entry paste\ncontent", entry.Text)
+	assert.Equal(t, 2, entry.CursorRow)
+	assert.Equal(t, 7, entry.CursorColumn)
+}
+
 func TestEntry_Tab(t *testing.T) {
 	e := NewEntry()
 	e.SetText("a\n\tb\nc")


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes the multiline entry cursor position when pasting content (with text wrap).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.