### PR TITLE
reverse the behavior of shift in MultiLineEntry if OnSubmitted function is set

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1186,9 +1186,9 @@ func (e *Entry) typedKeyReturn(provider *RichText, multiLine bool) {
 	e.propertyLock.RUnlock()
 
 	if !multiLine {
-		// Single line doesn't support newline.
-		// Call submitted callback, if any.
 		if onSubmitted != nil {
+			// Single line doesn't support newline.
+			// Call submitted callback, if any.
 			onSubmitted(text)
 		}
 		return
@@ -1198,6 +1198,7 @@ func (e *Entry) typedKeyReturn(provider *RichText, multiLine bool) {
 		onSubmitted(text)
 		return
 	}
+
 	e.propertyLock.Lock()
 	provider.insertAt(e.cursorTextPos(), "\n")
 	e.CursorColumn = 0

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1192,8 +1192,9 @@ func (e *Entry) typedKeyReturn(provider *RichText, multiLine bool) {
 			onSubmitted(text)
 		}
 		return
-	} else if selectDown && onSubmitted != nil {
-		// Multiline supports newline, unless shift is held and OnSubmitted is set.
+	} else if !selectDown && onSubmitted != nil {
+		// Multiline supports newline if shift is held, otherwise the return key causes the
+		// OnSubmitted function to be called if set.
 		onSubmitted(text)
 		return
 	}

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1323,24 +1323,25 @@ func TestEntry_Submit(t *testing.T) {
 		t.Run("MultiLine_ShiftEnter", func(t *testing.T) {
 			entry.MultiLine = true
 			entry.SetText("c")
+			submission = ""
 			typeKeys(entry, keyShiftLeftDown, fyne.KeyReturn, keyShiftLeftUp)
-			assert.Equal(t, "c", entry.Text)
-			assert.Equal(t, "c", submission)
+			assert.Equal(t, "\nc", entry.Text)
+			assert.Equal(t, "", submission)
 			entry.SetText("d")
 			typeKeys(entry, keyShiftRightDown, fyne.KeyReturn, keyShiftRightUp)
-			assert.Equal(t, "d", entry.Text)
-			assert.Equal(t, "d", submission)
+			assert.Equal(t, "\nd", entry.Text)
+			assert.Equal(t, "", submission)
 		})
 		t.Run("MultiLine_ShiftReturn", func(t *testing.T) {
 			entry.MultiLine = true
 			entry.SetText("e")
 			typeKeys(entry, keyShiftLeftDown, fyne.KeyReturn, keyShiftLeftUp)
-			assert.Equal(t, "e", entry.Text)
-			assert.Equal(t, "e", submission)
+			assert.Equal(t, "\ne", entry.Text)
+			assert.Equal(t, "", submission)
 			entry.SetText("f")
 			typeKeys(entry, keyShiftRightDown, fyne.KeyReturn, keyShiftRightUp)
-			assert.Equal(t, "f", entry.Text)
-			assert.Equal(t, "f", submission)
+			assert.Equal(t, "\nf", entry.Text)
+			assert.Equal(t, "", submission)
 		})
 	})
 	t.Run("NoCallback", func(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Currently, MultiLineEntry will call OnSubmitted (if set) when shift+enter is typed, and add a newline if enter is types.  This PR reverses the behavior of the shift key, such that enter will cause OnSubmitted to be called, and shift+enter will create a newline.  This brings the behavior of MultiLineEntry in line with common chat applications, such as Slack.

Fixes #2323

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Any breaking changes have a deprecation path or have been discussed.
