### PR TITLE
Provide glfw.Window as context

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1231,7 +1231,7 @@ func (w *window) rescaleOnMain() {
 }
 
 func (w *window) Context() interface{} {
-	return nil
+	return w.viewport
 }
 
 // Use this method to queue up a callback that handles an event. This ensures


### PR DESCRIPTION
That small change make possible to restore the fyne window from minimized state with this code snippet:

```
type WithContext interface {
	RunWithContext(f func())
	RescaleContext()
	Context() interface{}
}

func ShowWindow(wnd fyne.Window) {
	if ctx, ok := wnd.(WithContext); ok {
		contextWnd := ctx.Context()
		if gwnd, ok := contextWnd.(*glfw.Window); ok && gwnd != nil {
			gwnd.Restore()
		}
	}
	wnd.Show()
	wnd.RequestFocus()
}
```

At first attempt i was try to acheive the same with RunWithContext and glfw.GetCurrentContext().Restore() but it did not works  and sometimes causeing and error that context is already active.