### PR TITLE
Small cleanup to use fyne.Max over math.Max

### DIFF
--- a/internal/painter/draw.go
+++ b/internal/painter/draw.go
@@ -2,8 +2,8 @@ package painter
 
 import (
 	"image"
-	"math"
 
+	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 
 	"github.com/srwiley/rasterx"
@@ -14,7 +14,7 @@ import (
 // The bounds of the output image will be increased by vectorPad to allow for stroke overflow at the edges.
 // The scale function is used to understand how many pixels are required per unit of size.
 func DrawCircle(circle *canvas.Circle, vectorPad float32, scale func(float32) float32) *image.RGBA {
-	radius := float32(math.Min(float64(circle.Size().Width), float64(circle.Size().Height)) / 2)
+	radius := fyne.Min(circle.Size().Width, circle.Size().Height) / 2
 
 	width := int(scale(circle.Size().Width + vectorPad*2))
 	height := int(scale(circle.Size().Height + vectorPad*2))

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -515,7 +515,7 @@ func (t *textGridRenderer) Layout(size fyne.Size) {
 func (t *textGridRenderer) MinSize() fyne.Size {
 	longestRow := float32(0)
 	for _, row := range t.text.Rows {
-		longestRow = float32(math.Max(float64(longestRow), float64(len(row.Cells))))
+		longestRow = fyne.Max(longestRow, float32(len(row.Cells)))
 	}
 	return fyne.NewSize(t.cellSize.Width*longestRow,
 		t.cellSize.Height*float32(len(t.text.Rows)))


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

A very small PR that changes a `math.Min` to `fyne.Min` and a `math.Max` to `fyne.Max`. This saves us a few type conversions and gives a very minor performance improvement.
 
### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.