### PR TITLE
internal/driver/mobile: support darwin/arm64

### DIFF
--- a/internal/driver/mobile/gl/work.c
+++ b/internal/driver/mobile/gl/work.c
@@ -356,7 +356,7 @@ uintptr_t processFn(struct fnargs* args, char* parg) {
 		glScissor((GLint)args->a0, (GLint)args->a1, (GLint)args->a2, (GLint)args->a3);
 		break;
 	case glfnShaderSource:
-#if defined(os_ios) || defined(os_osx)
+#if defined(os_ios) || defined(os_macos)
 		glShaderSource((GLuint)args->a0, (GLsizei)args->a1, (const GLchar *const *)args->a2, NULL);
 #else
 		glShaderSource((GLuint)args->a0, (GLsizei)args->a1, (const GLchar **)args->a2, NULL);

--- a/internal/driver/mobile/gl/work.go
+++ b/internal/driver/mobile/gl/work.go
@@ -7,26 +7,21 @@
 package gl
 
 /*
-#cgo ios                LDFLAGS: -framework OpenGLES
-#cgo darwin,amd64,!ios  LDFLAGS: -framework OpenGL
-#cgo darwin,arm         LDFLAGS: -framework OpenGLES
-#cgo darwin,arm64       LDFLAGS: -framework OpenGLES
-#cgo linux              LDFLAGS: -lGLESv2
-#cgo openbsd            LDFLAGS: -L/usr/X11R6/lib/ -lGLESv2
-#cgo freebsd            LDFLAGS: -L/usr/local/X11R6/lib/ -lGLESv2
+#cgo ios          LDFLAGS: -framework OpenGLES
+#cgo darwin,!ios  LDFLAGS: -framework OpenGL
+#cgo linux        LDFLAGS: -lGLESv2
+#cgo openbsd      LDFLAGS: -L/usr/X11R6/lib/ -lGLESv2
+#cgo freebsd      LDFLAGS: -L/usr/local/X11R6/lib/ -lGLESv2
 
-#cgo android            CFLAGS: -Dos_android
-#cgo ios                CFLAGS: -Dos_ios
-#cgo darwin,amd64,!ios  CFLAGS: -Dos_osx
-#cgo darwin,arm         CFLAGS: -Dos_ios
-#cgo darwin,arm64       CFLAGS: -Dos_ios
-#cgo darwin             CFLAGS: -DGL_SILENCE_DEPRECATION
-#cgo linux              CFLAGS: -Dos_linux
-#cgo openbsd            CFLAGS: -Dos_openbsd
-#cgo freebsd            CFLAGS: -Dos_freebsd
-
-#cgo openbsd            CFLAGS: -I/usr/X11R6/include/
-#cgo freebsd            CFLAGS: -I/usr/local/X11R6/include/
+#cgo android      CFLAGS: -Dos_android
+#cgo ios          CFLAGS: -Dos_ios
+#cgo darwin,!ios  CFLAGS: -Dos_macos
+#cgo darwin       CFLAGS: -DGL_SILENCE_DEPRECATION
+#cgo linux        CFLAGS: -Dos_linux
+#cgo openbsd      CFLAGS: -Dos_openbsd
+#cgo freebsd      CFLAGS: -Dos_freebsd
+#cgo openbsd      CFLAGS: -I/usr/X11R6/include/
+#cgo freebsd      CFLAGS: -I/usr/local/X11R6/include/
 
 #include <stdint.h>
 #include "work.h"

--- a/internal/driver/mobile/gl/work.h
+++ b/internal/driver/mobile/gl/work.h
@@ -20,7 +20,7 @@
 #include <OpenGLES/ES2/glext.h>
 #endif
 
-#ifdef os_osx
+#ifdef os_macos
 #include <OpenGL/gl3.h>
 #define GL_ES_VERSION_3_0 1
 #endif


### PR DESCRIPTION
### Description:

This PR allows applications can use the mobile driver on darwin/arm64.

Before the change:

```
$ go run -tags mobile cmd/fyne_demo/main.go
# fyne.io/fyne/v2/internal/driver/mobile/gl
In file included from internal/driver/mobile/gl/work.go:32:
./work.h:20:10: fatal error: 'OpenGLES/ES2/glext.h' file not found
#include <OpenGLES/ES2/glext.h>
         ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

After the change:

```
$ go run -tags mobile cmd/fyne_demo/main.go
```

<img width="712" alt="Screenshot 2021-09-20 at 13 15 19" src="https://user-images.githubusercontent.com/5498964/133993655-5c977b66-8523-4569-bdc8-37c95a18e524.png">

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.