### PR TITLE
Fix issue fileicon not updating if uri mimetype changes

### DIFF
--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -119,11 +119,13 @@ func (i *FileIcon) isDir(uri fyne.URI) bool {
 		return true
 	}
 
-	can, err := storage.CanList(uri)
+	listable, err := storage.ListerForURI(uri)
 	if err != nil {
 		return false
 	}
-	return can
+
+	i.URI = listable // Avoid having to call storage.ListerForURI(uri) the next time.
+	return true
 }
 
 type fileIconRenderer struct {

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -26,7 +26,6 @@ type FileIcon struct {
 
 	resource  fyne.Resource
 	extension string
-	cachedURI fyne.URI
 }
 
 // NewFileIcon takes a filepath and creates an icon with an overlaid label using the detected mimetype and extension
@@ -40,10 +39,8 @@ func NewFileIcon(uri fyne.URI) *FileIcon {
 
 // SetURI changes the URI and makes the icon reflect a different file
 func (i *FileIcon) SetURI(uri fyne.URI) {
-	if uri != i.URI {
-		i.URI = uri
-		i.Refresh()
-	}
+	i.URI = uri
+	i.Refresh()
 }
 
 func (i *FileIcon) setURI(uri fyne.URI) {
@@ -53,7 +50,6 @@ func (i *FileIcon) setURI(uri fyne.URI) {
 	}
 
 	i.URI = uri
-	i.cachedURI = nil
 	i.resource = i.lookupIcon(i.URI)
 	i.extension = trimmedExtension(uri)
 }
@@ -85,7 +81,6 @@ func (i *FileIcon) CreateRenderer() fyne.WidgetRenderer {
 	s.ext.Alignment = fyne.TextAlignCenter
 
 	s.SetObjects([]fyne.CanvasObject{s.background, s.img, s.ext})
-	i.cachedURI = i.URI
 
 	return s
 }
@@ -170,17 +165,14 @@ func (s *fileIconRenderer) Layout(size fyne.Size) {
 }
 
 func (s *fileIconRenderer) Refresh() {
-	if s.file.URI != s.file.cachedURI {
-		s.file.propertyLock.Lock()
-		s.file.setURI(s.file.URI)
-		s.file.propertyLock.Unlock()
+	s.file.propertyLock.Lock()
+	s.file.setURI(s.file.URI)
+	s.file.propertyLock.Unlock()
 
-		s.file.propertyLock.RLock()
-		s.file.cachedURI = s.file.URI
-		s.img.Resource = s.file.resource
-		s.ext.Text = s.file.extension
-		s.file.propertyLock.RUnlock()
-	}
+	s.file.propertyLock.RLock()
+	s.img.Resource = s.file.resource
+	s.ext.Text = s.file.extension
+	s.file.propertyLock.RUnlock()
 
 	if s.file.Selected {
 		s.background.Show()

--- a/widget/fileicon_internal_test.go
+++ b/widget/fileicon_internal_test.go
@@ -168,3 +168,27 @@ func TestFileIcon_SetURI_WithFolder(t *testing.T) {
 	assert.Empty(t, item.extension)
 	assert.Equal(t, theme.FolderIcon(), item.resource)
 }
+
+func TestFileIcon_DirURIUpdated(t *testing.T) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		fyne.LogError("Could not get current working directory", err)
+		t.FailNow()
+	}
+	testDir := filepath.Join(workingDir, "testdata", "notCreatedYet")
+
+	uri := storage.NewFileURI(testDir)
+	item := newRenderedFileIcon(uri)
+
+	// The directory has not been created. It can not be listed yet.
+	assert.Equal(t, theme.FileTextIcon(), item.resource)
+
+	err = os.Mkdir(testDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testDir)
+
+	item.Refresh()
+	assert.Equal(t, theme.FolderIcon(), item.resource)
+}


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The caching caused this issue because it compared the new uri with the cached uri. However, several parts of the URI are methods and not part of the struct, thus the comparison can be false when it really should be true. The fix here was unfortunatelly to remove the caching, but I have added a small change to make sure that we can avoid calling `storage.CanList` multiple times on the same uri.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
