### PR TITLE
fix: allow apptabs to store state while transitioning tabs

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -425,30 +425,29 @@ func (r *appTabsRenderer) moveSelection(withAnimation bool) {
 		return
 	}
 
-	if withAnimation {
-		if r.animation != nil {
-			r.animation.Stop()
-		}
-		r.animation = canvas.NewPositionAnimation(r.underline.Position(), underlinePos, canvas.DurationShort, func(p fyne.Position) {
-			r.underline.Move(p)
-			canvas.Refresh(r.underline)
-			if p == underlinePos {
-				r.animation = nil
-			}
-		})
-		r.animation.Start()
-
-		canvas.NewSizeAnimation(r.underline.Size(), underlineSize, canvas.DurationShort, func(s fyne.Size) {
-			r.underline.Resize(s)
-			canvas.Refresh(r.underline)
-		}).Start()
-	} else {
-		if r.animation == nil {
-			r.underline.Move(underlinePos)
-			r.underline.Resize(underlineSize)
-			canvas.Refresh(r.underline)
-		}
+	if !withAnimation && r.animation == nil {
+		r.underline.Move(underlinePos)
+		r.underline.Resize(underlineSize)
+		canvas.Refresh(r.underline)
+		return
 	}
+
+	if r.animation != nil {
+		r.animation.Stop()
+	}
+	r.animation = canvas.NewPositionAnimation(r.underline.Position(), underlinePos, canvas.DurationShort, func(p fyne.Position) {
+		r.underline.Move(p)
+		canvas.Refresh(r.underline)
+		if p == underlinePos {
+			r.animation = nil
+		}
+	})
+	r.animation.Start()
+
+	canvas.NewSizeAnimation(r.underline.Size(), underlineSize, canvas.DurationShort, func(s fyne.Size) {
+		r.underline.Resize(s)
+		canvas.Refresh(r.underline)
+	}).Start()
 }
 
 func (r *appTabsRenderer) tabsInSync() bool {

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -18,10 +18,11 @@ import (
 type AppTabs struct {
 	widget.BaseWidget
 
-	Items       []*TabItem
-	OnChanged   func(tab *TabItem)
-	current     int
-	tabLocation TabLocation
+	Items           []*TabItem
+	OnChanged       func(tab *TabItem)
+	current         int
+	tabLocation     TabLocation
+	isTransitioning bool
 }
 
 // TabItem represents a single view in a AppTabs.
@@ -89,7 +90,7 @@ func (c *AppTabs) CreateRenderer() fyne.WidgetRenderer {
 	c.BaseWidget.ExtendBaseWidget(c)
 	r := &appTabsRenderer{line: canvas.NewRectangle(theme.ShadowColor()),
 		underline: canvas.NewRectangle(theme.PrimaryColor()), container: c}
-	r.updateTabs()
+	r.updateTabs(c.isTransitioning)
 	return r
 }
 
@@ -158,8 +159,10 @@ func (c *AppTabs) SelectTabIndex(index int) {
 	if index < 0 || index >= len(c.Items) || c.current == index {
 		return
 	}
+	c.isTransitioning = true
 	c.current = index
 	c.Refresh()
+	c.isTransitioning = false
 
 	if c.OnChanged != nil {
 		c.OnChanged(c.Items[c.current])
@@ -277,7 +280,7 @@ func (r *appTabsRenderer) Layout(size fyne.Size) {
 		child.Move(childPos)
 		child.Resize(childSize)
 	}
-	r.moveSelection()
+	r.moveSelection(r.container.isTransitioning)
 }
 
 func (r *appTabsRenderer) MinSize() fyne.Size {
@@ -311,7 +314,7 @@ func (r *appTabsRenderer) Refresh() {
 	r.line.Refresh()
 	r.underline.FillColor = theme.PrimaryColor()
 
-	if r.updateTabs() {
+	if r.updateTabs(r.container.isTransitioning) {
 		r.Layout(r.container.Size())
 	} else {
 		current := r.container.current
@@ -335,7 +338,7 @@ func (r *appTabsRenderer) Refresh() {
 			button.Refresh()
 		}
 	}
-	r.moveSelection()
+	r.moveSelection(r.container.isTransitioning)
 	canvas.Refresh(r.container)
 }
 
@@ -391,7 +394,7 @@ func (r *appTabsRenderer) buildTabBar(buttons []fyne.CanvasObject) *fyne.Contain
 	return fyne.NewContainerWithLayout(lay, buttons...)
 }
 
-func (r *appTabsRenderer) moveSelection() {
+func (r *appTabsRenderer) moveSelection(withAnimation bool) {
 	if r.container.current < 0 {
 		r.underline.Hide()
 		return
@@ -422,22 +425,30 @@ func (r *appTabsRenderer) moveSelection() {
 		return
 	}
 
-	if r.animation != nil {
-		r.animation.Stop()
-	}
-	r.animation = canvas.NewPositionAnimation(r.underline.Position(), underlinePos, canvas.DurationShort, func(p fyne.Position) {
-		r.underline.Move(p)
-		canvas.Refresh(r.underline)
-		if p == underlinePos {
-			r.animation = nil
+	if withAnimation {
+		if r.animation != nil {
+			r.animation.Stop()
 		}
-	})
-	r.animation.Start()
+		r.animation = canvas.NewPositionAnimation(r.underline.Position(), underlinePos, canvas.DurationShort, func(p fyne.Position) {
+			r.underline.Move(p)
+			canvas.Refresh(r.underline)
+			if p == underlinePos {
+				r.animation = nil
+			}
+		})
+		r.animation.Start()
 
-	canvas.NewSizeAnimation(r.underline.Size(), underlineSize, canvas.DurationShort, func(s fyne.Size) {
-		r.underline.Resize(s)
-		canvas.Refresh(r.underline)
-	}).Start()
+		canvas.NewSizeAnimation(r.underline.Size(), underlineSize, canvas.DurationShort, func(s fyne.Size) {
+			r.underline.Resize(s)
+			canvas.Refresh(r.underline)
+		}).Start()
+	} else {
+		if r.animation == nil {
+			r.underline.Move(underlinePos)
+			r.underline.Resize(underlineSize)
+			canvas.Refresh(r.underline)
+		}
+	}
 }
 
 func (r *appTabsRenderer) tabsInSync() bool {
@@ -468,7 +479,7 @@ func (r *appTabsRenderer) tabsInSync() bool {
 	return true
 }
 
-func (r *appTabsRenderer) updateTabs() bool {
+func (r *appTabsRenderer) updateTabs(withAnimation bool) bool {
 	if r.tabsInSync() {
 		return false
 	}
@@ -497,7 +508,7 @@ func (r *appTabsRenderer) updateTabs() bool {
 	}
 	r.tabBar = r.buildTabBar(buttons)
 	r.objects = objects
-	r.moveSelection()
+	r.moveSelection(withAnimation)
 
 	return true
 }

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -90,7 +90,7 @@ func (c *AppTabs) CreateRenderer() fyne.WidgetRenderer {
 	c.BaseWidget.ExtendBaseWidget(c)
 	r := &appTabsRenderer{line: canvas.NewRectangle(theme.ShadowColor()),
 		underline: canvas.NewRectangle(theme.PrimaryColor()), container: c}
-	r.updateTabs(c.isTransitioning)
+	r.updateTabs(false)
 	return r
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Added an internal field to AppTabs that stores the state when a tab change is happening, thereby allowing animations only on valid tab changes.
This is a port of #2187 for release 2.0.3.

Fixes #2135 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
