### PR TITLE
allow tabs to store transitioning state to enable transition animations

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -26,8 +26,9 @@ type AppTabs struct {
 	OnSelected   func(*TabItem)
 	OnUnselected func(*TabItem)
 
-	current  int
-	location TabLocation
+	current         int
+	location        TabLocation
+	isTransitioning bool
 
 	popUpMenu *widget.PopUpMenu
 }
@@ -59,7 +60,7 @@ func (t *AppTabs) CreateRenderer() fyne.WidgetRenderer {
 	// Initially setup the tab bar to only show one tab, all others will be in overflow.
 	// When the widget is laid out, and we know the size, the tab bar will be updated to show as many as can fit.
 	r.updateTabs(1)
-	r.updateIndicator()
+	r.updateIndicator(false)
 	r.applyTheme(t)
 	return r
 }
@@ -237,8 +238,16 @@ func (t *AppTabs) setSelected(selected int) {
 	t.current = selected
 }
 
+func (t *AppTabs) setTransitioning(transitioning bool) {
+	t.isTransitioning = transitioning
+}
+
 func (t *AppTabs) tabLocation() TabLocation {
 	return t.location
+}
+
+func (t *AppTabs) transitioning() bool {
+	return t.isTransitioning
 }
 
 // Declare conformity with WidgetRenderer interface.
@@ -268,7 +277,10 @@ func (r *appTabsRenderer) Layout(size fyne.Size) {
 	}
 
 	r.layout(r.appTabs, size)
-	r.updateIndicator()
+	r.updateIndicator(r.appTabs.transitioning())
+	if r.appTabs.transitioning() {
+		r.appTabs.setTransitioning(false)
+	}
 }
 
 func (r *appTabsRenderer) MinSize() fyne.Size {
@@ -354,7 +366,7 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 	return buttons
 }
 
-func (r *appTabsRenderer) updateIndicator() {
+func (r *appTabsRenderer) updateIndicator(animate bool) {
 	if r.appTabs.current < 0 {
 		r.indicator.Hide()
 		return
@@ -393,7 +405,7 @@ func (r *appTabsRenderer) updateIndicator() {
 		indicatorSize = fyne.NewSize(theme.Padding(), selectedSize.Height)
 	}
 
-	r.moveIndicator(indicatorPos, indicatorSize, true)
+	r.moveIndicator(indicatorPos, indicatorSize, animate)
 }
 
 func (r *appTabsRenderer) updateTabs(max int) {

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -27,8 +27,9 @@ type DocTabs struct {
 	OnSelected     func(*TabItem)
 	OnUnselected   func(*TabItem)
 
-	current  int
-	location TabLocation
+	current         int
+	location        TabLocation
+	isTransitioning bool
 
 	popUpMenu *widget.PopUpMenu
 }
@@ -193,8 +194,16 @@ func (t *DocTabs) setSelected(selected int) {
 	t.current = selected
 }
 
+func (t *DocTabs) setTransitioning(transitioning bool) {
+	t.isTransitioning = transitioning
+}
+
 func (t *DocTabs) tabLocation() TabLocation {
 	return t.location
+}
+
+func (t *DocTabs) transitioning() bool {
+	return t.isTransitioning
 }
 
 // Declare conformity with WidgetRenderer interface.
@@ -214,7 +223,10 @@ func (r *docTabsRenderer) Layout(size fyne.Size) {
 	r.updateCreateTab()
 	r.updateTabs()
 	r.layout(r.docTabs, size)
-	r.updateIndicator(true)
+	r.updateIndicator(r.docTabs.transitioning())
+	if r.docTabs.transitioning() {
+		r.docTabs.setTransitioning(false)
+	}
 }
 
 func (r *docTabsRenderer) MinSize() fyne.Size {

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -59,6 +59,9 @@ type baseTabs interface {
 	setSelected(int)
 
 	tabLocation() TabLocation
+
+	transitioning() bool
+	setTransitioning(bool)
 }
 
 func buildPopUpMenu(t baseTabs, button *widget.Button, items []*fyne.MenuItem) *widget.PopUpMenu {
@@ -136,6 +139,7 @@ func selectIndex(t baseTabs, index int) {
 		return
 	}
 
+	t.setTransitioning(true)
 	t.setSelected(index)
 
 	if f := t.onSelected(); f != nil {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Modified the `tabs` interface to enforce 2 new methods: `transitioning() bool` and `setTransitioning(bool)` which allows the implementations of `tabs` (currently: `AppTabs` and `DocTabs`) to capture the state while a tab change is happening.
This allows us to enable tab transitioning animation on the tab indicator only during a valid tab change and not every time the tab indicator is rendered.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/3107765/115457255-e5635b80-a241-11eb-93d0-32c79b325c8a.gif)

Fixes #2135 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
