### PR TITLE
Fixed: Tapped being triggered after Drag

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -820,7 +820,7 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 			w.mouseLock.Unlock()
 		} else if action == glfw.Release {
 			if co == mousePressed {
-				if button == desktop.MouseButtonSecondary && altTap {
+				if button == desktop.MouseButtonSecondary && altTap && !mouseDragStarted {
 					w.QueueEvent(func() { co.(fyne.SecondaryTappable).TappedSecondary(ev) })
 				}
 			}
@@ -828,7 +828,7 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 	}
 
 	// Check for double click/tap on left mouse button
-	if action == glfw.Release && button == desktop.MouseButtonPrimary {
+	if action == glfw.Release && button == desktop.MouseButtonPrimary && !mouseDragStarted {
 		w.mouseClickedHandleTapDoubleTap(co, ev)
 	}
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -628,7 +628,7 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 		}
 	}
 
-	if mouseButton != 0 && !mouseDragStarted {
+	if mouseButton != 0 && mouseButton != desktop.MouseButtonSecondary && !mouseDragStarted {
 		obj, pos, _ := w.findObjectAtPositionMatching(w.canvas, previousPos, func(object fyne.CanvasObject) bool {
 			_, ok := object.(fyne.Draggable)
 			return ok
@@ -687,7 +687,7 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 	mouseDraggedOffset := w.mouseDraggedOffset
 	mouseDragPos := w.mouseDragPos
 	w.mouseLock.RUnlock()
-	if mouseDragged != nil && mouseButton > 0 {
+	if mouseDragged != nil && mouseButton > 0 && mouseButton != desktop.MouseButtonSecondary {
 		draggedObjDelta := mouseDraggedObjStart.Subtract(mouseDragged.(fyne.CanvasObject).Position())
 		ev := new(fyne.DragEvent)
 		ev.AbsolutePosition = mousePos

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -820,7 +820,7 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 			w.mouseLock.Unlock()
 		} else if action == glfw.Release {
 			if co == mousePressed {
-				if button == desktop.MouseButtonSecondary && altTap && !mouseDragStarted {
+				if button == desktop.MouseButtonSecondary && altTap {
 					w.QueueEvent(func() { co.(fyne.SecondaryTappable).TappedSecondary(ev) })
 				}
 			}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -325,6 +325,30 @@ func TestWindow_HandleDragging(t *testing.T) {
 	assert.Nil(t, d1.popDragEvent())
 	assert.Nil(t, d2.popDragEvent())
 
+	// no drag event on secondary mouseDown
+	w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Press, 0)
+	w.WaitForEvents()
+	assert.Nil(t, d1.popDragEvent())
+	assert.Nil(t, d2.popDragEvent())
+
+	// no drag start and no drag event with pressed secondary mouse button
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Nil(t, d1.popDragEvent())
+	assert.Nil(t, d2.popDragEvent())
+
+	// no drag end event on secondary mouseUp
+	w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Release, 0)
+	w.WaitForEvents()
+	assert.Nil(t, d1.popDragEndEvent())
+	assert.Nil(t, d2.popDragEndEvent())
+
+	// no drag event in simple move
+	w.mouseMoved(w.viewport, 9, 9)
+	w.WaitForEvents()
+	assert.Nil(t, d1.popDragEvent())
+	assert.Nil(t, d2.popDragEvent())
+
 	// no drag event on mouseDown
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
 	w.WaitForEvents()

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -599,6 +599,25 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.NotNil(t, dh.popMouseOutEvent())
 }
 
+func TestWindow_DragEndWithoutTappedEvent(t *testing.T) {
+	w := createWindow("Test").(*window)
+	do := &draggableTappableObject{Rectangle: canvas.NewRectangle(color.White)}
+	do.SetMinSize(fyne.NewSize(10, 10))
+	w.SetContent(do)
+
+	repaintWindow(w)
+	require.Equal(t, fyne.NewPos(4, 4), do.Position())
+
+	w.mouseMoved(w.viewport, 9, 9)
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+
+	w.WaitForEvents()
+
+	assert.Nil(t, do.popTapEvent())
+}
+
 func TestWindow_Scrolled(t *testing.T) {
 	w := createWindow("Test").(*window)
 	o := &scrollable{Rectangle: canvas.NewRectangle(color.White)}
@@ -1350,6 +1369,12 @@ func (t *tappable) popTapEvent() (e interface{}) {
 func (t *tappable) popSecondaryTapEvent() (e interface{}) {
 	e, t.secondaryTapEvents = pop(t.secondaryTapEvents)
 	return
+}
+
+type draggableTappableObject struct {
+	*canvas.Rectangle
+	draggable
+	tappable
 }
 
 var _ fyne.Focusable = (*focusable)(nil)


### PR DESCRIPTION
### Description:
Added a new condition before firing the Tapped and SecondaryTapped events that we are not dragging

Fixes #2235

### Checklist:

- [x] Tests included.
- [ ] Lint and formatter run with no errors.
- [X] Tests all pass. (except TestFileIcon(maybe broken?))
