### PR TITLE
data/binding: optimized convertion using strconv

### DIFF
--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -5,6 +5,7 @@ package binding
 
 import (
 	"fmt"
+	"strconv"
 
 	"fyne.io/fyne/v2"
 )
@@ -23,7 +24,7 @@ type stringFromBool struct {
 //
 // Since: 2.0
 func BoolToString(v Bool) String {
-	return BoolToStringWithFormat(v, "%t")
+	return BoolToStringWithFormat(v, "")
 }
 
 // BoolToStringWithFormat creates a binding that connects a Bool data item to a String and is
@@ -43,17 +44,30 @@ func (s *stringFromBool) Get() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(s.format, val), nil
+	if s.format != "" {
+		return fmt.Sprintf(s.format, val), nil
+	}
+
+	return strconv.FormatBool(val), nil
 }
 
 func (s *stringFromBool) Set(str string) error {
 	var val bool
-	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
-	if err != nil {
-		return err
-	}
-	if n != 1 {
-		return errParseFailed
+
+	if s.format != "" {
+		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		if err != nil {
+			return err
+		}
+		if n != 1 {
+			return errParseFailed
+		}
+	} else {
+		new, err := strconv.ParseBool(str)
+		if err != nil {
+			return err
+		}
+		val = new
 	}
 
 	old, err := s.from.Get()
@@ -91,7 +105,7 @@ type stringFromFloat struct {
 //
 // Since: 2.0
 func FloatToString(v Float) String {
-	return FloatToStringWithFormat(v, "%f")
+	return FloatToStringWithFormat(v, "")
 }
 
 // FloatToStringWithFormat creates a binding that connects a Float data item to a String and is
@@ -111,17 +125,30 @@ func (s *stringFromFloat) Get() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(s.format, val), nil
+	if s.format != "" {
+		return fmt.Sprintf(s.format, val), nil
+	}
+
+	return strconv.FormatFloat(val, 'f', -1, 64), nil
 }
 
 func (s *stringFromFloat) Set(str string) error {
 	var val float64
-	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
-	if err != nil {
-		return err
-	}
-	if n != 1 {
-		return errParseFailed
+
+	if s.format != "" {
+		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		if err != nil {
+			return err
+		}
+		if n != 1 {
+			return errParseFailed
+		}
+	} else {
+		new, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return err
+		}
+		val = new
 	}
 
 	old, err := s.from.Get()
@@ -159,7 +186,7 @@ type stringFromInt struct {
 //
 // Since: 2.0
 func IntToString(v Int) String {
-	return IntToStringWithFormat(v, "%d")
+	return IntToStringWithFormat(v, "")
 }
 
 // IntToStringWithFormat creates a binding that connects a Int data item to a String and is
@@ -179,17 +206,30 @@ func (s *stringFromInt) Get() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(s.format, val), nil
+	if s.format != "" {
+		return fmt.Sprintf(s.format, val), nil
+	}
+
+	return strconv.Itoa(val), nil
 }
 
 func (s *stringFromInt) Set(str string) error {
 	var val int
-	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
-	if err != nil {
-		return err
-	}
-	if n != 1 {
-		return errParseFailed
+
+	if s.format != "" {
+		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		if err != nil {
+			return err
+		}
+		if n != 1 {
+			return errParseFailed
+		}
+	} else {
+		new, err := strconv.ParseInt(str, 0, 64)
+		if err != nil {
+			return err
+		}
+		val = int(new)
 	}
 
 	old, err := s.from.Get()
@@ -280,7 +320,7 @@ type stringToBool struct {
 //
 // Since: 2.0
 func StringToBool(str String) Bool {
-	return StringToBoolWithFormat(str, "%t")
+	return StringToBoolWithFormat(str, "")
 }
 
 // StringToBoolWithFormat creates a binding that connects a String data item to a Bool and is
@@ -302,19 +342,32 @@ func (s *stringToBool) Get() (bool, error) {
 	}
 
 	var val bool
-	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
-	if err != nil {
-		return false, err
-	}
-	if n != 1 {
-		return false, errParseFailed
+	if s.format != "" {
+		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		if err != nil {
+			return false, err
+		}
+		if n != 1 {
+			return false, errParseFailed
+		}
+	} else {
+		new, err := strconv.ParseBool(str)
+		if err != nil {
+			return false, err
+		}
+		val = new
 	}
 
 	return val, nil
 }
 
 func (s *stringToBool) Set(val bool) error {
-	str := fmt.Sprintf(s.format, val)
+	var str string
+	if s.format != "" {
+		str = fmt.Sprintf(s.format, val)
+	} else {
+		str = strconv.FormatBool(val)
+	}
 
 	old, err := s.from.Get()
 	if str == old {
@@ -349,7 +402,7 @@ type stringToFloat struct {
 //
 // Since: 2.0
 func StringToFloat(str String) Float {
-	return StringToFloatWithFormat(str, "%f")
+	return StringToFloatWithFormat(str, "")
 }
 
 // StringToFloatWithFormat creates a binding that connects a String data item to a Float and is
@@ -371,19 +424,32 @@ func (s *stringToFloat) Get() (float64, error) {
 	}
 
 	var val float64
-	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
-	if err != nil {
-		return 0.0, err
-	}
-	if n != 1 {
-		return 0.0, errParseFailed
+	if s.format != "" {
+		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		if err != nil {
+			return 0.0, err
+		}
+		if n != 1 {
+			return 0.0, errParseFailed
+		}
+	} else {
+		new, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return 0, err
+		}
+		val = new
 	}
 
 	return val, nil
 }
 
 func (s *stringToFloat) Set(val float64) error {
-	str := fmt.Sprintf(s.format, val)
+	var str string
+	if s.format != "" {
+		str = fmt.Sprintf(s.format, val)
+	} else {
+		str = strconv.FormatFloat(val, 'f', -1, 64)
+	}
 
 	old, err := s.from.Get()
 	if str == old {
@@ -418,7 +484,7 @@ type stringToInt struct {
 //
 // Since: 2.0
 func StringToInt(str String) Int {
-	return StringToIntWithFormat(str, "%d")
+	return StringToIntWithFormat(str, "")
 }
 
 // StringToIntWithFormat creates a binding that connects a String data item to a Int and is
@@ -440,19 +506,32 @@ func (s *stringToInt) Get() (int, error) {
 	}
 
 	var val int
-	n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
-	if err != nil {
-		return 0, err
-	}
-	if n != 1 {
-		return 0, errParseFailed
+	if s.format != "" {
+		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		if err != nil {
+			return 0, err
+		}
+		if n != 1 {
+			return 0, errParseFailed
+		}
+	} else {
+		new, err := strconv.Atoi(str)
+		if err != nil {
+			return 0, err
+		}
+		val = int(new)
 	}
 
 	return val, nil
 }
 
 func (s *stringToInt) Set(val int) error {
-	str := fmt.Sprintf(s.format, val)
+	var str string
+	if s.format != "" {
+		str = fmt.Sprintf(s.format, val)
+	} else {
+		str = strconv.Itoa(val)
+	}
 
 	old, err := s.from.Get()
 	if str == old {

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -129,7 +129,7 @@ func (s *stringFromFloat) Get() (string, error) {
 		return fmt.Sprintf(s.format, val), nil
 	}
 
-	return strconv.FormatFloat(val, 'f', -1, 64), nil
+	return strconv.FormatFloat(val, 'f', 6, 64), nil
 }
 
 func (s *stringFromFloat) Set(str string) error {
@@ -448,7 +448,7 @@ func (s *stringToFloat) Set(val float64) error {
 	if s.format != "" {
 		str = fmt.Sprintf(s.format, val)
 	} else {
-		str = strconv.FormatFloat(val, 'f', -1, 64)
+		str = strconv.FormatFloat(val, 'f', 6, 64)
 	}
 
 	old, err := s.from.Get()

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -5,7 +5,6 @@ package binding
 
 import (
 	"fmt"
-	"strconv"
 
 	"fyne.io/fyne/v2"
 )
@@ -24,7 +23,9 @@ type stringFromBool struct {
 //
 // Since: 2.0
 func BoolToString(v Bool) String {
-	return BoolToStringWithFormat(v, "")
+	str := &stringFromBool{from: v}
+	v.AddListener(str)
+	return str
 }
 
 // BoolToStringWithFormat creates a binding that connects a Bool data item to a String and is
@@ -33,6 +34,10 @@ func BoolToString(v Bool) String {
 //
 // Since: 2.0
 func BoolToStringWithFormat(v Bool, format string) String {
+	if format == "%t" { // Same as not using custom formatting.
+		return BoolToString(v)
+	}
+
 	str := &stringFromBool{from: v, format: format}
 	v.AddListener(str)
 	return str
@@ -48,12 +53,11 @@ func (s *stringFromBool) Get() (string, error) {
 		return fmt.Sprintf(s.format, val), nil
 	}
 
-	return strconv.FormatBool(val), nil
+	return formatBool(val), nil
 }
 
 func (s *stringFromBool) Set(str string) error {
 	var val bool
-
 	if s.format != "" {
 		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
 		if err != nil {
@@ -63,7 +67,7 @@ func (s *stringFromBool) Set(str string) error {
 			return errParseFailed
 		}
 	} else {
-		new, err := strconv.ParseBool(str)
+		new, err := parseBool(str)
 		if err != nil {
 			return err
 		}
@@ -105,7 +109,9 @@ type stringFromFloat struct {
 //
 // Since: 2.0
 func FloatToString(v Float) String {
-	return FloatToStringWithFormat(v, "")
+	str := &stringFromFloat{from: v}
+	v.AddListener(str)
+	return str
 }
 
 // FloatToStringWithFormat creates a binding that connects a Float data item to a String and is
@@ -114,6 +120,10 @@ func FloatToString(v Float) String {
 //
 // Since: 2.0
 func FloatToStringWithFormat(v Float, format string) String {
+	if format == "%f" { // Same as not using custom formatting.
+		return FloatToString(v)
+	}
+
 	str := &stringFromFloat{from: v, format: format}
 	v.AddListener(str)
 	return str
@@ -129,12 +139,11 @@ func (s *stringFromFloat) Get() (string, error) {
 		return fmt.Sprintf(s.format, val), nil
 	}
 
-	return strconv.FormatFloat(val, 'f', 6, 64), nil
+	return formatFloat(val), nil
 }
 
 func (s *stringFromFloat) Set(str string) error {
 	var val float64
-
 	if s.format != "" {
 		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
 		if err != nil {
@@ -144,7 +153,7 @@ func (s *stringFromFloat) Set(str string) error {
 			return errParseFailed
 		}
 	} else {
-		new, err := strconv.ParseFloat(str, 64)
+		new, err := parseFloat(str)
 		if err != nil {
 			return err
 		}
@@ -186,7 +195,9 @@ type stringFromInt struct {
 //
 // Since: 2.0
 func IntToString(v Int) String {
-	return IntToStringWithFormat(v, "")
+	str := &stringFromInt{from: v}
+	v.AddListener(str)
+	return str
 }
 
 // IntToStringWithFormat creates a binding that connects a Int data item to a String and is
@@ -195,6 +206,10 @@ func IntToString(v Int) String {
 //
 // Since: 2.0
 func IntToStringWithFormat(v Int, format string) String {
+	if format == "%d" { // Same as not using custom formatting.
+		return IntToString(v)
+	}
+
 	str := &stringFromInt{from: v, format: format}
 	v.AddListener(str)
 	return str
@@ -210,12 +225,11 @@ func (s *stringFromInt) Get() (string, error) {
 		return fmt.Sprintf(s.format, val), nil
 	}
 
-	return strconv.Itoa(val), nil
+	return formatInt(val), nil
 }
 
 func (s *stringFromInt) Set(str string) error {
 	var val int
-
 	if s.format != "" {
 		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
 		if err != nil {
@@ -225,11 +239,11 @@ func (s *stringFromInt) Set(str string) error {
 			return errParseFailed
 		}
 	} else {
-		new, err := strconv.ParseInt(str, 0, 64)
+		new, err := parseInt(str)
 		if err != nil {
 			return err
 		}
-		val = int(new)
+		val = new
 	}
 
 	old, err := s.from.Get()
@@ -320,7 +334,9 @@ type stringToBool struct {
 //
 // Since: 2.0
 func StringToBool(str String) Bool {
-	return StringToBoolWithFormat(str, "")
+	v := &stringToBool{from: str}
+	str.AddListener(v)
+	return v
 }
 
 // StringToBoolWithFormat creates a binding that connects a String data item to a Bool and is
@@ -330,6 +346,10 @@ func StringToBool(str String) Bool {
 //
 // Since: 2.0
 func StringToBoolWithFormat(str String, format string) Bool {
+	if format == "%t" { // Same as not using custom format.
+		return StringToBool(str)
+	}
+
 	v := &stringToBool{from: str, format: format}
 	str.AddListener(v)
 	return v
@@ -351,7 +371,7 @@ func (s *stringToBool) Get() (bool, error) {
 			return false, errParseFailed
 		}
 	} else {
-		new, err := strconv.ParseBool(str)
+		new, err := parseBool(str)
 		if err != nil {
 			return false, err
 		}
@@ -366,7 +386,7 @@ func (s *stringToBool) Set(val bool) error {
 	if s.format != "" {
 		str = fmt.Sprintf(s.format, val)
 	} else {
-		str = strconv.FormatBool(val)
+		str = formatBool(val)
 	}
 
 	old, err := s.from.Get()
@@ -402,7 +422,9 @@ type stringToFloat struct {
 //
 // Since: 2.0
 func StringToFloat(str String) Float {
-	return StringToFloatWithFormat(str, "")
+	v := &stringToFloat{from: str}
+	str.AddListener(v)
+	return v
 }
 
 // StringToFloatWithFormat creates a binding that connects a String data item to a Float and is
@@ -412,6 +434,10 @@ func StringToFloat(str String) Float {
 //
 // Since: 2.0
 func StringToFloatWithFormat(str String, format string) Float {
+	if format == "%f" { // Same as not using custom format.
+		return StringToFloat(str)
+	}
+
 	v := &stringToFloat{from: str, format: format}
 	str.AddListener(v)
 	return v
@@ -433,9 +459,9 @@ func (s *stringToFloat) Get() (float64, error) {
 			return 0.0, errParseFailed
 		}
 	} else {
-		new, err := strconv.ParseFloat(str, 64)
+		new, err := parseFloat(str)
 		if err != nil {
-			return 0, err
+			return 0.0, err
 		}
 		val = new
 	}
@@ -448,7 +474,7 @@ func (s *stringToFloat) Set(val float64) error {
 	if s.format != "" {
 		str = fmt.Sprintf(s.format, val)
 	} else {
-		str = strconv.FormatFloat(val, 'f', 6, 64)
+		str = formatFloat(val)
 	}
 
 	old, err := s.from.Get()
@@ -484,7 +510,9 @@ type stringToInt struct {
 //
 // Since: 2.0
 func StringToInt(str String) Int {
-	return StringToIntWithFormat(str, "")
+	v := &stringToInt{from: str}
+	str.AddListener(v)
+	return v
 }
 
 // StringToIntWithFormat creates a binding that connects a String data item to a Int and is
@@ -494,6 +522,10 @@ func StringToInt(str String) Int {
 //
 // Since: 2.0
 func StringToIntWithFormat(str String, format string) Int {
+	if format == "%d" { // Same as not using custom format.
+		return StringToInt(str)
+	}
+
 	v := &stringToInt{from: str, format: format}
 	str.AddListener(v)
 	return v
@@ -515,11 +547,11 @@ func (s *stringToInt) Get() (int, error) {
 			return 0, errParseFailed
 		}
 	} else {
-		new, err := strconv.Atoi(str)
+		new, err := parseInt(str)
 		if err != nil {
 			return 0, err
 		}
-		val = int(new)
+		val = new
 	}
 
 	return val, nil
@@ -530,7 +562,7 @@ func (s *stringToInt) Set(val int) error {
 	if s.format != "" {
 		str = fmt.Sprintf(s.format, val)
 	} else {
-		str = strconv.Itoa(val)
+		str = formatInt(val)
 	}
 
 	old, err := s.from.Get()

--- a/data/binding/convert_benchmark_test.go
+++ b/data/binding/convert_benchmark_test.go
@@ -1,0 +1,107 @@
+package binding
+
+import (
+	"testing"
+)
+
+func BenchmarkBoolToString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bo := NewBool()
+		s := BoolToString(bo)
+		s.Get()
+
+		bo.Set(true)
+		s.Get()
+
+		s.Set("trap")
+		bo.Get()
+
+		s.Set("false")
+		bo.Get()
+	}
+}
+
+func BenchmarkFloatToString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f := NewFloat()
+		s := FloatToString(f)
+		s.Get()
+
+		f.Set(0.3)
+		s.Get()
+
+		s.Set("wrong")
+		f.Get()
+
+		s.Set("5.00")
+		f.Get()
+	}
+}
+
+func BenchmarkIntToString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		i := NewInt()
+		s := IntToString(i)
+		s.Get()
+
+		i.Set(3)
+		s.Get()
+
+		s.Set("wrong")
+		i.Get()
+
+		s.Set("5")
+		i.Get()
+	}
+}
+
+func BenchmarkStringToBool(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		s := NewString()
+		b := StringToBool(s)
+		b.Get()
+
+		s.Set("true")
+		b.Get()
+
+		s.Set("trap") // bug in fmt.SScanf means "wrong" parses as "false"
+		b.Get()
+
+		b.Set(false)
+		s.Get()
+	}
+}
+
+func BenchmarkStringToFloat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		s := NewString()
+		f := StringToFloat(s)
+		f.Get()
+
+		s.Set("3")
+		f.Get()
+
+		s.Set("wrong")
+		f.Get()
+
+		f.Set(5)
+		s.Get()
+	}
+}
+
+func BenchmarkStringToInt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		s := NewString()
+		i := StringToInt(s)
+		i.Get()
+
+		s.Set("3")
+		i.Get()
+
+		s.Set("wrong")
+		i.Get()
+
+		i.Set(5)
+		s.Get()
+	}
+}

--- a/data/binding/convert_helper.go
+++ b/data/binding/convert_helper.go
@@ -1,6 +1,8 @@
 package binding
 
 import (
+	"strconv"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/storage"
 )
@@ -15,4 +17,42 @@ func uriToString(in fyne.URI) (string, error) {
 	}
 
 	return in.String(), nil
+}
+
+func parseBool(in string) (bool, error) {
+	out, err := strconv.ParseBool(in)
+	if err != nil {
+		return false, err
+	}
+
+	return out, nil
+}
+
+func parseFloat(in string) (float64, error) {
+	out, err := strconv.ParseFloat(in, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return out, nil
+}
+
+func parseInt(in string) (int, error) {
+	out, err := strconv.ParseInt(in, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return int(out), nil
+}
+
+func formatBool(in bool) string {
+	return strconv.FormatBool(in)
+}
+
+func formatFloat(in float64) string {
+	return strconv.FormatFloat(in, 'f', 6, 64)
+}
+
+func formatInt(in int) string {
+	return strconv.FormatInt(int64(in), 10)
 }


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This updates the data bindings to use the `strconv` package instead of `fmt` for conversions, leading to improved performance (benchmarks to come). This is currently WIP and is just a proof of concept with generations scripts yet to have been updated to take this into effect.

Fixes #1735

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
