### PR TITLE
Re-introduce exiting the runloop exiting when events end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Sequential writes to preferences does not save to file (#2449)
 * Correct Android keyboard handling (#2447)
 * MIUI-Android: The widget’s Hyperlink cannot open the URL (#1514)
-* Mobile simulator does not close (#2225)
 
 
 ## 2.0.4 - 6 August 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Sequential writes to preferences does not save to file (#2449)
 * Correct Android keyboard handling (#2447)
 * MIUI-Android: The widget’s Hyperlink cannot open the URL (#1514)
+* Mobile simulator does not close (#2225)
 
 
 ## 2.0.4 - 6 August 2021

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -151,7 +151,10 @@ func (d *mobileDriver) Run() {
 					}
 					c.applyThemeOutOfTreeObjects()
 				})
-			case e := <-a.Events():
+			case e, ok := <-a.Events():
+				if !ok {
+					return // events channel closed, app done
+				}
 				current := d.currentWindow()
 				if current == nil {
 					continue


### PR DESCRIPTION
Fixes #2225

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- mobile runloop still one of our not-unit-tested, just run and close on x11...
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
