### PR TITLE
Remove unnecessary usage of fmt.Sprintf

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,8 +4,8 @@
 package app // import "fyne.io/fyne/v2/app"
 
 import (
-	"fmt"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 
@@ -43,7 +43,7 @@ func (app *fyneApp) UniqueID() string {
 	}
 
 	fyne.LogError("Preferences API requires a unique ID, use app.NewWithID()", nil)
-	app.uniqueID = fmt.Sprintf("missing-id-%d", time.Now().Unix()) // This is a fake unique - it just has to not be reused...
+	app.uniqueID = "missing-id-" + strconv.FormatInt(time.Now().Unix(), 10) // This is a fake unique - it just has to not be reused...
 	return app.uniqueID
 }
 

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -1,11 +1,11 @@
 package commands
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/cmd/fyne/internal/mobile"
@@ -68,7 +68,7 @@ func (p *Packager) packageIOS() error {
 }
 
 func copyResizeIcon(size int, dir, source string) error {
-	path := fmt.Sprintf("%s/Icon_%d.png", dir, size)
-	strSize := fmt.Sprintf("%d", size)
+	strSize := strconv.Itoa(size)
+	path := dir + "/Icon_" + strSize + ".png"
 	return exec.Command("sips", "-o", path, "-Z", strSize, source).Run()
 }

--- a/cmd/fyne_demo/tutorials/advanced.go
+++ b/cmd/fyne_demo/tutorials/advanced.go
@@ -1,7 +1,7 @@
 package tutorials
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -11,7 +11,7 @@ import (
 )
 
 func scaleString(c fyne.Canvas) string {
-	return fmt.Sprintf("%0.2f", c.Scale())
+	return strconv.FormatFloat(float64(c.Scale()), 'f', 2, 32)
 }
 
 func prependTo(g *fyne.Container, s string) {

--- a/cmd/fyne_demo/tutorials/collection.go
+++ b/cmd/fyne_demo/tutorials/collection.go
@@ -2,6 +2,7 @@ package tutorials
 
 import (
 	"fmt"
+	"strconv"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -23,7 +24,7 @@ func collectionScreen(_ fyne.Window) fyne.CanvasObject {
 func makeListTab(_ fyne.Window) fyne.CanvasObject {
 	data := make([]string, 1000)
 	for i := range data {
-		data[i] = fmt.Sprintf("Test Item %d", i)
+		data[i] = "Test Item " + strconv.Itoa(i)
 	}
 
 	icon := widget.NewIcon(nil)

--- a/cmd/fyne_demo/tutorials/container.go
+++ b/cmd/fyne_demo/tutorials/container.go
@@ -3,6 +3,7 @@ package tutorials
 import (
 	"fmt"
 	"image/color"
+	"strconv"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -61,7 +62,7 @@ func makeButtonList(count int) []fyne.CanvasObject {
 	var items []fyne.CanvasObject
 	for i := 1; i <= count; i++ {
 		index := i // capture
-		items = append(items, widget.NewButton(fmt.Sprintf("Button %d", index), func() {
+		items = append(items, widget.NewButton("Button "+strconv.Itoa(index), func() {
 			fmt.Println("Tapped", index)
 		}))
 	}

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -3,7 +3,6 @@ package theme
 import (
 	"bytes"
 	"encoding/xml"
-	"fmt"
 	"image/color"
 
 	"fyne.io/fyne/v2"
@@ -657,7 +656,7 @@ type DisabledResource struct {
 
 // Name returns the resource source name prefixed with `disabled_` (used for caching)
 func (res *DisabledResource) Name() string {
-	return fmt.Sprintf("disabled_%s", res.source.Name())
+	return "disabled_" + res.source.Name()
 }
 
 // Content returns the disabled style content of the correct resource for the current theme

--- a/theme/svg.go
+++ b/theme/svg.go
@@ -3,10 +3,10 @@ package theme
 import (
 	"encoding/hex"
 	"encoding/xml"
-	"fmt"
 	"image/color"
 	"io"
 	"io/ioutil"
+	"strconv"
 )
 
 // svg holds the unmarshaled XML from a Scalable Vector Graphic
@@ -165,5 +165,5 @@ func svgFromXML(reader io.Reader) (*svg, error) {
 func colorToHexAndOpacity(color color.Color) (string, string) {
 	r, g, b, a := color.RGBA()
 	cBytes := []byte{byte(r), byte(g), byte(b)}
-	return fmt.Sprintf("#%s", hex.EncodeToString(cBytes)), fmt.Sprintf("%f", float64(a)/0xffff)
+	return "#" + hex.EncodeToString(cBytes), strconv.FormatFloat(float64(a)/0xffff, 'f', 6, 64)
 }

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -1,8 +1,8 @@
 package widget
 
 import (
-	"fmt"
 	"image/color"
+	"strconv"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -48,7 +48,7 @@ func (p *progressRenderer) updateBar() {
 	if text := p.progress.TextFormatter; text != nil {
 		p.label.Text = text()
 	} else {
-		p.label.Text = fmt.Sprintf(defaultText, int(ratio*100))
+		p.label.Text = strconv.Itoa(int(ratio*100)) + "%"
 	}
 
 	size := p.progress.Size()

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image/color"
 	"math"
+	"strconv"
 	"strings"
 
 	"fyne.io/fyne/v2/internal/cache"
@@ -452,7 +453,7 @@ func (t *textGridRenderer) refreshGrid() {
 }
 
 func (t *textGridRenderer) lineNumberWidth() int {
-	return len(fmt.Sprintf("%d", t.rows+1))
+	return len(strconv.Itoa(t.rows + 1))
 }
 
 func (t *textGridRenderer) updateGridSize(size fyne.Size) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This removes a couple uses of `fmt.Sprintf` that were unnecessary and replaces it with string appends or `strconv` in places where it does not noticeably hurt the code readability. Some of the changes should be more noticable than others, giving performance improvements all over the place. I think the changes to the `theme` package, `widget.ProgressBar` and `widget.TextGrid` should be the most noticeable cases, performance wise. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
