### PR TITLE
Populate the file dialog with more favorites

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -704,6 +704,9 @@ func getFavoriteIcons() map[string]fyne.Resource {
 		"Home":      theme.HomeIcon(),
 		"Documents": theme.DocumentIcon(),
 		"Downloads": theme.DownloadIcon(),
+		"Music":     theme.MediaMusicIcon(),
+		"Pictures":  theme.MediaPhotoIcon(),
+		"Videos":    theme.MediaVideoIcon(),
 	}
 }
 
@@ -712,5 +715,8 @@ func getFavoriteOrder() []string {
 		"Home",
 		"Documents",
 		"Downloads",
+		"Music",
+		"Pictures",
+		"Videos",
 	}
 }

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -700,6 +701,17 @@ func ShowFileSave(callback func(fyne.URIWriteCloser, error), parent fyne.Window)
 }
 
 func getFavoriteIcons() map[string]fyne.Resource {
+	if runtime.GOOS == "darwin" {
+		return map[string]fyne.Resource{
+			"Home":      theme.HomeIcon(),
+			"Documents": theme.DocumentIcon(),
+			"Downloads": theme.DownloadIcon(),
+			"Music":     theme.MediaMusicIcon(),
+			"Pictures":  theme.MediaPhotoIcon(),
+			"Movies":    theme.MediaVideoIcon(),
+		}
+	}
+
 	return map[string]fyne.Resource{
 		"Home":      theme.HomeIcon(),
 		"Documents": theme.DocumentIcon(),
@@ -711,7 +723,7 @@ func getFavoriteIcons() map[string]fyne.Resource {
 }
 
 func getFavoriteOrder() []string {
-	return []string{
+	order := []string{
 		"Home",
 		"Documents",
 		"Downloads",
@@ -719,4 +731,10 @@ func getFavoriteOrder() []string {
 		"Pictures",
 		"Videos",
 	}
+
+	if runtime.GOOS == "darwin" {
+		order[5] = "Movies"
+	}
+
+	return order
 }

--- a/dialog/file_xdg.go
+++ b/dialog/file_xdg.go
@@ -47,6 +47,9 @@ func getFavoriteLocations() (map[string]fyne.ListableURI, error) {
 	arguments := map[string]string{
 		"Documents": "DOCUMENTS",
 		"Downloads": "DOWNLOAD",
+		"Music":     "MUSIC",
+		"Pictures":  "PICTURES",
+		"Videos":    "VIDEOS",
 	}
 
 	favoriteLocations := make(map[string]fyne.ListableURI)

--- a/theme/bundled-icons.go
+++ b/theme/bundled-icons.go
@@ -290,6 +290,21 @@ var mailsendIconRes = &fyne.StaticResource{
 	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\"><path d=\"M2.01 21L23 12 2.01 3 2 10l15 2-15 2z\"/><path d=\"M0 0h24v24H0z\" fill=\"none\"/></svg>"),
 }
 
+var mediamusicIconRes = &fyne.StaticResource{
+	StaticName:    "media-music.svg",
+	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 0 24 24\" width=\"24px\" fill=\"#000000\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z\"/></svg>"),
+}
+
+var mediaphotoIconRes = &fyne.StaticResource{
+	StaticName:    "media-photo.svg",
+	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 0 24 24\" width=\"24px\" fill=\"#000000\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><circle cx=\"12\" cy=\"12\" r=\"3.2\"/><path d=\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\"/></svg>"),
+}
+
+var mediavideoIconRes = &fyne.StaticResource{
+	StaticName:    "media-video.svg",
+	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 0 24 24\" width=\"24px\" fill=\"#000000\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z\"/></svg>"),
+}
+
 var mediafastforwardIconRes = &fyne.StaticResource{
 	StaticName:    "media-fast-forward.svg",
 	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24\" viewBox=\"0 0 24 24\" width=\"24\"><path d=\"M4 18l8.5-6L4 6v12zm9-12v12l8.5-6L13 6z\"/><path d=\"M0 0h24v24H0z\" fill=\"none\"/></svg>"),

--- a/theme/gen.go
+++ b/theme/gen.go
@@ -162,6 +162,9 @@ func main() {
 	bundleIcon("mail-reply_all", f)
 	bundleIcon("mail-send", f)
 
+	bundleIcon("media-music", f)
+	bundleIcon("media-photo", f)
+	bundleIcon("media-video", f)
 	bundleIcon("media-fast-forward", f)
 	bundleIcon("media-fast-rewind", f)
 	bundleIcon("media-pause", f)

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -199,6 +199,21 @@ const (
 	// Since: 2.0
 	IconNameMailSend fyne.ThemeIconName = "mailSend"
 
+	// IconNameMediaMusic is the name of theme lookup for media music icon.
+	//
+	// Since: 2.1
+	IconNameMediaMusic fyne.ThemeIconName = "mediaMusic"
+
+	// IconNameMediaPhoto is the name of theme lookup for media photo icon.
+	//
+	// Since: 2.1
+	IconNameMediaPhoto fyne.ThemeIconName = "mediaPhoto"
+
+	// IconNameMediaVideo is the name of theme lookup for media video icon.
+	//
+	// Since: 2.1
+	IconNameMediaVideo fyne.ThemeIconName = "mediaVideo"
+
 	// IconNameMediaFastForward is the name of theme lookup for media fast-forward icon.
 	//
 	// Since: 2.0
@@ -488,6 +503,9 @@ var (
 		IconNameMailReplyAll:   NewThemedResource(mailreplyallIconRes),
 		IconNameMailSend:       NewThemedResource(mailsendIconRes),
 
+		IconNameMediaMusic:        NewThemedResource(mediamusicIconRes),
+		IconNameMediaPhoto:        NewThemedResource(mediaphotoIconRes),
+		IconNameMediaVideo:        NewThemedResource(mediavideoIconRes),
 		IconNameMediaFastForward:  NewThemedResource(mediafastforwardIconRes),
 		IconNameMediaFastRewind:   NewThemedResource(mediafastrewindIconRes),
 		IconNameMediaPause:        NewThemedResource(mediapauseIconRes),
@@ -961,6 +979,27 @@ func MailReplyAllIcon() fyne.Resource {
 // MailSendIcon returns a resource containing the standard mail send icon for the current theme
 func MailSendIcon() fyne.Resource {
 	return safeIconLookup(IconNameMailSend)
+}
+
+// MediaMusicIcon returns a resource containing the standard media music icon for the current theme
+//
+// Since: 2.1
+func MediaMusicIcon() fyne.Resource {
+	return safeIconLookup(IconNameMediaMusic)
+}
+
+// MediaPhotoIcon returns a resource containing the standard media photo icon for the current theme
+//
+// Since: 2.1
+func MediaPhotoIcon() fyne.Resource {
+	return safeIconLookup(IconNameMediaPhoto)
+}
+
+// MediaVideoIcon returns a resource containing the standard media video icon for the current theme
+//
+// Since: 2.1
+func MediaVideoIcon() fyne.Resource {
+	return safeIconLookup(IconNameMediaVideo)
 }
 
 // MediaFastForwardIcon returns a resource containing the standard media fast-forward icon for the current theme

--- a/theme/icons/media-music.svg
+++ b/theme/icons/media-music.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/></svg>

--- a/theme/icons/media-photo.svg
+++ b/theme/icons/media-photo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="3.2"/><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z"/></svg>

--- a/theme/icons/media-video.svg
+++ b/theme/icons/media-video.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z"/></svg>


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I have felt for quite some time that the file dialog has been missing a few very useful favorite locations, but I didn't want to add them because it would take up more space in the list. Now with the rework of the interface, I finally think it is worth it to add music, pictures andvideos as favorites. 
![image](https://user-images.githubusercontent.com/25466657/126871278-f7964c32-2475-46af-adb3-768806aa4420.png)

This is marked as draft for the time being as I want to test it on Windows and macOS and possibly add a few tests as well before marking as ready for review. Feel free to look at it if you want through.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
