### PR TITLE
Update staticcheck to 0.1.4 for CI

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -16,7 +16,7 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
         go install golang.org/x/lint/golint@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.1.3
+        go install honnef.co/go/tools/cmd/staticcheck@v0.1.4
 
     - name: Cleanup repository
       run: rm -rf vendor/


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Changelog can be found below:
- A false positive in S1017 when the len function has been shadowed
- A bug in Staticcheck's intermediate representation that would lead to nonsensical reports claiming that a value isn't being used when it is definitely being used (see issues [949](https://github.com/dominikh/go-tools/issues/949) and [981](https://github.com/dominikh/go-tools/issues/981) for more information)
- A rare crash (see issue [972](https://github.com/dominikh/go-tools/issues/972) for more information)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
