### PR TITLE
Fix unexpected hung when using select entry and changing the theme

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -241,10 +241,12 @@ func (c *glCanvas) SetOnTypedRune(typed func(rune)) {
 
 func (c *glCanvas) SetPadded(padded bool) {
 	c.Lock()
-	defer c.Unlock()
+	content := c.content
 	c.padded = padded
+	pos := c.contentPos()
+	c.Unlock()
 
-	c.content.Move(c.contentPos())
+	content.Move(pos)
 }
 
 func (c *glCanvas) reloadScale() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fix unexpected hung when using select entry and changing the theme. 
This code makes the whole app hangs:
```go
	selectEntry := widget.NewSelectEntry([]string{"Option A", "Option B", "Option C"})
      	selectEntry.PlaceHolder = "Type or select"

	themes := fyne.NewContainerWithLayout(layout.NewGridLayout(2),
		widget.NewButton("Dark", func() {
			a.Settings().SetTheme(theme.DarkTheme())
		}),
		widget.NewButton("Light", func() {
			a.Settings().SetTheme(theme.LightTheme())
		}),
	)

	hello := widget.NewLabel("Hello Fyne!")
	w.SetContent(container.NewVBox(
		hello,
		selectEntry,
		themes,
	))
```

https://user-images.githubusercontent.com/12239342/114791262-d6fdd700-9d4b-11eb-90fa-77d5cec3e1b0.mp4

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.