### PR TITLE
Refresh entry placeHolder by setting entry.PlaceHolder field and calling entry.Refresh

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1406,6 +1406,7 @@ func (r *entryContentRenderer) Refresh() {
 	r.content.entry.propertyLock.RLock()
 	provider := r.content.entry.textProvider()
 	placeholder := r.content.entry.placeholderProvider()
+	placeholderText := r.content.entry.PlaceHolder
 	content := r.content.entry.Text
 	focusedAppearance := r.content.entry.focused && !r.content.entry.disabled
 	selections := r.selection
@@ -1414,6 +1415,10 @@ func (r *entryContentRenderer) Refresh() {
 
 	if content != string(provider.buffer) {
 		return
+	}
+
+	if placeholderText != string(placeholder.buffer) {
+		placeholder.setText(placeholderText)
 	}
 
 	if provider.len() == 0 {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1162,6 +1162,23 @@ func TestEntry_SetPlaceHolder(t *testing.T) {
 	test.AssertRendersToMarkup(t, "entry/set_placeholder_replaced.xml", c)
 }
 
+func TestEntry_SetPlaceHolder_ByField(t *testing.T) {
+	entry, window := setupImageTest(t, false)
+	defer teardownImageTest(window)
+	c := window.Canvas()
+
+	assert.Equal(t, 0, len(entry.Text))
+
+	entry.PlaceHolder = "Test"
+	entry.Refresh()
+	assert.Equal(t, 0, len(entry.Text))
+	test.AssertRendersToMarkup(t, "entry/set_placeholder_set.xml", c)
+
+	entry.SetText("Hi")
+	assert.Equal(t, 2, len(entry.Text))
+	test.AssertRendersToMarkup(t, "entry/set_placeholder_replaced.xml", c)
+}
+
 func TestEntry_Disable_KeyDown(t *testing.T) {
 	entry := widget.NewEntry()
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Refresh entry placeHolder by setting entry.PlaceHolder field and calling entry.Refresh.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.