### PR TITLE
Use OpenGL to draw canvas lines

### DIFF
--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"flag"
 	"fmt"
+
 	// import image encodings
 	_ "image/jpeg"
 	_ "image/png"

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -131,7 +131,7 @@ func (p *glPainter) lineCoords(pos, pos1, pos2 fyne.Position, lineWidth, feather
 	normalObjX := normalX * 0.5 * frame.Width
 	normalObjY := normalY * 0.5 * frame.Height
 	widthMultiplier := float32(math.Sqrt(float64(normalObjX*normalObjX + normalObjY*normalObjY)))
-	halfWidth := (lineWidth * 0.5 + feather) / widthMultiplier
+	halfWidth := (lineWidth*0.5 + feather) / widthMultiplier
 	featherWidth := feather / widthMultiplier
 
 	return []float32{

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -108,12 +108,10 @@ func (p *glPainter) lineCoords(pos, pos1, pos2 fyne.Position, lineWidth, feather
 	// Shift line coordinates so that they match the target position.
 	xPosDiff := pos.X - fyne.Min(pos1.X, pos2.X)
 	yPosDiff := pos.Y - fyne.Min(pos1.Y, pos2.Y)
-	pos1.X += xPosDiff
-	pos1.Y += yPosDiff
-	pos2.X += xPosDiff
-	pos2.Y += yPosDiff
-	pos1 = fyne.Position{roundToPixel(pos1.X, p.pixScale), roundToPixel(pos1.Y, p.pixScale)}
-	pos2 = fyne.Position{roundToPixel(pos2.X, p.pixScale), roundToPixel(pos2.Y, p.pixScale)}
+	pos1.X = roundToPixel(pos1.X+xPosDiff, p.pixScale)
+	pos1.Y = roundToPixel(pos1.Y+yPosDiff, p.pixScale)
+	pos2.X = roundToPixel(pos2.X+xPosDiff, p.pixScale)
+	pos2.Y = roundToPixel(pos2.Y+yPosDiff, p.pixScale)
 
 	x1Pos := pos1.X / frame.Width
 	x1 := -1 + x1Pos*2
@@ -133,7 +131,7 @@ func (p *glPainter) lineCoords(pos, pos1, pos2 fyne.Position, lineWidth, feather
 	normalObjX := normalX * 0.5 * frame.Width
 	normalObjY := normalY * 0.5 * frame.Height
 	widthMultiplier := float32(math.Sqrt(float64(normalObjX*normalObjX + normalObjY*normalObjY)))
-	halfWidth := lineWidth * 0.5 / widthMultiplier
+	halfWidth := (lineWidth * 0.5 + feather) / widthMultiplier
 	featherWidth := feather / widthMultiplier
 
 	return []float32{

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -36,8 +36,10 @@ func (p *glPainter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame f
 }
 
 func (p *glPainter) drawLine(line *canvas.Line, pos fyne.Position, frame fyne.Size) {
-	p.drawTextureWithDetails(line, p.newGlLineTexture, pos, line.Size(), frame, canvas.ImageFillStretch,
-		1.0, painter.VectorPad(line))
+	points, halfWidth, feather := p.lineCoords(pos, line.Position1, line.Position2, line.StrokeWidth, 0.5, frame)
+	vbo := p.glCreateLineBuffer(points)
+	p.glDrawLine(halfWidth, line.StrokeColor, feather)
+	p.glFreeBuffer(vbo)
 }
 
 func (p *glPainter) drawImage(img *canvas.Image, pos fyne.Position, frame fyne.Size) {
@@ -100,6 +102,49 @@ func (p *glPainter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyn
 	case *canvas.RadialGradient:
 		p.drawGradient(obj, p.newGlRadialGradientTexture, pos, frame)
 	}
+}
+
+func (p *glPainter) lineCoords(pos, pos1, pos2 fyne.Position, lineWidth, feather float32, frame fyne.Size) ([]float32, float32, float32) {
+	// Shift line coordinates so that they match the target position.
+	xPosDiff := pos.X - fyne.Min(pos1.X, pos2.X)
+	yPosDiff := pos.Y - fyne.Min(pos1.Y, pos2.Y)
+	pos1.X += xPosDiff
+	pos1.Y += yPosDiff
+	pos2.X += xPosDiff
+	pos2.Y += yPosDiff
+	pos1 = fyne.Position{roundToPixel(pos1.X, p.pixScale), roundToPixel(pos1.Y, p.pixScale)}
+	pos2 = fyne.Position{roundToPixel(pos2.X, p.pixScale), roundToPixel(pos2.Y, p.pixScale)}
+
+	x1Pos := pos1.X / frame.Width
+	x1 := -1 + x1Pos*2
+	y1Pos := pos1.Y / frame.Height
+	y1 := 1 - y1Pos*2
+	x2Pos := pos2.X / frame.Width
+	x2 := -1 + x2Pos*2
+	y2Pos := pos2.Y / frame.Height
+	y2 := 1 - y2Pos*2
+
+	normalX := (pos2.Y - pos1.Y) / frame.Width
+	normalY := (pos2.X - pos1.X) / frame.Height
+	dirLength := float32(math.Sqrt(float64(normalX*normalX + normalY*normalY)))
+	normalX /= dirLength
+	normalY /= dirLength
+
+	normalObjX := normalX * 0.5 * frame.Width
+	normalObjY := normalY * 0.5 * frame.Height
+	widthMultiplier := float32(math.Sqrt(float64(normalObjX*normalObjX + normalObjY*normalObjY)))
+	halfWidth := lineWidth * 0.5 / widthMultiplier
+	featherWidth := feather / widthMultiplier
+
+	return []float32{
+		// coord x, y normal x, y
+		x1, y1, normalX, normalY,
+		x2, y2, normalX, normalY,
+		x2, y2, -normalX, -normalY,
+		x2, y2, -normalX, -normalY,
+		x1, y1, normalX, normalY,
+		x1, y1, -normalX, -normalY,
+	}, halfWidth, featherWidth
 }
 
 // rectCoords calculates the openGL coordinate space of a rectangle

--- a/internal/painter/gl/gl_common.go
+++ b/internal/painter/gl/gl_common.go
@@ -45,13 +45,6 @@ func (p *glPainter) newGlCircleTexture(obj fyne.CanvasObject) Texture {
 	return p.imgToTexture(raw, canvas.ImageScaleSmooth)
 }
 
-func (p *glPainter) newGlLineTexture(obj fyne.CanvasObject) Texture {
-	line := obj.(*canvas.Line)
-	raw := painter.DrawLine(line, painter.VectorPad(line), p.textureScale)
-
-	return p.imgToTexture(raw, canvas.ImageScaleSmooth)
-}
-
 func (p *glPainter) newGlRectTexture(obj fyne.CanvasObject) Texture {
 	rect := obj.(*canvas.Rectangle)
 	if rect.StrokeColor != nil && rect.StrokeWidth > 0 {

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -5,6 +5,7 @@ package gl
 import (
 	"fmt"
 	"image"
+	"image/color"
 	"image/draw"
 	"strings"
 
@@ -157,6 +158,42 @@ const (
         gl_FragColor = texture2D(tex, fragTexCoord);
     }
 ` + "\x00"
+
+	vertexLineShaderSource = `
+    #version 110
+    attribute vec2 vert;
+    attribute vec2 normal;
+    
+    uniform float lineWidth;
+
+    varying vec2 delta;
+
+    void main() {
+        delta = normal * lineWidth;
+
+        gl_Position = vec4(vert + delta, 0, 1);
+    }
+` + "\x00"
+
+	fragmentLineShaderSource = `
+    #version 110
+    uniform vec4 color;
+    uniform float lineWidth;
+    uniform float feather;
+
+    varying vec2 delta;
+
+    void main() {
+        float alpha = color.a;
+        float distance = length(delta);
+
+        if (feather == 0.0 || distance <= lineWidth - feather) {
+           gl_FragColor = color;
+        } else {
+           gl_FragColor = vec4(color.r, color.g, color.b, mix(color.a, 0.0, (distance - (lineWidth - feather)) / feather));
+        }
+    }
+` + "\x00"
 )
 
 func (p *glPainter) Init() {
@@ -176,6 +213,23 @@ func (p *glPainter) Init() {
 	logError()
 
 	p.program = Program(prog)
+
+	vertexLineShader, err := compileShader(vertexLineShaderSource, gl.VERTEX_SHADER)
+	if err != nil {
+		panic(err)
+	}
+	fragmentLineShader, err := compileShader(fragmentLineShaderSource, gl.FRAGMENT_SHADER)
+	if err != nil {
+		panic(err)
+	}
+
+	lineProg := gl.CreateProgram()
+	gl.AttachShader(lineProg, vertexLineShader)
+	gl.AttachShader(lineProg, fragmentLineShader)
+	gl.LinkProgram(lineProg)
+	logError()
+
+	p.lineProgram = Program(lineProg)
 }
 
 func (p *glPainter) glClearBuffer() {
@@ -201,6 +255,8 @@ func (p *glPainter) glScissorClose() {
 }
 
 func (p *glPainter) glCreateBuffer(points []float32) Buffer {
+	gl.UseProgram(uint32(p.program))
+
 	var vbo uint32
 	gl.GenBuffers(1, &vbo)
 	logError()
@@ -222,6 +278,30 @@ func (p *glPainter) glCreateBuffer(points []float32) Buffer {
 	return Buffer(vbo)
 }
 
+func (p *glPainter) glCreateLineBuffer(points []float32) Buffer {
+	gl.UseProgram(uint32(p.lineProgram))
+
+	var vbo uint32
+	gl.GenBuffers(1, &vbo)
+	logError()
+	gl.BindBuffer(gl.ARRAY_BUFFER, vbo)
+	logError()
+	gl.BufferData(gl.ARRAY_BUFFER, 4*len(points), gl.Ptr(points), gl.STATIC_DRAW)
+	logError()
+
+	vertAttrib := uint32(gl.GetAttribLocation(uint32(p.lineProgram), gl.Str("vert\x00")))
+	gl.EnableVertexAttribArray(vertAttrib)
+	gl.VertexAttribPointer(vertAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(0))
+	logError()
+
+	normalAttrib := uint32(gl.GetAttribLocation(uint32(p.lineProgram), gl.Str("normal\x00")))
+	gl.EnableVertexAttribArray(normalAttrib)
+	gl.VertexAttribPointer(normalAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
+	logError()
+
+	return Buffer(vbo)
+}
+
 func (p *glPainter) glFreeBuffer(vbo Buffer) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 	logError()
@@ -231,6 +311,8 @@ func (p *glPainter) glFreeBuffer(vbo Buffer) {
 }
 
 func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
+	gl.UseProgram(uint32(p.program))
+
 	// here we have to choose between blending the image alpha or fading it...
 	// TODO find a way to support both
 	if alpha != 1.0 {
@@ -246,6 +328,35 @@ func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
 	logError()
 
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
+	logError()
+}
+
+func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) {
+	gl.UseProgram(uint32(p.lineProgram))
+
+	r, g, b, a := col.RGBA()
+	if a != 0xffff {
+		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+	} else {
+		gl.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+	}
+	logError()
+
+	colorUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("color\x00"))
+	if a == 0 {
+		gl.Uniform4f(colorUniform, 0, 0, 0, 0)
+	} else {
+		alpha := float32(a)
+		col := []float32{float32(r) / alpha, float32(g) / alpha, float32(b) / alpha, alpha / 0xffff}
+		gl.Uniform4fv(colorUniform, 1, &col[0])
+	}
+	lineWidthUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("lineWidth\x00"))
+	gl.Uniform1f(lineWidthUniform, width)
+
+	featherUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("feather\x00"))
+	gl.Uniform1f(featherUniform, feather)
+
+	gl.DrawArrays(gl.TRIANGLES, 0, 6)
 	logError()
 }
 

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -334,15 +334,11 @@ func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
 func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) {
 	gl.UseProgram(uint32(p.lineProgram))
 
-	r, g, b, a := col.RGBA()
-	if a != 0xffff {
-		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
-	} else {
-		gl.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
-	}
+	gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
 	logError()
 
 	colorUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("color\x00"))
+	r, g, b, a := col.RGBA()
 	if a == 0 {
 		gl.Uniform4f(colorUniform, 0, 0, 0, 0)
 	} else {
@@ -355,6 +351,7 @@ func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) 
 
 	featherUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("feather\x00"))
 	gl.Uniform1f(featherUniform, feather)
+	logError()
 
 	gl.DrawArrays(gl.TRIANGLES, 0, 6)
 	logError()

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -7,6 +7,7 @@ package gl
 import (
 	"fmt"
 	"image"
+	"image/color"
 	"image/draw"
 	"strings"
 
@@ -159,6 +160,42 @@ const (
         gl_FragColor = texture2D(tex, fragTexCoord);
     }
 ` + "\x00"
+
+	vertexLineShaderSource = `
+    #version 100
+    attribute vec2 vert;
+    attribute vec2 normal;
+    
+    uniform float lineWidth;
+
+    varying highp vec2 delta;
+
+    void main() {
+        delta = normal * lineWidth;
+
+        gl_Position = vec4(vert + delta, 0, 1);
+    }
+` + "\x00"
+
+	fragmentLineShaderSource = `
+    #version 100
+    uniform highp vec4 color;
+    uniform highp float lineWidth;
+    uniform highp float feather;
+
+    varying highp vec2 delta;
+
+    void main() {
+        highp float alpha = color.a;
+        highp float distance = length(delta);
+
+        if (feather == 0.0 || distance <= lineWidth - feather) {
+           gl_FragColor = color;
+        } else {
+           gl_FragColor = vec4(color.r, color.g, color.b, mix(color.a, 0.0, (distance - (lineWidth - feather)) / feather));
+        }
+    }
+` + "\x00"
 )
 
 func (p *glPainter) Init() {
@@ -178,6 +215,23 @@ func (p *glPainter) Init() {
 	logError()
 
 	p.program = Program(prog)
+
+	vertexLineShader, err := compileShader(vertexLineShaderSource, gl.VERTEX_SHADER)
+	if err != nil {
+		panic(err)
+	}
+	fragmentLineShader, err := compileShader(fragmentLineShaderSource, gl.FRAGMENT_SHADER)
+	if err != nil {
+		panic(err)
+	}
+
+	lineProg := gl.CreateProgram()
+	gl.AttachShader(lineProg, vertexLineShader)
+	gl.AttachShader(lineProg, fragmentLineShader)
+	gl.LinkProgram(lineProg)
+	logError()
+
+	p.lineProgram = Program(lineProg)
 }
 
 func (p *glPainter) glClearBuffer() {
@@ -203,6 +257,8 @@ func (p *glPainter) glScissorClose() {
 }
 
 func (p *glPainter) glCreateBuffer(points []float32) Buffer {
+	gl.UseProgram(uint32(p.program))
+
 	var vbo uint32
 	gl.GenBuffers(1, &vbo)
 	logError()
@@ -224,6 +280,30 @@ func (p *glPainter) glCreateBuffer(points []float32) Buffer {
 	return Buffer(vbo)
 }
 
+func (p *glPainter) glCreateLineBuffer(points []float32) Buffer {
+	gl.UseProgram(uint32(p.lineProgram))
+
+	var vbo uint32
+	gl.GenBuffers(1, &vbo)
+	logError()
+	gl.BindBuffer(gl.ARRAY_BUFFER, vbo)
+	logError()
+	gl.BufferData(gl.ARRAY_BUFFER, 4*len(points), gl.Ptr(points), gl.STATIC_DRAW)
+	logError()
+
+	vertAttrib := uint32(gl.GetAttribLocation(uint32(p.lineProgram), gl.Str("vert\x00")))
+	gl.EnableVertexAttribArray(vertAttrib)
+	gl.VertexAttribPointer(vertAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(0))
+	logError()
+
+	normalAttrib := uint32(gl.GetAttribLocation(uint32(p.lineProgram), gl.Str("normal\x00")))
+	gl.EnableVertexAttribArray(normalAttrib)
+	gl.VertexAttribPointer(normalAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
+	logError()
+
+	return Buffer(vbo)
+}
+
 func (p *glPainter) glFreeBuffer(vbo Buffer) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 	logError()
@@ -233,6 +313,8 @@ func (p *glPainter) glFreeBuffer(vbo Buffer) {
 }
 
 func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
+	gl.UseProgram(uint32(p.program))
+
 	// here we have to choose between blending the image alpha or fading it...
 	// TODO find a way to support both
 	if alpha != 1.0 {
@@ -248,6 +330,35 @@ func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
 	logError()
 
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
+	logError()
+}
+
+func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) {
+	gl.UseProgram(uint32(p.lineProgram))
+
+	r, g, b, a := col.RGBA()
+	if a != 0xffff {
+		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+	} else {
+		gl.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+	}
+	logError()
+
+	colorUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("color\x00"))
+	if a == 0 {
+		gl.Uniform4f(colorUniform, 0, 0, 0, 0)
+	} else {
+		alpha := float32(a)
+		col := []float32{float32(r) / alpha, float32(g) / alpha, float32(b) / alpha, alpha / 0xffff}
+		gl.Uniform4fv(colorUniform, 1, &col[0])
+	}
+	lineWidthUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("lineWidth\x00"))
+	gl.Uniform1f(lineWidthUniform, width)
+
+	featherUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("feather\x00"))
+	gl.Uniform1f(featherUniform, feather)
+
+	gl.DrawArrays(gl.TRIANGLES, 0, 6)
 	logError()
 }
 

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -336,15 +336,11 @@ func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
 func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) {
 	gl.UseProgram(uint32(p.lineProgram))
 
-	r, g, b, a := col.RGBA()
-	if a != 0xffff {
-		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
-	} else {
-		gl.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
-	}
+	gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
 	logError()
 
 	colorUniform := gl.GetUniformLocation(uint32(p.lineProgram), gl.Str("color\x00"))
+	r, g, b, a := col.RGBA()
 	if a == 0 {
 		gl.Uniform4f(colorUniform, 0, 0, 0, 0)
 	} else {

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"image"
+	"image/color"
 	"image/draw"
 
 	"github.com/fyne-io/mobile/exp/f32"
@@ -147,6 +148,40 @@ const (
     void main() {
         gl_FragColor = texture2D(tex, fragTexCoord);
     }`
+
+	vertexLineShaderSource = `
+    #version 100
+    attribute vec2 vert;
+    attribute vec2 normal;
+    
+    uniform float lineWidth;
+
+    varying highp vec2 delta;
+
+    void main() {
+        delta = normal * lineWidth;
+
+        gl_Position = vec4(vert + delta, 0, 1);
+    }`
+
+	fragmentLineShaderSource = `
+    #version 100
+    uniform vec4 color;
+    uniform float lineWidth;
+    uniform float feather;
+
+    varying highp vec2 delta;
+
+    void main() {
+        float alpha = color.a;
+        float distance = length(delta);
+
+        if (feather == 0.0 || distance <= lineWidth - feather) {
+           gl_FragColor = color;
+        } else {
+           gl_FragColor = vec4(color.r, color.g, color.b, mix(color.a, 0.0, (distance - (lineWidth - feather)) / feather));
+        }
+    }`
 )
 
 func (p *glPainter) Init() {
@@ -169,7 +204,24 @@ func (p *glPainter) Init() {
 	p.logError()
 
 	p.program = Program(prog)
-	p.glctx().UseProgram(gl.Program(p.program))
+	p.logError()
+
+	vertexLineShader, err := p.compileShader(vertexLineShaderSource, gl.VERTEX_SHADER)
+	if err != nil {
+		panic(err)
+	}
+	fragmentLineShader, err := p.compileShader(fragmentLineShaderSource, gl.FRAGMENT_SHADER)
+	if err != nil {
+		panic(err)
+	}
+
+	lineProg := p.glctx().CreateProgram()
+	p.glctx().AttachShader(lineProg, vertexLineShader)
+	p.glctx().AttachShader(lineProg, fragmentLineShader)
+	p.glctx().LinkProgram(lineProg)
+	p.logError()
+
+	p.lineProgram = Program(lineProg)
 	p.logError()
 }
 
@@ -195,6 +247,8 @@ func (p *glPainter) glScissorClose() {
 func (p *glPainter) glCreateBuffer(points []float32) Buffer {
 	ctx := p.glctx()
 
+	p.glctx().UseProgram(gl.Program(p.program))
+
 	buf := ctx.CreateBuffer()
 	p.logError()
 	ctx.BindBuffer(gl.ARRAY_BUFFER, buf)
@@ -215,6 +269,31 @@ func (p *glPainter) glCreateBuffer(points []float32) Buffer {
 	return Buffer(buf)
 }
 
+func (p *glPainter) glCreateLineBuffer(points []float32) Buffer {
+	ctx := p.glctx()
+
+	p.glctx().UseProgram(gl.Program(p.lineProgram))
+
+	buf := ctx.CreateBuffer()
+	p.logError()
+	ctx.BindBuffer(gl.ARRAY_BUFFER, buf)
+	p.logError()
+	ctx.BufferData(gl.ARRAY_BUFFER, f32.Bytes(binary.LittleEndian, points...), gl.DYNAMIC_DRAW)
+	p.logError()
+
+	vertAttrib := ctx.GetAttribLocation(gl.Program(p.lineProgram), "vert")
+	ctx.EnableVertexAttribArray(vertAttrib)
+	ctx.VertexAttribPointer(vertAttrib, 2, gl.FLOAT, false, 4*4, 0)
+	p.logError()
+
+	normalAttrib := ctx.GetAttribLocation(gl.Program(p.lineProgram), "normal")
+	ctx.EnableVertexAttribArray(normalAttrib)
+	ctx.VertexAttribPointer(normalAttrib, 2, gl.FLOAT, false, 4*4, 2*4)
+	p.logError()
+
+	return Buffer(buf)
+}
+
 func (p *glPainter) glFreeBuffer(b Buffer) {
 	ctx := p.glctx()
 
@@ -226,6 +305,8 @@ func (p *glPainter) glFreeBuffer(b Buffer) {
 
 func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
 	ctx := p.glctx()
+
+	p.glctx().UseProgram(gl.Program(p.program))
 
 	// here we have to choose between blending the image alpha or fading it...
 	// TODO find a way to support both
@@ -242,6 +323,37 @@ func (p *glPainter) glDrawTexture(texture Texture, alpha float32) {
 	p.logError()
 
 	ctx.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
+	p.logError()
+}
+
+func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) {
+	ctx := p.glctx()
+
+	p.glctx().UseProgram(gl.Program(p.lineProgram))
+
+	r, g, b, a := col.RGBA()
+	if a != 0xffff {
+		ctx.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
+	} else {
+		ctx.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+	}
+	p.logError()
+
+	colorUniform := ctx.GetUniformLocation(gl.Program(p.lineProgram), "color")
+	if a == 0 {
+		ctx.Uniform4f(colorUniform, 0, 0, 0, 0)
+	} else {
+		alpha := float32(a)
+		col := []float32{float32(r) / alpha, float32(g) / alpha, float32(b) / alpha, alpha / 0xffff}
+		ctx.Uniform4fv(colorUniform, col)
+	}
+	lineWidthUniform := ctx.GetUniformLocation(gl.Program(p.lineProgram), "lineWidth")
+	ctx.Uniform1f(lineWidthUniform, width)
+
+	featherUniform := ctx.GetUniformLocation(gl.Program(p.lineProgram), "feather")
+	ctx.Uniform1f(featherUniform, feather)
+
+	ctx.DrawArrays(gl.TRIANGLES, 0, 6)
 	p.logError()
 }
 

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -331,15 +331,11 @@ func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) 
 
 	p.glctx().UseProgram(gl.Program(p.lineProgram))
 
-	r, g, b, a := col.RGBA()
-	if a != 0xffff {
-		ctx.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
-	} else {
-		ctx.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
-	}
+	ctx.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
 	p.logError()
 
 	colorUniform := ctx.GetUniformLocation(gl.Program(p.lineProgram), "color")
+	r, g, b, a := col.RGBA()
 	if a == 0 {
 		ctx.Uniform4f(colorUniform, 0, 0, 0, 0)
 	} else {

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -166,15 +166,15 @@ const (
 
 	fragmentLineShaderSource = `
     #version 100
-    uniform vec4 color;
-    uniform float lineWidth;
-    uniform float feather;
+    uniform highp vec4 color;
+    uniform highp float lineWidth;
+    uniform highp float feather;
 
     varying highp vec2 delta;
 
     void main() {
-        float alpha = color.a;
-        float distance = length(delta);
+        highp float alpha = color.a;
+        highp float distance = length(delta);
 
         if (feather == 0.0 || distance <= lineWidth - feather) {
            gl_FragColor = color;

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -35,11 +35,12 @@ type Painter interface {
 var _ Painter = (*glPainter)(nil)
 
 type glPainter struct {
-	canvas   fyne.Canvas
-	context  driver.WithContext
-	program  Program
-	texScale float32
-	pixScale float32 // pre-calculate scale*texScale for each draw
+	canvas      fyne.Canvas
+	context     driver.WithContext
+	program     Program
+	lineProgram Program
+	texScale    float32
+	pixScale    float32 // pre-calculate scale*texScale for each draw
 }
 
 func (p *glPainter) SetFrameBufferScale(scale float32) {


### PR DESCRIPTION
### Description:
Currently lines are drawn on canvas by first rasterizing them onto a texture and then painting the texture on the canvas.
This in some cases may require prohibitive amount of GPU memory.
My motivating use case was displaying a drawing consisting of hundreds of lines where user may zoom in into an arbitrary part of the drawing and drag it around the screen. Without this change the app was crashing running out of memory (and trying to recreate line textures with only parts that are visible was too slow and making dragging operation very choppy).

 
Updates #563

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
