### PR TITLE
Fix/1833

### DIFF
--- a/app/app_darwin.go
+++ b/app/app_darwin.go
@@ -1,75 +1,39 @@
 // +build !ci
 
-// +build !ios
-
 package app
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Foundation
+#cgo LDFLAGS: -framework Foundation -framework UserNotifications
 
-#include <AppKit/AppKit.h>
+#include <stdbool.h>
+#include <stdlib.h>
 
 bool isBundled();
-bool isDarkMode();
-void sendNotification(const char *title, const char *content);
-void watchTheme();
+void sendNotification(char *title, char *content);
 */
 import "C"
 import (
 	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"unsafe"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
-
 	"golang.org/x/sys/execabs"
 )
 
-func defaultVariant() fyne.ThemeVariant {
-	if C.isDarkMode() {
-		return theme.VariantDark
-	}
-	return theme.VariantLight
-}
-
-func rootConfigDir() string {
-	homeDir, _ := os.UserHomeDir()
-
-	desktopConfig := filepath.Join(filepath.Join(homeDir, "Library"), "Preferences")
-	return filepath.Join(desktopConfig, "fyne")
-}
-
-func (a *fyneApp) OpenURL(url *url.URL) error {
-	cmd := a.exec("open", url.String())
-	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-	return cmd.Run()
-}
-
 func (a *fyneApp) SendNotification(n *fyne.Notification) {
 	if C.isBundled() {
-		title := C.CString(n.Title)
-		defer C.free(unsafe.Pointer(title))
-		content := C.CString(n.Content)
-		defer C.free(unsafe.Pointer(content))
+		titleStr := C.CString(n.Title)
+		defer C.free(unsafe.Pointer(titleStr))
+		contentStr := C.CString(n.Content)
+		defer C.free(unsafe.Pointer(contentStr))
 
-		C.sendNotification(title, content)
+		C.sendNotification(titleStr, contentStr)
 		return
 	}
 
-	title := escapeNotificationString(n.Title)
-	content := escapeNotificationString(n.Content)
-	template := `display notification "%s" with title "%s"`
-	script := fmt.Sprintf(template, content, title)
-
-	err := execabs.Command("osascript", "-e", script).Start()
-	if err != nil {
-		fyne.LogError("Failed to launch darwin notify script", err)
-	}
+	fallbackNotification(n.Title, n.Content)
 }
 
 func escapeNotificationString(in string) string {
@@ -77,11 +41,19 @@ func escapeNotificationString(in string) string {
 	return strings.ReplaceAll(noSlash, "\"", "\\\"")
 }
 
-//export themeChanged
-func themeChanged() {
-	fyne.CurrentApp().Settings().(*settings).setupTheme()
+//export fallbackSend
+func fallbackSend(cTitle, cContent *C.char) {
+	title := C.GoString(cTitle)
+	content := C.GoString(cContent)
+	fallbackNotification(title, content)
 }
 
-func watchTheme() {
-	C.watchTheme()
+func fallbackNotification(title, content string) {
+	template := `display notification "%s" with title "%s"`
+	script := fmt.Sprintf(template, escapeNotificationString(content), escapeNotificationString(title))
+
+	err := execabs.Command("osascript", "-e", script).Start()
+	if err != nil {
+		fyne.LogError("Failed to launch darwin notify script", err)
+	}
 }

--- a/app/app_desktop_darwin.go
+++ b/app/app_desktop_darwin.go
@@ -1,0 +1,54 @@
+// +build !ci
+
+// +build !ios
+
+package app
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation
+
+#include <AppKit/AppKit.h>
+
+bool isBundled();
+bool isDarkMode();
+void watchTheme();
+*/
+import "C"
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+func defaultVariant() fyne.ThemeVariant {
+	if C.isDarkMode() {
+		return theme.VariantDark
+	}
+	return theme.VariantLight
+}
+
+func rootConfigDir() string {
+	homeDir, _ := os.UserHomeDir()
+
+	desktopConfig := filepath.Join(filepath.Join(homeDir, "Library"), "Preferences")
+	return filepath.Join(desktopConfig, "fyne")
+}
+
+func (a *fyneApp) OpenURL(url *url.URL) error {
+	cmd := a.exec("open", url.String())
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
+//export themeChanged
+func themeChanged() {
+	fyne.CurrentApp().Settings().(*settings).setupTheme()
+}
+
+func watchTheme() {
+	C.watchTheme()
+}

--- a/app/app_desktop_darwin.m
+++ b/app/app_desktop_darwin.m
@@ -1,0 +1,18 @@
+// +build !ci
+// +build !ios
+
+extern void themeChanged();
+
+#import <Foundation/Foundation.h>
+
+bool isDarkMode() {
+    NSString *style = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+    return [@"Dark" isEqualToString:style];
+}
+
+void watchTheme() {
+    [[NSDistributedNotificationCenter defaultCenter] addObserverForName:@"AppleInterfaceThemeChangedNotification" object:nil queue:nil
+        usingBlock:^(NSNotification *note) {
+        themeChanged(); // calls back into Go
+    }];
+}

--- a/app/app_mobile_ios.go
+++ b/app/app_mobile_ios.go
@@ -36,15 +36,6 @@ func (a *fyneApp) OpenURL(url *url.URL) error {
 	return nil
 }
 
-func (a *fyneApp) SendNotification(n *fyne.Notification) {
-	titleStr := C.CString(n.Title)
-	defer C.free(unsafe.Pointer(titleStr))
-	contentStr := C.CString(n.Content)
-	defer C.free(unsafe.Pointer(contentStr))
-
-	C.sendNotification(titleStr, contentStr)
-}
-
 func defaultVariant() fyne.ThemeVariant {
 	return systemTheme
 }

--- a/app/app_mobile_ios.m
+++ b/app/app_mobile_ios.m
@@ -3,48 +3,11 @@
 // +build ios
 
 #import <UIKit/UIKit.h>
-#import <UserNotifications/UserNotifications.h>
 
 void openURL(char *urlStr) {
     UIApplication *app = [UIApplication sharedApplication];
     NSURL *url = [NSURL URLWithString:[NSString stringWithUTF8String:urlStr]];
     [app openURL:url options:@{} completionHandler:nil];
-}
-
-static int notifyNum = 0;
-
-void doSendNotification(UNUserNotificationCenter *center, NSString *title, NSString *body) {
-    UNMutableNotificationContent *content = [UNMutableNotificationContent new];
-    [content autorelease];
-    content.title = title;
-    content.body = body;
-
-    notifyNum++;
-    NSString *identifier = [NSString stringWithFormat:@"fyne-notify-%d", notifyNum];
-    UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier
-        content:content trigger:nil];
-
-    [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
-        if (error != nil) {
-            NSLog(@"Could not send notification: %@", error);
-        }
-    }];
-}
-
-void sendNotification(char *cTitle, char *cBody) {
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    NSString *title = [NSString stringWithUTF8String:cTitle];
-    NSString *body = [NSString stringWithUTF8String:cBody];
-
-    UNAuthorizationOptions options = UNAuthorizationOptionAlert;
-    [center requestAuthorizationWithOptions:options
-        completionHandler:^(BOOL granted, NSError *_Nullable error) {
-            if (!granted) {
-                NSLog(@"Unable to get permission to send notifications");
-            } else {
-                doSendNotification(center, title, body);
-            }
-        }];
 }
 
 char *documentsPath() {

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -5,6 +5,15 @@
 
 const int menuTagMin = 5000;
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+NSControlStateValue STATE_ON = NSControlStateValueOn;
+NSControlStateValue STATE_OFF = NSControlStateValueOff;
+#else
+NSControlStateValue STATE_ON = NSOnState;
+NSControlStateValue STATE_OFF = NSOffState;
+#endif
+
+
 extern void menuCallback(int);
 extern BOOL menuEnabled(int);
 extern BOOL menuChecked(int);
@@ -21,9 +30,9 @@ extern void exceptionCallback(const char*);
 + (BOOL) validateMenuItem:(NSMenuItem*) item {
     BOOL checked = menuChecked([item tag]-menuTagMin);
     if (checked) {
-        [item setState:NSOnState];
+        [item setState:STATE_ON];
     } else {
-        [item setState:NSOffState];
+        [item setState:STATE_OFF];
     }
 
     return menuEnabled([item tag]-menuTagMin);


### PR DESCRIPTION

### Description:
Remove deprecated APIs to fix macOS warnings.
Sadly the new notifications are not as flexible as the old ones (apps must be signed) but we can't avoid that.
So we fall back to the script based ones instead.

Fixes #1833

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included. <- no new tests, switching out calls for existing features
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
