### PR TITLE
Fix possible issue with setting floats that have format precision

### DIFF
--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -59,7 +59,8 @@ func (s *stringFromBool) Get() (string, error) {
 func (s *stringFromBool) Set(str string) error {
 	var val bool
 	if s.format != "" {
-		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		safe := stripFormatPrecision(s.format)
+		n, err := fmt.Sscanf(str, safe+" ", &val) // " " denotes match to end of string
 		if err != nil {
 			return err
 		}
@@ -145,7 +146,8 @@ func (s *stringFromFloat) Get() (string, error) {
 func (s *stringFromFloat) Set(str string) error {
 	var val float64
 	if s.format != "" {
-		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		safe := stripFormatPrecision(s.format)
+		n, err := fmt.Sscanf(str, safe+" ", &val) // " " denotes match to end of string
 		if err != nil {
 			return err
 		}
@@ -231,7 +233,8 @@ func (s *stringFromInt) Get() (string, error) {
 func (s *stringFromInt) Set(str string) error {
 	var val int
 	if s.format != "" {
-		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		safe := stripFormatPrecision(s.format)
+		n, err := fmt.Sscanf(str, safe+" ", &val) // " " denotes match to end of string
 		if err != nil {
 			return err
 		}

--- a/data/binding/convert_helper.go
+++ b/data/binding/convert_helper.go
@@ -50,7 +50,7 @@ func stripFormatPrecision(in string) string {
 	if sizeRunes[0] == '.' { // formats like %.2f
 		return fmt.Sprintf("%s%s", string(runes[:start+1]), string(runes[end:]))
 	}
-	return fmt.Sprintf("%s%d%s", string(runes[:start+1]), int(width), string(runes[end:]))
+	return string(runes[:start+1]) + strconv.Itoa(int(width)) + string(runes[end:])
 }
 
 func uriFromString(in string) (fyne.URI, error) {

--- a/data/binding/convert_helper.go
+++ b/data/binding/convert_helper.go
@@ -48,7 +48,7 @@ func stripFormatPrecision(in string) string {
 	}
 
 	if sizeRunes[0] == '.' { // formats like %.2f
-		return fmt.Sprintf("%s%s", string(runes[:start+1]), string(runes[end:]))
+		return string(runes[:start+1]) + string(runes[end:])
 	}
 	return string(runes[:start+1]) + strconv.Itoa(int(width)) + string(runes[end:])
 }

--- a/data/binding/convert_helper.go
+++ b/data/binding/convert_helper.go
@@ -1,7 +1,6 @@
 package binding
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 

--- a/data/binding/convert_helper.go
+++ b/data/binding/convert_helper.go
@@ -11,7 +11,7 @@ import (
 
 func stripFormatPrecision(in string) string {
 	// quick exit if certainly not float
-	if strings.IndexAny(in, "f") == -1 {
+	if !strings.ContainsAny(in, "f") {
 		return in
 	}
 

--- a/data/binding/convert_helper_test.go
+++ b/data/binding/convert_helper_test.go
@@ -8,6 +8,22 @@ import (
 	"fyne.io/fyne/v2/storage"
 )
 
+func TestStripPrecision(t *testing.T) {
+	format := "%2.3f"
+	assert.Equal(t, "%2f", stripFormatPrecision(format))
+	format = "total=%3.4f%%"
+	assert.Equal(t, "total=%3f%%", stripFormatPrecision(format))
+
+	format = "%.2f"
+	assert.Equal(t, "%f", stripFormatPrecision(format))
+
+	format = "%4d"
+	assert.Equal(t, "%4d", stripFormatPrecision(format))
+
+	format = "%v"
+	assert.Equal(t, "%v", stripFormatPrecision(format))
+}
+
 func TestURIFromStringHelper(t *testing.T) {
 	str := "file:///tmp/test.txt"
 	u, err := uriFromString(str)

--- a/data/binding/convert_test.go
+++ b/data/binding/convert_test.go
@@ -85,16 +85,16 @@ func TestFloatToString(t *testing.T) {
 
 func TestFloatToStringWithFormat(t *testing.T) {
 	f := NewFloat()
-	s := FloatToStringWithFormat(f, "%f%%")
+	s := FloatToStringWithFormat(f, "%.2f%%")
 	v, err := s.Get()
 	assert.Nil(t, err)
-	assert.Equal(t, "0.000000%", v)
+	assert.Equal(t, "0.00%", v)
 
 	err = f.Set(0.3)
 	assert.Nil(t, err)
 	v, err = s.Get()
 	assert.Nil(t, err)
-	assert.Equal(t, "0.300000%", v)
+	assert.Equal(t, "0.30%", v)
 
 	err = s.Set("4.3") // valid float64 but not valid format
 	assert.NotNil(t, err)

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -236,7 +236,8 @@ func (s *stringFrom{{ .Name }}) Set(str string) error {
 {{ else }}
 	var val {{ .Type }}
 	if s.format != "" {
-		n, err := fmt.Sscanf(str, s.format+" ", &val) // " " denotes match to end of string
+		safe := stripFormatPrecision(s.format)
+		n, err := fmt.Sscanf(str, safe+" ", &val) // " " denotes match to end of string
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
The fmt.Scanf does not support precision for float verbs, so this strips that out for the `Set` call.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
