### PR TITLE
Optimizations for AppTabs and DocTabs

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -288,7 +288,7 @@ func (r *appTabsRenderer) Refresh() {
 }
 
 func (r *appTabsRenderer) buildOverflowTabsButton() (overflow *widget.Button) {
-	return &widget.Button{Icon: moreIcon(r.appTabs), Importance: widget.LowImportance, OnTapped: func() {
+	overflow = &widget.Button{Icon: moreIcon(r.appTabs), Importance: widget.LowImportance, OnTapped: func() {
 		// Show pop up containing all tabs which did not fit in the tab bar
 
 		itemLen, objLen := len(r.appTabs.Items), len(r.bar.Objects[0].(*fyne.Container).Objects)
@@ -309,6 +309,8 @@ func (r *appTabsRenderer) buildOverflowTabsButton() (overflow *widget.Button) {
 
 		r.appTabs.popUpMenu = buildPopUpMenu(r.appTabs, overflow, items)
 	}}
+
+	return overflow
 }
 
 func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -294,11 +294,10 @@ func (r *appTabsRenderer) buildOverflowTabsButton() (overflow *widget.Button) {
 		itemLen, objLen := len(r.appTabs.Items), len(r.bar.Objects[0].(*fyne.Container).Objects)
 		items := make([]*fyne.MenuItem, 0, itemLen-objLen)
 		for i := objLen; i < itemLen; i++ {
-			item := r.appTabs.Items[i]
 			index := i // capture
 			// FIXME MenuItem doesn't support icons (#1752)
 			// FIXME MenuItem can't show if it is the currently selected tab (#1753)
-			items = append(items, fyne.NewMenuItem(item.Text, func() {
+			items = append(items, fyne.NewMenuItem(r.appTabs.Items[i].Text, func() {
 				r.appTabs.SelectIndex(index)
 				if r.appTabs.popUpMenu != nil {
 					r.appTabs.popUpMenu.Hide()

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -288,16 +288,18 @@ func (r *appTabsRenderer) Refresh() {
 }
 
 func (r *appTabsRenderer) buildOverflowTabsButton() (overflow *widget.Button) {
-	overflow = widget.NewButtonWithIcon("", moreIcon(r.appTabs), func() {
+	return &widget.Button{Icon: moreIcon(r.appTabs), Importance: widget.LowImportance, OnTapped: func() {
 		// Show pop up containing all tabs which did not fit in the tab bar
 
-		var items []*fyne.MenuItem
-		for i := len(r.bar.Objects[0].(*fyne.Container).Objects); i < len(r.appTabs.Items); i++ {
+		itemLen, objLen := len(r.appTabs.Items), len(r.bar.Objects[0].(*fyne.Container).Objects)
+		items := make([]*fyne.MenuItem, 0, itemLen-objLen)
+		for i := objLen; i < itemLen; i++ {
 			item := r.appTabs.Items[i]
+			index := i // capture
 			// FIXME MenuItem doesn't support icons (#1752)
 			// FIXME MenuItem can't show if it is the currently selected tab (#1753)
 			items = append(items, fyne.NewMenuItem(item.Text, func() {
-				r.appTabs.Select(item)
+				r.appTabs.SelectIndex(index)
 				if r.appTabs.popUpMenu != nil {
 					r.appTabs.popUpMenu.Hide()
 					r.appTabs.popUpMenu = nil
@@ -306,9 +308,7 @@ func (r *appTabsRenderer) buildOverflowTabsButton() (overflow *widget.Button) {
 		}
 
 		r.appTabs.popUpMenu = buildPopUpMenu(r.appTabs, overflow, items)
-	})
-	overflow.Importance = widget.LowImportance
-	return
+	}}
 }
 
 func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
@@ -338,8 +338,9 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 		item := r.appTabs.Items[i]
 		button, ok := r.buttonCache[item]
 		if !ok {
+			index := i // capture
 			button = &tabButton{
-				onTapped: func() { r.appTabs.Select(item) },
+				onTapped: func() { r.appTabs.SelectIndex(index) },
 			}
 			r.buttonCache[item] = button
 		}

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -253,7 +253,7 @@ func (r *docTabsRenderer) Refresh() {
 }
 
 func (r *docTabsRenderer) buildAllTabsButton() (all *widget.Button) {
-	return &widget.Button{Importance: widget.LowImportance, OnTapped: func() {
+	all = &widget.Button{Importance: widget.LowImportance, OnTapped: func() {
 		// Show pop up containing all tabs
 
 		items := make([]*fyne.MenuItem, len(r.docTabs.Items))
@@ -273,6 +273,8 @@ func (r *docTabsRenderer) buildAllTabsButton() (all *widget.Button) {
 
 		r.docTabs.popUpMenu = buildPopUpMenu(r.docTabs, all, items)
 	}}
+
+	return all
 }
 
 func (r *docTabsRenderer) buildCreateTabsButton() *widget.Button {

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -258,11 +258,10 @@ func (r *docTabsRenderer) buildAllTabsButton() (all *widget.Button) {
 
 		items := make([]*fyne.MenuItem, len(r.docTabs.Items))
 		for i := 0; i < len(r.docTabs.Items); i++ {
-			item := r.docTabs.Items[i]
 			index := i // capture
 			// FIXME MenuItem doesn't support icons (#1752)
 			// FIXME MenuItem can't show if it is the currently selected tab (#1753)
-			items[i] = fyne.NewMenuItem(item.Text, func() {
+			items[i] = fyne.NewMenuItem(r.docTabs.Items[i].Text, func() {
 				r.docTabs.SelectIndex(index)
 				if r.docTabs.popUpMenu != nil {
 					r.docTabs.popUpMenu.Hide()

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -253,27 +253,26 @@ func (r *docTabsRenderer) Refresh() {
 }
 
 func (r *docTabsRenderer) buildAllTabsButton() (all *widget.Button) {
-	all = widget.NewButton("", func() {
+	return &widget.Button{Importance: widget.LowImportance, OnTapped: func() {
 		// Show pop up containing all tabs
 
-		var items []*fyne.MenuItem
+		items := make([]*fyne.MenuItem, len(r.docTabs.Items))
 		for i := 0; i < len(r.docTabs.Items); i++ {
 			item := r.docTabs.Items[i]
+			index := i // capture
 			// FIXME MenuItem doesn't support icons (#1752)
 			// FIXME MenuItem can't show if it is the currently selected tab (#1753)
-			items = append(items, fyne.NewMenuItem(item.Text, func() {
-				r.docTabs.Select(item)
+			items[i] = fyne.NewMenuItem(item.Text, func() {
+				r.docTabs.SelectIndex(index)
 				if r.docTabs.popUpMenu != nil {
 					r.docTabs.popUpMenu.Hide()
 					r.docTabs.popUpMenu = nil
 				}
-			}))
+			})
 		}
 
 		r.docTabs.popUpMenu = buildPopUpMenu(r.docTabs, all, items)
-	})
-	all.Importance = widget.LowImportance
-	return
+	}}
 }
 
 func (r *docTabsRenderer) buildCreateTabsButton() *widget.Button {
@@ -316,8 +315,9 @@ func (r *docTabsRenderer) buildTabButtons(count int) *fyne.Container {
 		item := r.docTabs.Items[i]
 		button, ok := r.buttonCache[item]
 		if !ok {
+			index := i // capture
 			button = &tabButton{
-				onTapped: func() { r.docTabs.Select(item) },
+				onTapped: func() { r.docTabs.SelectIndex(index) },
 				onClosed: func() { r.docTabs.close(item) },
 			}
 			r.buttonCache[item] = button


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This basically does two things. Firstly, we pre-allocate the slice of menu items that we are shoring in the drop-downs.
Secondly, we make sure to use the index of the tab instead of the tab item, for selection.
This avoids ranging through all the items to find the correct index.

There seems to be a panic happening sometimes when pressing the drop down button when it is already open, but does not seem to be related to this PR.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
