### PR TITLE
Add UnselectAll to collection widgets

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -144,6 +144,8 @@ func (l *List) Unselect(id ListItemID) {
 }
 
 // UnselectAll removes all items from the selection.
+//
+// Since: 2.1
 func (l *List) UnselectAll() {
 	if len(l.selected) == 0 {
 		return

--- a/widget/list.go
+++ b/widget/list.go
@@ -132,7 +132,7 @@ func (l *List) Select(id ListItemID) {
 
 // Unselect removes the item identified by the given ID from the selection.
 func (l *List) Unselect(id ListItemID) {
-	if len(l.selected) == 0 {
+	if len(l.selected) == 0 || l.selected[0] != id {
 		return
 	}
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -143,6 +143,22 @@ func (l *List) Unselect(id ListItemID) {
 	}
 }
 
+// UnselectAll removes all items from the selection.
+func (l *List) UnselectAll() {
+	if len(l.selected) == 0 {
+		return
+	}
+
+	selected := l.selected
+	l.selected = nil
+	l.Refresh()
+	if f := l.OnUnselected; f != nil {
+		for _, id := range selected {
+			f(id)
+		}
+	}
+}
+
 // Declare conformity with WidgetRenderer interface.
 var _ fyne.WidgetRenderer = (*listRenderer)(nil)
 

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -170,7 +170,12 @@ func TestList_Unselect(t *testing.T) {
 	assert.Nil(t, list.selected)
 	assert.Equal(t, 10, unselected)
 
+	unselected = -1
 	list.Select(11)
+	list.Unselect(9)
+	assert.Equal(t, 1, len(list.selected))
+	assert.Equal(t, -1, unselected)
+
 	list.UnselectAll()
 	assert.Nil(t, list.selected)
 	assert.Equal(t, 11, unselected)

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -154,6 +154,10 @@ func TestList_Select(t *testing.T) {
 
 func TestList_Unselect(t *testing.T) {
 	list := createList(1000)
+	var unselected ListItemID
+	list.OnUnselected = func(id ListItemID) {
+		unselected = id
+	}
 
 	list.Select(10)
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
@@ -164,6 +168,12 @@ func TestList_Unselect(t *testing.T) {
 	children = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
 	assert.False(t, children[10].(*listItem).background.Visible())
 	assert.Nil(t, list.selected)
+	assert.Equal(t, 10, unselected)
+
+	list.Select(11)
+	list.UnselectAll()
+	assert.Nil(t, list.selected)
+	assert.Equal(t, 11, unselected)
 }
 
 func TestList_DataChange(t *testing.T) {

--- a/widget/table.go
+++ b/widget/table.go
@@ -131,6 +131,24 @@ func (t *Table) Unselect(id TableCellID) {
 	}
 }
 
+// UnselectAll will mark all cells as unselected.
+func (t *Table) UnselectAll() {
+	if t.selectedCell == nil {
+		return
+	}
+
+	selected := *t.selectedCell
+	t.selectedCell = nil
+
+	if t.moveCallback != nil {
+		t.moveCallback()
+	}
+
+	if f := t.OnUnselected; f != nil {
+		f(selected)
+	}
+}
+
 func (t *Table) scrollTo(id TableCellID) {
 	if t.scroll == nil {
 		return

--- a/widget/table.go
+++ b/widget/table.go
@@ -132,6 +132,8 @@ func (t *Table) Unselect(id TableCellID) {
 }
 
 // UnselectAll will mark all cells as unselected.
+//
+// Since: 2.1
 func (t *Table) UnselectAll() {
 	if t.selectedCell == nil {
 		return

--- a/widget/table.go
+++ b/widget/table.go
@@ -117,7 +117,7 @@ func (t *Table) SetColumnWidth(id int, width float32) {
 
 // Unselect will mark the cell provided by id as unselected.
 func (t *Table) Unselect(id TableCellID) {
-	if t.selectedCell == nil {
+	if t.selectedCell == nil || id != *t.selectedCell {
 		return
 	}
 	t.selectedCell = nil

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -142,7 +142,7 @@ func TestTable_Unselect(t *testing.T) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
 		})
-	unselectedRow, unselectedColumn := 0, 0
+	unselectedRow, unselectedColumn := -1, -1
 	table.OnUnselected = func(id TableCellID) {
 		unselectedRow = id.Row
 		unselectedColumn = id.Col
@@ -157,7 +157,11 @@ func TestTable_Unselect(t *testing.T) {
 	assert.Equal(t, 1, unselectedColumn)
 	test.AssertImageMatches(t, "table/theme_initial.png", w.Canvas().Capture())
 
+	unselectedRow, unselectedColumn = -1, -1
 	table.Select(TableCellID{2, 2})
+	table.Unselect(TableCellID{1, 1})
+	assert.Equal(t, -1, unselectedRow)
+	assert.Equal(t, -1, unselectedColumn)
 
 	table.UnselectAll()
 	assert.Equal(t, 2, unselectedRow)

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -156,6 +156,12 @@ func TestTable_Unselect(t *testing.T) {
 	assert.Equal(t, 1, unselectedRow)
 	assert.Equal(t, 1, unselectedColumn)
 	test.AssertImageMatches(t, "table/theme_initial.png", w.Canvas().Capture())
+
+	table.Select(TableCellID{2, 2})
+
+	table.UnselectAll()
+	assert.Equal(t, 2, unselectedRow)
+	assert.Equal(t, 2, unselectedColumn)
 }
 
 func TestTable_Refresh(t *testing.T) {

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -236,7 +236,7 @@ func (t *Tree) ToggleBranch(uid string) {
 
 // Unselect marks the specified node to be not selected.
 func (t *Tree) Unselect(uid TreeNodeID) {
-	if len(t.selected) == 0 {
+	if len(t.selected) == 0 || t.selected[0] != uid {
 		return
 	}
 

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -248,6 +248,8 @@ func (t *Tree) Unselect(uid TreeNodeID) {
 }
 
 // UnselectAll sets all nodes to be not selected.
+//
+// Since: 2.1
 func (t *Tree) UnselectAll() {
 	if len(t.selected) == 0 {
 		return

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -234,7 +234,7 @@ func (t *Tree) ToggleBranch(uid string) {
 	}
 }
 
-// Unselect marks the specified node to be not selected
+// Unselect marks the specified node to be not selected.
 func (t *Tree) Unselect(uid TreeNodeID) {
 	if len(t.selected) == 0 {
 		return
@@ -244,6 +244,22 @@ func (t *Tree) Unselect(uid TreeNodeID) {
 	t.Refresh()
 	if f := t.OnUnselected; f != nil {
 		f(uid)
+	}
+}
+
+// UnselectAll sets all nodes to be not selected.
+func (t *Tree) UnselectAll() {
+	if len(t.selected) == 0 {
+		return
+	}
+
+	selected := t.selected
+	t.selected = nil
+	t.Refresh()
+	if f := t.OnUnselected; f != nil {
+		for _, uid := range selected {
+			f(uid)
+		}
 	}
 }
 

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -391,6 +391,9 @@ func TestTree_Select_Unselects(t *testing.T) {
 		assert.Fail(t, "Selection should have been unselected")
 	}
 
+	tree.Unselect("C")
+	assert.Equal(t, 1, len(tree.selected))
+
 	tree.UnselectAll()
 	assert.Equal(t, 0, len(tree.selected))
 	select {

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -390,6 +390,15 @@ func TestTree_Select_Unselects(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		assert.Fail(t, "Selection should have been unselected")
 	}
+
+	tree.UnselectAll()
+	assert.Equal(t, 0, len(tree.selected))
+	select {
+	case s := <-unselection:
+		assert.Equal(t, "B", s)
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "Selection should have been unselected")
+	}
 }
 
 func TestTree_ScrollToSelection(t *testing.T) {


### PR DESCRIPTION
Add UnselectAll to the collection widgets.
The documentation elements aimed to match the wording of the original author hence the variations.

See #1395

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
