### PR TITLE
Fix: filter out shortcut triggers where key-modifier is same

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1201,6 +1201,20 @@ func desktopModifier(mods glfw.ModifierKey) desktop.Modifier {
 	return m
 }
 
+func isKeyModifierPair(keyName fyne.KeyName, modifier desktop.Modifier) bool {
+	switch modifier {
+	case desktop.ShiftModifier:
+		return (keyName == desktop.KeyShiftLeft || keyName == desktop.KeyShiftRight)
+	case desktop.ControlModifier:
+		return (keyName == desktop.KeyControlLeft || keyName == desktop.KeyControlRight)
+	case desktop.AltModifier:
+		return (keyName == desktop.KeyAltLeft || keyName == desktop.KeyAltRight)
+	case desktop.SuperModifier:
+		return (keyName == desktop.KeySuperLeft || keyName == desktop.KeySuperRight)
+	}
+	return false
+}
+
 // charInput defines the character with modifiers callback which is called when a
 // Unicode character is input.
 //
@@ -1268,7 +1282,7 @@ func (w *window) triggersShortcut(keyName fyne.KeyName, modifier desktop.Modifie
 		}
 	}
 
-	if shortcut == nil && modifier != 0 && modifier != desktop.ShiftModifier {
+	if shortcut == nil && modifier != 0 && !isKeyModifierPair(keyName, modifier) && modifier != desktop.ShiftModifier {
 		shortcut = &desktop.CustomShortcut{
 			KeyName:  keyName,
 			Modifier: modifier,

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1201,20 +1201,6 @@ func desktopModifier(mods glfw.ModifierKey) desktop.Modifier {
 	return m
 }
 
-func isKeyModifierPair(keyName fyne.KeyName, modifier desktop.Modifier) bool {
-	switch modifier {
-	case desktop.ShiftModifier:
-		return (keyName == desktop.KeyShiftLeft || keyName == desktop.KeyShiftRight)
-	case desktop.ControlModifier:
-		return (keyName == desktop.KeyControlLeft || keyName == desktop.KeyControlRight)
-	case desktop.AltModifier:
-		return (keyName == desktop.KeyAltLeft || keyName == desktop.KeyAltRight)
-	case desktop.SuperModifier:
-		return (keyName == desktop.KeySuperLeft || keyName == desktop.KeySuperRight)
-	}
-	return false
-}
-
 // charInput defines the character with modifiers callback which is called when a
 // Unicode character is input.
 //
@@ -1236,6 +1222,20 @@ func (w *window) focused(_ *glfw.Window, isFocused bool) {
 		w.mousePos = fyne.Position{}
 		w.mouseLock.Unlock()
 	}
+}
+
+func isKeyModifierPair(keyName fyne.KeyName, modifier desktop.Modifier) bool {
+	switch modifier {
+	case desktop.ShiftModifier:
+		return (keyName == desktop.KeyShiftLeft || keyName == desktop.KeyShiftRight)
+	case desktop.ControlModifier:
+		return (keyName == desktop.KeyControlLeft || keyName == desktop.KeyControlRight)
+	case desktop.AltModifier:
+		return (keyName == desktop.KeyAltLeft || keyName == desktop.KeyAltRight)
+	case desktop.SuperModifier:
+		return (keyName == desktop.KeySuperLeft || keyName == desktop.KeySuperRight)
+	}
+	return false
 }
 
 func (w *window) triggersShortcut(keyName fyne.KeyName, modifier desktop.Modifier) bool {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -993,6 +993,27 @@ func TestWindow_Focus(t *testing.T) {
 	assert.Equal(t, "ef", e2.Text)
 }
 
+func TestWindow_CaptureTypedShortcut(t *testing.T) {
+	w := createWindow("Test").(*window)
+	content := &typedShortcutable{}
+	content.SetMinSize(fyne.NewSize(10, 10))
+	w.SetContent(content)
+	repaintWindow(w)
+
+	w.mouseMoved(w.viewport, 5, 5)
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Action(glfw.Press), glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyA, 0, glfw.Action(glfw.Press), glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Action(glfw.Release), glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyA, 0, glfw.Action(glfw.Release), glfw.ModControl)
+
+	w.waitForEvents()
+
+	assert.Equal(t, 1, len(content.capturedShortcuts))
+	assert.Equal(t, "CustomDesktop:Control+A", content.capturedShortcuts[0].ShortcutName())
+}
+
 func TestWindow_ManualFocus(t *testing.T) {
 	w := createWindow("Test").(*window)
 	content := &focusable{}
@@ -1331,6 +1352,15 @@ func (f *focusable) Disable() {
 
 func (f *focusable) Disabled() bool {
 	return f.disabled
+}
+
+type typedShortcutable struct {
+	focusable
+	capturedShortcuts []fyne.Shortcut
+}
+
+func (ts *typedShortcutable) TypedShortcut(s fyne.Shortcut) {
+	ts.capturedShortcuts = append(ts.capturedShortcuts, s)
 }
 
 //


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Shortcuts triggered an event to the queue for the shortcut's modifier key press. Added a filter to prevent the modifier key press from triggering the shortcut callback.

Fixes #2148

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
