### PR TITLE
Fix potential crash after multiple app tabs overflow taps

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -57,6 +57,8 @@ func (t *AppTabs) CreateRenderer() fyne.WidgetRenderer {
 		},
 		appTabs: t,
 	}
+	r.action = r.buildOverflowTabsButton()
+
 	// Initially setup the tab bar to only show one tab, all others will be in overflow.
 	// When the widget is laid out, and we know the size, the tab bar will be updated to show as many as can fit.
 	r.updateTabs(1)
@@ -407,13 +409,12 @@ func (r *appTabsRenderer) updateTabs(max int) {
 
 	// Set overflow action
 	if tabCount <= max {
-		r.action = nil
+		r.action.Hide()
 		r.bar.Layout = layout.NewMaxLayout()
 	} else {
 		tabCount = max
-		if r.action == nil {
-			r.action = r.buildOverflowTabsButton()
-		}
+		r.action.Show()
+
 		// Set layout of tab bar containing tab buttons and overflow action
 		if r.appTabs.location == TabLocationLeading || r.appTabs.location == TabLocationTrailing {
 			r.bar.Layout = layout.NewBorderLayout(nil, r.action, nil, nil)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Fix a race around button creation

Fixes #2275
### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- runtime issue, easily replicated in fyne_demo
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
