### PR TITLE
fix #2229

### DIFF
--- a/container/tabs.go
+++ b/container/tabs.go
@@ -324,11 +324,12 @@ func (r *baseTabsRenderer) moveIndicator(pos fyne.Position, siz fyne.Size, anima
 		return
 	}
 
+	r.lastIndicatorMutex.Lock()
+	r.lastIndicatorPos = pos
+	r.lastIndicatorSize = siz
+	r.lastIndicatorMutex.Unlock()
+
 	if animate {
-		r.lastIndicatorMutex.Lock()
-		r.lastIndicatorPos = pos
-		r.lastIndicatorSize = siz
-		r.lastIndicatorMutex.Unlock()
 		r.positionAnimation = canvas.NewPositionAnimation(r.indicator.Position(), pos, canvas.DurationShort, func(p fyne.Position) {
 			r.indicator.Move(p)
 			r.indicator.Refresh()


### PR DESCRIPTION
### Description:
When moving an indicator, it's current (before making the move) positions and size are not being saved in the fields: `lastIndicatorPos` and `lastIndicatorSize` in case no animation is requested: (animate = false)
`moveIndicator(pos fyne.Position, siz fyne.Size, animate bool)`

Fixes #2229

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [X] Tests all pass.
