### PR TITLE
Clean up the entry right-click menu to use the shortcuts

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -498,19 +498,19 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 
 	e.requestFocus()
 	clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
+	super := e.super()
 
 	cutItem := fyne.NewMenuItem("Cut", func() {
-		e.TypedShortcut(&fyne.ShortcutCut{Clipboard: clipboard})
+		super.(fyne.Shortcutable).TypedShortcut(&fyne.ShortcutCut{Clipboard: clipboard})
 	})
 	copyItem := fyne.NewMenuItem("Copy", func() {
-		e.TypedShortcut(&fyne.ShortcutCopy{Clipboard: clipboard})
+		super.(fyne.Shortcutable).TypedShortcut(&fyne.ShortcutCopy{Clipboard: clipboard})
 	})
 	pasteItem := fyne.NewMenuItem("Paste", func() {
-		e.TypedShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
+		super.(fyne.Shortcutable).TypedShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
 	})
 	selectAllItem := fyne.NewMenuItem("Select all", e.selectAll)
 
-	super := e.super()
 	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(super)
 	popUpPos := entryPos.Add(fyne.NewPos(pe.Position.X, pe.Position.Y))
 	c := fyne.CurrentApp().Driver().CanvasForObject(super)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -497,17 +497,16 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	}
 
 	e.requestFocus()
+	clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
+
 	cutItem := fyne.NewMenuItem("Cut", func() {
-		clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
-		e.cutToClipboard(clipboard)
+		e.TypedShortcut(&fyne.ShortcutCut{Clipboard: clipboard})
 	})
 	copyItem := fyne.NewMenuItem("Copy", func() {
-		clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
-		e.copyToClipboard(clipboard)
+		e.TypedShortcut(&fyne.ShortcutCopy{Clipboard: clipboard})
 	})
 	pasteItem := fyne.NewMenuItem("Paste", func() {
-		clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
-		e.pasteFromClipboard(clipboard)
+		e.TypedShortcut(&fyne.ShortcutPaste{Clipboard: clipboard})
 	})
 	selectAllItem := fyne.NewMenuItem("Select all", e.selectAll)
 


### PR DESCRIPTION

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
This cleans up the right-click menu in `widget.Entry` to use the shortcut code directly and thus allow an extended widget that overwrites the `TypedShortcut()` method to have it apply in the menu as well.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
