### PR TITLE
ScrollTo API on List widget

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -147,6 +147,22 @@ func (l *List) ScrollTo(id ListItemID) {
 	l.Refresh()
 }
 
+// ScrollToBottom scrolls to the end of the list
+func (l *List) ScrollToBottom() {
+	length := 0
+	if f := l.Length; f != nil {
+		length = f()
+	}
+	l.scrollTo(length)
+	l.Refresh()
+}
+
+// ScrollToTop scrolls to the start of the list
+func (l *List) ScrollToTop() {
+	l.scrollTo(0)
+	l.Refresh()
+}
+
 // Unselect removes the item identified by the given ID from the selection.
 func (l *List) Unselect(id ListItemID) {
 	if len(l.selected) == 0 || l.selected[0] != id {

--- a/widget/list.go
+++ b/widget/list.go
@@ -99,7 +99,7 @@ func (l *List) scrollTo(id ListItemID) {
 	if l.scroller == nil {
 		return
 	}
-	y := float32(id) * (l.itemMin.Height + theme.SeparatorThicknessSize())
+	y := (float32(id) * l.itemMin.Height) + (float32(id) * theme.SeparatorThicknessSize())
 	if y < l.scroller.Offset.Y {
 		l.scroller.Offset.Y = y
 	} else if y+l.itemMin.Height > l.scroller.Offset.Y+l.scroller.Size().Height {
@@ -153,7 +153,7 @@ func (l *List) ScrollToBottom() {
 	if f := l.Length; f != nil {
 		length = f()
 	}
-	l.scrollTo(length)
+	l.scrollTo(length - 1)
 	l.Refresh()
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -135,6 +135,8 @@ func (l *List) Select(id ListItemID) {
 }
 
 // ScrollTo scrolls to the item represented by id
+//
+// Since: 2.1
 func (l *List) ScrollTo(id ListItemID) {
 	length := 0
 	if f := l.Length; f != nil {
@@ -148,6 +150,8 @@ func (l *List) ScrollTo(id ListItemID) {
 }
 
 // ScrollToBottom scrolls to the end of the list
+//
+// Since: 2.1
 func (l *List) ScrollToBottom() {
 	length := 0
 	if f := l.Length; f != nil {
@@ -161,6 +165,8 @@ func (l *List) ScrollToBottom() {
 }
 
 // ScrollToTop scrolls to the start of the list
+//
+// Since: 2.1
 func (l *List) ScrollToTop() {
 	l.scrollTo(0)
 	l.Refresh()

--- a/widget/list.go
+++ b/widget/list.go
@@ -99,7 +99,7 @@ func (l *List) moveFocusTo(id ListItemID) {
 	if l.scroller == nil {
 		return
 	}
-	y := (float32(id) * l.itemMin.Height) + (float32(id) * theme.SeparatorThicknessSize())
+	y := float32(id) * (l.itemMin.Height + theme.SeparatorThicknessSize())
 	if y < l.scroller.Offset.Y {
 		l.scroller.Offset.Y = y
 	} else if y+l.itemMin.Height > l.scroller.Offset.Y+l.scroller.Size().Height {

--- a/widget/list.go
+++ b/widget/list.go
@@ -153,7 +153,10 @@ func (l *List) ScrollToBottom() {
 	if f := l.Length; f != nil {
 		length = f()
 	}
-	l.scrollTo(length - 1)
+	if length > 0 {
+		length -= 1
+	}
+	l.scrollTo(length)
 	l.Refresh()
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -95,6 +95,19 @@ func (l *List) MinSize() fyne.Size {
 	return l.BaseWidget.MinSize()
 }
 
+func (l *List) moveFocusTo(id ListItemID) {
+	if l.scroller == nil {
+		return
+	}
+	y := (float32(id) * l.itemMin.Height) + (float32(id) * theme.SeparatorThicknessSize())
+	if y < l.scroller.Offset.Y {
+		l.scroller.Offset.Y = y
+	} else if y+l.itemMin.Height > l.scroller.Offset.Y+l.scroller.Size().Height {
+		l.scroller.Offset.Y = y + l.itemMin.Height - l.scroller.Size().Height
+	}
+	l.offsetUpdated(l.scroller.Offset)
+}
+
 // Select add the item identified by the given ID to the selection.
 func (l *List) Select(id ListItemID) {
 	if len(l.selected) > 0 && id == l.selected[0] {
@@ -117,16 +130,20 @@ func (l *List) Select(id ListItemID) {
 			f(id)
 		}
 	}()
-	if l.scroller == nil {
+	l.moveFocusTo(id)
+	l.Refresh()
+}
+
+// ScrollTo scrolls to the item represented by id
+func (l *List) ScrollTo(id ListItemID) {
+	length := 0
+	if f := l.Length; f != nil {
+		length = f()
+	}
+	if id < 0 || id >= length {
 		return
 	}
-	y := (float32(id) * l.itemMin.Height) + (float32(id) * theme.SeparatorThicknessSize())
-	if y < l.scroller.Offset.Y {
-		l.scroller.Offset.Y = y
-	} else if y+l.itemMin.Height > l.scroller.Offset.Y+l.scroller.Size().Height {
-		l.scroller.Offset.Y = y + l.itemMin.Height - l.scroller.Size().Height
-	}
-	l.offsetUpdated(l.scroller.Offset)
+	l.moveFocusTo(id)
 	l.Refresh()
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -95,7 +95,7 @@ func (l *List) MinSize() fyne.Size {
 	return l.BaseWidget.MinSize()
 }
 
-func (l *List) moveFocusTo(id ListItemID) {
+func (l *List) scrollTo(id ListItemID) {
 	if l.scroller == nil {
 		return
 	}
@@ -130,7 +130,7 @@ func (l *List) Select(id ListItemID) {
 			f(id)
 		}
 	}()
-	l.moveFocusTo(id)
+	l.scrollTo(id)
 	l.Refresh()
 }
 
@@ -143,7 +143,7 @@ func (l *List) ScrollTo(id ListItemID) {
 	if id < 0 || id >= length {
 		return
 	}
-	l.moveFocusTo(id)
+	l.scrollTo(id)
 	l.Refresh()
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -154,7 +154,7 @@ func (l *List) ScrollToBottom() {
 		length = f()
 	}
 	if length > 0 {
-		length -= 1
+		length--
 	}
 	l.scrollTo(length)
 	l.Refresh()

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -97,6 +97,42 @@ func TestList_Hover(t *testing.T) {
 	}
 }
 
+func TestList_ScrollTo(t *testing.T) {
+	list := createList(1000)
+
+	offset := float32(0)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+
+	list.ScrollTo(20)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+
+	offset = float32(8245)
+	list.ScrollTo(200)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+
+	offset = float32(44999)
+	list.ScrollTo(999)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+
+	offset = float32(23000)
+	list.ScrollTo(500)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+
+	list.ScrollTo(1000)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+
+	offset = float32(46)
+	list.ScrollTo(1)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+}
+
 func TestList_Selection(t *testing.T) {
 	list := createList(1000)
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -133,6 +133,24 @@ func TestList_ScrollTo(t *testing.T) {
 	assert.Equal(t, offset, list.scroller.Offset.Y)
 }
 
+func TestList_ScrollToBottom(t *testing.T) {
+	list := createList(1000)
+
+	offset := float32(44999)
+	list.ScrollToBottom()
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+}
+
+func TestList_ScrollToTop(t *testing.T) {
+	list := createList(1000)
+
+	offset := float32(0)
+	list.ScrollToTop()
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+}
+
 func TestList_Selection(t *testing.T) {
 	list := createList(1000)
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Exposed a `ScrollTo` API that scrolls a List widget and sets the focus on the ListItem represented by the id given to the API.

Fixes #2105 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

- [x] Public APIs match existing style.
