### PR TITLE
Mobile storage writer

### DIFF
--- a/app/preferences_android.go
+++ b/app/preferences_android.go
@@ -12,7 +12,7 @@ func (p *preferences) storagePath() string {
 
 // storageRoot returns the location of the app storage
 func (a *fyneApp) storageRoot() string {
-	return filepath.Join(rootConfigDir(), a.uniqueID)
+	return rootConfigDir()
 }
 
 func (p *preferences) watch() {


### PR DESCRIPTION
### Description:
Adds the ability to write/save files using fyne storage interface on android.

There is two parts:

The default root on android is already unique (data/app/id/path/files) without needing to go to a further subdirectory (data/app/id/path/files/app.id.path/).

The second commit is for handling the case where any URI path is sent to writer. In that case, we need to create any necessary directories, and create the file.

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
