### PR TITLE
Initialize bindings queue lazily

### DIFF
--- a/data/binding/queue.go
+++ b/data/binding/queue.go
@@ -8,7 +8,7 @@ var (
 	itemQueueIn      chan<- *itemData
 	itemQueueOut     <-chan *itemData
 	processOnce      sync.Once
-	queueInitialized = make(chan int)
+	queueInitialized = make(chan struct{})
 )
 
 type itemData struct {

--- a/data/binding/queue_test.go
+++ b/data/binding/queue_test.go
@@ -1,11 +1,21 @@
 package binding
 
 import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	testQueueLazyInit()
+	os.Exit(m.Run())
+}
 
 func TestQueueItem(t *testing.T) {
 	called := 0
@@ -40,4 +50,48 @@ func TestMakeInfiniteQueue(t *testing.T) {
 
 	wg.Wait()
 	assert.Equal(t, 2048, c)
+}
+
+type mainTest struct {
+	name string
+}
+
+func newMainTest(name string) *mainTest {
+	t := &mainTest{name: name}
+	fmt.Printf("=== RUN   %s\n", name)
+	return t
+}
+
+func (m *mainTest) exitError() {
+	fmt.Printf("--- FAIL: %s (0.00s)\n", m.name)
+	fmt.Println("FAIL")
+	os.Exit(1)
+}
+
+func (m *mainTest) Errorf(format string, args ...interface{}) {
+	_, file, line, ok := runtime.Caller(3)
+	if ok {
+		fmt.Fprintf(os.Stderr, "\t%s:%d\n", file, line)
+	}
+	fmt.Fprintf(os.Stderr, strings.TrimLeft(format, "\n"), args...)
+	m.exitError()
+}
+
+func testQueueLazyInit() {
+	t := newMainTest("TestQueueLazyInit")
+	assert.Nil(t, itemQueueIn)
+	assert.Nil(t, itemQueueOut)
+
+	initialGoRoutines := runtime.NumGoroutine()
+
+	for i := 0; i < 1000; i++ {
+		go queueItem(func() {})
+	}
+
+	waitForItems()
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, initialGoRoutines+2, runtime.NumGoroutine())
+	assert.NotNil(t, itemQueueIn)
+	assert.NotNil(t, itemQueueOut)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Initialize bindings queue lazily. In this way, projects that do not use binding, don't need to deal with a 1024 queue length.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.