### PR TITLE
Don't render carriage returns (\r). Fixes #2456

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -359,6 +359,7 @@ func (t *RichText) updateRowBounds() {
 				continue
 			}
 			textSeg := seg.(*TextSegment)
+			textSeg.Text = strings.ReplaceAll(textSeg.Text, "\r", "") // remove "\r" characters that otherwise render as space
 			textStyle := textSeg.Style.TextStyle
 			textSize := textSeg.size()
 

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -422,6 +422,9 @@ func (t *textGridRenderer) refreshGrid() {
 			if i >= t.cols { // would be an overflow - bad
 				continue
 			}
+			if r.Rune == '\r' { // remove "\r" characters that don't render correctly
+				continue
+			}
 			if t.text.ShowWhitespace && (r.Rune == ' ' || r.Rune == '\t') {
 				sym := textAreaSpaceSymbol
 				if r.Rune == '\t' {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Changed both RichText (which most things use as a renderer) and TextGrid to ignore/remove \r characters from input.

Each fix seems to me like the most straight-forward approach, but if there are any tweaks I should make, please let me know.

Fixes #2456 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass. (some tests are failing in develop, but these changes don't seem to affect anything)

