### PR TITLE
data/validation: add time format validator

### DIFF
--- a/data/validation/time.go
+++ b/data/validation/time.go
@@ -8,7 +8,8 @@ import (
 
 // NewTime creates a new validator that verifies times using time.Parse.
 // The validator will return nil if valid, otherwise returns an error with a reason text.
-// See time.Parse() for reference time format: https://pkg.go.dev/time#Parse
+// The reference time for the format: Mon Jan 2 15:04:05 -0700 MST 2006.
+// See time.Parse() for more information about the reference time: https://pkg.go.dev/time#Parse
 //
 // Since: 2.1
 func NewTime(format string) fyne.StringValidator {

--- a/data/validation/time.go
+++ b/data/validation/time.go
@@ -13,10 +13,7 @@ import (
 // Since: 2.1
 func NewTime(format string) fyne.StringValidator {
 	return func(text string) error {
-		if _, err := time.Parse(format, text); err != nil {
-			return err
-		}
-
-		return nil
+		_, err := time.Parse(format, text)
+		return err
 	}
 }

--- a/data/validation/time.go
+++ b/data/validation/time.go
@@ -7,8 +7,8 @@ import (
 )
 
 // NewTime creates a new validator that verifies times using time.Parse.
-// The reference time for the format: Mon Jan 2 15:04:05 -0700 MST 2006.
 // The validator will return nil if valid, otherwise returns an error with a reason text.
+// See time.Parse() for reference time format: https://pkg.go.dev/time#Parse
 //
 // Since: 2.1
 func NewTime(format string) fyne.StringValidator {

--- a/data/validation/time.go
+++ b/data/validation/time.go
@@ -1,0 +1,21 @@
+package validation
+
+import (
+	"fyne.io/fyne/v2"
+	"time"
+)
+
+// NewTime creates a new validator that verifies times using time.Parse.
+// The reference time for the format: Mon Jan 2 15:04:05 -0700 MST 2006.
+// The validator will return nil if valid, otherwise returns an error with a reason text.
+//
+// Since: 2.1
+func NewTime(format string) fyne.StringValidator {
+	return func(text string) error {
+		if _, err := time.Parse(format, text); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/data/validation/time.go
+++ b/data/validation/time.go
@@ -1,8 +1,9 @@
 package validation
 
 import (
-	"fyne.io/fyne/v2"
 	"time"
+
+	"fyne.io/fyne/v2"
 )
 
 // NewTime creates a new validator that verifies times using time.Parse.

--- a/data/validation/time_test.go
+++ b/data/validation/time_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestTime(t *testing.T) {
-	time := validation.NewTime("2006-01-02")
+	validate := validation.NewTime("2006-01-02")
 
-	assert.NoError(t, time("2021-02-21"))
-	assert.Error(t, time("21/02-2021"))
+	assert.NoError(t, validate("2021-02-21"))
+	assert.Error(t, validate("21/02-2021"))
 
-	time = validation.NewTime("15:04")
+	validate = validation.NewTime("15:04")
 
-	assert.NoError(t, time("12:30"))
-	assert.Error(t, time("25:77"))
+	assert.NoError(t, validate("12:30"))
+	assert.Error(t, validate("25:77"))
 }

--- a/data/validation/time_test.go
+++ b/data/validation/time_test.go
@@ -1,0 +1,21 @@
+package validation_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/data/validation"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTime(t *testing.T) {
+	time := validation.NewTime("2006-01-02")
+
+	assert.NoError(t, time("2021-02-21"))
+	assert.Error(t, time("21/02-2021"))
+
+	time = validation.NewTime("15:04")
+
+	assert.NoError(t, time("12:30"))
+	assert.Error(t, time("25:77"))
+}


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Adds a validator that I used in [Sparta](https://github.com/Jacalz/sparta) for verifying that dates and times were correct.
Can probably be useful for a lot of other use cases as well :)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
