### PR TITLE
Make the platform specific scancode available

### DIFF
--- a/event.go
+++ b/event.go
@@ -3,6 +3,8 @@ package fyne
 // KeyEvent describes a keyboard input event.
 type KeyEvent struct {
 	Name KeyName
+	// ScanCode is a platform specific field that reports the hardware ID of the key event
+	ScanCode int
 }
 
 // PointEvent describes a pointer input event. The position is relative to the

--- a/event.go
+++ b/event.go
@@ -1,15 +1,18 @@
 package fyne
 
-// ScanCode represents a hardware ID for (normally desktop) keyboard events.
+// HardwareKey contains information associated with physical key events
 // Most applications should use KeyName for cross-platform compatibility.
-type ScanCode int
+type HardwareKey struct {
+	// ScanCode represents a hardware ID for (normally desktop) keyboard events.
+	ScanCode int
+}
 
 // KeyEvent describes a keyboard input event.
 type KeyEvent struct {
 	// Name describes the keyboard event that is consistent across platforms.
 	Name KeyName
-	// HardwareCode is a platform specific field that reports the hardware ID of the keyboard events.
-	HardwareCode ScanCode
+	// Physical is a platform specific field that reports the hardware information of physical keyboard events.
+	Physical HardwareKey
 }
 
 // PointEvent describes a pointer input event. The position is relative to the

--- a/event.go
+++ b/event.go
@@ -1,10 +1,15 @@
 package fyne
 
+// ScanCode represents a hardware ID for (normally desktop) keyboard events.
+// Most applications should use KeyName for cross-platform compatibility.
+type ScanCode int
+
 // KeyEvent describes a keyboard input event.
 type KeyEvent struct {
+	// Name describes the keyboard event that is consistent across platforms.
 	Name KeyName
-	// ScanCode is a platform specific field that reports the hardware ID of the key event
-	ScanCode int
+	// HardwareCode is a platform specific field that reports the hardware ID of the keyboard events.
+	HardwareCode ScanCode
 }
 
 // PointEvent describes a pointer input event. The position is relative to the

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1118,7 +1118,7 @@ func (w *window) capturesTab(modifier desktop.Modifier) bool {
 
 func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 	keyName := keyToName(key, scancode)
-	keyEvent := &fyne.KeyEvent{Name: keyName, HardwareCode: fyne.ScanCode(scancode)}
+	keyEvent := &fyne.KeyEvent{Name: keyName, Physical: fyne.HardwareKey{ScanCode: scancode}}
 
 	keyDesktopModifier := desktopModifier(mods)
 	pendingMenuToggle := w.menuTogglePending

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1118,7 +1118,7 @@ func (w *window) capturesTab(modifier desktop.Modifier) bool {
 
 func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 	keyName := keyToName(key, scancode)
-	keyEvent := &fyne.KeyEvent{Name: keyName, ScanCode: scancode}
+	keyEvent := &fyne.KeyEvent{Name: keyName, HardwareCode: fyne.ScanCode(scancode)}
 
 	keyDesktopModifier := desktopModifier(mods)
 	pendingMenuToggle := w.menuTogglePending

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1118,8 +1118,8 @@ func (w *window) capturesTab(modifier desktop.Modifier) bool {
 
 func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 	keyName := keyToName(key, scancode)
+	keyEvent := &fyne.KeyEvent{Name: keyName, ScanCode: scancode}
 
-	keyEvent := &fyne.KeyEvent{Name: keyName}
 	keyDesktopModifier := desktopModifier(mods)
 	pendingMenuToggle := w.menuTogglePending
 	pendingMenuDeactivation := w.menuDeactivationPending

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1090,7 +1090,7 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	keyName := glfw.GetKeyName(code, scancode)
 	ret, ok = keyNameMap[keyName]
 	if !ok {
-		return ""
+		return fyne.KeyUnknown
 	}
 
 	return ret
@@ -1166,9 +1166,6 @@ func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action g
 		// key repeat will fall through to TypedKey and TypedShortcut
 	}
 
-	if keyName == "" { // don't emit unknown
-		return
-	}
 	if (keyName == fyne.KeyTab && !w.capturesTab(keyDesktopModifier)) || w.triggersShortcut(keyName, keyDesktopModifier) {
 		return
 	}

--- a/key.go
+++ b/key.go
@@ -167,4 +167,10 @@ const (
 	KeyPlus KeyName = "+"
 	// KeyBackTick is the key "`" on a US keyboard
 	KeyBackTick KeyName = "`"
+
+	// KeyUnknown is used for key events where the underlying hardware generated an
+	// event that Fyne could not decode.
+	//
+	// Since: 2.1
+	KeyUnknown KeyName = ""
 )


### PR DESCRIPTION
This is a complex topic and the int will vary based on platform (macOS is strange).
Some applications need a reference to the source and we can't expose GLFW abstraction

Fixes #1523 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- we don't have any way to test glfw generated events
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
