### PR TITLE
add go1.16 embed file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module fyne.io/fyne/v2
 
-go 1.12
+go 1.16
 
 require (
 	github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9

--- a/resource.go
+++ b/resource.go
@@ -1,10 +1,14 @@
 package fyne
 
 import (
+	"embed"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 )
+
+var embedRes embed.FS
 
 // Resource represents a single binary resource, such as an image or font.
 // A resource has an identifying name and byte array content.
@@ -46,9 +50,28 @@ func NewStaticResource(name string, content []byte) *StaticResource {
 	}
 }
 
+// Set up embedded file resources
+func SetEmbedResource(list embed.FS) {
+	embedRes = list
+}
+
 // LoadResourceFromPath creates a new StaticResource in memory using the contents of the specified file.
 func LoadResourceFromPath(path string) (Resource, error) {
-	bytes, err := ioutil.ReadFile(filepath.Clean(path))
+	if len(path) == 0 {
+		return nil, errors.New("file path is empty")
+	}
+
+	var (
+		bytes []byte
+		err error
+	)
+
+	if path[0] == '-' { //Used to distinguish whether it is an embedded file
+		bytes, err = embedRes.ReadFile(path[1:])
+	} else {
+		bytes, err = ioutil.ReadFile(filepath.Clean(path))
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. -->

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Add go1.16 embed file function, compatible with existing functions
```go
package main

import (
    "embed"
    "fyne.io/fyne/v2"
    "fyne.io/fyne/v2/app"
)

//go:embed logo.png
var res embed.FS

func init() {
    fyne.SetEmbedResource(res)
}

func main() {
    a := app.New()
    logo, err := fyne.LoadResourceFromPath("-logo.png") // - Indicates that the file is an embed file
    if err != nil {
        log.Fatalln(err)
    }
    a.SetIcon(logo)
}
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.