### PR TITLE
Fix Android builds for darwin/arm64

### DIFF
--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -326,6 +326,13 @@ func archNDK() string {
 		arch = "x86"
 	case "amd64":
 		arch = "x86_64"
+	case "arm64":
+		// For darwin/arm64, see https://golang.org/cl/346153.
+		if runtime.GOOS == "darwin" {
+			arch = "x86_64"
+			break
+		}
+		fallthrough
 	default:
 		panic("unsupported GOARCH: " + runtime.GOARCH)
 	}


### PR DESCRIPTION
### Description:

`fyne package` currently does not work on Apple M1 Macs, this change fixes this situation. See relevant gomobile discussion: https://golang.org/cl/346153

Fixes #2439 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
