### PR TITLE
cmd/fyne: support -os iossimulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ single codebase.
 Version 2.1 is the current release of the Fyne API, it introduced RichText
 and the DocTabs container, as well as the document storage API and FyneApp.toml
 metadata support.
-We are now working towards the next big release, codenamed 
+We are now working towards the next big release, codenamed
 [bowmore](https://github.com/fyne-io/fyne/milestone/15)
 and more news will follow in our news feeds and GitHub project.
 
@@ -60,7 +60,7 @@ And even running on a mobile device:
 
 Fyne is designed to be really easy to code with.
 If you have followed the prerequisite steps above then all you need is a
-Go IDE (or a text editor). 
+Go IDE (or a text editor).
 
 Open a new file and you're ready to write your first app!
 
@@ -114,6 +114,8 @@ There is a helpful mobile simulation mode that gives a hint of how your app woul
 
     $ go run -tags mobile main.go
 
+Another option is to use `fyne` command, see [Packaging for mobile](#packaging-for-mobile).
+
 # Installing
 
 Using `go install` will copy the executable into your go `bin` dir.
@@ -133,6 +135,14 @@ Once packaged you can install using the platform development tools or the fyne "
     $ fyne package -os android -appID my.domain.appname
     $ fyne install -os android
 
+The built Android application can run either in a real device or an Android emulator.
+However, building for iOS is slightly different.
+If the "-os" argument is "ios", it is build only for a real iOS device.
+Specify "-os" to "iossimulator" allows the application be able to run in an iOS simulator:
+
+    $ fyne package -os ios -appID my.domain.appname
+    $ fyne package -os iossimulator -appID my.domain.appname
+
 # Preparing a release
 
 Using the fyne utility "release" subcommand you can package up your app for release
@@ -142,7 +152,7 @@ Then you can execute something like the following, notice the `-os ios` paramete
 building an iOS app from macOS computer. Other combinations work as well :)
 
     $ fyne release -os ios -certificate "Apple Distribution" -profile "My App Distribution" -appID "com.example.myapp"
-    
+
 The above command will create a '.ipa' file that can then be uploaded to the iOS App Store.
 
 # Documentation

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -19,8 +19,8 @@ func (p *Packager) packageAndroid(arch string) error {
 	return mobile.RunNewBuild(arch, p.appID, p.icon, p.name, p.appVersion, p.appBuild, p.release, "", "")
 }
 
-func (p *Packager) packageIOS() error {
-	err := mobile.RunNewBuild("ios", p.appID, p.icon, p.name, p.appVersion, p.appBuild, p.release, p.certificate, p.profile)
+func (p *Packager) packageIOS(target string) error {
+	err := mobile.RunNewBuild(target, p.appID, p.icon, p.name, p.appVersion, p.appBuild, p.release, p.certificate, p.profile)
 	if err != nil {
 		return err
 	}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -38,7 +38,7 @@ func Package() *cli.Command {
 			&cli.StringFlag{
 				Name:        "target",
 				Aliases:     []string{"os"},
-				Usage:       "The mobile platform to target (android, android/arm, android/arm64, android/amd64, android/386, ios).",
+				Usage:       "The mobile platform to target (android, android/arm, android/arm64, android/amd64, android/386, ios, iossimulator).",
 				Destination: &p.os,
 			},
 			&cli.StringFlag{
@@ -227,8 +227,8 @@ func (p *Packager) doPackage() error {
 		return p.packageWindows()
 	case "android/arm", "android/arm64", "android/amd64", "android/386", "android":
 		return p.packageAndroid(p.os)
-	case "ios":
-		return p.packageIOS()
+	case "ios", "iossimulator":
+		return p.packageIOS(p.os)
 	default:
 		return fmt.Errorf("unsupported target operating system \"%s\"", p.os)
 	}

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"fyne.io/fyne/v2/cmd/fyne/internal/util"
@@ -302,8 +303,8 @@ func addBuildFlags(cmd *command) {
 func addBuildFlagsNVXWork(cmd *command) {
 	cmd.Flag.BoolVar(&buildN, "n", false, "")
 	cmd.Flag.BoolVar(&buildV, "v", false, "")
-	cmd.Flag.BoolVar(&buildX, "x", false, "")
-	cmd.Flag.BoolVar(&buildWork, "work", false, "")
+	cmd.Flag.BoolVar(&buildX, "x", true, "")
+	cmd.Flag.BoolVar(&buildWork, "work", true, "")
 }
 
 func init() {
@@ -423,6 +424,19 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	if os == "ios" {
 		targetOS = "darwin"
 	}
+
+	if buildTarget == "iossimulator" {
+		if before116 {
+			// If the build target is iossimulator, and the go distribution also before
+			// 1.16, then we can only build amd64 arch app for simulators. Because
+			// arm64 simulators is only supported after go 1.16.
+			allArchs[os] = []string{"amd64"}
+		} else {
+			// Otherwise, the iossimulator arch is depending on the host arch.
+			allArchs[os] = []string{runtime.GOARCH}
+		}
+	}
+
 	if all {
 		return targetOS, allArchs[os], nil
 	}

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -15,6 +15,8 @@ import (
 	"regexp"
 	"strings"
 
+	"fyne.io/fyne/v2/cmd/fyne/internal/util"
+
 	"golang.org/x/sys/execabs"
 	"golang.org/x/tools/go/packages"
 )
@@ -372,8 +374,11 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	archNames := []string{}
 	for i, p := range strings.Split(buildTarget, ",") {
 		osarch := strings.SplitN(p, "/", 2) // len(osarch) > 0
-		if osarch[0] != "android" && osarch[0] != "ios" {
+		if !util.IsAndroid(osarch[0]) && !util.IsIOS(osarch[0]) {
 			return "", nil, fmt.Errorf(`unsupported os`)
+		}
+		if osarch[0] == "iossimulator" {
+			osarch[0] = "ios"
 		}
 
 		if i == 0 {

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -303,8 +303,8 @@ func addBuildFlags(cmd *command) {
 func addBuildFlagsNVXWork(cmd *command) {
 	cmd.Flag.BoolVar(&buildN, "n", false, "")
 	cmd.Flag.BoolVar(&buildV, "v", false, "")
-	cmd.Flag.BoolVar(&buildX, "x", true, "")
-	cmd.Flag.BoolVar(&buildWork, "work", true, "")
+	cmd.Flag.BoolVar(&buildX, "x", false, "")
+	cmd.Flag.BoolVar(&buildWork, "work", false, "")
 }
 
 func init() {

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -82,7 +82,7 @@ func AppOutputName(os, name string) string {
 	switch os {
 	case "android":
 		return androidPkgName(name) + ".apk"
-	case "ios":
+	case "ios", "iossimulator":
 		return rfc1034Label(name) + ".app"
 	}
 

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -154,9 +154,13 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 		}
 	}
 
-	// Use codesign to sign the application so that it can be used in iOS simulator.
-	if err := execabs.Command("codesign", "--force", "--sign", "-", buildO).Run(); err != nil {
-		return nil, err
+	// Use codesign to remove the codesign certificate for the built application
+	// so that it can run in iOS simulator.
+	if buildTarget == "iossimulator" {
+		if out, err := execabs.Command("codesign", "--force", "--sign", "-", buildO).CombinedOutput(); err != nil {
+			printcmd("codesign --force --sign --keychain %s\n%s", buildO, out)
+			return nil, err
+		}
 	}
 
 	return nmpkgs, nil

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -153,6 +153,12 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 			return nil, err
 		}
 	}
+
+	// Use codesign to sign the application so that it can be used in iOS simulator.
+	if err := execabs.Command("codesign", "--force", "--sign", "-", buildO).Run(); err != nil {
+		return nil, err
+	}
+
 	return nmpkgs, nil
 }
 

--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -29,7 +29,7 @@ var (
 
 	allArchs = map[string][]string{
 		"android":      {"arm", "arm64", "386", "amd64"},
-		"ios":          {"arm64", "amd64"},
+		"ios":          {"arm64"},
 		"iossimulator": {"arm64", "amd64"},
 	}
 

--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -86,14 +86,17 @@ func buildEnvInit() (cleanup func(), err error) {
 	return cleanupFn, nil
 }
 
+var (
+	before115 = false
+	before116 = false
+)
+
 func envInit() (err error) {
 	// Check the current Go version by go-list.
 	// An arbitrary standard package ('runtime' here) is given to go-list.
 	// This is because go-list tries to analyze the module at the current directory if no packages are given,
 	// and if the module doesn't have any Go file, go-list fails. See golang/go#36668.
 
-	before115 := false
-	before116 := false
 	ver, err := exec.Command("go", "version").Output()
 	if err == nil && string(ver) != "" {
 		fields := strings.Split(string(ver), " ")

--- a/cmd/fyne/internal/util/mobile.go
+++ b/cmd/fyne/internal/util/mobile.go
@@ -41,9 +41,14 @@ func IsAndroid(os string) bool {
 	return strings.HasPrefix(os, "android")
 }
 
+// IsIOS returns true if the given os parameter represents one of the iOS targets (ios, iossimulator)
+func IsIOS(os string) bool {
+	return strings.HasPrefix(os, "ios")
+}
+
 // IsMobile returns true if the given os parameter represents a platform handled by gomobile.
 func IsMobile(os string) bool {
-	return os == "ios" || IsAndroid(os)
+	return IsIOS(os) || IsAndroid(os)
 }
 
 // RequireAndroidSDK will return an error if it cannot establish the location of a valid Android SDK installation.

--- a/internal/driver/mobile/gl/work114.go
+++ b/internal/driver/mobile/gl/work114.go
@@ -2,23 +2,27 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || linux || openbsd || freebsd) && go115
+//go:build (darwin || linux || openbsd || freebsd) && !go115
 // +build darwin linux openbsd freebsd
-// +build go115
+// +build !go115
 
 package gl
 
 /*
-#cgo ios          LDFLAGS: -framework OpenGLES
-#cgo darwin,!ios  LDFLAGS: -framework OpenGL
-#cgo linux        LDFLAGS: -lGLESv2
-#cgo openbsd      LDFLAGS: -L/usr/X11R6/lib/ -lGLESv2
-#cgo freebsd      LDFLAGS: -L/usr/local/X11R6/lib/ -lGLESv2
+#cgo ios                LDFLAGS: -framework OpenGLES
+#cgo darwin,amd64,!ios  LDFLAGS: -framework OpenGL
+#cgo darwin,arm         LDFLAGS: -framework OpenGLES
+#cgo darwin,arm64       LDFLAGS: -framework OpenGLES
+#cgo linux              LDFLAGS: -lGLESv2
+#cgo openbsd            LDFLAGS: -L/usr/X11R6/lib/ -lGLESv2
+#cgo freebsd            LDFLAGS: -L/usr/local/X11R6/lib/ -lGLESv2
 
-#cgo android      CFLAGS: -Dos_android
-#cgo ios          CFLAGS: -Dos_ios
-#cgo darwin,!ios  CFLAGS: -Dos_macos
-#cgo darwin       CFLAGS: -DGL_SILENCE_DEPRECATION
+#cgo android            CFLAGS: -Dos_android
+#cgo ios                CFLAGS: -Dos_ios
+#cgo darwin,amd64,!ios  CFLAGS: -Dos_macos
+#cgo darwin,arm         CFLAGS: -Dos_ios
+#cgo darwin,arm64       CFLAGS: -Dos_ios
+#cgo darwin             CFLAGS: -DGL_SILENCE_DEPRECATION
 #cgo linux        CFLAGS: -Dos_linux
 #cgo openbsd      CFLAGS: -Dos_openbsd
 #cgo freebsd      CFLAGS: -Dos_freebsd


### PR DESCRIPTION
### Description:

This PR adds `-os iossimulator` to the fyne command, and fixes the iOS simulator issue on darwin/arm64.

Fixes #1917

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
