### PR TITLE
Run resize draw events on the draw thread

### DIFF
--- a/internal/driver/glfw/window_notlinux.go
+++ b/internal/driver/glfw/window_notlinux.go
@@ -7,7 +7,23 @@ import "fyne.io/fyne/v2"
 func (w *window) platformResize(canvasSize fyne.Size) {
 	d, ok := fyne.CurrentApp().Driver().(*gLDriver)
 	if !ok { // don't wait to redraw in this way if we are running on test
-		w.canvas.Resize(canvasSize)
+
+		// A resize event is triggered on the main thread, whereas the
+		// related rendering operations (draw calls) are signaled on a
+		// different thread, the draw thread.
+		//
+		// Theoretically, when resizing a window, the underlying hardware
+		// frame buffer resizes (call from the event thread) concurrently
+		// with other relevant draw calls (especially glClear and glClearColor),
+		// which are issued from the draw thread. Intrinsically, there is
+		// a data race on the frame buffer. (e.g. a race on the glClear and
+		// the framebuffer resize) Hence, the following Resize must run on
+		// the draw thread too. Otherwise, it executes graphics calls
+		// concurrently with the draw thread, and the data race happens
+		// and will result in a crash.
+		//
+		// See https://github.com/fyne-io/fyne/issues/2188
+		runOnDraw(w, func() { w.canvas.Resize(canvasSize) })
 		return
 	}
 


### PR DESCRIPTION
### Description:

I encountered a reliable crashing issue when resizing the window.
The issue will cause the window can never be resized because it
crashes instantly.  Hence I tested these platforms: Ubuntu Linux
(NVIDIA, and Intel), macOS/amd64 (Intel), macOS/amd64 (M1),
Windows (NVIDIA, Intel).

Based on the tests, it looks like the issue reliably happens on
macOS(M1), and the rest of the platforms are good.
After a careful review, and debugging, I found the reason:

A resize event is triggered on the main thread, whereas the
related rendering operations (draw calls) are signaled on a
different thread, the draw thread.
Theoretically, when resizing a window, the underlying hardware
frame buffer resizes (call from the event thread) concurrently
with other relevant draw calls (especially glClear and glClearColor)
that manipulates the buffer from a different thread, which may
access data outside the buffer (if frame buffer shrinks).
 Intrinsically, there is a data race on the frame buffer. (e.g. a race
on the glClear and the framebuffer resize) 

On other platforms, this type of data race is ignored, as there
is no harm to the OS. But with M1, as it has a unified memory
architecture, the M1 seems to decide to signal a SIGSEGV
then crash the entire app.

In summary, the Resize event-related drawing, must run on
the draw thread too. Otherwise, it executes graphics calls
concurrently with the draw thread, and the data race happens
and will result in a crash.

Fixes #2188 

```
2021/09/03 20:08:58 Lifecycle: Started
2021/09/03 20:08:58 Lifecycle: Entered Foreground
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x2 addr=0x1000000000000010 pc=0x132a4eebc]

runtime stack:
runtime.throw({0x10453c145, 0x1400040c340})
        /Users/changkun/dev/godev/go-gerrit/src/runtime/panic.go:965 +0x50
runtime.sigpanic()
        /Users/changkun/dev/godev/go-gerrit/src/runtime/signal_unix.go:720 +0x1e8

goroutine 38 [syscall, locked to thread]:
runtime.cgocall(0x10450f6d4, 0x140000f3d28)
        /Users/changkun/dev/godev/go-gerrit/src/runtime/cgocall.go:157 +0x54 fp=0x140000f3cf0 sp=0x140000f3cb0 pc=0x1040a2e44
github.com/go-gl/gl/v3.2-core/gl._Cfunc_glowClear(0x215e1096c, 0x4100)
        _cgo_gotypes.go:3794 +0x38 fp=0x140000f3d20 sp=0x140000f3cf0 pc=0x1043320a8
github.com/go-gl/gl/v3.2-core/gl.Clear(...)
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/go-gl/gl/v3.2-core/gl/package.go:8941
fyne.io/fyne/v2/internal/painter/gl.(*glPainter).glClearBuffer(0x140000f3d78)
        /Users/changkun/dev/changkun.de/fyne/internal/painter/gl/gl_core.go:243 +0xd0 fp=0x140000f3d50 sp=0x140000f3d20 pc=0x104353d10
fyne.io/fyne/v2/internal/painter/gl.(*glPainter).Clear(0x140000f3d98)
        /Users/changkun/dev/changkun.de/fyne/internal/painter/gl/painter.go:52 +0x20 fp=0x140000f3d70 sp=0x140000f3d50 pc=0x104354b20
fyne.io/fyne/v2/internal/driver/glfw.(*glCanvas).paint(0x14000440120, {0x0, 0x0})
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/canvas.go:271 +0x64 fp=0x140000f3df0 sp=0x140000f3d70 pc=0x10448f4a4
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).repaintWindow.func1()
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/loop.go:171 +0x84 fp=0x140000f3e50 sp=0x140000f3df0 pc=0x104491954
fyne.io/fyne/v2/internal/driver/glfw.(*window).RunWithContext(0x1400044a000, 0x140000f3e90)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/window.go:1317 +0x50 fp=0x140000f3e70 sp=0x140000f3e50 pc=0x10449a490
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).repaintWindow(0x140000f3f88, 0x140000f3f08)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/loop.go:162 +0x48 fp=0x140000f3eb0 sp=0x140000f3e70 pc=0x1044918a8
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).startDrawThread.func1()
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/loop.go:225 +0x2f0 fp=0x140000f3fd0 sp=0x140000f3eb0 pc=0x104491f50
runtime.goexit()
        /Users/changkun/dev/godev/go-gerrit/src/runtime/asm_arm64.s:1259 +0x4 fp=0x140000f3fd0 sp=0x140000f3fd0 pc=0x1040ffe24
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).startDrawThread
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/loop.go:189 +0xd0

goroutine 1 [chan send, locked to thread]:
fyne.io/fyne/v2/internal/driver/glfw.runOnDraw(0x1400044a000, 0x140006ce020)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/loop.go:70 +0xc0
fyne.io/fyne/v2/internal/driver/glfw.(*window).platformResize(0x1400044a000, {0x440120, 0x140})
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/window_notlinux.go:14 +0xd0
fyne.io/fyne/v2/internal/driver/glfw.(*window).resized(0x1400044a000, 0x104489c00, 0x104d05a50, 0x14001fb59f0)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/window.go:551 +0xcc
github.com/go-gl/glfw/v3.3/glfw.goWindowSizeCB(0x14001fb5a58, 0x28a, 0x214)
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/go-gl/glfw/v3.3/glfw/window.go:213 +0x58
github.com/go-gl/glfw/v3.3/glfw._Cfunc_glfwPollEvents()
        _cgo_gotypes.go:1474 +0x38
github.com/go-gl/glfw/v3.3/glfw.PollEvents()
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/go-gl/glfw/v3.3/glfw/window.go:949 +0x20
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).tryPollEvents(0x140001b1e18)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/loop.go:240 +0x3c
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).runGL(0x1400007acd0)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/loop.go:109 +0x1dc
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).Run(0x1400044a000)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/driver.go:83 +0x34
fyne.io/fyne/v2/internal/driver/glfw.(*window).ShowAndRun(0x1400044a000)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/window.go:458 +0x30
main.main()
        /Users/changkun/dev/changkun.de/fyne/cmd/fyne_demo/main.go:66 +0x440

goroutine 4 [chan receive]:
fyne.io/fyne/v2/test.NewApp.func1()
        /Users/changkun/dev/changkun.de/fyne/test/testapp.go:113 +0x44
created by fyne.io/fyne/v2/test.NewApp
        /Users/changkun/dev/changkun.de/fyne/test/testapp.go:111 +0x310

goroutine 5 [syscall]:
syscall.syscall6(0x1044b2e30, 0x3, 0x0, 0x0, 0x14000069e68, 0xa, 0x104d389c0)
        /Users/changkun/dev/godev/go-gerrit/src/runtime/sys_darwin.go:44 +0x1c
golang.org/x/sys/unix.kevent(0x0, 0x0, 0x14000069dc4, 0x0, 0x0, 0x1400007c420)
        /Users/changkun/dev/changkun.de/fyne/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go:276 +0x5c
golang.org/x/sys/unix.Kevent(0x0, {0x0, 0x1400005c538, 0x1044b46d0}, {0x14000069e68, 0x14000069dc4, 0x2}, 0x2)
        /Users/changkun/dev/changkun.de/fyne/vendor/golang.org/x/sys/unix/syscall_bsd.go:429 +0x4c
github.com/fsnotify/fsnotify.read(0x14000069e28, {0x14000069e68, 0x5, 0xa}, 0x0)
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/fsnotify/fsnotify/kqueue.go:511 +0x44
github.com/fsnotify/fsnotify.(*Watcher).readEvents(0x14000113080)
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/fsnotify/fsnotify/kqueue.go:274 +0x78
created by github.com/fsnotify/fsnotify.NewWatcher
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/fsnotify/fsnotify/kqueue.go:62 +0x1ac

goroutine 34 [chan receive]:
fyne.io/fyne/v2/app.watchFile.func1()
        /Users/changkun/dev/changkun.de/fyne/app/settings_desktop.go:42 +0x64
created by fyne.io/fyne/v2/app.watchFile
        /Users/changkun/dev/changkun.de/fyne/app/settings_desktop.go:41 +0x120

goroutine 36 [syscall]:
syscall.syscall6(0x1044b2e30, 0xa, 0x0, 0x0, 0x1400043a668, 0xa, 0x104d389c0)
        /Users/changkun/dev/godev/go-gerrit/src/runtime/sys_darwin.go:44 +0x1c
golang.org/x/sys/unix.kevent(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/changkun/dev/changkun.de/fyne/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go:276 +0x5c
golang.org/x/sys/unix.Kevent(0x0, {0x0, 0x1400043a538, 0x1044b46d0}, {0x1400043a668, 0x0, 0x0}, 0x0)
        /Users/changkun/dev/changkun.de/fyne/vendor/golang.org/x/sys/unix/syscall_bsd.go:429 +0x4c
github.com/fsnotify/fsnotify.read(0x0, {0x1400043a668, 0x0, 0xa}, 0x0)
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/fsnotify/fsnotify/kqueue.go:511 +0x44
github.com/fsnotify/fsnotify.(*Watcher).readEvents(0x140004001e0)
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/fsnotify/fsnotify/kqueue.go:274 +0x78
created by github.com/fsnotify/fsnotify.NewWatcher
        /Users/changkun/dev/changkun.de/fyne/vendor/github.com/fsnotify/fsnotify/kqueue.go:62 +0x1ac

goroutine 37 [chan receive]:
fyne.io/fyne/v2/app.watchFile.func1()
        /Users/changkun/dev/changkun.de/fyne/app/settings_desktop.go:42 +0x64
created by fyne.io/fyne/v2/app.watchFile
        /Users/changkun/dev/changkun.de/fyne/app/settings_desktop.go:41 +0x120

goroutine 39 [chan receive]:
fyne.io/fyne/v2/internal/driver/common.(*Window).RunEventQueue(0x1400044a000)
        /Users/changkun/dev/changkun.de/fyne/internal/driver/common/window.go:57 +0x70
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).createWindow.func1
        /Users/changkun/dev/changkun.de/fyne/internal/driver/glfw/window.go:1376 +0x15c

goroutine 40 [chan receive]:
fyne.io/fyne/v2/internal/async.NewUnboundedCanvasObjectChan.func1()
        /Users/changkun/dev/changkun.de/fyne/internal/async/chan_canvasobject.go:35 +0x90
created by fyne.io/fyne/v2/internal/async.NewUnboundedCanvasObjectChan
        /Users/changkun/dev/changkun.de/fyne/internal/async/chan_canvasobject.go:27 +0xd8
exit status 2
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
