### PR TITLE
Optimisation: perform row-first scan when generating a raster image

### DIFF
--- a/canvas/raster.go
+++ b/canvas/raster.go
@@ -98,8 +98,8 @@ func NewRasterWithPixels(pixelColor func(x, y, w, h int) color.Color) *Raster {
 				pix.img = dst
 			}
 
-			for x := 0; x < w; x++ {
-				for y := 0; y < h; y++ {
+			for y := 0; y < h; y++ {
+				for x := 0; x < w; x++ {
 					pix.img.Set(x, y, pixelColor(x, y, w, h))
 				}
 			}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
The current implementation of `NewRasterWithPixels` does a column-first scan to set the pixels of the raster image. This works fine for smaller rasters (less than approx 10000 pixels), but starts showing performance issues as the raster size increases. This is because large memory jumps have to be made to traverse the 2D array in a column-first manner.

As horizontally-adjacent data is stored closer in memory, a row-first scan takes advantage of cache coherence and provides a 3x better performance while scanning a 2D array (the raster image in this case).

Column first scan rendering:
![column-first](https://user-images.githubusercontent.com/3107765/116898871-8c89bf00-ac54-11eb-91bd-f930c23067bc.gif)

Row first scan rendering:
![row-first](https://user-images.githubusercontent.com/3107765/116898808-7419a480-ac54-11eb-938f-f5033ccf7077.gif)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
