### PR TITLE
Fix crash when no text color is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file lists the main changes with each version of the Fyne toolkit.
 More detailed release notes can be found on the [releases page](https://github.com/fyne-io/fyne/releases). 
 
-## 2.0.4 - 4 August 2021
+## 2.0.4 - 6 August 2021
 
 ### Changed
 
@@ -28,6 +28,8 @@ More detailed release notes can be found on the [releases page](https://github.c
 * ScrollToBottom not always scrolling all the way when items added to container.Scroller
 * Fixed scrollbar disappearing after changing content (#2303)
 * Calling SetContent a second time with the same content will not show
+* Drawing text can panic when Color is nil (#2347)
+* Optimisations when drawing transparent rectangle or whitespace strings
 
 
 ## 2.0.3 - 30 April 2021

--- a/internal/painter/gl/gl_common.go
+++ b/internal/painter/gl/gl_common.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"runtime"
 
+	"fyne.io/fyne/v2/theme"
 	"github.com/goki/freetype"
 	"github.com/goki/freetype/truetype"
 	"golang.org/x/image/font"
@@ -72,6 +73,10 @@ func (p *glPainter) newGlStrokedRectTexture(obj fyne.CanvasObject) Texture {
 
 func (p *glPainter) newGlTextTexture(obj fyne.CanvasObject) Texture {
 	text := obj.(*canvas.Text)
+	color := text.Color
+	if color == nil {
+		color = theme.ForegroundColor()
+	}
 
 	bounds := text.MinSize()
 	width := int(p.textureScale(bounds.Width))
@@ -86,7 +91,7 @@ func (p *glPainter) newGlTextTexture(obj fyne.CanvasObject) Texture {
 
 	d := font.Drawer{}
 	d.Dst = img
-	d.Src = &image.Uniform{C: text.Color}
+	d.Src = &image.Uniform{C: color}
 	d.Face = face
 	d.Dot = freetype.Pt(0, height-face.Metrics().Descent.Ceil())
 	d.DrawString(text.Text)

--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/painter"
+	"fyne.io/fyne/v2/theme"
 
 	"github.com/goki/freetype"
 	"github.com/goki/freetype/truetype"
@@ -139,6 +140,11 @@ func drawText(c fyne.Canvas, text *canvas.Text, pos fyne.Position, base *image.N
 	height := internal.ScaleInt(c, bounds.Height)
 	txtImg := image.NewRGBA(image.Rect(0, 0, width, height))
 
+	color := text.Color
+	if color == nil {
+		color = theme.ForegroundColor()
+	}
+
 	var opts truetype.Options
 	fontSize := text.TextSize * c.Scale()
 	opts.Size = float64(fontSize)
@@ -147,7 +153,7 @@ func drawText(c fyne.Canvas, text *canvas.Text, pos fyne.Position, base *image.N
 
 	d := font.Drawer{}
 	d.Dst = txtImg
-	d.Src = &image.Uniform{C: text.Color}
+	d.Src = &image.Uniform{C: color}
 	d.Face = face
 	d.Dot = freetype.Pt(0, height-face.Metrics().Descent.Ceil())
 	d.DrawString(text.Text)

--- a/widget/form.go
+++ b/widget/form.go
@@ -111,6 +111,7 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 func (f *Form) createLabel(text string) *canvas.Text {
 	return &canvas.Text{Text: text,
 		Alignment: fyne.TextAlignTrailing,
+		Color:     theme.ForegroundColor(),
 		TextSize:  theme.TextSize(),
 		TextStyle: fyne.TextStyle{Bold: true}}
 }


### PR DESCRIPTION
### Description:
Fix crash when no text color is provided 

Fixes #2347

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
