### PR TITLE
Move file dialog to match selection (currently focus) color

### DIFF
--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -137,7 +137,7 @@ func (s fileItemRenderer) MinSize() fyne.Size {
 
 func (s fileItemRenderer) Refresh() {
 	if s.item.isCurrent {
-		s.background.FillColor = theme.FocusColor()
+		s.background.FillColor = theme.SelectionColor()
 		s.background.Show()
 	} else if s.item.hovered {
 		s.background.FillColor = theme.HoverColor()

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -137,7 +137,7 @@ func (s fileItemRenderer) MinSize() fyne.Size {
 
 func (s fileItemRenderer) Refresh() {
 	if s.item.isCurrent {
-		s.background.FillColor = theme.PrimaryColor()
+		s.background.FillColor = theme.FocusColor()
 		s.background.Show()
 	} else if s.item.hovered {
 		s.background.FillColor = theme.HoverColor()
@@ -146,7 +146,6 @@ func (s fileItemRenderer) Refresh() {
 		s.background.Hide()
 	}
 	s.background.Refresh()
-	s.icon.SetSelected(s.item.isCurrent)
 	canvas.Refresh(s.item)
 }
 

--- a/test/markup_renderer.go
+++ b/test/markup_renderer.go
@@ -395,6 +395,7 @@ func knownColor(c color.Color) string {
 		nrgbaColor(theme.PlaceHolderColor()):    "placeholder",
 		nrgbaColor(theme.PrimaryColor()):        "primary",
 		nrgbaColor(theme.ScrollBarColor()):      "scrollbar",
+		nrgbaColor(theme.SelectionColor()):      "selection",
 		nrgbaColor(theme.ShadowColor()):         "shadow",
 	}[nrgbaColor(c)]
 }

--- a/test/testtheme.go
+++ b/test/testtheme.go
@@ -30,6 +30,7 @@ func NewTheme() fyne.Theme {
 			theme.ColorNamePressed:         blue,
 			theme.ColorNamePrimary:         green,
 			theme.ColorNameScrollBar:       blue,
+			theme.ColorNameSelection:       color.RGBA{red.R, red.G, red.B, 44},
 			theme.ColorNameShadow:          blue,
 		},
 		fonts: map[fyne.TextStyle]fyne.Resource{

--- a/test/theme.go
+++ b/test/theme.go
@@ -35,6 +35,7 @@ func Theme() fyne.Theme {
 				theme.ColorNamePressed:         color.NRGBA{A: 0x33},
 				theme.ColorNamePrimary:         color.NRGBA{R: 0xff, G: 0xcc, B: 0x80, A: 0xff},
 				theme.ColorNameScrollBar:       color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0xaa},
+				theme.ColorNameSelection:       color.NRGBA{R: 0x78, G: 0x3a, B: 0x3a, A: 0x99},
 				theme.ColorNameShadow:          color.NRGBA{A: 0x88},
 			},
 			fonts: map[fyne.TextStyle]fyne.Resource{

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -108,7 +108,7 @@ const (
 	// Since: 2.0
 	ColorNameScrollBar fyne.ThemeColorName = "scrollBar"
 
-	// ColorNamePrimary is the name of theme lookup for primary color.
+	// ColorNameSelection is the name of theme lookup for selection color.
 	//
 	// Since: 2.1
 	ColorNameSelection fyne.ThemeColorName = "selection"

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -108,6 +108,11 @@ const (
 	// Since: 2.0
 	ColorNameScrollBar fyne.ThemeColorName = "scrollBar"
 
+	// ColorNamePrimary is the name of theme lookup for primary color.
+	//
+	// Since: 2.1
+	ColorNameSelection fyne.ThemeColorName = "selection"
+
 	// ColorNameShadow is the name of theme lookup for shadow color.
 	//
 	// Since: 2.0
@@ -190,6 +195,16 @@ var (
 		ColorPurple: color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff},
 		ColorBrown:  color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff},
 		ColorGray:   color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff},
+	}
+	selectionColors = map[string]color.Color{
+		ColorRed:    color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f},
+		ColorOrange: color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x3f},
+		ColorYellow: color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x3f},
+		ColorGreen:  color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x3f},
+		ColorBlue:   color.NRGBA{R: 0x21, G: 0x96, B: 0xf3, A: 0x3f},
+		ColorPurple: color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x3f},
+		ColorBrown:  color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f},
+		ColorGray:   color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x3f},
 	}
 
 	//	themeSecondaryColor = color.NRGBA{R: 0xff, G: 0x40, B: 0x81, A: 0xff}
@@ -284,6 +299,8 @@ func (t *builtinTheme) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.C
 		return PrimaryColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
 	} else if n == ColorNameFocus {
 		return focusColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
+	} else if n == ColorNameSelection {
+		return selectionColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
 	}
 
 	if c, ok := colors[n]; ok {
@@ -425,6 +442,13 @@ func ForegroundColor() color.Color {
 // InputBackgroundColor returns the color used to draw underneath input elements.
 func InputBackgroundColor() color.Color {
 	return current().Color(ColorNameInputBackground, currentVariant())
+}
+
+// SelectionColor returns the color for a selected element.
+//
+// Since: 2.1
+func SelectionColor() color.Color {
+	return safeColorLookup(ColorNameSelection, currentVariant())
 }
 
 // ScrollBarColor returns the color (and translucency) for a scrollBar
@@ -605,6 +629,14 @@ func safeFontLookup(s fyne.TextStyle) fyne.Resource {
 	}
 
 	return DefaultTextFont()
+}
+
+func selectionColorNamed(name string) color.Color {
+	col, ok := selectionColors[name]
+	if !ok {
+		return selectionColors[ColorBlue]
+	}
+	return col
 }
 
 func setupDefaultTheme() fyne.Theme {

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -29,7 +29,7 @@ type FileIcon struct {
 	cachedURI fyne.URI
 }
 
-// NewFileIcon takes a filepath and creates an icon with an overlayed label using the detected mimetype and extension
+// NewFileIcon takes a filepath and creates an icon with an overlaid label using the detected mimetype and extension
 //
 // Since: 1.4
 func NewFileIcon(uri fyne.URI) *FileIcon {
@@ -74,9 +74,8 @@ func (i *FileIcon) CreateRenderer() fyne.WidgetRenderer {
 	i.propertyLock.RLock()
 	defer i.propertyLock.RUnlock()
 
-	// TODO should FileIcon render a background representing selection, or should it be in the collection?
-	// TODO file dialog currently uses a container with NewGridWrapLayout, but if this changes to List, or Table then the primary color background would be rendered twice.
-	background := canvas.NewRectangle(theme.PrimaryColor())
+	// TODO remove background when `SetSelected` is gone.
+	background := canvas.NewRectangle(theme.FocusColor())
 	background.Hide()
 
 	s := &fileIconRenderer{file: i, background: background}
@@ -183,7 +182,7 @@ func (s *fileIconRenderer) Refresh() {
 
 	if s.file.Selected {
 		s.background.Show()
-		s.ext.Color = theme.PrimaryColor()
+		s.ext.Color = theme.FocusColor()
 		if _, ok := s.img.Resource.(*theme.InvertedThemedResource); !ok {
 			s.img.Resource = theme.NewInvertedThemedResource(s.img.Resource)
 		}

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -75,7 +75,7 @@ func (i *FileIcon) CreateRenderer() fyne.WidgetRenderer {
 	defer i.propertyLock.RUnlock()
 
 	// TODO remove background when `SetSelected` is gone.
-	background := canvas.NewRectangle(theme.FocusColor())
+	background := canvas.NewRectangle(theme.SelectionColor())
 	background.Hide()
 
 	s := &fileIconRenderer{file: i, background: background}
@@ -182,7 +182,7 @@ func (s *fileIconRenderer) Refresh() {
 
 	if s.file.Selected {
 		s.background.Show()
-		s.ext.Color = theme.FocusColor()
+		s.ext.Color = theme.SelectionColor()
 		if _, ok := s.img.Resource.(*theme.InvertedThemedResource); !ok {
 			s.img.Resource = theme.NewInvertedThemedResource(s.img.Resource)
 		}

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -90,7 +90,9 @@ func (i *FileIcon) CreateRenderer() fyne.WidgetRenderer {
 	return s
 }
 
-// SetSelected makes the file look like it is selected
+// SetSelected makes the file look like it is selected.
+//
+// Deprecated: Selection is now handled externally.
 func (i *FileIcon) SetSelected(selected bool) {
 	i.Selected = selected
 	i.Refresh()

--- a/widget/list.go
+++ b/widget/list.go
@@ -331,7 +331,7 @@ func (li *listItemRenderer) Layout(size fyne.Size) {
 
 func (li *listItemRenderer) Refresh() {
 	if li.item.selected {
-		li.item.background.FillColor = theme.FocusColor()
+		li.item.background.FillColor = theme.SelectionColor()
 		li.item.background.Show()
 	} else if li.item.hovered {
 		li.item.background.FillColor = theme.HoverColor()

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -157,12 +157,12 @@ func TestList_Selection(t *testing.T) {
 
 	assert.False(t, children[0].(*listItem).background.Visible())
 	children[0].(*listItem).Tapped(&fyne.PointEvent{})
-	assert.Equal(t, children[0].(*listItem).background.FillColor, theme.FocusColor())
+	assert.Equal(t, children[0].(*listItem).background.FillColor, theme.SelectionColor())
 	assert.True(t, children[0].(*listItem).background.Visible())
 	assert.Equal(t, 1, len(list.selected))
 	assert.Equal(t, 0, list.selected[0])
 	children[1].(*listItem).Tapped(&fyne.PointEvent{})
-	assert.Equal(t, children[1].(*listItem).background.FillColor, theme.FocusColor())
+	assert.Equal(t, children[1].(*listItem).background.FillColor, theme.SelectionColor())
 	assert.True(t, children[1].(*listItem).background.Visible())
 	assert.Equal(t, 1, len(list.selected))
 	assert.Equal(t, 1, list.selected[0])
@@ -189,20 +189,20 @@ func TestList_Select(t *testing.T) {
 	list.Select(50)
 	assert.Equal(t, float32(937), list.offsetY)
 	visible := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).visible
-	assert.Equal(t, visible[50].background.FillColor, theme.FocusColor())
+	assert.Equal(t, visible[50].background.FillColor, theme.SelectionColor())
 	assert.True(t, visible[50].background.Visible())
 
 	list.Select(5)
 	assert.Equal(t, float32(190), list.offsetY)
 	visible = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).visible
-	assert.Equal(t, visible[5].background.FillColor, theme.FocusColor())
+	assert.Equal(t, visible[5].background.FillColor, theme.SelectionColor())
 	assert.True(t, visible[5].background.Visible())
 
 	list.Select(6)
 	assert.Equal(t, float32(190), list.offsetY)
 	visible = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).visible
 	assert.False(t, visible[5].background.Visible())
-	assert.Equal(t, visible[6].background.FillColor, theme.FocusColor())
+	assert.Equal(t, visible[6].background.FillColor, theme.SelectionColor())
 	assert.True(t, visible[6].background.Visible())
 }
 
@@ -215,7 +215,7 @@ func TestList_Unselect(t *testing.T) {
 
 	list.Select(10)
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
-	assert.Equal(t, children[10].(*listItem).background.FillColor, theme.FocusColor())
+	assert.Equal(t, children[10].(*listItem).background.FillColor, theme.SelectionColor())
 	assert.True(t, children[10].(*listItem).background.Visible())
 
 	list.Unselect(10)

--- a/widget/testdata/tree/layout_multiple_branch_opened_leaf_selected.xml
+++ b/widget/testdata/tree/layout_multiple_branch_opened_leaf_selected.xml
@@ -34,7 +34,7 @@
 						<rectangle fillColor="disabled" size="210x1"/>
 					</widget>
 					<widget pos="0,114" size="210x37" type="*widget.leaf">
-						<rectangle fillColor="focus" size="210x37"/>
+						<rectangle fillColor="selection" size="210x37"/>
 						<widget pos="52,0" size="158x37" type="*widget.Label">
 							<text pos="8,8" size="142x21">2222222222</text>
 						</widget>

--- a/widget/testdata/tree/layout_multiple_branch_opened_selected.xml
+++ b/widget/testdata/tree/layout_multiple_branch_opened_selected.xml
@@ -23,7 +23,7 @@
 						<rectangle fillColor="disabled" size="210x1"/>
 					</widget>
 					<widget pos="0,76" size="210x37" type="*widget.branch">
-						<rectangle fillColor="focus" size="210x37"/>
+						<rectangle fillColor="selection" size="210x37"/>
 						<widget pos="28,0" size="182x37" type="*widget.Label">
 							<text pos="8,8" size="166x21">B</text>
 						</widget>

--- a/widget/testdata/tree/layout_multiple_branch_selected.xml
+++ b/widget/testdata/tree/layout_multiple_branch_selected.xml
@@ -15,7 +15,7 @@
 						<rectangle fillColor="disabled" size="192x1"/>
 					</widget>
 					<widget pos="0,38" size="192x37" type="*widget.branch">
-						<rectangle fillColor="focus" size="192x37"/>
+						<rectangle fillColor="selection" size="192x37"/>
 						<widget pos="28,0" size="164x37" type="*widget.Label">
 							<text pos="8,8" size="148x21">B</text>
 						</widget>

--- a/widget/testdata/tree/layout_multiple_leaf_selected.xml
+++ b/widget/testdata/tree/layout_multiple_leaf_selected.xml
@@ -12,7 +12,7 @@
 						<rectangle fillColor="disabled" size="192x1"/>
 					</widget>
 					<widget pos="0,38" size="192x37" type="*widget.leaf">
-						<rectangle fillColor="focus" size="192x37"/>
+						<rectangle fillColor="selection" size="192x37"/>
 						<widget pos="28,0" size="164x37" type="*widget.Label">
 							<text pos="8,8" size="148x21">2222222222</text>
 						</widget>

--- a/widget/testdata/tree/layout_multiple_selected.xml
+++ b/widget/testdata/tree/layout_multiple_selected.xml
@@ -26,7 +26,7 @@
 						<rectangle fillColor="disabled" size="192x1"/>
 					</widget>
 					<widget pos="0,76" size="192x37" type="*widget.leaf">
-						<rectangle fillColor="focus" size="192x37"/>
+						<rectangle fillColor="selection" size="192x37"/>
 						<widget pos="28,0" size="164x37" type="*widget.Label">
 							<text pos="8,8" size="148x21">44444444444444444444</text>
 						</widget>

--- a/widget/testdata/tree/layout_single_branch_opened_leaf_selected.xml
+++ b/widget/testdata/tree/layout_single_branch_opened_leaf_selected.xml
@@ -15,7 +15,7 @@
 						<rectangle fillColor="disabled" size="192x1"/>
 					</widget>
 					<widget pos="0,38" size="192x37" type="*widget.leaf">
-						<rectangle fillColor="focus" size="192x37"/>
+						<rectangle fillColor="selection" size="192x37"/>
 						<widget pos="52,0" size="140x37" type="*widget.Label">
 							<text pos="8,8" size="124x21">11111</text>
 						</widget>

--- a/widget/testdata/tree/layout_single_branch_opened_selected.xml
+++ b/widget/testdata/tree/layout_single_branch_opened_selected.xml
@@ -4,7 +4,7 @@
 			<widget size="192x292" type="*widget.Scroll">
 				<widget size="192x292" type="*widget.treeContent">
 					<widget size="192x37" type="*widget.branch">
-						<rectangle fillColor="focus" size="192x37"/>
+						<rectangle fillColor="selection" size="192x37"/>
 						<widget pos="28,0" size="164x37" type="*widget.Label">
 							<text pos="8,8" size="148x21">A</text>
 						</widget>

--- a/widget/testdata/tree/layout_single_branch_selected.xml
+++ b/widget/testdata/tree/layout_single_branch_selected.xml
@@ -4,7 +4,7 @@
 			<widget size="192x292" type="*widget.Scroll">
 				<widget size="192x292" type="*widget.treeContent">
 					<widget size="192x37" type="*widget.branch">
-						<rectangle fillColor="focus" size="192x37"/>
+						<rectangle fillColor="selection" size="192x37"/>
 						<widget pos="28,0" size="164x37" type="*widget.Label">
 							<text pos="8,8" size="148x21">A</text>
 						</widget>

--- a/widget/testdata/tree/layout_single_leaf_selected.xml
+++ b/widget/testdata/tree/layout_single_leaf_selected.xml
@@ -4,7 +4,7 @@
 			<widget size="192x292" type="*widget.Scroll">
 				<widget size="192x292" type="*widget.treeContent">
 					<widget size="192x37" type="*widget.leaf">
-						<rectangle fillColor="focus" size="192x37"/>
+						<rectangle fillColor="selection" size="192x37"/>
 						<widget pos="28,0" size="164x37" type="*widget.Label">
 							<text pos="8,8" size="148x21">11111</text>
 						</widget>

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -716,7 +716,7 @@ func (r *treeNodeRenderer) partialRefresh() {
 		r.treeNode.icon.Refresh()
 	}
 	if len(r.treeNode.tree.selected) > 0 && r.treeNode.uid == r.treeNode.tree.selected[0] {
-		r.background.FillColor = theme.FocusColor()
+		r.background.FillColor = theme.SelectionColor()
 		r.background.Show()
 	} else if r.treeNode.hovered {
 		r.background.FillColor = theme.HoverColor()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Moving the filedialog selection to match other selections

Relates to #2197

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- turns out it's just a colour change
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

