### PR TITLE
internal/cache: use sync.Map to avoid data race

### DIFF
--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -267,7 +268,7 @@ func testClearAll() {
 	skippedCleanWithCanvasRefresh = false
 	canvases = make(map[fyne.CanvasObject]*canvasInfo, 1024)
 	svgs = make(map[string]*svgInfo)
-	textures = make(map[fyne.CanvasObject]*textureInfo, 1024)
+	textures = sync.Map{}
 	renderers = map[fyne.Widget]*rendererInfo{}
 	timeNow = time.Now
 }

--- a/internal/cache/texture_desktop_test.go
+++ b/internal/cache/texture_desktop_test.go
@@ -13,6 +13,7 @@ import (
 // go test -race
 func TestTextureDesktop(t *testing.T) {
 	wg := sync.WaitGroup{}
+	wg.Add(2)
 
 	go func() {
 		defer wg.Done()

--- a/internal/cache/texture_desktop_test.go
+++ b/internal/cache/texture_desktop_test.go
@@ -1,3 +1,6 @@
+//go:build !android && !ios && !mobile
+// +build !android,!ios,!mobile
+
 package cache_test
 
 import (
@@ -8,7 +11,7 @@ import (
 )
 
 // go test -race
-func TestTexture(t *testing.T) {
+func TestTextureDesktop(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	go func() {

--- a/internal/cache/texture_gomobile_test.go
+++ b/internal/cache/texture_gomobile_test.go
@@ -1,0 +1,28 @@
+//go:build android || ios || mobile
+// +build android ios mobile
+
+package cache_test
+
+import (
+	"sync"
+	"testing"
+
+	"fyne.io/fyne/v2/internal/cache"
+	"github.com/fyne-io/mobile/gl"
+)
+
+// go test -race
+func TestTextureGomobile(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	go func() {
+		defer wg.Done()
+		cache.SetTexture(nil, gl.Texture{0}, nil)
+	}()
+	go func() {
+		defer wg.Done()
+		cache.SetTexture(nil, gl.Texture{1}, nil)
+	}()
+
+	wg.Wait()
+}

--- a/internal/cache/texture_gomobile_test.go
+++ b/internal/cache/texture_gomobile_test.go
@@ -14,6 +14,7 @@ import (
 // go test -race
 func TestTextureGomobile(t *testing.T) {
 	wg := sync.WaitGroup{}
+	wg.Add(2)
 
 	go func() {
 		defer wg.Done()

--- a/internal/cache/texture_test.go
+++ b/internal/cache/texture_test.go
@@ -1,0 +1,24 @@
+package cache_test
+
+import (
+	"sync"
+	"testing"
+
+	"fyne.io/fyne/v2/internal/cache"
+)
+
+// go test -race
+func TestTexture(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	go func() {
+		defer wg.Done()
+		cache.SetTexture(nil, 0, nil)
+	}()
+	go func() {
+		defer wg.Done()
+		cache.SetTexture(nil, 1, nil)
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
### Description:

See the corresponding issue.

Fixes #2414 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
