### PR TITLE
Add a markdown parser for RichText

### DIFF
--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -156,53 +156,20 @@ func makeTextTab(_ fyne.Window) fyne.CanvasObject {
 	hyperlink.Wrapping = fyne.TextWrapWord
 	entryLoremIpsum.Wrapping = fyne.TextWrapWord
 
-	u, _ := url.Parse("https://fyne.io/")
-	rich := widget.NewRichText(
-		&widget.TextSegment{
-			Style: widget.RichTextStyleHeading,
-			Text:  "RichText Heading",
-		},
-		&widget.TextSegment{
-			Style: widget.RichTextStyleSubHeading,
-			Text:  "A Sub Heading",
-		},
-		&widget.SeparatorSegment{},
-		&widget.TextSegment{
-			Style: widget.RichTextStyleParagraph,
-			Text:  "A paragraph between separators that is very long, it should respect the wrapping flag",
-		},
-		&widget.SeparatorSegment{},
-		&widget.TextSegment{
-			Style: widget.RichTextStyle{
-				Inline: true,
-			},
-			Text: "Normal ",
-		},
-		&widget.TextSegment{
-			Style: widget.RichTextStyleStrong,
-			Text:  "Bold ",
-		},
-		&widget.TextSegment{
-			Style: widget.RichTextStyleEmphasis,
-			Text:  "Italic ",
-		},
-		&widget.HyperlinkSegment{
-			Text: "Link",
-			URL:  u,
-		},
-		&widget.TextSegment{
-			Style: widget.RichTextStyle{
-				Inline: true,
-			},
-			Text: ". This styled row should also wrap as expected, but only ",
-		},
-		&widget.TextSegment{
-			Style: widget.RichTextStyle{
-				Inline:    true,
-				TextStyle: fyne.TextStyle{Italic: true},
-			},
-			Text: "when required.",
-		})
+	rich := widget.NewRichTextFromMarkdown(`
+# RichText Heading
+
+## A Sub Heading
+
+---
+
+A paragraph between separators that is very long, it should respect the wrapping flag.
+
+---
+
+Normal **Bold** *Italic* [Link](https://fyne.io/).
+This styled row should also wrap as expected, but only *when required*.
+`)
 
 	radioAlign := widget.NewRadioGroup([]string{"Text Alignment Leading", "Text Alignment Center", "Text Alignment Trailing"}, func(s string) {
 		var align fyne.TextAlign

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -1,0 +1,88 @@
+package widget
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/russross/blackfriday/v2"
+
+	"fyne.io/fyne/v2"
+)
+
+// NewRichTextFromMarkdown configures a RichText widget by parsing the provided markdown content.
+//
+// Since: 2.1
+func NewRichTextFromMarkdown(content string) *RichText {
+	return NewRichText(parseMarkdown(content)...)
+}
+
+func parseMarkdown(content string) []RichTextSegment {
+	nodes := blackfriday.New().Parse([]byte(content))
+	var segs []RichTextSegment
+
+	var nextSeg RichTextSegment
+	nodes.Walk(func(node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+		if !entering {
+			if text, ok := nextSeg.(*TextSegment); ok && text.Style == RichTextStyleInline {
+				text.Style = RichTextStyleParagraph
+			}
+			nextSeg = &TextSegment{
+				Style: RichTextStyleInline,
+			}
+
+			return blackfriday.GoToNext
+		}
+
+		switch node.Type {
+		case blackfriday.Heading:
+			switch node.HeadingData.Level {
+			case 1:
+				nextSeg = &TextSegment{
+					Style: RichTextStyleHeading,
+					Text:  string(node.Literal),
+				}
+			case 2:
+				nextSeg = &TextSegment{
+					Style: RichTextStyleSubHeading,
+					Text:  string(node.Literal),
+				}
+			}
+		case blackfriday.HorizontalRule:
+			segs = append(segs, &SeparatorSegment{})
+		case blackfriday.Link:
+			link, _ := url.Parse(string(node.LinkData.Destination))
+			nextSeg = &HyperlinkSegment{fyne.TextAlignLeading, strings.TrimSpace(string(node.LinkData.Title)), link}
+		case blackfriday.Paragraph:
+			nextSeg = &TextSegment{
+				Style: RichTextStyleInline, // we make it a paragraph at the end if there are no more elements
+				Text:  string(node.Literal),
+			}
+		case blackfriday.Emph:
+			nextSeg = &TextSegment{
+				Style: RichTextStyleEmphasis,
+				Text:  string(node.Literal),
+			}
+		case blackfriday.Strong:
+			nextSeg = &TextSegment{
+				Style: RichTextStyleStrong,
+				Text:  string(node.Literal),
+			}
+		case blackfriday.Text:
+			trimmed := string(node.Literal)
+			trimmed = strings.ReplaceAll(trimmed, "\n", " ") // newline inside paragraph is not newline
+			if trimmed == "" {
+				return blackfriday.GoToNext
+			}
+			if text, ok := nextSeg.(*TextSegment); ok {
+				text.Text = trimmed
+			}
+			if link, ok := nextSeg.(*HyperlinkSegment); ok {
+				link.Text = trimmed
+			}
+			segs = append(segs, nextSeg)
+		}
+
+		return blackfriday.GoToNext
+	})
+	return segs
+}

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -1,0 +1,71 @@
+package widget
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRichTextMarkdown_Heading(t *testing.T) {
+	r := NewRichTextFromMarkdown("# Head1\n\n## Head2\n")
+
+	assert.Equal(t, 2, len(r.Segments))
+	if text, ok := r.Segments[0].(*TextSegment); ok {
+		assert.Equal(t, "Head1", text.Text)
+		assert.Equal(t, RichTextStyleHeading, text.Style)
+	} else {
+		t.Error("Segment should be Text")
+	}
+	if text, ok := r.Segments[1].(*TextSegment); ok {
+		assert.Equal(t, "Head2", text.Text)
+		assert.Equal(t, RichTextStyleSubHeading, text.Style)
+	} else {
+		t.Error("Segment should be Text")
+	}
+}
+
+func TestRichTextMarkdown_Hyperlink(t *testing.T) {
+	r := NewRichTextFromMarkdown("[title](https://fyne.io/)")
+
+	assert.Equal(t, 1, len(r.Segments))
+	if link, ok := r.Segments[0].(*HyperlinkSegment); ok {
+		assert.Equal(t, "title", link.Text)
+		assert.Equal(t, "fyne.io", link.URL.Host)
+	} else {
+		t.Error("Segment should be a Hyperlink")
+	}
+}
+
+func TestRichTextMarkdown_Lines(t *testing.T) {
+	r := NewRichTextFromMarkdown("line1\nline2\n") // a single newline is not a new paragraph
+
+	assert.Equal(t, 1, len(r.Segments))
+	if text, ok := r.Segments[0].(*TextSegment); ok {
+		assert.Equal(t, "line1 line2", text.Text)
+	} else {
+		t.Error("Segment should be Text")
+	}
+
+	r = NewRichTextFromMarkdown("line1\n\nline2\n")
+
+	assert.Equal(t, 2, len(r.Segments))
+	if text, ok := r.Segments[0].(*TextSegment); ok {
+		assert.Equal(t, "line1", text.Text)
+	} else {
+		t.Error("Segment should be Text")
+	}
+	if text, ok := r.Segments[1].(*TextSegment); ok {
+		assert.Equal(t, "line2", text.Text)
+	} else {
+		t.Error("Segment should be Text")
+	}
+}
+
+func TestRichTextMarkdown_Separator(t *testing.T) {
+	r := NewRichTextFromMarkdown("---\n")
+
+	assert.Equal(t, 1, len(r.Segments))
+	if _, ok := r.Segments[0].(*SeparatorSegment); !ok {
+		t.Error("Segment should be a separator")
+	}
+}


### PR DESCRIPTION
### Description

Functionality is not complete, it will expand as RichText supports more.
Probably still need to add:

-[ ] List
-[ ] Code
-[ ] Inline Code
-[ ] Blockquote

Possibly other PR:
-[ ] Image

Fixes #149

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
