### PR TITLE
Re-fix #2449

### DIFF
--- a/app/preferences.go
+++ b/app/preferences.go
@@ -14,8 +14,8 @@ import (
 type preferences struct {
 	*internal.InMemoryPreferences
 
-	prefLock     sync.RWMutex
-	ignoreChange bool
+	prefLock          sync.RWMutex
+	ignoreChange      bool
 	numIgnoredChanges int
 
 	app *fyneApp

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -14,8 +14,16 @@ import (
 type preferences struct {
 	*internal.InMemoryPreferences
 
-	prefLock            sync.RWMutex
-	loadingInProgress   bool
+	prefLock sync.RWMutex
+	// Normally, any update of preferences is immediately written to disk,
+	// but the initial operation of loading the preferences file performs many separate
+	// changes. To avoid "load->changes!->write" pattern (rewriting preferences file
+	// after each loading), saving file to disk is disabled
+	// during the loading progress. Access guarded by prefLock.
+	loadingInProgress bool
+	// If an application changes its preferences 1000 times per second, we don't want to
+	// rewrite the preferences file after every update. Instead, a time-out mechanism is
+	// implemented in resetSuspend(), limiting the number of file operations per second.
 	suspendChange       bool
 	numSuspendedChanges int
 

--- a/app/preferences_other.go
+++ b/app/preferences_other.go
@@ -17,7 +17,7 @@ func (a *fyneApp) storageRoot() string {
 func (p *preferences) watch() {
 	watchFile(p.storagePath(), func() {
 		p.prefLock.RLock()
-		shouldIgnoreChange := p.ignoreChange
+		shouldIgnoreChange := p.suspendChange
 		p.prefLock.RUnlock()
 		if shouldIgnoreChange {
 			return

--- a/app/preferences_other.go
+++ b/app/preferences_other.go
@@ -17,7 +17,7 @@ func (a *fyneApp) storageRoot() string {
 func (p *preferences) watch() {
 	watchFile(p.storagePath(), func() {
 		p.prefLock.RLock()
-		shouldIgnoreChange := p.suspendChange
+		shouldIgnoreChange := p.savedRecently
 		p.prefLock.RUnlock()
 		if shouldIgnoreChange {
 			return

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -41,7 +41,7 @@ func (p *InMemoryPreferences) WriteValues(fn func(map[string]interface{})) {
 	fn(p.values)
 	p.lock.Unlock()
 
-	p.FireChange()
+	p.fireChange()
 }
 
 func (p *InMemoryPreferences) set(key string, value interface{}) {
@@ -50,7 +50,7 @@ func (p *InMemoryPreferences) set(key string, value interface{}) {
 	p.values[key] = value
 	p.lock.Unlock()
 
-	p.FireChange()
+	p.fireChange()
 }
 
 func (p *InMemoryPreferences) get(key string) (interface{}, bool) {
@@ -69,7 +69,7 @@ func (p *InMemoryPreferences) remove(key string) {
 }
 
 // FireChange causes InMemoryPreferences to activate all its .changeListeners
-func (p *InMemoryPreferences) FireChange() {
+func (p *InMemoryPreferences) fireChange() {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -68,6 +68,7 @@ func (p *InMemoryPreferences) remove(key string) {
 	delete(p.values, key)
 }
 
+// FireChange causes InMemoryPreferences to activate all its .changeListeners
 func (p *InMemoryPreferences) FireChange() {
 	p.lock.RLock()
 	defer p.lock.RUnlock()

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -68,7 +68,6 @@ func (p *InMemoryPreferences) remove(key string) {
 	delete(p.values, key)
 }
 
-// FireChange causes InMemoryPreferences to activate all its .changeListeners
 func (p *InMemoryPreferences) fireChange() {
 	p.lock.RLock()
 	defer p.lock.RUnlock()

--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -41,7 +41,7 @@ func (p *InMemoryPreferences) WriteValues(fn func(map[string]interface{})) {
 	fn(p.values)
 	p.lock.Unlock()
 
-	p.fireChange()
+	p.FireChange()
 }
 
 func (p *InMemoryPreferences) set(key string, value interface{}) {
@@ -50,7 +50,7 @@ func (p *InMemoryPreferences) set(key string, value interface{}) {
 	p.values[key] = value
 	p.lock.Unlock()
 
-	p.fireChange()
+	p.FireChange()
 }
 
 func (p *InMemoryPreferences) get(key string) (interface{}, bool) {
@@ -68,7 +68,7 @@ func (p *InMemoryPreferences) remove(key string) {
 	delete(p.values, key)
 }
 
-func (p *InMemoryPreferences) fireChange() {
+func (p *InMemoryPreferences) FireChange() {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 


### PR DESCRIPTION

### Description:

The issue #2449 is still not fixed by the pull request #2450 for me since concurrent writes are not the only problem. There is another problem:
* `preferences.saveToFile()` sets ignoreChanges to `true` for 100 ms (using resetIgnore()).
* A default change listener added in newPreferences() just ignores all changes made during that time window.
* If no changes in preferences occur after the 100ms window, the ignored changes are not saved to disk since the change listener responsible for that will never be invoked.

Suggested solution implemented in this pull request:
* Add a counter `numIgnoredChanges int` to `preferences`. The access is guarded by the same `.prefLock` as `.ignoreChanges`.
* Let the default change listener count how many times it was invoked while ignoreChanges is true (guarded by `p.prefLock.Lock()` instead of `p.prefLock.RLock()` since we modify the contents).
* Change `resetIgnore()` to reset `p.numIgnoredChanges` as well, and if the number was not zero, call `p.InMemoryPreferences.fireChange()`. This is not possible as `fireChange()` is not an exported method of the `internal` module, so it was made public.

Fixes #2449

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
