### PR TITLE
Fix line move / resize when rotated

### DIFF
--- a/canvas/line.go
+++ b/canvas/line.go
@@ -45,9 +45,12 @@ func (l *Line) Position() fyne.Position {
 
 // Move the line object to a new position, relative to its parent / canvas
 func (l *Line) Move(pos fyne.Position) {
-	size := l.Size()
-	l.Position1 = pos
-	l.Position2 = fyne.NewPos(l.Position1.X+size.Width, l.Position1.Y+size.Height)
+	oldPos := l.Position()
+	deltaX := pos.X - oldPos.X
+	deltaY := pos.Y - oldPos.Y
+
+	l.Position1 = l.Position1.Add(fyne.NewPos(deltaX, deltaY))
+	l.Position2 = l.Position2.Add(fyne.NewPos(deltaX, deltaY))
 }
 
 // MinSize for a Line simply returns Size{1, 1} as there is no

--- a/canvas/line.go
+++ b/canvas/line.go
@@ -34,7 +34,16 @@ func (l *Line) Resize(size fyne.Size) {
 		return
 	}
 
-	l.Position2 = fyne.NewPos(l.Position1.X+size.Width, l.Position1.Y+size.Height)
+	if l.Position1.X <= l.Position2.X {
+		l.Position2.X = l.Position1.X + size.Width
+	} else {
+		l.Position1.X = l.Position2.X + size.Width
+	}
+	if l.Position1.Y <= l.Position2.Y {
+		l.Position2.Y = l.Position1.Y + size.Height
+	} else {
+		l.Position1.Y = l.Position2.Y + size.Height
+	}
 	Refresh(l)
 }
 

--- a/canvas/line_test.go
+++ b/canvas/line_test.go
@@ -45,6 +45,13 @@ func TestLine_Resize(t *testing.T) {
 
 	assert.Equal(t, float32(10), size.Width)
 	assert.Equal(t, float32(0), size.Height)
+
+	// rotate
+	line.Position1 = fyne.NewPos(0, 10)
+	line.Position2 = fyne.NewPos(10, 0)
+	line.Resize(fyne.NewSize(20, 20))
+	assert.Equal(t, fyne.NewPos(0, 20), line.Position1)
+	assert.Equal(t, fyne.NewPos(20, 0), line.Position2)
 }
 
 func TestLine_StrokeColor(t *testing.T) {

--- a/canvas/line_test.go
+++ b/canvas/line_test.go
@@ -18,6 +18,25 @@ func TestLine_MinSize(t *testing.T) {
 	assert.True(t, min.Height > 0)
 }
 
+func TestLine_Move(t *testing.T) {
+	line := canvas.NewLine(color.Black)
+
+	line.Resize(fyne.NewSize(10, 10))
+	assert.Equal(t, fyne.NewPos(0, 0), line.Position1)
+	assert.Equal(t, fyne.NewPos(10, 10), line.Position2)
+
+	line.Move(fyne.NewPos(5, 5))
+	assert.Equal(t, fyne.NewPos(5, 5), line.Position1)
+	assert.Equal(t, fyne.NewPos(15, 15), line.Position2)
+
+	// rotate
+	line.Position1 = fyne.NewPos(0, 10)
+	line.Position2 = fyne.NewPos(10, 0)
+	line.Move(fyne.NewPos(10, 10))
+	assert.Equal(t, fyne.NewPos(10, 20), line.Position1)
+	assert.Equal(t, fyne.NewPos(20, 10), line.Position2)
+}
+
 func TestLine_Resize(t *testing.T) {
 	line := canvas.NewLine(color.Black)
 


### PR DESCRIPTION
### Description:
Fixes an issue when lines that were positive slope would flip back on move or resize

Fixes #2208

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

