### PR TITLE
Reduce duplicate Slider events when using float64 Step value

### DIFF
--- a/widget/slider.go
+++ b/widget/slider.go
@@ -104,7 +104,7 @@ func (s *Slider) Dragged(e *fyne.DragEvent) {
 
 	s.updateValue(ratio)
 
-	if lastValue == s.Value {
+	if s.almostEqual(lastValue, s.Value) {
 		return
 	}
 
@@ -186,7 +186,7 @@ func (s *Slider) SetValue(value float64) {
 	s.Value = value
 	s.clampValueToRange()
 
-	if lastValue == s.Value {
+	if s.almostEqual(lastValue, s.Value) {
 		return
 	}
 
@@ -217,6 +217,11 @@ func (s *Slider) CreateRenderer() fyne.WidgetRenderer {
 	slide := &sliderRenderer{widget.NewBaseRenderer(objects), track, active, thumb, s}
 	slide.Refresh() // prepare for first draw
 	return slide
+}
+
+func (s *Slider) almostEqual(a, b float64) bool {
+	delta := math.Abs(a - b)
+	return delta <= s.Step/2
 }
 
 // Unbind disconnects any configured data source from this Slider.

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -163,10 +163,15 @@ func (s *Slider) clampValueToRange() {
 		return
 	}
 
-	i := -(math.Log10(s.Step))
-	p := math.Pow(10, i)
-
-	s.Value = float64(int(s.Value*p)) / p
+	rem := math.Mod(s.Value, s.Step)
+	if rem == 0 {
+		return
+	}
+	min := s.Value - rem
+	if rem > s.Step/2 {
+		min += s.Step
+	}
+	s.Value = min
 }
 
 func (s *Slider) updateValue(ratio float64) {

--- a/widget/slider_test.go
+++ b/widget/slider_test.go
@@ -147,6 +147,40 @@ func TestSlider_OnChanged(t *testing.T) {
 	assert.Equal(t, 2, changes)
 }
 
+func TestSlider_OnChanged_Float(t *testing.T) {
+	slider := NewSlider(0, 1)
+	slider.Step = 0.5
+	slider.Resize(slider.MinSize())
+	assert.Empty(t, slider.OnChanged)
+
+	changes := 0
+
+	slider.OnChanged = func(_ float64) {
+		changes++
+	}
+
+	assert.Equal(t, 0, changes)
+
+	slider.SetValue(0.15)
+	assert.Equal(t, 0, changes)
+
+	drag := &fyne.DragEvent{}
+	drag.PointEvent.Position = fyne.NewPos(25, 2)
+	slider.Dragged(drag)
+	assert.Equal(t, 1, changes)
+
+	drag.PointEvent.Position = fyne.NewPos(25, 2)
+	slider.Dragged(drag)
+	assert.Equal(t, 1, changes)
+
+	drag.PointEvent.Position = fyne.NewPos(50, 2)
+	slider.Dragged(drag)
+	assert.Equal(t, 2, changes)
+
+	slider.SetValue(0.9)
+	assert.Equal(t, 2, changes)
+}
+
 func TestSlider_SetValue(t *testing.T) {
 	slider := NewSlider(0, 2)
 	assert.Equal(t, 0.0, slider.Value)


### PR DESCRIPTION
Add an approximate comparison for floats which leads to fewer repeated events.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

