### PR TITLE
Add support for finding directory MimeTypes

### DIFF
--- a/storage/repository/uri.go
+++ b/storage/repository/uri.go
@@ -48,8 +48,11 @@ func (u *uri) MimeType() string {
 		if err == nil {
 			defer readCloser.Close()
 			scanner := bufio.NewScanner(readCloser)
-			if scanner.Scan() && !utf8.Valid(scanner.Bytes()) {
+			bytes := scanner.Bytes()
+			if scanner.Scan() && !utf8.Valid(bytes) {
 				mimeTypeFull = "application/octet-stream"
+			} else if bytes == nil { // A readable uri without content is a directory.
+				mimeTypeFull = "inode/directory"
 			}
 		}
 	}

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -99,15 +99,13 @@ func (i *FileIcon) SetSelected(selected bool) {
 }
 
 func (i *FileIcon) lookupIcon(uri fyne.URI) fyne.Resource {
-	if i.isDir(uri) {
-		return theme.FolderIcon()
-	}
-
 	switch splitMimeType(uri) {
 	case "application":
 		return theme.FileApplicationIcon()
 	case "audio":
 		return theme.FileAudioIcon()
+	case "directory", "x-directory":
+		return theme.FolderIcon()
 	case "image":
 		return theme.FileImageIcon()
 	case "text":
@@ -115,11 +113,16 @@ func (i *FileIcon) lookupIcon(uri fyne.URI) fyne.Resource {
 	case "video":
 		return theme.FileVideoIcon()
 	default:
+		if i.isDirSlow(uri) {
+			return theme.FolderIcon()
+		}
+
 		return theme.FileIcon()
 	}
 }
 
-func (i *FileIcon) isDir(uri fyne.URI) bool {
+// isDirSlow is a fallback if we can't find the directory using mime types.
+func (i *FileIcon) isDirSlow(uri fyne.URI) bool {
 	if _, ok := uri.(fyne.ListableURI); ok {
 		return true
 	}


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This updates `uri.MimeType()` to try and get a MimeType for folders. This can be done by trying to read the URI and if that works with nothing returned, we can state it as a directory by returning the "inode/directory" MimeType that is part of the freedesktop specification.

It also updates `widget.FileIcon` to be able to take advantage of this and thus trying to avoid calling `uri.CanList()` in cases where we find the directory using mimes. It also updates the slow directory check to only run if we can't find a suitable MimeType, thus making known types use the fast path.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
