### PR TITLE
internal/driver/mobile: clear touchIDs at every touch end event

### DIFF
--- a/internal/driver/mobile/app/darwin_ios.go
+++ b/internal/driver/mobile/app/darwin_ios.go
@@ -154,12 +154,7 @@ func updateConfig(width, height, orientation int32) {
 //
 // It is widely reported that the iPhone can handle up to 5 simultaneous
 // touch events, while the iPad can handle 11.
-var (
-	// touchIDs may arrive concurrently, use a lock for safety.
-	// See https://github.com/fyne-io/fyne/issues/2407.
-	touchMu  sync.RWMutex
-	touchIDs [11]uintptr
-)
+var touchIDs [11]uintptr
 
 var touchEvents struct {
 	sync.Mutex
@@ -169,17 +164,12 @@ var touchEvents struct {
 //export sendTouch
 func sendTouch(cTouch, cTouchType uintptr, x, y float32) {
 	id := -1
-
-	touchMu.RLock()
 	for i, val := range touchIDs {
 		if val == cTouch {
 			id = i
 			break
 		}
 	}
-	touchMu.RUnlock()
-
-	touchMu.Lock()
 	if id == -1 {
 		for i, val := range touchIDs {
 			if val == 0 {
@@ -195,9 +185,14 @@ func sendTouch(cTouch, cTouchType uintptr, x, y float32) {
 
 	t := touch.Type(cTouchType)
 	if t == touch.TypeEnd {
-		touchIDs[id] = 0
+		// Clear all touchIDs when touch ends. The UITouch pointers are unique
+		// at every multi-touch event. See:
+		// https://github.com/fyne-io/fyne/issues/2407
+		// https://developer.apple.com/documentation/uikit/touches_presses_and_gestures?language=objc
+		for idx := range touchIDs {
+			touchIDs[idx] = 0
+		}
 	}
-	touchMu.Unlock()
 
 	theApp.eventsIn <- touch.Event{
 		X:        x,


### PR DESCRIPTION
### Description:

The pointer addresses of UITouch* are used as touchIDs, but they are only unique during a round of touch begin and touch end events. Only clear one touchID when touch.TypeEnd arrives can cause out of touchID panic. So, clear the entire touchIDs at every touch ends.

Fixes #2407 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
