### PR TITLE
Remove some unnecessary type convertions

### DIFF
--- a/cmd/fyne/internal/mobile/binres/pool.go
+++ b/cmd/fyne/internal/mobile/binres/pool.go
@@ -131,7 +131,7 @@ func (pl *Pool) UnmarshalBinary(bin []byte) error {
 			}
 
 			data := bin[offset : offset+nbytes]
-			if x := uint8(bin[offset+nbytes]); x != 0 {
+			if x := bin[offset+nbytes]; x != 0 {
 				return fmt.Errorf("expected zero terminator, got 0x%02X for nchars=%v nbytes=%v data=%q", x, nchars, nbytes, data)
 			}
 			pl.strings[i] = string(data)

--- a/cmd/fyne/internal/mobile/binres/table.go
+++ b/cmd/fyne/internal/mobile/binres/table.go
@@ -405,8 +405,8 @@ func (spec *TypeSpec) UnmarshalBinary(bin []byte) error {
 	if spec.typ != ResTableTypeSpec {
 		return errWrongType(spec.typ, ResTableTypeSpec)
 	}
-	spec.id = uint8(bin[8])
-	spec.res0 = uint8(bin[9])
+	spec.id = bin[8]
+	spec.res0 = bin[9]
 	spec.res1 = btou16(bin[10:])
 	spec.entryCount = btou32(bin[12:])
 
@@ -425,7 +425,7 @@ func (spec *TypeSpec) MarshalBinary() ([]byte, error) {
 	putu16(bin[2:], 16)
 	putu32(bin[4:], uint32(len(bin)))
 
-	bin[8] = byte(spec.id)
+	bin[8] = spec.id
 	// [9] = 0
 	// [10:12] = 0
 	putu32(bin[12:], uint32(len(spec.entries)))
@@ -507,8 +507,8 @@ func (typ *Type) UnmarshalBinary(bin []byte) error {
 		return errWrongType(typ.typ, ResTableType)
 	}
 
-	typ.id = uint8(bin[8])
-	typ.res0 = uint8(bin[9])
+	typ.id = bin[8]
+	typ.res0 = bin[9]
 	typ.res1 = btou16(bin[10:])
 	typ.entryCount = btou32(bin[12:])
 	typ.entriesStart = btou32(bin[16:])
@@ -522,19 +522,19 @@ func (typ *Type) UnmarshalBinary(bin []byte) error {
 	typ.config.imsi.mnc = btou16(bin[26:])
 	typ.config.locale.language = btou16(bin[28:])
 	typ.config.locale.country = btou16(bin[30:])
-	typ.config.screenType.orientation = uint8(bin[32])
-	typ.config.screenType.touchscreen = uint8(bin[33])
+	typ.config.screenType.orientation = bin[32]
+	typ.config.screenType.touchscreen = bin[33]
 	typ.config.screenType.density = btou16(bin[34:])
-	typ.config.input.keyboard = uint8(bin[36])
-	typ.config.input.navigation = uint8(bin[37])
-	typ.config.input.inputFlags = uint8(bin[38])
-	typ.config.input.inputPad0 = uint8(bin[39])
+	typ.config.input.keyboard = bin[36]
+	typ.config.input.navigation = bin[37]
+	typ.config.input.inputFlags = bin[38]
+	typ.config.input.inputPad0 = bin[39]
 	typ.config.screenSize.width = btou16(bin[40:])
 	typ.config.screenSize.height = btou16(bin[42:])
 	typ.config.version.sdk = btou16(bin[44:])
 	typ.config.version.minor = btou16(bin[46:])
-	typ.config.screenConfig.layout = uint8(bin[48])
-	typ.config.screenConfig.uiMode = uint8(bin[49])
+	typ.config.screenConfig.layout = bin[48]
+	typ.config.screenConfig.uiMode = bin[49]
 	typ.config.screenConfig.smallestWidthDP = btou16(bin[50:])
 	typ.config.screenSizeDP.width = btou16(bin[52:])
 	typ.config.screenSizeDP.height = btou16(bin[54:])
@@ -572,7 +572,7 @@ func (typ *Type) MarshalBinary() ([]byte, error) {
 	putu16(bin, uint16(ResTableType))
 	putu16(bin[2:], 56)
 
-	bin[8] = byte(typ.id)
+	bin[8] = typ.id
 	// [9] = 0
 	// [10:12] = 0
 	putu32(bin[12:], uint32(len(typ.entries)))
@@ -755,7 +755,7 @@ type Data struct {
 // UnmarshalBinary creates the data item from binary data
 func (d *Data) UnmarshalBinary(bin []byte) error {
 	d.ByteSize = btou16(bin)
-	d.Res0 = uint8(bin[2])
+	d.Res0 = bin[2]
 	d.Type = DataType(bin[3])
 	d.Value = btou32(bin[4:])
 	return nil
@@ -765,7 +765,7 @@ func (d *Data) UnmarshalBinary(bin []byte) error {
 func (d *Data) MarshalBinary() ([]byte, error) {
 	bin := make([]byte, 8)
 	putu16(bin, 8)
-	bin[2] = byte(d.Res0)
+	bin[2] = d.Res0
 	bin[3] = byte(d.Type)
 	putu32(bin[4:], d.Value)
 	return bin, nil

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1061,12 +1061,12 @@ func TestWindow_CaptureTypedShortcut(t *testing.T) {
 	w.mouseMoved(w.viewport, 5, 5)
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
 
-	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Action(glfw.Press), glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyLeftShift, 0, glfw.Action(glfw.Press), glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyF, 0, glfw.Action(glfw.Press), glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyLeftShift, 0, glfw.Action(glfw.Press), glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Action(glfw.Release), glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyF, 0, glfw.Action(glfw.Release), glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Press, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyLeftShift, 0, glfw.Press, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyF, 0, glfw.Press, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyLeftShift, 0, glfw.Press, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Release, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyF, 0, glfw.Release, glfw.ModControl)
 
 	w.WaitForEvents()
 

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -360,7 +360,7 @@ func (p *glPainter) glDrawLine(width float32, col color.Color, feather float32) 
 func (p *glPainter) glCapture(width, height int32, pixels *[]uint8) {
 	gl.ReadBuffer(gl.FRONT)
 	logError()
-	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(*pixels))
+	gl.ReadPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(*pixels))
 	logError()
 }
 

--- a/widget/entry_cursor_anim.go
+++ b/widget/entry_cursor_anim.go
@@ -32,9 +32,9 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 	cursorOpaque := theme.PrimaryColor()
 	r, g, b, _ := col.ToNRGBA(theme.PrimaryColor())
 	cursorDim := color.NRGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: 0x16}
-	start, end := color.Color(cursorDim), color.Color(cursorOpaque)
+	start, end := color.Color(cursorDim), cursorOpaque
 	if inverted {
-		start, end = color.Color(cursorOpaque), color.Color(cursorDim)
+		start, end = cursorOpaque, color.Color(cursorDim)
 	}
 	interrupted := false
 	anim := canvas.NewColorRGBAAnimation(start, end, time.Second/2, func(c color.Color) {


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This commit applies the work done by running `unconvert -apply ./...` on the codebase in order to remove a few unnecessary conversions. It essentially carries on where https://github.com/fyne-io/fyne/pull/1999 left off and replaces it.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
