### PR TITLE
Fix/consistentbasewidget

### DIFF
--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -62,7 +62,7 @@ func (t *DocTabs) CreateRenderer() fyne.WidgetRenderer {
 			buttonCache: make(map[*TabItem]*tabButton),
 		},
 		docTabs:  t,
-		scroller: &Scroll{},
+		scroller: NewScroll(nil),
 	}
 	r.action = r.buildAllTabsButton()
 	r.create = r.buildCreateTabsButton()

--- a/internal/driver/glfw/menu_bar.go
+++ b/internal/driver/glfw/menu_bar.go
@@ -25,8 +25,11 @@ type MenuBar struct {
 func NewMenuBar(mainMenu *fyne.MainMenu, canvas fyne.Canvas) *MenuBar {
 	items := make([]fyne.CanvasObject, len(mainMenu.Items))
 	b := &MenuBar{Items: items, canvas: canvas}
+	b.ExtendBaseWidget(b)
 	for i, menu := range mainMenu.Items {
-		items[i] = &menuBarItem{Menu: menu, Parent: b}
+		barItem := &menuBarItem{Menu: menu, Parent: b}
+		barItem.ExtendBaseWidget(barItem)
+		items[i] = barItem
 	}
 	return b
 }
@@ -38,6 +41,7 @@ func (b *MenuBar) CreateRenderer() fyne.WidgetRenderer {
 	cont := fyne.NewContainerWithLayout(layout.NewHBoxLayout(), b.Items...)
 	background := canvas.NewRectangle(theme.ButtonColor())
 	underlay := &menuBarUnderlay{action: b.deactivate}
+	underlay.ExtendBaseWidget(underlay)
 	objects := []fyne.CanvasObject{underlay, background, cont}
 	for _, item := range b.Items {
 		objects = append(objects, item.(*menuBarItem).Child())
@@ -55,49 +59,6 @@ func (b *MenuBar) CreateRenderer() fyne.WidgetRenderer {
 // An active menu bar shows the current selected menu and should have the focus.
 func (b *MenuBar) IsActive() bool {
 	return b.active
-}
-
-// Hide hides the menu bar.
-//
-// Implements: fyne.Widget
-func (b *MenuBar) Hide() {
-	widget.HideWidget(&b.Base, b)
-}
-
-// MinSize returns the minimal size of the menu bar.
-//
-// Implements: fyne.Widget
-func (b *MenuBar) MinSize() fyne.Size {
-	return widget.MinSizeOf(b)
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (b *MenuBar) Move(pos fyne.Position) {
-	widget.MoveWidget(&b.Base, b, pos)
-}
-
-// Refresh triggers a redraw of the menu bar.
-//
-// Implements: fyne.Widget
-func (b *MenuBar) Refresh() {
-	widget.RefreshWidget(b)
-}
-
-// Resize resizes the menu bar.
-// It only affects the width because menu bars are always displayed with their minimal height.
-//
-// Implements: fyne.Widget
-func (b *MenuBar) Resize(size fyne.Size) {
-	widget.ResizeWidget(&b.Base, b, size)
-}
-
-// Show makes the menu bar visible.
-//
-// Implements: fyne.Widget
-func (b *MenuBar) Show() {
-	widget.ShowWidget(&b.Base, b)
 }
 
 // Toggle changes the activation state of the menu bar.
@@ -199,6 +160,7 @@ func (r *menuBarRenderer) Refresh() {
 	r.Layout(r.b.Size())
 	r.background.FillColor = theme.ButtonColor()
 	r.background.Refresh()
+	r.ShadowingRenderer.RefreshShadow()
 	canvas.Refresh(r.b)
 }
 
@@ -217,14 +179,6 @@ func (u *menuBarUnderlay) CreateRenderer() fyne.WidgetRenderer {
 	return &menuUnderlayRenderer{}
 }
 
-func (u *menuBarUnderlay) Hide() {
-	widget.HideWidget(&u.Base, u)
-}
-
-func (u *menuBarUnderlay) MinSize() fyne.Size {
-	return widget.MinSizeOf(u)
-}
-
 func (u *menuBarUnderlay) MouseIn(*desktop.MouseEvent) {
 }
 
@@ -232,22 +186,6 @@ func (u *menuBarUnderlay) MouseOut() {
 }
 
 func (u *menuBarUnderlay) MouseMoved(*desktop.MouseEvent) {
-}
-
-func (u *menuBarUnderlay) Move(pos fyne.Position) {
-	widget.MoveWidget(&u.Base, u, pos)
-}
-
-func (u *menuBarUnderlay) Refresh() {
-	widget.RefreshWidget(u)
-}
-
-func (u *menuBarUnderlay) Resize(size fyne.Size) {
-	widget.ResizeWidget(&u.Base, u, size)
-}
-
-func (u *menuBarUnderlay) Show() {
-	widget.ShowWidget(&u.Base, u)
 }
 
 func (u *menuBarUnderlay) Tapped(*fyne.PointEvent) {

--- a/internal/driver/glfw/menu_bar.go
+++ b/internal/driver/glfw/menu_bar.go
@@ -89,6 +89,7 @@ func (b *MenuBar) activateChild(item *menuBarItem) {
 		return
 	}
 
+	item.Refresh()
 	item.Child().Show()
 	b.Refresh()
 }

--- a/internal/driver/glfw/menu_bar_item.go
+++ b/internal/driver/glfw/menu_bar_item.go
@@ -68,20 +68,6 @@ func (i *menuBarItem) Focused() bool {
 	return i.active
 }
 
-// Hide hides the menu bar item.
-//
-// Implements: fyne.Widget
-func (i *menuBarItem) Hide() {
-	widget.HideWidget(&i.Base, i)
-}
-
-// MinSize returns the minimal size of the menu bar item.
-//
-// Implements: fyne.Widget
-func (i *menuBarItem) MinSize() fyne.Size {
-	return widget.MinSizeOf(i)
-}
-
 // MouseIn activates the item and shows the menu if the bar is active.
 // The menu that was displayed before will be hidden.
 //
@@ -119,34 +105,6 @@ func (i *menuBarItem) MouseMoved(_ *desktop.MouseEvent) {
 func (i *menuBarItem) MouseOut() {
 	i.hovered = false
 	i.Refresh()
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (i *menuBarItem) Move(pos fyne.Position) {
-	widget.MoveWidget(&i.Base, i, pos)
-}
-
-// Refresh triggers a redraw of the menu bar item.
-//
-// Implements: fyne.Widget
-func (i *menuBarItem) Refresh() {
-	widget.RefreshWidget(i)
-}
-
-// Resize changes the size of the menu bar item.
-//
-// Implements: fyne.Widget
-func (i *menuBarItem) Resize(size fyne.Size) {
-	widget.ResizeWidget(&i.Base, i, size)
-}
-
-// Show makes the menu bar item visible.
-//
-// Implements: fyne.Widget
-func (i *menuBarItem) Show() {
-	widget.ShowWidget(&i.Base, i)
 }
 
 // Tapped toggles the activation state of the menu bar.

--- a/internal/driver/glfw/menu_bar_item.go
+++ b/internal/driver/glfw/menu_bar_item.go
@@ -113,11 +113,6 @@ func (i *menuBarItem) MouseOut() {
 // Implements: fyne.Tappable
 func (i *menuBarItem) Tapped(*fyne.PointEvent) {
 	i.Parent.toggle(i)
-
-	if i.Parent.active {
-		i.Parent.canvas.Focus(i)
-	}
-	i.Refresh()
 }
 
 func (i *menuBarItem) TypedKey(event *fyne.KeyEvent) {

--- a/internal/driver/glfw/menu_bar_item.go
+++ b/internal/driver/glfw/menu_bar_item.go
@@ -113,6 +113,11 @@ func (i *menuBarItem) MouseOut() {
 // Implements: fyne.Tappable
 func (i *menuBarItem) Tapped(*fyne.PointEvent) {
 	i.Parent.toggle(i)
+
+	if i.Parent.active {
+		i.Parent.canvas.Focus(i)
+	}
+	i.Refresh()
 }
 
 func (i *menuBarItem) TypedKey(event *fyne.KeyEvent) {

--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -10,9 +10,9 @@ import (
 
 // Base provides a helper that handles basic widget behaviours.
 type Base struct {
-	size     fyne.Size
-	position fyne.Position
 	hidden   bool
+	position fyne.Position
+	size     fyne.Size
 
 	impl         fyne.Widget
 	propertyLock sync.RWMutex

--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -8,60 +8,79 @@ import (
 	"fyne.io/fyne/v2/internal/cache"
 )
 
-// Base is a simple base widget for internal use.
+// Base provides a helper that handles basic widget behaviours.
 type Base struct {
-	hidden bool
-	pos    fyne.Position
-	size   fyne.Size
+	size     fyne.Size
+	position fyne.Position
+	hidden   bool
 
+	impl         fyne.Widget
 	propertyLock sync.RWMutex
 }
 
-// Position returns the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (b *Base) Position() fyne.Position {
-	b.propertyLock.RLock()
-	defer b.propertyLock.RUnlock()
-
-	return b.pos
-}
-
-// Size returns the current size of the widget.
-//
-// Implements: fyne.Widget
-func (b *Base) Size() fyne.Size {
-	b.propertyLock.RLock()
-	defer b.propertyLock.RUnlock()
-
-	return b.size
-}
-
-// Visible returns whether the widget is visible or not.
-//
-// Implements: fyne.Widget
-func (b *Base) Visible() bool {
-	b.propertyLock.RLock()
-	defer b.propertyLock.RUnlock()
-
-	return !b.hidden
-}
-
-// HideWidget is a helper method to hide and refresh a widget.
-func HideWidget(b *Base, w fyne.Widget) {
-	if !b.Visible() {
+// ExtendBaseWidget is used by an extending widget to make use of BaseWidget functionality.
+func (w *Base) ExtendBaseWidget(wid fyne.Widget) {
+	impl := w.super()
+	if impl != nil {
 		return
 	}
 
-	b.propertyLock.Lock()
-	b.hidden = true
-	b.propertyLock.Unlock()
-	canvas.Refresh(w)
+	w.propertyLock.Lock()
+	defer w.propertyLock.Unlock()
+	w.impl = wid
 }
 
-// MinSizeOf is a helper method to get the minSize of a widget.
-func MinSizeOf(w fyne.Widget) fyne.Size {
-	r := cache.Renderer(w)
+// Size gets the current size of this widget.
+func (w *Base) Size() fyne.Size {
+	w.propertyLock.RLock()
+	defer w.propertyLock.RUnlock()
+
+	return w.size
+}
+
+// Resize sets a new size for a widget.
+// Note this should not be used if the widget is being managed by a Layout within a Container.
+func (w *Base) Resize(size fyne.Size) {
+	w.propertyLock.RLock()
+	baseSize := w.size
+	impl := w.impl
+	w.propertyLock.RUnlock()
+	if baseSize == size {
+		return
+	}
+
+	w.propertyLock.Lock()
+	w.size = size
+	w.propertyLock.Unlock()
+
+	if impl == nil {
+		return
+	}
+	cache.Renderer(impl).Layout(size)
+}
+
+// Position gets the current position of this widget, relative to its parent.
+func (w *Base) Position() fyne.Position {
+	w.propertyLock.RLock()
+	defer w.propertyLock.RUnlock()
+
+	return w.position
+}
+
+// Move the widget to a new position, relative to its parent.
+// Note this should not be used if the widget is being managed by a Layout within a Container.
+func (w *Base) Move(pos fyne.Position) {
+	w.propertyLock.Lock()
+	defer w.propertyLock.Unlock()
+
+	w.position = pos
+}
+
+// MinSize for the widget - it should never be resized below this value.
+func (w *Base) MinSize() fyne.Size {
+	impl := w.super()
+
+	r := cache.Renderer(impl)
 	if r == nil {
 		return fyne.NewSize(0, 0)
 	}
@@ -69,54 +88,73 @@ func MinSizeOf(w fyne.Widget) fyne.Size {
 	return r.MinSize()
 }
 
-// MoveWidget is a helper method to set the position of a widget relative to its parent.
-func MoveWidget(b *Base, w fyne.Widget, pos fyne.Position) {
-	b.propertyLock.Lock()
-	b.pos = pos
-	b.propertyLock.Unlock()
+// Visible returns whether or not this widget should be visible.
+// Note that this may not mean it is currently visible if a parent has been hidden.
+func (w *Base) Visible() bool {
+	w.propertyLock.RLock()
+	defer w.propertyLock.RUnlock()
 
-	RefreshWidget(w)
+	return !w.hidden
 }
 
-// RefreshWidget is a helper method to refresh a widget.
-func RefreshWidget(w fyne.Widget) {
-	r := cache.Renderer(w)
-	if r == nil {
+// Show this widget so it becomes visible
+func (w *Base) Show() {
+	if w.Visible() {
 		return
 	}
 
-	r.Refresh()
+	w.setFieldsAndRefresh(func() {
+		w.hidden = false
+	})
 }
 
-// ResizeWidget is a helper method to resize a widget.
-func ResizeWidget(b *Base, w fyne.Widget, size fyne.Size) {
-	b.propertyLock.RLock()
-	baseSize := b.size
-	b.propertyLock.RUnlock()
-	if baseSize == size {
+// Hide this widget so it is no longer visible
+func (w *Base) Hide() {
+	if !w.Visible() {
 		return
 	}
 
-	b.propertyLock.Lock()
-	b.size = size
-	b.propertyLock.Unlock()
-	r := cache.Renderer(w)
-	if r == nil {
+	w.propertyLock.Lock()
+	w.hidden = true
+	impl := w.impl
+	w.propertyLock.Unlock()
+
+	if impl == nil {
 		return
 	}
-
-	r.Layout(size)
+	canvas.Refresh(impl)
 }
 
-// ShowWidget is a helper method to show and refresh a widget.
-func ShowWidget(b *Base, w fyne.Widget) {
-	if b.Visible() {
+// Refresh causes this widget to be redrawn in it's current state
+func (w *Base) Refresh() {
+	impl := w.super()
+	if impl == nil {
 		return
 	}
 
-	b.propertyLock.Lock()
-	b.hidden = false
-	b.propertyLock.Unlock()
+	render := cache.Renderer(impl)
+	render.Refresh()
+}
 
-	RefreshWidget(w)
+// setFieldsAndRefresh helps to make changes to a widget that should be followed by a refresh.
+// This method is a guaranteed thread-safe way of directly manipulating widget fields.
+func (w *Base) setFieldsAndRefresh(f func()) {
+	w.propertyLock.Lock()
+	f()
+	impl := w.impl
+	w.propertyLock.Unlock()
+
+	if impl == nil {
+		return
+	}
+	impl.Refresh()
+}
+
+// super will return the actual object that this represents.
+// If extended then this is the extending widget, otherwise it is nil.
+func (w *Base) super() fyne.Widget {
+	w.propertyLock.RLock()
+	impl := w.impl
+	w.propertyLock.RUnlock()
+	return impl
 }

--- a/internal/widget/overlay_container.go
+++ b/internal/widget/overlay_container.go
@@ -20,7 +20,9 @@ type OverlayContainer struct {
 
 // NewOverlayContainer creates an OverlayContainer.
 func NewOverlayContainer(c fyne.CanvasObject, canvas fyne.Canvas, onDismiss func()) *OverlayContainer {
-	return &OverlayContainer{canvas: canvas, Content: c, onDismiss: onDismiss}
+	o := &OverlayContainer{canvas: canvas, Content: c, onDismiss: onDismiss}
+	o.ExtendBaseWidget(o)
+	return o
 }
 
 // CreateRenderer returns a new renderer for the overlay container.
@@ -38,15 +40,7 @@ func (o *OverlayContainer) Hide() {
 		o.canvas.Overlays().Remove(o)
 		o.shown = false
 	}
-	HideWidget(&o.Base, o)
-}
-
-// MinSize returns the minimal size of the overlay container.
-// This is the same as the size of the canvas.
-//
-// Implements: fyne.Widget
-func (o *OverlayContainer) MinSize() fyne.Size {
-	return MinSizeOf(o)
+	o.Base.Hide()
 }
 
 // MouseIn catches mouse-in events not handled by the container’s content. It does nothing.
@@ -67,28 +61,6 @@ func (o *OverlayContainer) MouseMoved(*desktop.MouseEvent) {
 func (o *OverlayContainer) MouseOut() {
 }
 
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (o *OverlayContainer) Move(pos fyne.Position) {
-	MoveWidget(&o.Base, o, pos)
-}
-
-// Refresh triggers a redraw of the overlay container.
-//
-// Implements: fyne.Widget
-func (o *OverlayContainer) Refresh() {
-	RefreshWidget(o)
-}
-
-// Resize changes the size of the overlay container.
-// This is normally called by the canvas overlay management.
-//
-// Implements: fyne.Widget
-func (o *OverlayContainer) Resize(size fyne.Size) {
-	ResizeWidget(&o.Base, o, size)
-}
-
 // Show makes the overlay container visible.
 //
 // Implements: fyne.Widget
@@ -97,7 +69,7 @@ func (o *OverlayContainer) Show() {
 		o.canvas.Overlays().Add(o)
 		o.shown = true
 	}
-	ShowWidget(&o.Base, o)
+	o.Base.Show()
 }
 
 // Tapped catches tap events not handled by the container’s content.

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -444,6 +444,10 @@ func (s *Scroll) Refresh() {
 
 // Resize is called when this scroller should change size. We refresh to ensure the scroll bars are updated.
 func (s *Scroll) Resize(sz fyne.Size) {
+	if sz == s.size {
+		return
+	}
+
 	s.Base.Resize(sz)
 	s.Refresh()
 }

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -105,48 +105,6 @@ func (b *scrollBar) Dragged(e *fyne.DragEvent) {
 	b.area.moveBar(b.draggedDistance+b.dragStart, b.Size())
 }
 
-// Hide hides the shadow.
-//
-// Implements: fyne.Widget
-func (b *scrollBar) Hide() {
-	HideWidget(&b.Base, b)
-}
-
-// MinSize returns the minimal size of the shadow.
-//
-// Implements: fyne.Widget
-func (b *scrollBar) MinSize() fyne.Size {
-	return MinSizeOf(b)
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (b *scrollBar) Move(pos fyne.Position) {
-	MoveWidget(&b.Base, b, pos)
-}
-
-// Refresh triggers a redraw of the shadow.
-//
-// Implements: fyne.Widget
-func (b *scrollBar) Refresh() {
-	RefreshWidget(b)
-}
-
-// Resize changes the size of the shadow.
-//
-// Implements: fyne.Widget
-func (b *scrollBar) Resize(size fyne.Size) {
-	ResizeWidget(&b.Base, b, size)
-}
-
-// Show makes the shadow visible.
-//
-// Implements: fyne.Widget
-func (b *scrollBar) Show() {
-	ShowWidget(&b.Base, b)
-}
-
 func (b *scrollBar) MouseIn(e *desktop.MouseEvent) {
 	b.area.MouseIn(e)
 }
@@ -160,6 +118,7 @@ func (b *scrollBar) MouseOut() {
 
 func newScrollBar(area *scrollBarArea) *scrollBar {
 	b := &scrollBar{area: area, orientation: area.orientation}
+	b.ExtendBaseWidget(b)
 	return b
 }
 
@@ -236,20 +195,6 @@ func (a *scrollBarArea) CreateRenderer() fyne.WidgetRenderer {
 	return &scrollBarAreaRenderer{BaseRenderer: NewBaseRenderer([]fyne.CanvasObject{bar}), area: a, bar: bar}
 }
 
-// Hide hides the shadow.
-//
-// Implements: fyne.Widget
-func (a *scrollBarArea) Hide() {
-	HideWidget(&a.Base, a)
-}
-
-// MinSize returns the minimal size of the shadow.
-//
-// Implements: fyne.Widget
-func (a *scrollBarArea) MinSize() fyne.Size {
-	return MinSizeOf(a)
-}
-
 func (a *scrollBarArea) MouseIn(*desktop.MouseEvent) {
 	a.isLarge = true
 	a.scroll.Refresh()
@@ -261,34 +206,6 @@ func (a *scrollBarArea) MouseMoved(*desktop.MouseEvent) {
 func (a *scrollBarArea) MouseOut() {
 	a.isLarge = false
 	a.scroll.Refresh()
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (a *scrollBarArea) Move(pos fyne.Position) {
-	MoveWidget(&a.Base, a, pos)
-}
-
-// Refresh triggers a redraw of the shadow.
-//
-// Implements: fyne.Widget
-func (a *scrollBarArea) Refresh() {
-	RefreshWidget(a)
-}
-
-// Resize changes the size of the shadow.
-//
-// Implements: fyne.Widget
-func (a *scrollBarArea) Resize(size fyne.Size) {
-	ResizeWidget(&a.Base, a, size)
-}
-
-// Show makes the shadow visible.
-//
-// Implements: fyne.Widget
-func (a *scrollBarArea) Show() {
-	ShowWidget(&a.Base, a)
 }
 
 func (a *scrollBarArea) moveBar(offset float32, barSize fyne.Size) {
@@ -318,6 +235,7 @@ func (a *scrollBarArea) computeScrollOffset(length, offset, scrollLength, conten
 
 func newScrollBarArea(scroll *Scroll, orientation scrollBarOrientation) *scrollBarArea {
 	a := &scrollBarArea{scroll: scroll, orientation: orientation}
+	a.ExtendBaseWidget(a)
 	return a
 }
 
@@ -497,13 +415,6 @@ func (s *Scroll) Dragged(e *fyne.DragEvent) {
 	}
 }
 
-// Hide hides the shadow.
-//
-// Implements: fyne.Widget
-func (s *Scroll) Hide() {
-	HideWidget(&s.Base, s)
-}
-
 // MinSize returns the smallest size this widget can shrink to
 func (s *Scroll) MinSize() fyne.Size {
 	min := fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize).Max(s.minSize)
@@ -516,13 +427,6 @@ func (s *Scroll) MinSize() fyne.Size {
 		return s.Content.MinSize()
 	}
 	return min
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (s *Scroll) Move(pos fyne.Position) {
-	MoveWidget(&s.Base, s, pos)
 }
 
 // SetMinSize specifies a minimum size for this scroll container.
@@ -538,16 +442,13 @@ func (s *Scroll) Refresh() {
 	s.refreshWithoutOffsetUpdate()
 }
 
-func (s *Scroll) refreshWithoutOffsetUpdate() {
-	RefreshWidget(s)
+func (s *Scroll) Resize(sz fyne.Size) {
+	s.Base.Resize(sz)
+	s.Refresh()
 }
 
-// Resize sets a new size for the scroll container.
-func (s *Scroll) Resize(size fyne.Size) {
-	if size != s.size {
-		s.size = size
-		s.Refresh()
-	}
+func (s *Scroll) refreshWithoutOffsetUpdate() {
+	s.Base.Refresh()
 }
 
 // Scrolled is called when an input device triggers a scroll event
@@ -559,13 +460,6 @@ func (s *Scroll) Scrolled(ev *fyne.ScrollEvent) {
 	if s.updateOffset(dx, dy) {
 		s.refreshWithoutOffsetUpdate()
 	}
-}
-
-// Show makes the shadow visible.
-//
-// Implements: fyne.Widget
-func (s *Scroll) Show() {
-	ShowWidget(&s.Base, s)
 }
 
 func (s *Scroll) updateOffset(deltaX, deltaY float32) bool {
@@ -599,19 +493,25 @@ func computeOffset(start, delta, outerWidth, innerWidth float32) float32 {
 // NewScroll creates a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize to be smaller than that of the passed object.
 func NewScroll(content fyne.CanvasObject) *Scroll {
-	return newScrollContainerWithDirection(ScrollBoth, content)
+	s := newScrollContainerWithDirection(ScrollBoth, content)
+	s.ExtendBaseWidget(s)
+	return s
 }
 
 // NewHScroll create a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize.Width to be smaller than that of the passed object.
 func NewHScroll(content fyne.CanvasObject) *Scroll {
-	return newScrollContainerWithDirection(ScrollHorizontalOnly, content)
+	s := newScrollContainerWithDirection(ScrollHorizontalOnly, content)
+	s.ExtendBaseWidget(s)
+	return s
 }
 
 // NewVScroll create a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize.Height to be smaller than that of the passed object.
 func NewVScroll(content fyne.CanvasObject) *Scroll {
-	return newScrollContainerWithDirection(ScrollVerticalOnly, content)
+	s := newScrollContainerWithDirection(ScrollVerticalOnly, content)
+	s.ExtendBaseWidget(s)
+	return s
 }
 
 func newScrollContainerWithDirection(direction ScrollDirection, content fyne.CanvasObject) *Scroll {
@@ -619,5 +519,6 @@ func newScrollContainerWithDirection(direction ScrollDirection, content fyne.Can
 		Direction: direction,
 		Content:   content,
 	}
+	s.ExtendBaseWidget(s)
 	return s
 }

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -442,6 +442,7 @@ func (s *Scroll) Refresh() {
 	s.refreshWithoutOffsetUpdate()
 }
 
+// Resize is called when this scroller should change size. We refresh to ensure the scroll bars are updated.
 func (s *Scroll) Resize(sz fyne.Size) {
 	s.Base.Resize(sz)
 	s.Refresh()

--- a/internal/widget/shadow.go
+++ b/internal/widget/shadow.go
@@ -46,7 +46,9 @@ const (
 
 // NewShadow create a new Shadow.
 func NewShadow(typ ShadowType, level ElevationLevel) *Shadow {
-	return &Shadow{typ: typ, level: level}
+	s := &Shadow{typ: typ, level: level}
+	s.ExtendBaseWidget(s)
+	return s
 }
 
 // CreateRenderer returns a new renderer for the shadow.
@@ -56,48 +58,6 @@ func (s *Shadow) CreateRenderer() fyne.WidgetRenderer {
 	r := &shadowRenderer{s: s}
 	r.createShadows()
 	return r
-}
-
-// Hide hides the shadow.
-//
-// Implements: fyne.Widget
-func (s *Shadow) Hide() {
-	HideWidget(&s.Base, s)
-}
-
-// MinSize returns the minimal size of the shadow.
-//
-// Implements: fyne.Widget
-func (s *Shadow) MinSize() fyne.Size {
-	return MinSizeOf(s)
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (s *Shadow) Move(pos fyne.Position) {
-	MoveWidget(&s.Base, s, pos)
-}
-
-// Refresh triggers a redraw of the shadow.
-//
-// Implements: fyne.Widget
-func (s *Shadow) Refresh() {
-	RefreshWidget(s)
-}
-
-// Resize changes the size of the shadow.
-//
-// Implements: fyne.Widget
-func (s *Shadow) Resize(size fyne.Size) {
-	ResizeWidget(&s.Base, s, size)
-}
-
-// Show makes the shadow visible.
-//
-// Implements: fyne.Widget
-func (s *Shadow) Show() {
-	ShowWidget(&s.Base, s)
 }
 
 type shadowRenderer struct {

--- a/internal/widget/shadowing_renderer.go
+++ b/internal/widget/shadowing_renderer.go
@@ -39,3 +39,11 @@ func (r *ShadowingRenderer) SetObjects(objects []fyne.CanvasObject) {
 	}
 	r.BaseRenderer.SetObjects(objects)
 }
+
+// RefreshShadow asks the shadow graphical element to update to current theme
+func (r *ShadowingRenderer) RefreshShadow() {
+	if r.shadow == nil {
+		return
+	}
+	r.shadow.Refresh()
+}

--- a/widget/button.go
+++ b/widget/button.go
@@ -302,6 +302,7 @@ func (r *buttonRenderer) applyTheme() {
 			}
 		}
 	}
+	r.ShadowingRenderer.RefreshShadow()
 }
 
 func (r *buttonRenderer) buttonColor() color.Color {

--- a/widget/card.go
+++ b/widget/card.go
@@ -214,6 +214,7 @@ func (c *cardRenderer) Refresh() {
 
 	c.applyTheme()
 	c.Layout(c.card.Size())
+	c.ShadowingRenderer.RefreshShadow()
 	canvas.Refresh(c.card.super())
 }
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -182,7 +182,7 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 
 	e.cursorAnim = newEntryCursorAnimation(cursor)
 	e.content = &entryContent{entry: e}
-	e.scroll = &widget.Scroll{}
+	e.scroll = widget.NewScroll(nil)
 	objects := []fyne.CanvasObject{box, line}
 	if e.Wrapping != fyne.TextWrapOff {
 		e.scroll.Content = e.content

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -24,6 +24,7 @@ type Menu struct {
 func NewMenu(menu *fyne.Menu) *Menu {
 	items := make([]fyne.CanvasObject, len(menu.Items))
 	m := &Menu{Items: items}
+	m.ExtendBaseWidget(m)
 	for i, item := range menu.Items {
 		if item.IsSeparator {
 			items[i] = NewSeparator()
@@ -102,6 +103,7 @@ func (m *Menu) ActivatePrevious() {
 //
 // Implements: fyne.Widget
 func (m *Menu) CreateRenderer() fyne.WidgetRenderer {
+	m.ExtendBaseWidget(m)
 	box := newMenuBox(m.Items)
 	scroll := widget.NewVScroll(box)
 	scroll.SetMinSize(box.MinSize())
@@ -142,46 +144,12 @@ func (m *Menu) DeactivateLastSubmenu() bool {
 	return m.activeItem.deactivateLastSubmenu()
 }
 
-// Hide hides the menu.
-//
-// Implements: fyne.Widget
-func (m *Menu) Hide() {
-	widget.HideWidget(&m.Base, m)
-}
-
 // MinSize returns the minimal size of the menu.
 //
 // Implements: fyne.Widget
 func (m *Menu) MinSize() fyne.Size {
-	return widget.MinSizeOf(m)
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (m *Menu) Move(pos fyne.Position) {
-	widget.MoveWidget(&m.Base, m, pos)
-}
-
-// Refresh triggers a redraw of the menu.
-//
-// Implements: fyne.Widget
-func (m *Menu) Refresh() {
-	widget.RefreshWidget(m)
-}
-
-// Resize has no effect because menus are always displayed with their minimal size.
-//
-// Implements: fyne.Widget
-func (m *Menu) Resize(size fyne.Size) {
-	widget.ResizeWidget(&m.Base, m, size)
-}
-
-// Show makes the menu visible.
-//
-// Implements: fyne.Widget
-func (m *Menu) Show() {
-	widget.ShowWidget(&m.Base, m)
+	m.ExtendBaseWidget(m)
+	return m.Base.MinSize()
 }
 
 // Tapped catches taps on separators and the menu background. It doesn’t perform any action.
@@ -268,6 +236,7 @@ func (r *menuRenderer) MinSize() fyne.Size {
 
 func (r *menuRenderer) Refresh() {
 	r.layoutActiveChild()
+	r.ShadowingRenderer.RefreshShadow()
 	canvas.Refresh(r.m)
 }
 

--- a/widget/menu_item.go
+++ b/widget/menu_item.go
@@ -21,7 +21,9 @@ type menuItem struct {
 
 // newMenuItem creates a new menuItem.
 func newMenuItem(item *fyne.MenuItem, parent *Menu) *menuItem {
-	return &menuItem{Item: item, Parent: parent}
+	i := &menuItem{Item: item, Parent: parent}
+	i.ExtendBaseWidget(i)
+	return i
 }
 
 func (i *menuItem) Child() *Menu {
@@ -56,20 +58,6 @@ func (i *menuItem) CreateRenderer() fyne.WidgetRenderer {
 	}
 }
 
-// Hide hides the menu item.
-//
-// Implements: fyne.Widget
-func (i *menuItem) Hide() {
-	widget.HideWidget(&i.Base, i)
-}
-
-// MinSize returns the minimal size of the menu item.
-//
-// Implements: fyne.Widget
-func (i *menuItem) MinSize() fyne.Size {
-	return widget.MinSizeOf(i)
-}
-
 // MouseIn activates the item which shows the submenu if the item has one.
 // The submenu of any sibling of the item will be hidden.
 //
@@ -91,34 +79,6 @@ func (i *menuItem) MouseOut() {
 	if !i.isSubmenuOpen() {
 		i.deactivate()
 	}
-}
-
-// Move sets the position of the widget relative to its parent.
-//
-// Implements: fyne.Widget
-func (i *menuItem) Move(pos fyne.Position) {
-	widget.MoveWidget(&i.Base, i, pos)
-}
-
-// Refresh triggers a redraw of the menu item.
-//
-// Implements: fyne.Widget
-func (i *menuItem) Refresh() {
-	widget.RefreshWidget(i)
-}
-
-// Resize changes the size of the menu item.
-//
-// Implements: fyne.Widget
-func (i *menuItem) Resize(size fyne.Size) {
-	widget.ResizeWidget(&i.Base, i, size)
-}
-
-// Show makes the menu item visible.
-//
-// Implements: fyne.Widget
-func (i *menuItem) Show() {
-	widget.ShowWidget(&i.Base, i)
 }
 
 // Tapped performs the action of the item and dismisses the menu.

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -209,6 +209,7 @@ func (r *popUpRenderer) Refresh() {
 	}
 	r.popUp.Content.Refresh()
 	r.background.Refresh()
+	r.ShadowingRenderer.RefreshShadow()
 }
 
 type modalPopUpRenderer struct {

--- a/widget/popup_menu.go
+++ b/widget/popup_menu.go
@@ -55,14 +55,14 @@ func (p *PopUpMenu) Hide() {
 //
 // Implements: fyne.Widget
 func (p *PopUpMenu) Move(pos fyne.Position) {
-	widget.MoveWidget(&p.Base, p, p.adjustedPosition(pos, p.Size()))
+	p.Base.Move(p.adjustedPosition(pos, p.Size()))
 }
 
 // Resize changes the size of the pop-up menu.
 //
 // Implements: fyne.Widget
 func (p *PopUpMenu) Resize(size fyne.Size) {
-	widget.MoveWidget(&p.Base, p, p.adjustedPosition(p.Position(), size))
+	p.Base.Move(p.adjustedPosition(p.Position(), size))
 	p.Menu.Resize(size)
 }
 

--- a/widget/separator.go
+++ b/widget/separator.go
@@ -13,20 +13,23 @@ var _ fyne.Widget = (*Separator)(nil)
 //
 // Since: 1.4
 type Separator struct {
-	widget.Base
+	BaseWidget
 }
 
 // NewSeparator creates a new separator.
 //
 // Since: 1.4
 func NewSeparator() *Separator {
-	return &Separator{}
+	s := &Separator{}
+	s.ExtendBaseWidget(s)
+	return s
 }
 
 // CreateRenderer returns a new renderer for the separator.
 //
 // Implements: fyne.Widget
 func (s *Separator) CreateRenderer() fyne.WidgetRenderer {
+	s.ExtendBaseWidget(s)
 	bar := canvas.NewRectangle(theme.DisabledColor())
 	objects := []fyne.CanvasObject{bar}
 	return &separatorRenderer{
@@ -36,47 +39,13 @@ func (s *Separator) CreateRenderer() fyne.WidgetRenderer {
 	}
 }
 
-// Hide hides the separator.
-//
-// Implements: fyne.Widget
-func (s *Separator) Hide() {
-	widget.HideWidget(&s.Base, s)
-}
-
 // MinSize returns the minimal size of the separator.
 //
 // Implements: fyne.Widget
 func (s *Separator) MinSize() fyne.Size {
+	s.ExtendBaseWidget(s)
 	t := theme.SeparatorThicknessSize()
 	return fyne.NewSize(t, t)
-}
-
-// Move sets the position of the separator relative to its parent.
-//
-// Implements: fyne.Widget
-func (s *Separator) Move(pos fyne.Position) {
-	widget.MoveWidget(&s.Base, s, pos)
-}
-
-// Refresh triggers a redraw of the separator.
-//
-// Implements: fyne.Widget
-func (s *Separator) Refresh() {
-	widget.RefreshWidget(s)
-}
-
-// Resize changes the size of the separator.
-//
-// Implements: fyne.Widget
-func (s *Separator) Resize(size fyne.Size) {
-	widget.ResizeWidget(&s.Base, s, size)
-}
-
-// Show makes the separator visible.
-//
-// Implements: fyne.Widget
-func (s *Separator) Show() {
-	widget.ShowWidget(&s.Base, s)
 }
 
 var _ fyne.WidgetRenderer = (*separatorRenderer)(nil)

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -643,6 +643,12 @@ func (n *treeNode) Tapped(*fyne.PointEvent) {
 	n.tree.Select(n.uid)
 }
 
+func (n *treeNode) Resize(s fyne.Size) {
+	n.BaseWidget.Resize(s)
+	// TODO find out if the indentation changed. If not, and size is the same, then we can skip this as normal
+	cache.Renderer(n.super()).Layout(s)
+}
+
 func (n *treeNode) partialRefresh() {
 	if r := cache.Renderer(n.super()); r != nil {
 		r.(*treeNodeRenderer).partialRefresh()

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -453,7 +453,7 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 			// Node is below viewport and not visible
 		} else {
 			// Node is in viewport
-			var n *treeNode
+			var n fyne.CanvasObject
 			if isBranch {
 				b, ok := r.branches[uid]
 				if !ok {
@@ -464,7 +464,7 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 					b.update(uid, depth)
 				}
 				branches[uid] = b
-				n = b.treeNode
+				n = b
 				r.objects = append(r.objects, b)
 			} else {
 				l, ok := r.leaves[uid]
@@ -476,7 +476,7 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 					l.update(uid, depth)
 				}
 				leaves[uid] = l
-				n = l.treeNode
+				n = l
 				r.objects = append(r.objects, l)
 			}
 			if n != nil {
@@ -643,12 +643,6 @@ func (n *treeNode) Tapped(*fyne.PointEvent) {
 	n.tree.Select(n.uid)
 }
 
-func (n *treeNode) Resize(s fyne.Size) {
-	n.BaseWidget.Resize(s)
-	// TODO find out if the indentation changed. If not, and size is the same, then we can skip this as normal
-	cache.Renderer(n.super()).Layout(s)
-}
-
 func (n *treeNode) partialRefresh() {
 	if r := cache.Renderer(n.super()); r != nil {
 		r.(*treeNodeRenderer).partialRefresh()
@@ -731,6 +725,7 @@ func (r *treeNodeRenderer) partialRefresh() {
 		r.background.Hide()
 	}
 	r.background.Refresh()
+	r.Layout(r.treeNode.size)
 	canvas.Refresh(r.treeNode.super())
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Move our internal Base widget (that could not be extended) to be consistent with the public BaseWidget.
Now we have just 1 API and the ability to extend both.
It is still 2 different classes due to the cycle issues. One cannot be an alias of the other due to certain unexported APIs.
This will be further tidied before 2.1 by hopefully replacing the `ExtendBaseWidget` idea - but for now it should unblock some keyboard operation items.


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
