### PR TITLE
Delivery mouse events by interface

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -817,7 +817,7 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 	}
 
 	// when click outside currently Focusable object, remove focus.
-	if w.canvas.Focused() != nil && focusableO.(fyne.Focusable) != w.canvas.Focused() {
+	if focusableO, ok := focusableO.(fyne.Focusable); ok && w.canvas.Focused() != nil && focusableO != w.canvas.Focused() {
 		w.canvas.Unfocus()
 	}
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -607,6 +607,9 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 		if cursorable, ok := object.(desktop.Cursorable); ok {
 			cursor = cursorable.Cursor()
 		}
+		if _, ok := object.(fyne.Draggable); ok {
+			return true
+		}
 
 		_, hover := object.(desktop.Hoverable)
 		return hover

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -71,19 +71,20 @@ type window struct {
 	centered   bool
 	visible    bool
 
-	mouseLock            sync.RWMutex
-	mousePos             fyne.Position
-	mouseDragged         fyne.Draggable
-	mouseDraggedObjStart fyne.Position
-	mouseDraggedOffset   fyne.Position
-	mouseDragPos         fyne.Position
-	mouseDragStarted     bool
-	mouseButton          desktop.MouseButton
-	mouseOver            desktop.Hoverable
-	mouseLastClick       fyne.CanvasObject
-	mousePressed         fyne.CanvasObject
-	mouseClickCount      int
-	mouseCancelFunc      context.CancelFunc
+	mouseLock             sync.RWMutex
+	mousePos              fyne.Position
+	mouseDragged          fyne.Draggable
+	mouseDraggedObjStart  fyne.Position
+	mouseDraggedOffset    fyne.Position
+	mouseDragPos          fyne.Position
+	mouseDragStarted      bool
+	mouseButton           desktop.MouseButton
+	mouseOver             desktop.Hoverable
+	mouseLastClick        fyne.CanvasObject
+	mouseSecondaryPressed fyne.SecondaryTappable
+	mousePrimaryPressed   fyne.Tappable
+	mouseDoublePressed    fyne.CanvasObject
+	mouseCancelFunc       context.CancelFunc
 
 	onClosed           func()
 	onCloseIntercepted func()
@@ -652,7 +653,7 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 	isObjDragged := w.objIsDragged(obj)
 	isMouseOverDragged := w.objIsDragged(mouseOver)
 	w.mouseLock.RUnlock()
-	if obj != nil && !isObjDragged {
+	if obj != nil {
 		ev := new(desktop.MouseEvent)
 		ev.AbsolutePosition = mousePos
 		ev.Position = pos
@@ -660,12 +661,18 @@ func (w *window) mouseMoved(viewport *glfw.Window, xpos float64, ypos float64) {
 
 		if hovered, ok := obj.(desktop.Hoverable); ok {
 			if hovered == mouseOver {
-				w.QueueEvent(func() { hovered.MouseMoved(ev) })
+				// send MouseMoved when same object as before, unless object was dragged
+				if !isObjDragged {
+					w.QueueEvent(func() { hovered.MouseMoved(ev) })
+				}
 			} else {
+				// change the hover object
 				w.mouseOut()
 				w.mouseIn(hovered, ev)
 			}
 		} else if mouseOver != nil {
+			// mouse was over the hoverable
+			// send mouse out unless obj is child of current hoverable
 			isChild := false
 			driver.WalkCompleteObjectTree(mouseOver.(fyne.CanvasObject),
 				func(co fyne.CanvasObject, p1, p2 fyne.Position, s fyne.Size) bool {
@@ -752,34 +759,65 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 		w.mouseLock.Unlock()
 	}
 
-	co, pos, _ := w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) bool {
-		switch object.(type) {
-		case fyne.Tappable, fyne.SecondaryTappable, fyne.DoubleTappable, fyne.Focusable, desktop.Mouseable, desktop.Hoverable:
-			return true
-		case fyne.Draggable:
-			if mouseDragStarted {
-				return true
+	// find individual objects with clickable interfaces
+	var tappableO fyne.CanvasObject
+	var secondaryTappableO fyne.CanvasObject
+	var doubleTappableO fyne.CanvasObject
+	var focusableO fyne.CanvasObject
+	var mouseableO fyne.CanvasObject
+	var draggableO fyne.CanvasObject
+
+	_, pos, _ := w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) (ret bool) {
+		ret = false
+		// each Tappable, SecondaryTappable, DoubleTappable and Mouseable must receive appropriate event
+		if _, ok := object.(fyne.Tappable); ok {
+			tappableO = object
+			ret = true
+		}
+		if _, ok := object.(fyne.SecondaryTappable); ok {
+			secondaryTappableO = object
+			ret = true
+		}
+		if _, ok := object.(fyne.DoubleTappable); ok {
+			doubleTappableO = object
+			ret = true
+		}
+		if _, ok := object.(desktop.Mouseable); ok {
+			mouseableO = object
+			ret = true
+		}
+		// find fyne.Focusable to release focus when mouse clicked outside of currently focused object
+		if _, ok := object.(fyne.Focusable); ok {
+			focusableO = object
+			ret = true
+		}
+		// when drag started, we may need to know if mouse within the fyne.Draggable to ?
+		if mouseDragStarted {
+			if _, ok := object.(fyne.Draggable); ok {
+				draggableO = object
+				ret = true
 			}
 		}
-
-		return false
+		return
 	})
 	ev := new(fyne.PointEvent)
 	ev.Position = pos
 	ev.AbsolutePosition = mousePos
 
-	coMouse := co
 	button, modifiers := convertMouseButton(btn, mods)
-	if wid, ok := co.(desktop.Mouseable); ok {
+
+	// deliver Mouseable when one found
+	if mouseableO != nil {
 		mev := new(desktop.MouseEvent)
 		mev.Position = ev.Position
 		mev.AbsolutePosition = mousePos
 		mev.Button = button
 		mev.Modifier = modifiers
-		w.mouseClickedHandleMouseable(mev, action, wid)
+		w.mouseClickedHandleMouseable(mev, action, mouseableO.(desktop.Mouseable))
 	}
 
-	if wid, ok := co.(fyne.Focusable); !ok || wid != w.canvas.Focused() {
+	// when click outside currently Focusable object, remove focus.
+	if w.canvas.Focused() != nil && focusableO.(fyne.Focusable) != w.canvas.Focused() {
 		w.canvas.Unfocus()
 	}
 
@@ -792,11 +830,16 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 
 	mouseDragged := w.mouseDragged
 	mouseDragStarted = w.mouseDragStarted
-	mouseOver := w.mouseOver
-	shouldMouseOut := w.objIsDragged(mouseOver) && !w.objIsDragged(coMouse)
-	mousePressed := w.mousePressed
+	shouldMouseOut := w.objIsDragged(w.mouseOver) // mouseOut on mouse release after dragging out of dragged object's area
+	mousePrimaryPressed := w.mousePrimaryPressed
 	w.mouseLock.Unlock()
 
+	// when drag ends in Hoverable object, do not send MouseOut
+	if _, ok := draggableO.(desktop.Hoverable); ok {
+		shouldMouseOut = false
+	}
+
+	// button release must sent DragEnd during drag cycle
 	if action == glfw.Release && mouseDragged != nil {
 		if mouseDragStarted {
 			w.QueueEvent(mouseDragged.DragEnd)
@@ -810,27 +853,56 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 		w.mouseLock.Lock()
 		w.mouseDragged = nil
 		w.mouseLock.Unlock()
+		// do not send clicked on drag end
+		tappableO = nil
 	}
 
-	_, tap := co.(fyne.Tappable)
-	_, altTap := co.(fyne.SecondaryTappable)
-	if tap || altTap {
-		if action == glfw.Press {
-			w.mouseLock.Lock()
-			w.mousePressed = co
-			w.mouseLock.Unlock()
-		} else if action == glfw.Release {
-			if co == mousePressed {
-				if button == desktop.MouseButtonSecondary && altTap {
-					w.QueueEvent(func() { co.(fyne.SecondaryTappable).TappedSecondary(ev) })
-				}
+	// trigger TappedSecondary on Secondary mouse release
+	if secondaryTappableO != nil && button == desktop.MouseButtonSecondary {
+		w.mouseClickedHandleButtonSecondary(ev, action, secondaryTappableO.(fyne.SecondaryTappable))
+	}
+
+	if action == glfw.Release && button == desktop.MouseButtonPrimary {
+		if doubleTappableO != nil {
+			w.mouseClickedHandleTapDoubleTap(doubleTappableO, ev)
+			if doubleTappableO == tappableO {
+				tappableO = nil
 			}
 		}
+		if tappableO != nil && mousePrimaryPressed == tappableO.(fyne.Tappable) {
+			w.QueueEvent(func() { tappableO.(fyne.Tappable).Tapped(ev) })
+		}
+		w.mouseLock.Lock()
+		w.mousePrimaryPressed = nil
+		w.mouseDoublePressed = nil
+		w.mouseLock.Unlock()
 	}
 
-	// Check for double click/tap on left mouse button
-	if action == glfw.Release && button == desktop.MouseButtonPrimary && !mouseDragStarted {
-		w.mouseClickedHandleTapDoubleTap(co, ev)
+	if action == glfw.Press {
+		if tappableO != nil {
+			w.mouseLock.Lock()
+			w.mousePrimaryPressed = tappableO.(fyne.Tappable)
+			w.mouseLock.Unlock()
+		}
+		if doubleTappableO != nil {
+			w.mouseLock.Lock()
+			w.mouseDoublePressed = doubleTappableO
+			w.mouseLock.Unlock()
+		}
+	}
+}
+
+func (w *window) mouseClickedHandleButtonSecondary(pev *fyne.PointEvent, action glfw.Action, wid fyne.SecondaryTappable) {
+	w.mouseLock.Lock()
+	defer w.mouseLock.Unlock()
+	if action == glfw.Release {
+		if wid == w.mouseSecondaryPressed {
+			w.QueueEvent(func() { wid.TappedSecondary(pev) })
+		} else {
+			w.mouseSecondaryPressed = nil
+		}
+	} else {
+		w.mouseSecondaryPressed = wid
 	}
 }
 
@@ -856,32 +928,35 @@ func (w *window) mouseClickedHandleMouseable(mev *desktop.MouseEvent, action glf
 	}
 }
 
+// mouseClickedHandleTapDoubleTap return true when DoubleTapped was sent
 func (w *window) mouseClickedHandleTapDoubleTap(co fyne.CanvasObject, ev *fyne.PointEvent) {
-	_, doubleTap := co.(fyne.DoubleTappable)
-	if doubleTap {
-		w.mouseLock.Lock()
-		w.mouseClickCount++
-		w.mouseLastClick = co
-		mouseCancelFunc := w.mouseCancelFunc
-		w.mouseLock.Unlock()
-		if mouseCancelFunc != nil {
-			mouseCancelFunc()
-			return
+	w.mouseLock.Lock()
+	mouseLastClick := w.mouseLastClick
+	w.mouseLastClick = co
+	if mouseLastClick == co {
+		// it means this is a second click for the same object within the double click timer
+		// fire double tap
+		if w.mouseCancelFunc != nil {
+			w.mouseCancelFunc()
+			w.mouseCancelFunc = nil
 		}
-		go w.waitForDoubleTap(co, ev)
-	} else {
-		w.mouseLock.Lock()
-		if wid, ok := co.(fyne.Tappable); ok && co == w.mousePressed {
-			w.QueueEvent(func() { wid.Tapped(ev) })
-		}
-		w.mousePressed = nil
+		w.QueueEvent(func() { co.(fyne.DoubleTappable).DoubleTapped(ev) })
+		w.mouseLastClick = nil
 		w.mouseLock.Unlock()
+		return
 	}
+	w.mouseLock.Unlock()
+	// start double click timer for new object
+	go w.waitForDoubleTap(co, ev)
 }
 
 func (w *window) waitForDoubleTap(co fyne.CanvasObject, ev *fyne.PointEvent) {
 	var ctx context.Context
 	w.mouseLock.Lock()
+	// cancel any previous routine
+	if w.mouseCancelFunc != nil {
+		w.mouseCancelFunc()
+	}
 	ctx, w.mouseCancelFunc = context.WithDeadline(context.TODO(), time.Now().Add(time.Millisecond*doubleClickDelay))
 	defer w.mouseCancelFunc()
 	w.mouseLock.Unlock()
@@ -891,18 +966,10 @@ func (w *window) waitForDoubleTap(co fyne.CanvasObject, ev *fyne.PointEvent) {
 	w.mouseLock.Lock()
 	defer w.mouseLock.Unlock()
 
-	if w.mouseClickCount == 2 && w.mouseLastClick == co {
-		if wid, ok := co.(fyne.DoubleTappable); ok {
-			w.QueueEvent(func() { wid.DoubleTapped(ev) })
-		}
-	} else if co == w.mousePressed {
-		if wid, ok := co.(fyne.Tappable); ok {
-			w.QueueEvent(func() { wid.Tapped(ev) })
-		}
+	if wid, ok := co.(fyne.Tappable); ok && co == w.mouseLastClick {
+		w.QueueEvent(func() { wid.Tapped(ev) })
 	}
 
-	w.mouseClickCount = 0
-	w.mousePressed = nil
 	w.mouseCancelFunc = nil
 	w.mouseLastClick = nil
 }

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -556,6 +556,7 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	)
 
 	// drag event going outside the widget's area
+	// expected behavior is to keep hover and only get DragEvent without mouse move
 	w.mouseMoved(w.viewport, 16, 8)
 	w.WaitForEvents()
 	assert.Equal(t,
@@ -570,6 +571,7 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.Nil(t, dh.popMouseOutEvent())
 
 	// drag event going inside the widget's area again
+	// expected behavior is to keep hover and only get DragEvent without mouse move
 	w.mouseMoved(w.viewport, 8, 8)
 	w.WaitForEvents()
 	assert.Equal(t,
@@ -584,11 +586,13 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.Nil(t, dh.popMouseMovedEvent())
 
 	// no hover events on end of drag event
+	// only DragEnd
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 	w.WaitForEvents()
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.Nil(t, dh.popMouseOutEvent())
+	assert.NotNil(t, dh.popDragEndEvent())
 
 	// mouseOut on mouse release after dragging out of area
 	w.mouseMoved(w.viewport, 8, 8)
@@ -599,390 +603,237 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.NotNil(t, dh.popMouseOutEvent())
 }
 
-func TestWindow_HoverableUnderDraggable(t *testing.T) {
+func TestWindow_HoverableOnDraggingOverDraggable(t *testing.T) {
 	w := createWindow("Test").(*window)
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
 	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-
-	c := container.NewWithoutLayout(h, d, dh)
-	h.Resize(fyne.NewSize(50, 50))
-	h.Move(fyne.NewPos(0, 0))
-	d.Resize(fyne.NewSize(30, 30))
-	d.Move(fyne.NewPos(10, 10))
+	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
+	c := container.NewWithoutLayout(dh, d)
 	dh.Resize(fyne.NewSize(10, 10))
-	dh.Move(fyne.NewPos(20, 20))
-
+	d.Move(fyne.NewPos(10, 0))
+	d.Resize(fyne.NewSize(10, 10))
 	w.SetContent(c)
 
 	repaintWindow(w)
-
-	// 1. move over to hoverableObject and verify
-	//  - mouseIn received by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 5, 5)
+	w.mouseMoved(w.viewport, 8, 8)
 	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(5, 5)}}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 1.a test for drag in non-draggable
-	//  - move in hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}},
+		dh.popMouseInEvent(),
+	)
+	// start drag, on Move get the DragEvent
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 6, 6)
+	w.mouseMoved(w.viewport, 8, 8)
 	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(6, 6)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(0, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
-
-	// 2. move over to draggableObject and verify
-	//  - mouseMoved by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 15, 15)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
-		AbsolutePosition: fyne.NewPos(15, 15)}}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
 	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
 
-	// 2.a test for drag in draggable
-	//  - move in hoverableObject
-	//  - drag begin by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 16, 16)
+	// drag event going to another draggable widget area
+	// expected to get DragEvent (due to move) and loose hover
+	w.mouseMoved(w.viewport, 16, 8)
 	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 12),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Dragged: fyne.NewDelta(1, 1)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
+				AbsolutePosition: fyne.NewPos(16, 8)},
+			Dragged: fyne.NewDelta(8, 0),
+		},
+		dh.popDragEvent())
 	assert.Nil(t, dh.popDragEndEvent())
-
-	// 2.b drag end
-	//  - no events by hoverableObject
-	//  - drag end by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.NotNil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 3. move to draggableHoverableObject and verify
-	// - mouseOut received by hoverableObject
-	// - no events by draggableObject
-	// - mouseIn by draggableHoverableObject
-	w.mouseMoved(w.viewport, 25, 25)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.NotNil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(25, 25)}}, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 4. move over to draggableObject and verify
-	// - mouseIn received by hoverableObject
-	// - no events by draggableObject
-	// - mouseOut by draggableHoverableObject
-	w.mouseMoved(w.viewport, 35, 35)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(31, 31),
-		AbsolutePosition: fyne.NewPos(35, 35)}}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 5. move to  hoverableObject and verify
-	//  - mouseMoved by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 45, 45)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(41, 41),
-		AbsolutePosition: fyne.NewPos(45, 45)}}, h.popMouseMovedEvent())
 	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
 
-	// 6. move ouside hoverableObject and verify
-	//  - mouseOut by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 55, 55)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.NotNil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-}
-
-func TestWindow_HoverableUnderDraggable_DragAcross(t *testing.T) {
-	w := createWindow("Test").(*window)
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
-	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-
-	c := container.NewWithoutLayout(h, d, dh)
-	h.Resize(fyne.NewSize(50, 50))
-	h.Move(fyne.NewPos(0, 0))
-	d.Resize(fyne.NewSize(30, 30))
-	d.Move(fyne.NewPos(10, 10))
-	dh.Resize(fyne.NewSize(10, 10))
-	dh.Move(fyne.NewPos(20, 20))
-
-	w.SetContent(c)
-
-	repaintWindow(w)
-
-	// 1. drag across hoverable
-	//  - mouseIn by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 15, 15)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
-		AbsolutePosition: fyne.NewPos(15, 15)}}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 2 start drag in draggable
-	//  - move in hoverableObject
-	//  - drag begin by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 16, 16)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 12),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Dragged: fyne.NewDelta(1, 1)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 3 drag to draggable+hoverable
-	//  - moveOut hoverableObject
-	//  - drag events by draggableObject
-	//  - moveIn by draggableHoverableObject
-	w.mouseMoved(w.viewport, 25, 25)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.NotNil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
-		AbsolutePosition: fyne.NewPos(25, 25)}, Dragged: fyne.NewDelta(9, 9)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(25, 25)}, Button: 1, Modifier: 0}, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 4 move over to draggableObject and verify
-	// - mouseIn received by hoverableObject
-	// - drag event by draggableObject
-	// - mouseOut by draggableHoverableObject
-	w.mouseMoved(w.viewport, 35, 35)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(31, 31),
-		AbsolutePosition: fyne.NewPos(35, 35)}, Button: 1, Modifier: 0}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(21, 21),
-		AbsolutePosition: fyne.NewPos(35, 35)}, Dragged: fyne.NewDelta(10, 10)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 5 drag end
-	//  - no events by hoverableObject
-	//  - drag end by draggableObject
-	//  - no events by draggableHoverableObject
+	// on release expect DragEng
+	// no hover events on end of drag event
+	// TODO the second draggable must get EndDrag as well
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.NotNil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-}
-
-func TestWindow_HoverableUnderDraggable_Drag_draggableHoverable(t *testing.T) {
-	w := createWindow("Test").(*window)
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
-	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-
-	c := container.NewWithoutLayout(h, d, dh)
-	h.Resize(fyne.NewSize(50, 50))
-	h.Move(fyne.NewPos(0, 0))
-	d.Resize(fyne.NewSize(30, 30))
-	d.Move(fyne.NewPos(10, 10))
-	dh.Resize(fyne.NewSize(10, 10))
-	dh.Move(fyne.NewPos(20, 20))
-
-	w.SetContent(c)
-
-	repaintWindow(w)
-
-	// 1. drag of draggableHoverable
-	//  - no event by hoverableObject
-	//  - no event by draggableObject
-	//  - moveIn event by draggableHoverableObject
-	w.mouseMoved(w.viewport, 25, 25)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(25, 25)}}, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 2. start drag in draggableHoverable
-	//  - no events by hoverableObject
-	//  - no events by draggableObject
-	//  - drag begin by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 26, 26)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(26, 26)}, Dragged: fyne.NewDelta(1, 1)}, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 3. drag to hoverable
-	//  - moveIn by hoverableObject
-	//  - no events by draggableObject
-	//  - drag and moveOut by draggableHoverableObject
-	w.mouseMoved(w.viewport, 45, 45)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(41, 41),
-		AbsolutePosition: fyne.NewPos(45, 45)}, Button: 1, Modifier: 0}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(21, 21),
-		AbsolutePosition: fyne.NewPos(45, 45)}, Dragged: fyne.NewDelta(19, 19)}, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 4. drag end
-	//  - no events by hoverableObject
-	//  - no events by draggableObject
-	//  - drag end by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
 	assert.Nil(t, dh.popDragEvent())
 	assert.NotNil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+}
+
+func TestWindow_HoverableOnDraggingOverHoverable(t *testing.T) {
+	w := createWindow("Test").(*window)
+	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	c := container.NewWithoutLayout(dh, h)
+	dh.Resize(fyne.NewSize(10, 10))
+	h.Move(fyne.NewPos(10, 0))
+	h.Resize(fyne.NewSize(10, 10))
+	w.SetContent(c)
+
+	repaintWindow(w)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}},
+		dh.popMouseInEvent(),
+	)
+	// start drag
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(0, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// drag event going outside the widget's area and over to second Hoverable
+	// second Hoverable get MouseIn
+	w.mouseMoved(w.viewport, 16, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
+				AbsolutePosition: fyne.NewPos(16, 8)},
+			Dragged: fyne.NewDelta(8, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 4),
+			AbsolutePosition: fyne.NewPos(16, 8)}, Button: 1},
+		h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// no hover events on end of drag event
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.WaitForEvents()
+	assert.Nil(t, dh.popDragEvent())
+	assert.NotNil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+}
+
+func TestWindow_HoverableOnDraggingOverHoverableAndBack(t *testing.T) {
+	w := createWindow("Test").(*window)
+	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	c := container.NewWithoutLayout(dh, h)
+	dh.Resize(fyne.NewSize(10, 10))
+	h.Move(fyne.NewPos(10, 0))
+	h.Resize(fyne.NewSize(10, 10))
+	w.SetContent(c)
+
+	repaintWindow(w)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}},
+		dh.popMouseInEvent(),
+	)
+	// start drag
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(0, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// drag event going outside the widget's area
+	// expected to get MouseOut
+	// Second Hoverable get MouseIn
+	w.mouseMoved(w.viewport, 16, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
+				AbsolutePosition: fyne.NewPos(16, 8)},
+			Dragged: fyne.NewDelta(8, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 4),
+			AbsolutePosition: fyne.NewPos(16, 8)}, Button: 1},
+		h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// drag event going back inside the widget's area again
+	// expected to get MouseOut for second object
+	// DragEvent and MoueIn for first object
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(-8, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}, Button: 1},
+		dh.popMouseInEvent(),
+	)
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.NotNil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// no hover events on end of drag event
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.WaitForEvents()
+	assert.NotNil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
 }
 
 func TestWindow_DragEndWithoutTappedEvent(t *testing.T) {
@@ -1504,8 +1355,8 @@ func TestWindow_Clipboard(t *testing.T) {
 	text := "My content from test window"
 	cb := w.Clipboard()
 
-	cliboardContent := cb.Content()
-	if cliboardContent != "" {
+	clipboardContent := cb.Content()
+	if clipboardContent != "" {
 		// Current environment has some content stored in clipboard,
 		// set temporary to an empty string to allow test and restore later.
 		cb.SetContent("")
@@ -1517,7 +1368,7 @@ func TestWindow_Clipboard(t *testing.T) {
 	assert.Equal(t, text, cb.Content())
 
 	// Restore clipboardContent, if any
-	cb.SetContent(cliboardContent)
+	cb.SetContent(clipboardContent)
 }
 
 func TestWindow_ClipboardCopy_DisabledEntry(t *testing.T) {


### PR DESCRIPTION
### Description:
This change will allow more precision on delivering a mouse event to objects implementing such event  interfaces.
The existing implementation picks the topmost object and try to apply the mouse event to it. The event will be lost when object doesn't implement the interface. For example in List, when a transparent object added to canvas object returned by create function to intercept right-click or double click, the single click on such item will not select the list item as event not delivered to listItem.

### Checklist:
- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [ ] Tests all pass.
