### PR TITLE
Use Go 1.17 for static analysis

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: WillAbides/setup-go-faster@v1.6.0
       with:
-        go-version: '1.16.x'     
+        go-version: '1.17.x'     
 
     - name: Get dependencies
       run: |
@@ -16,7 +16,7 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
         go install golang.org/x/lint/golint@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.2.0
+        go install honnef.co/go/tools/cmd/staticcheck@v0.2.1
 
     - name: Cleanup repository
       run: rm -rf vendor/


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Also upgrades staticcheck to v0.2.1 for Go 1.17 support and some false positive fixes.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.