### PR TITLE
Export table scrolling methods

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -92,10 +92,7 @@ func (t *Table) Select(id TableCellID) {
 	}
 	t.selectedCell = &id
 
-	t.scrollTo(id)
-	if t.moveCallback != nil {
-		t.moveCallback()
-	}
+	t.ScrollTo(id)
 
 	if f := t.OnSelected; f != nil {
 		f(id)
@@ -161,6 +158,10 @@ func (t *Table) ScrollTo(id TableCellID) {
 		return
 	}
 
+	if t.scroll == nil {
+		return
+	}
+
 	rows, cols := t.Length()
 	if id.Row >= rows {
 		id.Row = rows - 1
@@ -170,19 +171,42 @@ func (t *Table) ScrollTo(id TableCellID) {
 		id.Col = cols - 1
 	}
 
-	t.scrollTo(id)
+	scrollPos := t.offset
+
+	cellX, cellWidth := t.findX(id.Col)
+	if cellX < scrollPos.X {
+		scrollPos.X = cellX
+	} else if cellX+cellWidth > scrollPos.X+t.scroll.Size().Width {
+		scrollPos.X = cellX + cellWidth - t.scroll.Size().Width
+	}
+
+	cellY, cellHeight := t.findY(id.Row)
+	if cellY < scrollPos.Y {
+		scrollPos.Y = cellY
+	} else if cellY+cellHeight > scrollPos.Y+t.scroll.Size().Height {
+		scrollPos.Y = cellY + cellHeight - t.scroll.Size().Height
+	}
+
+	t.scroll.Offset = scrollPos
+	t.offset = scrollPos
+	t.finishScroll()
 }
 
 // ScrollToBottom scrolls to the last row in the table
 //
 // Since: 2.1
 func (t *Table) ScrollToBottom() {
-	if t.Length == nil {
+	if t.Length == nil || t.scroll == nil {
 		return
 	}
 
 	rows, _ := t.Length()
-	t.scrollTo(TableCellID{Row: rows - 1})
+	cellY, cellHeight := t.findY(rows - 1)
+	y := cellY + cellHeight - t.scroll.Size().Height
+
+	t.scroll.Offset.Y = y
+	t.offset.Y = y
+	t.finishScroll()
 }
 
 // ScrollToLeading scrolls horizontally to the leading edge of the table
@@ -195,18 +219,20 @@ func (t *Table) ScrollToLeading() {
 
 	t.scroll.Offset.X = 0
 	t.offset.X = 0
-	if t.moveCallback != nil {
-		t.moveCallback()
-	}
-	t.scroll.Refresh()
-	t.cells.Refresh()
+	t.finishScroll()
 }
 
 // ScrollToTop scrolls to the first row in the table
 //
 // Since: 2.1
 func (t *Table) ScrollToTop() {
-	t.scrollTo(TableCellID{0, 0})
+	if t.scroll == nil {
+		return
+	}
+
+	t.scroll.Offset.Y = 0
+	t.offset.Y = 0
+	t.finishScroll()
 }
 
 // ScrollToTrailing scrolls horizontally to the trailing edge of the table
@@ -218,44 +244,17 @@ func (t *Table) ScrollToTrailing() {
 	}
 
 	_, cols := t.Length()
-	lastCol := cols - 1
-
-	cellSize := t.templateSize()
-	cellX := float32(0)
-	cellWidth := float32(0)
-	for i := 0; i <= lastCol; i++ {
-		if cellWidth > 0 {
-			cellX += cellWidth + theme.SeparatorThicknessSize()
-		}
-
-		width := cellSize.Width
-		if w, ok := t.columnWidths[i]; ok {
-			width = w
-		}
-		cellWidth = width
-	}
-
+	cellX, cellWidth := t.findX(cols - 1)
 	scrollX := cellX + cellWidth - t.scroll.Size().Width
+
 	t.scroll.Offset.X = scrollX
 	t.offset.X = scrollX
-
-	if t.moveCallback != nil {
-		t.moveCallback()
-	}
-	t.scroll.Refresh()
-	t.cells.Refresh()
+	t.finishScroll()
 }
 
-func (t *Table) scrollTo(id TableCellID) {
-	if t.scroll == nil {
-		return
-	}
-	scrollPos := t.offset
-
+func (t *Table) findX(col int) (cellX float32, cellWidth float32) {
 	cellSize := t.templateSize()
-	cellX := float32(0)
-	cellWidth := float32(0)
-	for i := 0; i <= id.Col; i++ {
+	for i := 0; i <= col; i++ {
 		if cellWidth > 0 {
 			cellX += cellWidth + theme.SeparatorThicknessSize()
 		}
@@ -266,21 +265,17 @@ func (t *Table) scrollTo(id TableCellID) {
 		}
 		cellWidth = width
 	}
+	return
+}
 
-	if cellX < scrollPos.X {
-		scrollPos.X = cellX
-	} else if cellX+cellWidth > scrollPos.X+t.scroll.Size().Width {
-		scrollPos.X = cellX + cellWidth - t.scroll.Size().Width
-	}
+func (t *Table) findY(row int) (cellY float32, cellHeight float32) {
+	cellSize := t.templateSize()
+	cellHeight = cellSize.Height
+	cellY = float32(row) * (cellHeight + theme.SeparatorThicknessSize())
+	return
+}
 
-	cellY := float32(id.Row) * (cellSize.Height + theme.SeparatorThicknessSize())
-	if cellY < scrollPos.Y {
-		scrollPos.Y = cellY
-	} else if cellY+cellSize.Height > scrollPos.Y+t.scroll.Size().Height {
-		scrollPos.Y = cellY + cellSize.Height - t.scroll.Size().Height
-	}
-	t.scroll.Offset = scrollPos
-	t.offset = scrollPos
+func (t *Table) finishScroll() {
 	if t.moveCallback != nil {
 		t.moveCallback()
 	}

--- a/widget/table.go
+++ b/widget/table.go
@@ -173,25 +173,22 @@ func (t *Table) ScrollTo(id TableCellID) {
 	t.scrollTo(id)
 }
 
-// ScrollToEnd will scroll to the last cell in the table
+// ScrollToBottom will scroll to the last row in the table
 //
 // Since: 2.1
-func (t *Table) ScrollToEnd() {
+func (t *Table) ScrollToBottom() {
 	if t.Length == nil {
 		return
 	}
 
-	rows, cols := t.Length()
-	t.scrollTo(TableCellID{
-		Row: rows - 1,
-		Col: cols - 1,
-	})
+	rows, _ := t.Length()
+	t.scrollTo(TableCellID{Row: rows - 1})
 }
 
-// ScrollToStart will scroll to the first cell in the table
+// ScrollToTop will scroll to the first row in the table
 //
 // Since: 2.1
-func (t *Table) ScrollToStart() {
+func (t *Table) ScrollToTop() {
 	t.scrollTo(TableCellID{0, 0})
 }
 

--- a/widget/table.go
+++ b/widget/table.go
@@ -151,6 +151,50 @@ func (t *Table) UnselectAll() {
 	}
 }
 
+// ScrollTo will scroll to the given cell without changing the selection.
+// Attempting to scroll beyond the limits of the table will scroll to
+// the edge of the table instead.
+//
+// Since: 2.1
+func (t *Table) ScrollTo(id TableCellID) {
+	if t.Length == nil {
+		return
+	}
+
+	rows, cols := t.Length()
+	if id.Row >= rows {
+		id.Row = rows - 1
+	}
+
+	if id.Col >= cols {
+		id.Col = cols - 1
+	}
+
+	t.scrollTo(id)
+}
+
+// ScrollToEnd will scroll to the last cell in the table
+//
+// Since: 2.1
+func (t *Table) ScrollToEnd() {
+	if t.Length == nil {
+		return
+	}
+
+	rows, cols := t.Length()
+	t.scrollTo(TableCellID{
+		Row: rows - 1,
+		Col: cols - 1,
+	})
+}
+
+// ScrollToStart will scroll to the first cell in the table
+//
+// Since: 2.1
+func (t *Table) ScrollToStart() {
+	t.scrollTo(TableCellID{0, 0})
+}
+
 func (t *Table) scrollTo(id TableCellID) {
 	if t.scroll == nil {
 		return

--- a/widget/table.go
+++ b/widget/table.go
@@ -173,7 +173,7 @@ func (t *Table) ScrollTo(id TableCellID) {
 	t.scrollTo(id)
 }
 
-// ScrollToBottom will scroll to the last row in the table
+// ScrollToBottom scrolls to the last row in the table
 //
 // Since: 2.1
 func (t *Table) ScrollToBottom() {
@@ -185,11 +185,65 @@ func (t *Table) ScrollToBottom() {
 	t.scrollTo(TableCellID{Row: rows - 1})
 }
 
-// ScrollToTop will scroll to the first row in the table
+// ScrollToLeading scrolls horizontally to the leading edge of the table
+//
+// Since: 2.1
+func (t *Table) ScrollToLeading() {
+	if t.scroll == nil {
+		return
+	}
+
+	t.scroll.Offset.X = 0
+	t.offset.X = 0
+	if t.moveCallback != nil {
+		t.moveCallback()
+	}
+	t.scroll.Refresh()
+	t.cells.Refresh()
+}
+
+// ScrollToTop scrolls to the first row in the table
 //
 // Since: 2.1
 func (t *Table) ScrollToTop() {
 	t.scrollTo(TableCellID{0, 0})
+}
+
+// ScrollToTrailing scrolls horizontally to the trailing edge of the table
+//
+// Since: 2.1
+func (t *Table) ScrollToTrailing() {
+	if t.scroll == nil || t.Length == nil {
+		return
+	}
+
+	_, cols := t.Length()
+	lastCol := cols - 1
+
+	cellSize := t.templateSize()
+	cellX := float32(0)
+	cellWidth := float32(0)
+	for i := 0; i <= lastCol; i++ {
+		if cellWidth > 0 {
+			cellX += cellWidth + theme.SeparatorThicknessSize()
+		}
+
+		width := cellSize.Width
+		if w, ok := t.columnWidths[i]; ok {
+			width = w
+		}
+		cellWidth = width
+	}
+
+	scrollX := cellX + cellWidth - t.scroll.Size().Width
+	t.scroll.Offset.X = scrollX
+	t.offset.X = scrollX
+
+	if t.moveCallback != nil {
+		t.moveCallback()
+	}
+	t.scroll.Refresh()
+	t.cells.Refresh()
 }
 
 func (t *Table) scrollTo(id TableCellID) {

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -189,6 +189,165 @@ func TestTable_Refresh(t *testing.T) {
 	assert.Equal(t, "replaced", cellRenderer.(*tableCellsRenderer).Objects()[7].(*Label).Text)
 }
 
+func TestTable_ScrollTo(t *testing.T) {
+	test.NewApp()
+	defer test.NewApp()
+
+	// for this test the separator thickness is 0
+	test.ApplyTheme(t, &separatorThicknessZeroTheme{test.Theme()})
+
+	// we will test a 20 row x 5 column table where each cell is 50x50
+	const (
+		maxRows int     = 20
+		maxCols int     = 5
+		width   float32 = 50
+		height  float32 = 50
+	)
+
+	templ := canvas.NewRectangle(color.Gray16{})
+	templ.SetMinSize(fyne.Size{Width: width, Height: height})
+
+	table := NewTable(
+		func() (int, int) { return maxRows, maxCols },
+		func() fyne.CanvasObject { return templ },
+		func(TableCellID, fyne.CanvasObject) {})
+
+	w := test.NewWindow(table)
+	defer w.Close()
+
+	// these position expectations have a built-in assumption that the window
+	// is smaller than the size of a single table cell.
+	expectedOffset := func(row, col float32) fyne.Position {
+		return fyne.Position{
+			X: col * width,
+			Y: row * height,
+		}
+	}
+
+	tt := []struct {
+		name string
+		in   TableCellID
+		want fyne.Position
+	}{
+		{
+			"row 0, col 0",
+			TableCellID{},
+			expectedOffset(0, 0),
+		},
+		{
+			"row 0, col 1",
+			TableCellID{Row: 0, Col: 1},
+			expectedOffset(0, 1),
+		},
+		{
+			"row 1, col 0",
+			TableCellID{Row: 1, Col: 0},
+			expectedOffset(1, 0),
+		},
+		{
+			"row 1, col 1",
+			TableCellID{Row: 1, Col: 1},
+			expectedOffset(1, 1),
+		},
+		{
+			"second last element",
+			TableCellID{Row: maxRows - 2, Col: maxCols - 2},
+			expectedOffset(float32(maxRows)-2, float32(maxCols)-2),
+		},
+		{
+			"last element",
+			TableCellID{Row: maxRows - 1, Col: maxCols - 1},
+			expectedOffset(float32(maxRows)-1, float32(maxCols)-1),
+		},
+		{
+			"row 0, col 0 (scrolling backwards)",
+			TableCellID{},
+			expectedOffset(0, 0),
+		},
+		{
+			"row 99, col 99 (scrolling beyond the end)",
+			TableCellID{Row: 99, Col: 99},
+			expectedOffset(float32(maxRows)-1, float32(maxCols)-1),
+		},
+		{
+			"row -1, col -1 (scrolling before the start)",
+			TableCellID{Row: -1, Col: -1},
+			expectedOffset(0, 0),
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			table.ScrollTo(tc.in)
+			assert.Equal(t, tc.want, table.offset)
+			assert.Equal(t, tc.want, table.scroll.Offset)
+		})
+	}
+}
+
+func TestTable_ScrollToEnd(t *testing.T) {
+	test.NewApp()
+	defer test.NewApp()
+
+	// we will test a 20 row x 5 column table where each cell is 50x50
+	// this table has a separator thickness of 1
+	const (
+		maxRows int     = 20
+		maxCols int     = 5
+		width   float32 = 50
+		height  float32 = 50
+	)
+
+	templ := canvas.NewRectangle(color.Gray16{})
+	templ.SetMinSize(fyne.Size{Width: width, Height: height})
+
+	table := NewTable(
+		func() (int, int) { return maxRows, maxCols },
+		func() fyne.CanvasObject { return templ },
+		func(TableCellID, fyne.CanvasObject) {})
+
+	w := test.NewWindow(table)
+	defer w.Close()
+
+	table.ScrollToEnd()
+
+	// element size of 50, plus separator thickness of 1
+	want := fyne.Position{X: 4 * (50 + 1), Y: 19 * (50 + 1)}
+	assert.Equal(t, want, table.offset)
+	assert.Equal(t, want, table.scroll.Offset)
+}
+
+func TestTable_ScrollToStart(t *testing.T) {
+	test.NewApp()
+	defer test.NewApp()
+
+	const (
+		maxRows int     = 20
+		maxCols int     = 5
+		width   float32 = 50
+		height  float32 = 50
+	)
+
+	templ := canvas.NewRectangle(color.Gray16{})
+	templ.SetMinSize(fyne.Size{Width: width, Height: height})
+
+	table := NewTable(
+		func() (int, int) { return maxRows, maxCols },
+		func() fyne.CanvasObject { return templ },
+		func(TableCellID, fyne.CanvasObject) {})
+
+	w := test.NewWindow(table)
+	defer w.Close()
+
+	table.scrollTo(TableCellID{12, 3})
+	table.ScrollToStart()
+
+	want := fyne.Position{}
+	assert.Equal(t, want, table.offset)
+	assert.Equal(t, want, table.scroll.Offset)
+}
+
 func TestTable_Selection(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -286,7 +286,7 @@ func TestTable_ScrollTo(t *testing.T) {
 	}
 }
 
-func TestTable_ScrollToEnd(t *testing.T) {
+func TestTable_ScrollToBottom(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()
 
@@ -310,15 +310,15 @@ func TestTable_ScrollToEnd(t *testing.T) {
 	w := test.NewWindow(table)
 	defer w.Close()
 
-	table.ScrollToEnd()
+	table.ScrollToBottom()
 
 	// element size of 50, plus separator thickness of 1
-	want := fyne.Position{X: 4 * (50 + 1), Y: 19 * (50 + 1)}
+	want := fyne.Position{X: 0, Y: 19 * (50 + 1)}
 	assert.Equal(t, want, table.offset)
 	assert.Equal(t, want, table.scroll.Offset)
 }
 
-func TestTable_ScrollToStart(t *testing.T) {
+func TestTable_ScrollToTop(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()
 
@@ -341,7 +341,7 @@ func TestTable_ScrollToStart(t *testing.T) {
 	defer w.Close()
 
 	table.scrollTo(TableCellID{12, 3})
-	table.ScrollToStart()
+	table.ScrollToTop()
 
 	want := fyne.Position{}
 	assert.Equal(t, want, table.offset)


### PR DESCRIPTION
### Description:
This PR adds the following public methods to widget.Table:
- ScrollTo(id)
- ScrollToEnd()
- ScrollToStart()

Fixes #1892 

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.

I'm not certain about the public API style.  The issue mentioned creating ScrollToTop() and ScrollToBottom() but a table is 2D, so I went with ScrollToStart() and ScrollToEnd().   Any thoughts on this?

I figured I'd get some feedback on this before working on scrolling for widget.Tree
