### PR TITLE
Update windows.go to fix miss-clicks issues/2484

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -813,6 +813,7 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 			w.mouseLock.Lock()
 			w.mouseDragStarted = false
 			w.mouseLock.Unlock()
+			mouseDragStarted = false
 		}
 		if shouldMouseOut {
 			w.mouseOut()


### PR DESCRIPTION
From the code above I understand that there is some logic to alter the w.mouseDragStarted state. However in the last if, we use the mouseDragStarted value which we only set once at the beginning of the function. As part of this change, I've updated mouseDragStarted back to false to properly reflect the correct state

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #(2484)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
