### PR TITLE
Some smaller optimizations of SelectEntry

### DIFF
--- a/widget/select_entry.go
+++ b/widget/select_entry.go
@@ -80,10 +80,10 @@ func (e *SelectEntry) Resize(size fyne.Size) {
 // SetOptions sets the options the user might select from.
 func (e *SelectEntry) SetOptions(options []string) {
 	e.options = options
-	var items []*fyne.MenuItem
-	for _, option := range options {
+	items := make([]*fyne.MenuItem, len(options))
+	for i, option := range options {
 		option := option // capture
-		items = append(items, fyne.NewMenuItem(option, func() { e.SetText(option) }))
+		items[i] = fyne.NewMenuItem(option, func() { e.SetText(option) })
 	}
 	e.dropDown = fyne.NewMenu("", items...)
 

--- a/widget/select_entry.go
+++ b/widget/select_entry.go
@@ -15,10 +15,9 @@ type SelectEntry struct {
 
 // NewSelectEntry creates a SelectEntry.
 func NewSelectEntry(options []string) *SelectEntry {
-	e := &SelectEntry{}
+	e := &SelectEntry{options: options}
 	e.ExtendBaseWidget(e)
 	e.Wrapping = fyne.TextTruncate
-	e.options = options
 	return e
 }
 

--- a/widget/select_entry.go
+++ b/widget/select_entry.go
@@ -59,8 +59,9 @@ func (e *SelectEntry) MinSize() fyne.Size {
 	min := e.Entry.MinSize()
 
 	if e.dropDown != nil {
+		padding := fyne.NewSize(4*theme.Padding(), 0)
 		for _, item := range e.dropDown.Items {
-			itemMin := fyne.MeasureText(item.Label, theme.TextSize(), fyne.TextStyle{}).Add(fyne.NewSize(4*theme.Padding(), 0))
+			itemMin := fyne.MeasureText(item.Label, theme.TextSize(), fyne.TextStyle{}).Add(padding)
 			min = min.Max(itemMin)
 		}
 	}


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This does two smaller things. Firstly, it avoids creating and calculating a padding size on each iteration of the loop. This is not a huge speedup be any means, but good to add given how often MinSize seems to be called. Secondly, SetupOptions now preallocates the slice of menu items beforehand. My testing in fyne_demo indicates up to 30-40% improvement in speed there (from about 1200ns to 770ns). It was pretty fast already, but this should, especially for larger amounts of items, result in a good improvement.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

