### PR TITLE
Deprecate fileicon selection

### DIFF
--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -91,7 +91,9 @@ func (i *FileIcon) CreateRenderer() fyne.WidgetRenderer {
 	return s
 }
 
-// SetSelected makes the file look like it is selected
+// SetSelected makes the file look like it is selected.
+//
+// Deprecated: Selection will be handled externally in the future.
 func (i *FileIcon) SetSelected(selected bool) {
 	i.Selected = selected
 	i.Refresh()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Just adding a deprecation notice for now.
Not really useful until we have selection colour.
The wording can probably be a bit better. Feel free to come with better ideas.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.