### PR TITLE
Some simple optimizations for widget.Select

### DIFF
--- a/widget/select.go
+++ b/widget/select.go
@@ -236,9 +236,9 @@ func (s *Select) popUpPos() fyne.Position {
 
 func (s *Select) showPopUp() {
 	items := make([]*fyne.MenuItem, len(s.Options))
-	for i, option := range s.Options {
-		text := option // capture
-		items[i] = fyne.NewMenuItem(option, func() {
+	for i := range s.Options {
+		text := s.Options[i] // capture
+		items[i] = fyne.NewMenuItem(text, func() {
 			s.optionTapped(text)
 		})
 	}

--- a/widget/select.go
+++ b/widget/select.go
@@ -224,11 +224,6 @@ func (s *Select) object() fyne.Widget {
 	return nil
 }
 
-func (s *Select) optionTapped(text string) {
-	s.SetSelected(text)
-	s.popUp = nil
-}
-
 func (s *Select) popUpPos() fyne.Position {
 	buttonPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(s.super())
 	return buttonPos.Add(fyne.NewPos(0, s.Size().Height-theme.InputBorderSize()))
@@ -239,7 +234,8 @@ func (s *Select) showPopUp() {
 	for i := range s.Options {
 		text := s.Options[i] // capture
 		items[i] = fyne.NewMenuItem(text, func() {
-			s.optionTapped(text)
+			s.updateSelected(text)
+			s.popUp = nil
 		})
 	}
 

--- a/widget/select.go
+++ b/widget/select.go
@@ -235,13 +235,12 @@ func (s *Select) popUpPos() fyne.Position {
 }
 
 func (s *Select) showPopUp() {
-	var items []*fyne.MenuItem
-	for _, option := range s.Options {
+	items := make([]*fyne.MenuItem, len(s.Options))
+	for i, option := range s.Options {
 		text := option // capture
-		item := fyne.NewMenuItem(option, func() {
+		items[i] = fyne.NewMenuItem(option, func() {
 			s.optionTapped(text)
 		})
-		items = append(items, item)
 	}
 
 	c := fyne.CurrentApp().Driver().CanvasForObject(s.super())


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This makes the creation of the menu items about 30% faster when we have 500 objects.
Updates #2164

I don't judge this to be a final fix as it is still very slow. Mostly because the menu items are recreated each time they are shown, but this is at least a step in the right direction in the meantime. I also optimized selection quite a bit. It used the slow path fore selection, SetSelected(), which loops through all options.

We know that our item is in the list and can thus use the fast path.


```go
package main

import (
	"strconv"

	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/container"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.New()
	w := a.NewWindow("Example")

	s := make([]string, 500)
	for i := range s {
		s[i] = strconv.Itoa(i)
	}

	selecty := &widget.Select{Options: s, PlaceHolder: "Numbers"}

	w.SetContent(container.NewVBox(selecty))
	w.Resize(fyne.Size{600, 600})
	w.ShowAndRun()
}
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
