### PR TITLE
Fix crash in label with binding

### DIFF
--- a/widget/label.go
+++ b/widget/label.go
@@ -98,11 +98,12 @@ func (l *Label) SetText(text string) {
 //
 // Since: 2.0
 func (l *Label) Unbind() {
-	if l.textSource == nil || l.textListener == nil {
+	src := l.textSource
+	if src == nil {
 		return
 	}
 
-	l.textSource.RemoveListener(l.textListener)
+	src.RemoveListener(l.textListener)
 	l.textSource = nil
 }
 
@@ -112,10 +113,11 @@ func (l *Label) createListener() {
 	}
 
 	l.textListener = binding.NewDataListener(func() {
-		if l.textSource == nil {
+		src := l.textSource
+		if src == nil {
 			return
 		}
-		val, err := l.textSource.Get()
+		val, err := src.Get()
 		if err != nil {
 			fyne.LogError("Error getting current data value", err)
 			return

--- a/widget/label.go
+++ b/widget/label.go
@@ -55,18 +55,7 @@ func NewLabelWithStyle(text string, alignment fyne.TextAlign, style fyne.TextSty
 func (l *Label) Bind(data binding.String) {
 	l.Unbind()
 	l.textSource = data
-	l.textListener = binding.NewDataListener(func() {
-		val, err := l.textSource.Get()
-		if err != nil {
-			fyne.LogError("Error getting current data value", err)
-			return
-		}
-
-		l.Text = val
-		if cache.IsRendered(l) {
-			l.Refresh()
-		}
-	})
+	l.createListener()
 	data.AddListener(l.textListener)
 }
 
@@ -114,8 +103,29 @@ func (l *Label) Unbind() {
 	}
 
 	l.textSource.RemoveListener(l.textListener)
-	l.textListener = nil
 	l.textSource = nil
+}
+
+func (l *Label) createListener() {
+	if l.textListener != nil {
+		return
+	}
+
+	l.textListener = binding.NewDataListener(func() {
+		if l.textSource == nil {
+			return
+		}
+		val, err := l.textSource.Get()
+		if err != nil {
+			fyne.LogError("Error getting current data value", err)
+			return
+		}
+
+		l.Text = val
+		if cache.IsRendered(l) {
+			l.Refresh()
+		}
+	})
 }
 
 // textAlign tells the rendering textProvider our alignment


### PR DESCRIPTION
Moved to a different setup model where we don't recreate listeners all the time.
Fixes #2125

If this is a desirable change we could move other Bind/Unbind widget to match.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- race
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

