### PR TITLE
Fix: hidden table seperators being rendered incorrectly

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -373,7 +373,7 @@ func (t *tableRenderer) moveIndicators() {
 	}
 
 	for i := divs; i < len(t.dividers); i++ {
-		t.dividers[divs].Hide()
+		t.dividers[i].Hide()
 	}
 	canvas.Refresh(t.t)
 }

--- a/widget/testdata/table/desktop/hovered.xml
+++ b/widget/testdata/table/desktop/hovered.xml
@@ -42,12 +42,6 @@
 			<widget pos="4,79" size="168x1" type="*widget.Separator">
 				<rectangle fillColor="disabled" size="168x1"/>
 			</widget>
-			<widget size="0x0" type="*widget.Separator">
-				<rectangle fillColor="disabled" size="0x0"/>
-			</widget>
-			<widget size="0x0" type="*widget.Separator">
-				<rectangle fillColor="disabled" size="0x0"/>
-			</widget>
 		</widget>
 	</content>
 </canvas>

--- a/widget/testdata/table/desktop/hovered_out.xml
+++ b/widget/testdata/table/desktop/hovered_out.xml
@@ -31,15 +31,6 @@
 			<widget pos="4,41" size="168x1" type="*widget.Separator">
 				<rectangle fillColor="disabled" size="168x1"/>
 			</widget>
-			<widget size="0x0" type="*widget.Separator">
-				<rectangle fillColor="disabled" size="0x0"/>
-			</widget>
-			<widget size="0x0" type="*widget.Separator">
-				<rectangle fillColor="disabled" size="0x0"/>
-			</widget>
-			<widget size="0x0" type="*widget.Separator">
-				<rectangle fillColor="disabled" size="0x0"/>
-			</widget>
 		</widget>
 	</content>
 </canvas>


### PR DESCRIPTION
### Description:
The table separators (that are not in view) that should be hidden were still being rendered due to an incorrect variable being used.
Fixed the issue and the incorrect test templates.

Fixes #2266 

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
