### PR TITLE
Do not double update color channels when their associated entry text is changed programmatically, fixes #2075

### DIFF
--- a/dialog/color_channel.go
+++ b/dialog/color_channel.go
@@ -126,9 +126,6 @@ func (r *colorChannelRenderer) updateObjects() {
 
 type colorChannelEntry struct {
 	userChangeEntry
-
-	lock      sync.RWMutex
-	userTyped bool
 }
 
 func newColorChannelEntry(c *colorChannel) *colorChannelEntry {

--- a/dialog/color_channel.go
+++ b/dialog/color_channel.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"strconv"
+	"sync"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -124,25 +125,24 @@ func (r *colorChannelRenderer) updateObjects() {
 }
 
 type colorChannelEntry struct {
-	widget.Entry
+	userChangeEntry
+
+	lock      sync.RWMutex
+	userTyped bool
 }
 
 func newColorChannelEntry(c *colorChannel) *colorChannelEntry {
-	e := &colorChannelEntry{
-		Entry: widget.Entry{
-			Text: "0",
-			OnChanged: func(text string) {
-				value, err := strconv.Atoi(text)
-				if err != nil {
-					fyne.LogError("Couldn't parse: "+text, err)
-				} else {
-					c.SetValue(value)
-				}
-			},
-			// TODO add number min/max validator
-		},
-	}
+	e := &colorChannelEntry{}
+	e.Text = "0"
 	e.ExtendBaseWidget(e)
+	e.setOnChanged(func(text string) {
+		value, err := strconv.Atoi(text)
+		if err != nil {
+			fyne.LogError("Couldn't parse: "+text, err)
+			return
+		}
+		c.SetValue(value)
+	})
 	return e
 }
 
@@ -151,4 +151,50 @@ func (e *colorChannelEntry) MinSize() fyne.Size {
 	min := fyne.MeasureText("000", theme.TextSize(), fyne.TextStyle{})
 	min = min.Add(fyne.NewSize(theme.Padding()*6, theme.Padding()*4))
 	return min.Max(e.Entry.MinSize())
+}
+
+type userChangeEntry struct {
+	widget.Entry
+
+	lock      sync.RWMutex
+	userTyped bool
+}
+
+func newUserChangeEntry(text string) *userChangeEntry {
+	e := &userChangeEntry{}
+	e.Entry.Text = text
+	e.ExtendBaseWidget(e)
+	return e
+}
+
+func (e *userChangeEntry) setOnChanged(onChanged func(s string)) {
+	e.Entry.OnChanged = func(text string) {
+		e.lock.Lock()
+		userTyped := e.userTyped
+		if userTyped {
+			e.userTyped = false
+		}
+		e.lock.Unlock()
+		if !userTyped {
+			return
+		}
+		if onChanged != nil {
+			onChanged(text)
+		}
+	}
+	e.ExtendBaseWidget(e)
+}
+
+func (e *userChangeEntry) TypedRune(r rune) {
+	e.lock.Lock()
+	e.userTyped = true
+	e.lock.Unlock()
+	e.Entry.TypedRune(r)
+}
+
+func (e *userChangeEntry) TypedKey(ev *fyne.KeyEvent) {
+	e.lock.Lock()
+	e.userTyped = true
+	e.lock.Unlock()
+	e.Entry.TypedKey(ev)
 }

--- a/dialog/color_picker.go
+++ b/dialog/color_picker.go
@@ -162,17 +162,16 @@ func (p *colorAdvancedPicker) CreateRenderer() fyne.WidgetRenderer {
 	})
 
 	// Hex
-	hex := &widget.Entry{
-		OnChanged: func(text string) {
-			c, err := stringToColor(text)
-			if err != nil {
-				fyne.LogError("Error parsing color: "+text, err)
-				// TODO trigger entry invalid state
-			} else {
-				p.SetColor(c)
-			}
-		},
-	}
+	hex := newUserChangeEntry("")
+	hex.setOnChanged(func(text string) {
+		c, err := stringToColor(text)
+		if err != nil {
+			fyne.LogError("Error parsing color: "+text, err)
+			// TODO trigger entry invalid state
+		} else {
+			p.SetColor(c)
+		}
+	})
 
 	contents := fyne.NewContainerWithLayout(layout.NewPaddedLayout(), container.NewVBox(
 		container.NewGridWithColumns(3,
@@ -264,7 +263,7 @@ type colorPickerRenderer struct {
 	wheel             *colorWheel
 	preview           *canvas.Rectangle
 	alphaChannel      *colorChannel
-	hex               *widget.Entry
+	hex               *userChangeEntry
 	contents          fyne.CanvasObject
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #2075

While this PR fixes #2075, color picker still has some problems on mobile, when the user move the slider in one of the R G B channels, the remaining RGB channels are moved too sometimes 😞

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.