### PR TITLE
Wait for goroutines to finish when firing a change to an app preferences 

### DIFF
--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -23,10 +23,7 @@ func (p *InMemoryPreferences) AddChangeListener(listener func()) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.changeListeners = append(p.changeListeners, func() {
-		defer p.wg.Done()
-		listener()
-	})
+	p.changeListeners = append(p.changeListeners, listener)
 }
 
 // ReadValues provides read access to the underlying value map - for internal use only...
@@ -77,7 +74,10 @@ func (p *InMemoryPreferences) fireChange() {
 
 	for _, l := range p.changeListeners {
 		p.wg.Add(1)
-		go l()
+		go func() {
+			defer p.wg.Done()
+			l()
+		}()
 	}
 
 	p.wg.Wait()

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -11,7 +11,7 @@ type InMemoryPreferences struct {
 	values          map[string]interface{}
 	lock            sync.RWMutex
 	changeListeners []func()
-	waitGroup       *sync.WaitGroup
+	wg              *sync.WaitGroup
 }
 
 // Declare conformity with Preferences interface
@@ -24,7 +24,7 @@ func (p *InMemoryPreferences) AddChangeListener(listener func()) {
 	defer p.lock.Unlock()
 
 	p.changeListeners = append(p.changeListeners, func() {
-		defer p.waitGroup.Done()
+		defer p.wg.Done()
 		listener()
 	})
 }
@@ -76,11 +76,11 @@ func (p *InMemoryPreferences) fireChange() {
 	defer p.lock.RUnlock()
 
 	for _, l := range p.changeListeners {
-		p.waitGroup.Add(1)
+		p.wg.Add(1)
 		go l()
 	}
 
-	p.waitGroup.Wait()
+	p.wg.Wait()
 }
 
 // Bool looks up a boolean value for the key
@@ -187,7 +187,7 @@ func (p *InMemoryPreferences) RemoveValue(key string) {
 // NewInMemoryPreferences creates a new preferences implementation stored in memory
 func NewInMemoryPreferences() *InMemoryPreferences {
 	return &InMemoryPreferences{
-		values:    make(map[string]interface{}),
-		waitGroup: &sync.WaitGroup{},
+		values: make(map[string]interface{}),
+		wg:     &sync.WaitGroup{},
 	}
 }

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -186,8 +186,9 @@ func (p *InMemoryPreferences) RemoveValue(key string) {
 
 // NewInMemoryPreferences creates a new preferences implementation stored in memory
 func NewInMemoryPreferences() *InMemoryPreferences {
-	p := &InMemoryPreferences{}
-	p.values = make(map[string]interface{})
-	p.waitGroup = &sync.WaitGroup{}
+	p := &InMemoryPreferences{
+		values: make(map[string]interface{}),
+		waitGroup: &sync.WaitGroup{},
+	}
 	return p
 }

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -74,10 +74,10 @@ func (p *InMemoryPreferences) fireChange() {
 
 	for _, l := range p.changeListeners {
 		p.wg.Add(1)
-		go func() {
+		go func(listener func()) {
 			defer p.wg.Done()
-			l()
-		}()
+			listener()
+		}(l)
 	}
 
 	p.wg.Wait()

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -18,7 +18,7 @@ type InMemoryPreferences struct {
 var _ fyne.Preferences = (*InMemoryPreferences)(nil)
 
 // AddChangeListener allows code to be notified when some preferences change. This will fire on any update.
-// listener should not try to write values
+// The passed 'listener' should not try to write values.
 func (p *InMemoryPreferences) AddChangeListener(listener func()) {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -186,9 +186,8 @@ func (p *InMemoryPreferences) RemoveValue(key string) {
 
 // NewInMemoryPreferences creates a new preferences implementation stored in memory
 func NewInMemoryPreferences() *InMemoryPreferences {
-	p := &InMemoryPreferences{
-		values: make(map[string]interface{}),
+	return &InMemoryPreferences{
+		values:    make(map[string]interface{}),
 		waitGroup: &sync.WaitGroup{},
 	}
-	return p
 }


### PR DESCRIPTION
### Description:
Mainly there was two problems:
- the first and probably the main bug is that sometimes the app closes too early without waiting for the goroutines that were called in [fireChange()](https://github.com/fyne-io/fyne/blob/3814a66f75ff5d24be6fa107f1dfb9c4faa859b1/internal/preferences.go#L69) and one of those goroutines is the one that calls [save()](https://github.com/fyne-io/fyne/blob/3814a66f75ff5d24be6fa107f1dfb9c4faa859b1/app/preferences.go#L35) an easy fix was to implement the sync.WaitGroup functionality which i expected to work just fine, yet it didn't due to
- the second issue which was a misuse of the lockers, in lines [70 and 71](https://github.com/fyne-io/fyne/blob/3814a66f75ff5d24be6fa107f1dfb9c4faa859b1/internal/preferences.go#L70-L71) are using Lock() and after that there are goroutines that are expected to read the same struct, well they won't be able to because Lock() only allows one goroutine (read/write) at a time and in fact the goroutines functions that were thought are being executed were actually not, they were just in stuck position waiting for the fireChange() to return (and to trigger it's defer function to Unlock()) so all those go l() were only waiting for fireChange() to return then get executed, well after the fix (1) the function will never return because it's waiting for the goroutines functions which will never work either because they are waiting for fireChange() ,,, deadlock ; the fix was pretty clear is to use RLock() instead of Lock() that way, where multiple goroutines can read(but not write) the struct and the fireChange() will only returns after all the goroutines are done and only after that the app will close



Fixes #2241

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [X] Tests all pass. (except  TestFileIcon(?))
