### PR TITLE
Remove lots of unnecessary refresh in list

### DIFF
--- a/container.go
+++ b/container.go
@@ -82,7 +82,6 @@ func (c *Container) MinSize() Size {
 // Move the container (and all its children) to a new position, relative to its parent.
 func (c *Container) Move(pos Position) {
 	c.position = pos
-	c.layout()
 }
 
 // Position gets the current position of this Container, relative to its parent.

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -106,7 +106,7 @@ func (c *Canvas) EnsureMinSize() bool {
 		c.impl.Resize(csize.Max(min))
 	}
 
-	if lastParent != nil {
+	if lastParent != nil && windowNeedsMinSizeUpdate {
 		c.RLock()
 		updateLayout(lastParent)
 		c.RUnlock()

--- a/widget/list.go
+++ b/widget/list.go
@@ -108,6 +108,7 @@ func (l *List) scrollTo(id ListItemID) {
 	l.offsetUpdated(l.scroller.Offset)
 }
 
+// Resize is called when this list should change size. We refresh to ensure invisible items are drawn.
 func (l *List) Resize(s fyne.Size) {
 	l.BaseWidget.Resize(s)
 	l.scroller.Content.(*fyne.Container).Layout.(*listLayout).updateList(true)

--- a/widget/list.go
+++ b/widget/list.go
@@ -108,6 +108,11 @@ func (l *List) scrollTo(id ListItemID) {
 	l.offsetUpdated(l.scroller.Offset)
 }
 
+func (l *List) Resize(s fyne.Size) {
+	l.BaseWidget.Resize(s)
+	l.scroller.Content.(*fyne.Container).Layout.(*listLayout).updateList(true)
+}
+
 // Select add the item identified by the given ID to the selection.
 func (l *List) Select(id ListItemID) {
 	if len(l.selected) > 0 && id == l.selected[0] {
@@ -234,6 +239,7 @@ func (l *listRenderer) Refresh() {
 	}
 	l.Layout(l.list.Size())
 	l.scroller.Refresh()
+	l.layout.Layout.(*listLayout).updateList(true)
 	canvas.Refresh(l.list.super())
 }
 
@@ -363,7 +369,7 @@ func newListLayout(list *List) fyne.Layout {
 }
 
 func (l *listLayout) Layout([]fyne.CanvasObject, fyne.Size) {
-	l.updateList()
+	l.updateList(true)
 }
 
 func (l *listLayout) MinSize([]fyne.CanvasObject) fyne.Size {
@@ -389,7 +395,7 @@ func (l *listLayout) offsetUpdated(pos fyne.Position) {
 		return
 	}
 	l.list.offsetY = pos.Y
-	l.updateList()
+	l.updateList(false)
 }
 
 func (l *listLayout) setupListItem(li *listItem, id ListItemID) {
@@ -412,7 +418,7 @@ func (l *listLayout) setupListItem(li *listItem, id ListItemID) {
 	}
 }
 
-func (l *listLayout) updateList() {
+func (l *listLayout) updateList(refresh bool) {
 	l.renderLock.Lock()
 	defer l.renderLock.Unlock()
 	separatorThickness := theme.SeparatorThicknessSize()
@@ -442,11 +448,17 @@ func (l *listLayout) updateList() {
 			if c == nil {
 				continue
 			}
+			c.Resize(size)
+			l.setupListItem(c, row)
 		}
 
 		c.Move(fyne.NewPos(0, y))
-		c.Resize(size)
-		l.setupListItem(c, row)
+		if refresh {
+			c.Resize(size)
+			if ok { // refresh visible
+				l.setupListItem(c, row)
+			}
+		}
 
 		y += l.list.itemMin.Height + separatorThickness
 		l.visible[row] = c


### PR DESCRIPTION

### Description:
Mostly just removing the loop that refreshes all items visible all the time.
Also found that other actions in list could trigger refresh further up the widget tree, fixing that too.

Fixes #2408

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- optimisations, test remain unchanged.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
