### PR TITLE
Bugfix #2404: menu uses correct object when determining canvas or absolute position

### DIFF
--- a/widget/menu.go
+++ b/widget/menu.go
@@ -13,7 +13,7 @@ var _ fyne.Tappable = (*Menu)(nil)
 
 // Menu is a widget for displaying a fyne.Menu.
 type Menu struct {
-	widget.Base
+	BaseWidget
 	alignment     fyne.TextAlign
 	Items         []fyne.CanvasObject
 	OnDismiss     func()
@@ -144,7 +144,7 @@ func (m *Menu) DeactivateLastSubmenu() bool {
 // Implements: fyne.Widget
 func (m *Menu) MinSize() fyne.Size {
 	m.ExtendBaseWidget(m)
-	return m.Base.MinSize()
+	return m.BaseWidget.MinSize()
 }
 
 // Refresh updates the menu to reflect changes in the data.
@@ -154,7 +154,7 @@ func (m *Menu) Refresh() {
 	for _, item := range m.Items {
 		item.Refresh()
 	}
-	m.Base.Refresh()
+	m.BaseWidget.Refresh()
 }
 
 func (m *Menu) getContainsCheck() bool {

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -237,8 +237,8 @@ func (r *menuRenderer) Layout(s fyne.Size) {
 		boxSize = minSize
 	}
 	scrollSize := boxSize
-	if c := fyne.CurrentApp().Driver().CanvasForObject(r.m); c != nil {
-		ap := fyne.CurrentApp().Driver().AbsolutePositionForObject(r.m)
+	if c := fyne.CurrentApp().Driver().CanvasForObject(r.m.super()); c != nil {
+		ap := fyne.CurrentApp().Driver().AbsolutePositionForObject(r.m.super())
 		pos, size := c.InteractiveArea()
 		bottomPad := c.Size().Height - pos.Y - size.Height
 		if ah := c.Size().Height - bottomPad - ap.Y; ah < boxSize.Height {

--- a/widget/popup_menu.go
+++ b/widget/popup_menu.go
@@ -64,14 +64,14 @@ func (p *PopUpMenu) Hide() {
 //
 // Implements: fyne.Widget
 func (p *PopUpMenu) Move(pos fyne.Position) {
-	p.Base.Move(p.adjustedPosition(pos, p.Size()))
+	p.BaseWidget.Move(p.adjustedPosition(pos, p.Size()))
 }
 
 // Resize changes the size of the pop-up menu.
 //
 // Implements: fyne.Widget
 func (p *PopUpMenu) Resize(size fyne.Size) {
-	p.Base.Move(p.adjustedPosition(p.Position(), size))
+	p.BaseWidget.Move(p.adjustedPosition(p.Position(), size))
 	p.Menu.Resize(size)
 }
 


### PR DESCRIPTION
### Description:

The introduction of keyboard controlled menus changed the way pop-up menus were rendered and this revealed a bug in the `Menu` where it did not use the correct object (`super()`) when determining the canvas or the absolute position.
To fix this, the `Menu` had to modified to base on `widget.BaseWidget` first.

Sadly no tests because the bug also relies on the canvas cache which the test driver doesn’t use.

Fixes #2404

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
