### PR TITLE
Mobile (Android): get filename of content:// URI

### DIFF
--- a/internal/driver/gomobile/android.c
+++ b/internal/driver/gomobile/android.c
@@ -215,7 +215,6 @@ bool hasPrefix(char* string, char* prefix) {
 bool canListContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 	JNIEnv *env = (JNIEnv*)jni_env;
 	jobject resolver = getContentResolver(jni_env, ctx);
-	jstring uriStr = (*env)->NewStringUTF(env, uriCstr);
 	jobject uri = parseURI(jni_env, ctx, uriCstr);
 	jthrowable loadErr = (*env)->ExceptionOccurred(env);
 
@@ -278,7 +277,6 @@ bool canListURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 char* contentURIGetFileName(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 	JNIEnv *env = (JNIEnv*)jni_env;
 	jobject resolver = getContentResolver(jni_env, ctx);
-	jstring uriStr = (*env)->NewStringUTF(env, uriCstr);
 	jobject uri = parseURI(jni_env, ctx, uriCstr);
 	jthrowable loadErr = (*env)->ExceptionOccurred(env);
 
@@ -311,7 +309,6 @@ char* contentURIGetFileName(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 	JNIEnv *env = (JNIEnv*)jni_env;
 	jobject resolver = getContentResolver(jni_env, ctx);
-	jstring uriStr = (*env)->NewStringUTF(env, uriCstr);
 	jobject uri = parseURI(jni_env, ctx, uriCstr);
 	jthrowable loadErr = (*env)->ExceptionOccurred(env);
 

--- a/internal/driver/gomobile/file.go
+++ b/internal/driver/gomobile/file.go
@@ -9,12 +9,6 @@ import (
 	"fyne.io/fyne/v2/storage"
 )
 
-// Override Name on android for content://
-type mobileURI struct {
-	systemURI string
-	fyne.URI
-}
-
 type fileOpen struct {
 	io.ReadCloser
 	uri  fyne.URI

--- a/internal/driver/gomobile/file.go
+++ b/internal/driver/gomobile/file.go
@@ -9,6 +9,12 @@ import (
 	"fyne.io/fyne/v2/storage"
 )
 
+// Override Name on android for content://
+type mobileURI struct {
+	systemURI string
+	fyne.URI
+}
+
 type fileOpen struct {
 	io.ReadCloser
 	uri  fyne.URI
@@ -56,7 +62,10 @@ func ShowFileOpenPicker(callback func(fyne.URIReadCloser, error), filter storage
 				callback(nil, nil)
 				return
 			}
-			f, err := fileReaderForURI(storage.NewURI(uri))
+			f, err := fileReaderForURI(&mobileURI{
+				URI:       storage.NewURI(uri),
+				systemURI: uri,
+			})
 			if f != nil {
 				f.(*fileOpen).done = closer
 			}

--- a/internal/driver/gomobile/file.go
+++ b/internal/driver/gomobile/file.go
@@ -56,10 +56,7 @@ func ShowFileOpenPicker(callback func(fyne.URIReadCloser, error), filter storage
 				callback(nil, nil)
 				return
 			}
-			f, err := fileReaderForURI(&mobileURI{
-				URI:       storage.NewURI(uri),
-				systemURI: uri,
-			})
+			f, err := fileReaderForURI(nativeURI(uri))
 			if f != nil {
 				f.(*fileOpen).done = closer
 			}

--- a/internal/driver/gomobile/file_android.go
+++ b/internal/driver/gomobile/file_android.go
@@ -12,33 +12,17 @@ char* readStream(uintptr_t jni_env, uintptr_t ctx, void* stream, int len, int* t
 void* saveStream(uintptr_t jni_env, uintptr_t ctx, char* uriCstr);
 void writeStream(uintptr_t jni_env, uintptr_t ctx, void* stream, char* data, int len);
 void closeStream(uintptr_t jni_env, uintptr_t ctx, void* stream);
-char* contentURIGetFileName(uintptr_t jni_env, uintptr_t ctx, char* uriCstr);
 */
 import "C"
 import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"fyne.io/fyne/v2/storage/repository"
 	"github.com/fyne-io/mobile/app"
 )
-
-func (m mobileURI) Name() string {
-	if m.Scheme() == "content" {
-		result := contentURIGetFileName(m.systemURI)
-		if result != "" {
-			return result
-		}
-	}
-	return m.URI.Name()
-}
-
-func (m mobileURI) Extension() string {
-	return filepath.Ext(m.Name())
-}
 
 type javaStream struct {
 	stream unsafe.Pointer // java.io.InputStream
@@ -93,25 +77,6 @@ func openStream(uri string) unsafe.Pointer {
 		return nil
 	})
 	return stream
-}
-
-func contentURIGetFileName(uri string) string {
-	uriStr := C.CString(uri)
-	defer C.free(unsafe.Pointer(uriStr))
-
-	var filename string
-	app.RunOnJVM(func(_, env, ctx uintptr) error {
-		fnamePtr := C.contentURIGetFileName(C.uintptr_t(env), C.uintptr_t(ctx), uriStr)
-		vPtr := unsafe.Pointer(fnamePtr)
-		if vPtr == C.NULL {
-			return nil
-		}
-		filename = C.GoString(fnamePtr)
-		C.free(vPtr)
-
-		return nil
-	})
-	return filename
 }
 
 func nativeFileOpen(f *fileOpen) (io.ReadCloser, error) {

--- a/internal/driver/gomobile/file_android.go
+++ b/internal/driver/gomobile/file_android.go
@@ -12,17 +12,33 @@ char* readStream(uintptr_t jni_env, uintptr_t ctx, void* stream, int len, int* t
 void* saveStream(uintptr_t jni_env, uintptr_t ctx, char* uriCstr);
 void writeStream(uintptr_t jni_env, uintptr_t ctx, void* stream, char* data, int len);
 void closeStream(uintptr_t jni_env, uintptr_t ctx, void* stream);
+char* contentURIGetFileName(uintptr_t jni_env, uintptr_t ctx, char* uriCstr);
 */
 import "C"
 import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"unsafe"
 
 	"fyne.io/fyne/v2/storage/repository"
 	"github.com/fyne-io/mobile/app"
 )
+
+func (m mobileURI) Name() string {
+	if m.Scheme() == "content" {
+		result := contentURIGetFileName(m.systemURI)
+		if result != "" {
+			return result
+		}
+	}
+	return m.URI.Name()
+}
+
+func (m mobileURI) Extension() string {
+	return filepath.Ext(m.Name())
+}
 
 type javaStream struct {
 	stream unsafe.Pointer // java.io.InputStream
@@ -77,6 +93,25 @@ func openStream(uri string) unsafe.Pointer {
 		return nil
 	})
 	return stream
+}
+
+func contentURIGetFileName(uri string) string {
+	uriStr := C.CString(uri)
+	defer C.free(unsafe.Pointer(uriStr))
+
+	var filename string
+	app.RunOnJVM(func(_, env, ctx uintptr) error {
+		fnamePtr := C.contentURIGetFileName(C.uintptr_t(env), C.uintptr_t(ctx), uriStr)
+		vPtr := unsafe.Pointer(fnamePtr)
+		if vPtr == C.NULL {
+			return nil
+		}
+		filename = C.GoString(fnamePtr)
+		C.free(vPtr)
+
+		return nil
+	})
+	return filename
 }
 
 func nativeFileOpen(f *fileOpen) (io.ReadCloser, error) {

--- a/internal/driver/gomobile/uri.go
+++ b/internal/driver/gomobile/uri.go
@@ -1,11 +1,12 @@
+// +build !android
+
 package gomobile
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/storage"
 )
 
-// Override Name on android for content://
-type mobileURI struct {
-	systemURI string
-	fyne.URI
+func nativeURI(uri string) fyne.URI {
+	return storage.NewURI(uri)
 }

--- a/internal/driver/gomobile/uri.go
+++ b/internal/driver/gomobile/uri.go
@@ -1,0 +1,11 @@
+package gomobile
+
+import (
+	"fyne.io/fyne/v2"
+)
+
+// Override Name on android for content://
+type mobileURI struct {
+	systemURI string
+	fyne.URI
+}

--- a/internal/driver/gomobile/uri_android.go
+++ b/internal/driver/gomobile/uri_android.go
@@ -1,0 +1,51 @@
+// +build android
+
+package gomobile
+
+/*
+#cgo LDFLAGS: -landroid -llog
+
+#include <stdlib.h>
+
+char* contentURIGetFileName(uintptr_t jni_env, uintptr_t ctx, char* uriCstr);
+*/
+import "C"
+import (
+	"path/filepath"
+	"unsafe"
+
+	"github.com/fyne-io/mobile/app"
+)
+
+func (m *mobileURI) Name() string {
+	if m.Scheme() == "content" {
+		result := contentURIGetFileName(m.systemURI)
+		if result != "" {
+			return result
+		}
+	}
+	return m.URI.Name()
+}
+
+func (m *mobileURI) Extension() string {
+	return filepath.Ext(m.Name())
+}
+
+func contentURIGetFileName(uri string) string {
+	uriStr := C.CString(uri)
+	defer C.free(unsafe.Pointer(uriStr))
+
+	var filename string
+	app.RunOnJVM(func(_, env, ctx uintptr) error {
+		fnamePtr := C.contentURIGetFileName(C.uintptr_t(env), C.uintptr_t(ctx), uriStr)
+		vPtr := unsafe.Pointer(fnamePtr)
+		if vPtr == C.NULL {
+			return nil
+		}
+		filename = C.GoString(fnamePtr)
+		C.free(vPtr)
+
+		return nil
+	})
+	return filename
+}

--- a/internal/driver/gomobile/uri_android.go
+++ b/internal/driver/gomobile/uri_android.go
@@ -14,21 +14,29 @@ import (
 	"path/filepath"
 	"unsafe"
 
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/storage"
 	"github.com/fyne-io/mobile/app"
 )
 
-func (m *mobileURI) Name() string {
-	if m.Scheme() == "content" {
-		result := contentURIGetFileName(m.systemURI)
+type androidURI struct {
+	systemURI string
+	fyne.URI
+}
+
+// Override Name on android for content://
+func (a *androidURI) Name() string {
+	if a.Scheme() == "content" {
+		result := contentURIGetFileName(a.systemURI)
 		if result != "" {
 			return result
 		}
 	}
-	return m.URI.Name()
+	return a.URI.Name()
 }
 
-func (m *mobileURI) Extension() string {
-	return filepath.Ext(m.Name())
+func (a *androidURI) Extension() string {
+	return filepath.Ext(a.Name())
 }
 
 func contentURIGetFileName(uri string) string {
@@ -48,4 +56,8 @@ func contentURIGetFileName(uri string) string {
 		return nil
 	})
 	return filename
+}
+
+func nativeURI(uri string) fyne.URI {
+	return &androidURI{URI: storage.NewURI(uri), systemURI: uri}
 }


### PR DESCRIPTION
### Description:
When we open content on android, sometimes we don't get nice "file://path/to/file/here.txt" URI, we get "content://34234" instead.
In cases where we want to show the name of the file, this is not ideal. This change overrides the Name() and Ext() functions of the URI interface to instead get the actual filename represented by the content:// URI.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
