### PR TITLE
Fix label.Refresh() not refreshing, and causing future SetText()s to fail

### DIFF
--- a/widget/label.go
+++ b/widget/label.go
@@ -117,7 +117,7 @@ func (l *Label) SetText(text string) {
 	if l.provider == nil { // not created until visible
 		return
 	}
-	l.provider.Segments[0].(*TextSegment).Text = text
+	l.syncSegments()
 	l.provider.Refresh()
 }
 
@@ -160,12 +160,10 @@ func (l *Label) createListener() {
 
 func (l *Label) syncSegments() {
 	l.provider.Wrapping = l.Wrapping
-	l.provider.Segments = []RichTextSegment{&TextSegment{
-		Style: RichTextStyle{
-			Alignment: l.Alignment,
-			Inline:    true,
-			TextStyle: l.TextStyle,
-		},
-		Text: l.Text,
-	}}
+	l.provider.Segments[0].(*TextSegment).Style = RichTextStyle{
+		Alignment: l.Alignment,
+		Inline:    true,
+		TextStyle: l.TextStyle,
+	}
+	l.provider.Segments[0].(*TextSegment).Text = l.Text
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Ok, this is a weird one. When I was digging around in the label code, I noticed some odd behavior.

If you assign `label.Text` and then call `label.Refresh()`, it doesn't refresh the label. But more than that, further refreshes or even `SetText` calls don't work afterwards. If you just use `SetText`, it works fine.

I have some sample code to demonstrate:
```go
func main() {
	a := app.New()
	w := a.NewWindow("Testing")
	l := widget.NewLabel("initial")
	w.SetContent(container.NewMax(l))
	w.Resize(fyne.Size{Width: 200, Height: 200})
	w.CenterOnScreen()

	refresh := func() {
		time.Sleep(2 * time.Second)
		fmt.Println("assign and refresh")
		l.Text = "Assigned and refreshed"
		l.Refresh()
	}

	settext := func() {
		time.Sleep(2 * time.Second)
		fmt.Println("calling SetText")
		l.SetText("SetText")
	}

	go func() {
		// if refresh happens first, settext doesn't work
		// flip the order and settext works
		refresh()
		settext()
	}()

	w.ShowAndRun()
}
```

I tracked it down to the `syncSegments` function in label.go. If that gets called (after the original call to it in `CreateRenderer`), everything breaks.

If I change `syncSegments` to just set the values instead of assigning a new `[]RichTextSegment`, it seems to work fine and all tests still pass. Pretty sure this isn't the "correct" fix, but I'm also not sure what specifically is causing the assignment in `syncSegments` to break things. Other widgets such as hyperlinks have similar `syncSegments` functions that work fine. And actually, if you have a label and a hyperlink in the same container, refreshing the hyperlink fixes the label too.

If there's a better way of tackling this, or something that I'm overlooking, please let me know.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

