### PR TITLE
Add basic Undo/Redo functionality to Entry widget

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1274,6 +1274,12 @@ func (w *window) triggersShortcut(keyName fyne.KeyName, modifier desktop.Modifie
 		case fyne.KeyA:
 			// detect selectAll shortcut
 			shortcut = &fyne.ShortcutSelectAll{}
+		case fyne.KeyZ:
+			// detect undo shortcut
+			shortcut = &fyne.ShortcutUndo{}
+		case fyne.KeyY:
+			// detect redo shortcut
+			shortcut = &fyne.ShortcutRedo{}
 		}
 	}
 

--- a/shortcut.go
+++ b/shortcut.go
@@ -83,3 +83,19 @@ type ShortcutSelectAll struct{}
 func (se *ShortcutSelectAll) ShortcutName() string {
 	return "SelectAll"
 }
+
+// ShortcutUndo describes a shortcut undo action.
+type ShortcutUndo struct{}
+
+// ShortcutName returns the shortcut name
+func (se *ShortcutUndo) ShortcutName() string {
+	return "Undo"
+}
+
+// ShortcutRedo describes a shortcut redo action.
+type ShortcutRedo struct{}
+
+// ShortcutName returns the shortcut name
+func (se *ShortcutRedo) ShortcutName() string {
+	return "Redo"
+}

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -90,7 +90,7 @@ type Entry struct {
 	textSource   binding.String
 	textListener binding.DataListener
 
-	HistoryEnabled bool
+	HistoryDisabled bool
 	// timestamper is a function that returns the current moment. It is usually
 	// just time.Now(), but can be changed during widget tests.
 	timestamper   func() time.Time
@@ -480,7 +480,7 @@ func (e *Entry) SetText(text string) {
 	e.updateText(text)
 	e.updateCursor()
 
-	if e.HistoryEnabled {
+	if !e.HistoryDisabled {
 		e.registerInitialState()
 	}
 }
@@ -491,7 +491,7 @@ func (e *Entry) SetTextUndoable(text string) {
 	e.updateText(text)
 	e.updateCursor()
 
-	if e.HistoryEnabled {
+	if !e.HistoryDisabled {
 		e.registerAction(entryActionSetText)
 	}
 }
@@ -524,7 +524,7 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	super := e.super()
 
 	historyItems := make([]*fyne.MenuItem, 0)
-	if e.HistoryEnabled {
+	if !e.HistoryDisabled {
 		historyItems = append(historyItems, fyne.NewMenuItem("Undo", func() {
 			super.(fyne.Shortcutable).TypedShortcut(&fyne.ShortcutUndo{})
 		}))
@@ -624,7 +624,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 		pos := e.cursorTextPos()
 		provider.deleteFromTo(pos-1, pos)
 		e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos - 1)
-		if e.HistoryEnabled {
+		if !e.HistoryDisabled {
 			e.registerAction(entryActionErasing)
 		}
 		e.propertyLock.Unlock()
@@ -636,7 +636,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 
 		e.propertyLock.Lock()
 		provider.deleteFromTo(pos, pos+1)
-		if e.HistoryEnabled {
+		if !e.HistoryDisabled {
 			e.registerAction(entryActionErasing)
 		}
 		e.propertyLock.Unlock()
@@ -783,7 +783,7 @@ func (e *Entry) TypedRune(r rune) {
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos + len(runes))
 
 	content := provider.String()
-	if e.HistoryEnabled {
+	if !e.HistoryDisabled {
 		e.registerAction(entryActionTypedRune)
 	}
 	e.propertyLock.Unlock()
@@ -848,7 +848,7 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 
 	e.copyToClipboard(clipboard)
 	e.eraseSelection()
-	if e.HistoryEnabled {
+	if !e.HistoryDisabled {
 		e.registerAction(entryActionCut)
 	}
 }
@@ -914,7 +914,7 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 	content := provider.String()
 	e.updateText(content)
 
-	if e.HistoryEnabled {
+	if !e.HistoryDisabled {
 		e.registerAction(entryActionPaste)
 	}
 
@@ -1035,7 +1035,7 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 	case fyne.KeyBackspace, fyne.KeyDelete:
 		// clears the selection -- return handled
 		e.eraseSelection()
-		if e.HistoryEnabled {
+		if !e.HistoryDisabled {
 			e.propertyLock.RLock()
 			e.registerAction(entryActionErasing)
 			e.propertyLock.RUnlock()
@@ -1263,7 +1263,7 @@ func (e *Entry) typedKeyReturn(provider *RichText, multiLine bool) {
 	e.CursorColumn = 0
 	e.CursorRow++
 
-	if e.HistoryEnabled {
+	if !e.HistoryDisabled {
 		e.registerAction(entryActionTypedRune)
 	}
 	e.propertyLock.Unlock()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -631,6 +631,9 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 		pos := e.cursorTextPos()
 		provider.deleteFromTo(pos-1, pos)
 		e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos - 1)
+		if e.historyEnabled {
+			e.registerAction(entryActionErasing)
+		}
 		e.propertyLock.Unlock()
 	case fyne.KeyDelete:
 		pos := e.cursorTextPos()
@@ -640,6 +643,9 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 
 		e.propertyLock.Lock()
 		provider.deleteFromTo(pos, pos+1)
+		if e.historyEnabled {
+			e.registerAction(entryActionErasing)
+		}
 		e.propertyLock.Unlock()
 	case fyne.KeyReturn, fyne.KeyEnter:
 		e.typedKeyReturn(provider, multiLine)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -2,7 +2,6 @@ package widget
 
 import (
 	"image/color"
-	"log"
 	"math"
 	"strings"
 	"time"
@@ -975,11 +974,9 @@ func (e *Entry) registerShortcut() {
 		e.selectAll()
 	})
 	e.shortcut.AddShortcut(&fyne.ShortcutUndo{}, func(se fyne.Shortcut) {
-		log.Printf("Ctrl+Z performed!\n")
 		e.Undo()
 	})
-	e.shortcut.AddShortcut(&fyne.ShortcutRedo{}, func(shortcut fyne.Shortcut) {
-		log.Printf("Redo!\n")
+	e.shortcut.AddShortcut(&fyne.ShortcutRedo{}, func(se fyne.Shortcut) {
 		e.Redo()
 	})
 }

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"image/color"
+	"log"
 	"math"
 	"strings"
 	"time"
@@ -541,6 +542,15 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
 	super := e.super()
 
+	historyItems := make([]*fyne.MenuItem, 0)
+	if e.historyEnabled {
+		historyItems = append(historyItems, fyne.NewMenuItem("Undo", func() {
+			super.(fyne.Shortcutable).TypedShortcut(&fyne.ShortcutUndo{})
+		}))
+		historyItems = append(historyItems, fyne.NewMenuItem("Redo", func() {
+			super.(fyne.Shortcutable).TypedShortcut(&fyne.ShortcutRedo{})
+		}))
+	}
 	cutItem := fyne.NewMenuItem("Cut", func() {
 		super.(fyne.Shortcutable).TypedShortcut(&fyne.ShortcutCut{Clipboard: clipboard})
 	})
@@ -562,7 +572,9 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	} else if e.Password {
 		menu = fyne.NewMenu("", pasteItem, selectAllItem)
 	} else {
-		menu = fyne.NewMenu("", cutItem, copyItem, pasteItem, selectAllItem)
+		menuItems := historyItems
+		menuItems = append(menuItems, cutItem, copyItem, pasteItem, selectAllItem)
+		menu = fyne.NewMenu("", menuItems...)
 	}
 
 	e.popUp = NewPopUpMenu(menu, c)
@@ -961,6 +973,14 @@ func (e *Entry) registerShortcut() {
 	})
 	e.shortcut.AddShortcut(&fyne.ShortcutSelectAll{}, func(se fyne.Shortcut) {
 		e.selectAll()
+	})
+	e.shortcut.AddShortcut(&fyne.ShortcutUndo{}, func(se fyne.Shortcut) {
+		log.Printf("Ctrl+Z performed!\n")
+		e.Undo()
+	})
+	e.shortcut.AddShortcut(&fyne.ShortcutRedo{}, func(shortcut fyne.Shortcut) {
+		log.Printf("Redo!\n")
+		e.Redo()
 	})
 }
 

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -3,6 +3,8 @@ package widget
 import (
 	"log"
 	"time"
+
+	"fyne.io/fyne/v2"
 )
 
 type entryActionType int
@@ -19,6 +21,8 @@ const (
 type entryHistoryState struct {
 	content                 string
 	cursorRow, cursorColumn int
+	scrollOffset            fyne.Position
+	contentScrollOffset     fyne.Position
 }
 
 type entryUserAction struct {
@@ -30,9 +34,10 @@ type entryUserAction struct {
 // registerAction creates a new action of the specified type and stores
 // the snapshot in the action log. It expects the caller to hold .propertyLock().
 func (e *Entry) registerAction(actionType entryActionType) {
-	if !e.historyEnabled {
+	if !e.HistoryEnabled {
 		return
 	}
+	e.ensureHistoryDefined()
 
 	action := entryUserAction{
 		actionType: actionType,
@@ -77,22 +82,24 @@ func (e *Entry) shouldMergeAction(action entryUserAction) bool {
 
 // IsUndoAvailable returns true if Undo() may be called.
 func (e *Entry) IsUndoAvailable() bool {
-	return e.historyEnabled && (len(e.actionLog)-e.redoOffset > 0)
+	return e.HistoryEnabled && (len(e.actionLog)-e.redoOffset > 0)
 }
 
 // IsRedoAvailable returns true if Redo() may be called, i.e.,
 // if some action has just been undone.
 func (e *Entry) IsRedoAvailable() bool {
-	return e.historyEnabled && (e.redoOffset > 0)
+	return e.HistoryEnabled && (e.redoOffset > 0)
 }
 
+// Undo rolls back one user action at a time if history tracking is enabled.
 func (e *Entry) Undo() {
-	if !e.historyEnabled {
+	if !e.HistoryEnabled {
 		return
 	}
+	e.ensureHistoryDefined()
 
 	actionIndex := len(e.actionLog) - 2 - e.redoOffset
-	newState := e.historyOrigin
+	newState := *e.historyOrigin
 	if actionIndex >= 0 {
 		newState = e.actionLog[actionIndex].state
 	}
@@ -103,10 +110,12 @@ func (e *Entry) Undo() {
 	e.restoreHistorySnapshot(newState)
 }
 
+// Redo replicates the recently undone action.
 func (e *Entry) Redo() {
-	if !e.historyEnabled || (e.redoOffset == 0) {
+	if !e.HistoryEnabled || (e.redoOffset == 0) {
 		return
 	}
+	e.ensureHistoryDefined()
 
 	actionIndex := len(e.actionLog) - e.redoOffset
 	e.restoreHistorySnapshot(e.actionLog[actionIndex].state)
@@ -121,25 +130,49 @@ func (e *Entry) historySnapshot() entryHistoryState {
 	state.content = e.textProvider().String()
 	state.cursorRow = e.CursorRow
 	state.cursorColumn = e.CursorColumn
+	state.scrollOffset = e.scroll.Offset
+	state.contentScrollOffset = e.content.scroll.Offset
 	return state
 }
 
 func (e *Entry) restoreHistorySnapshot(state entryHistoryState) {
 	e.updateText(state.content)
+	e.selecting = false
+	e.selectKeyDown = false
+
 	e.CursorRow = state.cursorRow
 	e.CursorColumn = state.cursorColumn
 	e.updateCursor()
+
+	e.scroll.Offset = state.scrollOffset
+	e.content.scroll.Offset = state.scrollOffset
+	e.content.scroll.Refresh()
+	e.scroll.Refresh()
+
+	e.Refresh()
 }
 
 // registerInitialState resets the action history of an entry.
 func (e *Entry) registerInitialState() {
-	e.historyOrigin = e.historySnapshot()
+	snapshot := e.historySnapshot()
+	e.historyOrigin = &snapshot
 	e.actionLog = nil
 	e.redoOffset = 0
 }
 
+// ensureHistoryDefined handles the situation when user just switched HistoryEnabled flag
+// and various history-associated pieces of data may need to be initialized.
+func (e *Entry) ensureHistoryDefined() {
+	if e.historyOrigin == nil {
+		e.registerInitialState()
+	}
+	if e.timestamper == nil {
+		e.timestamper = time.Now
+	}
+}
+
 func (e *Entry) DumpHistoryState() {
-	if !e.historyEnabled {
+	if !e.HistoryEnabled {
 		log.Printf("History is disabled, nothing to dump\n")
 		return
 	}

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -1,7 +1,6 @@
 package widget
 
 import (
-	"log"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -168,18 +167,5 @@ func (e *Entry) ensureHistoryDefined() {
 	}
 	if e.timestamper == nil {
 		e.timestamper = time.Now
-	}
-}
-
-func (e *Entry) DumpHistoryState() {
-	if !e.HistoryEnabled {
-		log.Printf("History is disabled, nothing to dump\n")
-		return
-	}
-	log.Printf("Entry history action log with %d items\n", len(e.actionLog))
-	for i := range e.actionLog {
-		log.Printf("Action %d of type %d\n", i, int(e.actionLog[i].actionType))
-		log.Printf("Performed at %s\n", e.actionLog[i].timestamp.String())
-		log.Printf("Contents: %s\n", e.actionLog[i].state.content)
 	}
 }

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -144,8 +144,12 @@ func (e *Entry) restoreHistorySnapshot(state entryHistoryState) {
 
 	e.scroll.Offset = state.scrollOffset
 	e.content.scroll.Offset = state.scrollOffset
-	e.content.scroll.Refresh()
-	e.scroll.Refresh()
+	if e.content.scroll.Content != nil {
+		e.content.scroll.Refresh()
+	}
+	if e.scroll.Content != nil {
+		e.scroll.Refresh()
+	}
 
 	e.Refresh()
 }

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -28,7 +28,7 @@ type entryUserAction struct {
 }
 
 // registerAction creates a new action of the specified type and stores
-// the snapshot in the action log. It expects the called to hold .propertyLock().
+// the snapshot in the action log. It expects the caller to hold .propertyLock().
 func (e *Entry) registerAction(actionType entryActionType) {
 	if !e.historyEnabled {
 		return
@@ -75,10 +75,13 @@ func (e *Entry) shouldMergeAction(action entryUserAction) bool {
 	return (shouldMergeTyped || shouldMergeErased)
 }
 
+// IsUndoAvailable returns true if Undo() may be called.
 func (e *Entry) IsUndoAvailable() bool {
 	return e.historyEnabled && (len(e.actionLog)-e.redoOffset > 0)
 }
 
+// IsRedoAvailable returns true if Redo() may be called, i.e.,
+// if some action has just been undone.
 func (e *Entry) IsRedoAvailable() bool {
 	return e.historyEnabled && (e.redoOffset > 0)
 }
@@ -92,6 +95,8 @@ func (e *Entry) Undo() {
 	newState := e.historyOrigin
 	if actionIndex >= 0 {
 		newState = e.actionLog[actionIndex].state
+	}
+	if actionIndex >= -1 {
 		e.redoOffset++
 	}
 

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -16,11 +16,10 @@ type entryActionType int
 
 const (
 	entryActionTypedRune entryActionType = iota
+	entryActionErasing
 	entryActionCut
 	entryActionPaste
-	entryActionErasing
 	entryActionSetText
-	entryActionOriginal
 )
 
 type entryHistoryState struct {

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -125,11 +125,20 @@ func (e *Entry) shouldMergeAction(action entryUserAction) bool {
 // It expects the caller to hold propertyLock().
 func (e *Entry) historySnapshot() entryHistoryState {
 	state := entryHistoryState{}
-	state.content = e.textProvider().String()
+	provider := e.textProvider()
+	if provider != nil {
+		state.content = provider.String()
+	} else {
+		state.content = ""
+	}
 	state.cursorRow = e.CursorRow
 	state.cursorColumn = e.CursorColumn
-	state.scrollOffset = e.scroll.Offset
-	state.contentScrollOffset = e.content.scroll.Offset
+	if e.scroll != nil {
+		state.scrollOffset = e.scroll.Offset
+	}
+	if (e.content != nil) && (e.content.scroll != nil) {
+		state.contentScrollOffset = e.content.scroll.Offset
+	}
 	return state
 }
 

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -7,6 +7,12 @@ import (
 	"fyne.io/fyne/v2"
 )
 
+type entryUserAction struct {
+	actionType entryActionType
+	timestamp  time.Time
+	state      entryHistoryState
+}
+
 type entryActionType int
 
 const (
@@ -23,12 +29,6 @@ type entryHistoryState struct {
 	cursorRow, cursorColumn int
 	scrollOffset            fyne.Position
 	contentScrollOffset     fyne.Position
-}
-
-type entryUserAction struct {
-	actionType entryActionType
-	timestamp  time.Time
-	state      entryHistoryState
 }
 
 // registerAction creates a new action of the specified type and stores

--- a/widget/entry_undo.go
+++ b/widget/entry_undo.go
@@ -1,0 +1,97 @@
+package widget
+
+import (
+	"time"
+)
+
+type entryActionType int
+
+const (
+	entryActionTypedRune entryActionType = iota
+	entryActionCut
+	entryActionPaste
+	entryActionErasing
+	entryActionSetText
+	entryActionOriginal
+)
+
+type entryHistoryState struct {
+	content string
+	// .cursorTextPosition is stored to unite a sequence of several typed runes into a single
+	// undoable action. It is not used if actionType != entryActionTypedRune.
+	cursorTextPosition int
+}
+
+type entryUserAction struct {
+	actionType entryActionType
+	timestamp  time.Time
+	state      entryHistoryState
+}
+
+// registerAction creates a new action of the specified type and stores
+// the snapshot in the action log. It expects the called to hold .propertyLock().
+func (e *Entry) registerAction(actionType entryActionType) {
+	if !e.historyEnabled {
+		return
+	}
+
+	action := entryUserAction{
+		actionType: actionType,
+		timestamp:  e.timestamper(),
+		state:      e.historySnapshot(),
+	}
+
+	// TODO: a sequence of typed runes should be a single undoable action.
+	if e.redoOffset > 0 {
+		actionIndex := len(e.actionLog) - e.redoOffset
+		e.redoOffset = 0
+		e.actionLog[actionIndex] = action
+		e.actionLog = e.actionLog[:actionIndex+1]
+	} else {
+		e.actionLog = append(e.actionLog, action)
+	}
+}
+
+func (e *Entry) IsUndoAvailable() bool {
+	return e.historyEnabled && (len(e.actionLog)-e.redoOffset > 0)
+}
+
+func (e *Entry) IsRedoAvailable() bool {
+	return e.historyEnabled && (e.redoOffset > 0)
+}
+
+func (e *Entry) Undo() {
+	if !e.historyEnabled {
+		return
+	}
+
+	actionIndex := len(e.actionLog) - e.redoOffset - 1
+	if actionIndex == -1 {
+		return
+	}
+
+	e.restoreHistorySnapshot(e.actionLog[actionIndex].state)
+	e.redoOffset++
+}
+
+// historySnapshot returns the information sufficient to restore the entry state
+// (content, cursor position, scroll position etc) after an undo or redo.
+// It expects the caller to hold propertyLock().
+func (e *Entry) historySnapshot() entryHistoryState {
+	state := entryHistoryState{}
+	state.content = e.textProvider().String()
+	state.cursorTextPosition = e.cursorTextPos()
+	return state
+}
+
+func (e *Entry) restoreHistorySnapshot(state entryHistoryState) {
+	e.updateText(state.content)
+	e.updateCursor()
+}
+
+// registerInitialState resets the action history of an entry.
+func (e *Entry) registerInitialState() {
+	e.historyOrigin = e.historySnapshot()
+	e.actionLog = nil
+	e.redoOffset = 0
+}

--- a/widget/entry_undo_internal_test.go
+++ b/widget/entry_undo_internal_test.go
@@ -1,0 +1,169 @@
+package widget
+
+import (
+	"testing"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntry_UndoMerge(t *testing.T) {
+	text := "abc def"
+	entry, fakeTime := newEntryWithFakeTimestamper()
+
+	// Successive TypedRune() events should be merged into a single action.
+	entry.SetText(text)
+	entry.CursorColumn = 3
+	typeToEntry(entry, "XYZ", fakeTime)
+	entry.Undo()
+	assert.Equal(t, text, entry.Text)
+
+	// Not all TypedRune events are merged into a single action.
+	entry.SetText(text)
+	entry.CursorColumn = 3
+	typeToEntry(entry, " NO", fakeTime)
+	fakeTime.add(10 * time.Second)
+	typeToEntry(entry, "YES ", fakeTime) // only this should be cancelled due to a large delay
+	entry.Undo()
+	assert.Equal(t, "abc NO def", entry.Text)
+	assert.Equal(t, 1, entry.redoOffset)
+	assert.Equal(t, 2, len(entry.actionLog))
+
+	// Sequence of deletions is also merged into a single action.
+	entry.SetText(text)
+	entry.CursorColumn = 3
+	for i := 0; i < 3; i++ {
+		entry.TypedKey(&fyne.KeyEvent{
+			Name: fyne.KeyBackspace,
+		})
+	}
+	entry.Undo()
+	assert.Equal(t, text, entry.Text)
+
+	// Pressing Enter is merged with TypedRune() actions
+	entry.SetText(text)
+	entry.MultiLine = true
+	entry.CursorColumn = 3
+	entry.TypedKey(&fyne.KeyEvent{
+		Name: fyne.KeyEnter,
+	})
+	typeToEntry(entry, "Second line", fakeTime)
+	entry.Undo()
+	assert.Equal(t, text, entry.Text)
+}
+
+func TestEntry_UndoUndoables(t *testing.T) {
+	text := "abc def"
+	entry, fakeTime := newEntryWithFakeTimestamper()
+
+	// SetTextUndoable() is undoable.
+	entry.SetText("")
+	typeToEntry(entry, text, fakeTime)
+	entry.SetTextUndoable("WOW")
+	entry.CursorRow = 0
+	entry.CursorColumn = 3
+	typeToEntry(entry, " OWO", fakeTime)
+	entry.Undo()
+	entry.Undo()
+	assert.Equal(t, text, entry.Text)
+	entry.Undo()
+	assert.Equal(t, "", entry.Text)
+
+	// Cutting is undoable.
+	clipboard := test.NewClipboard()
+	entry.SetText(text)
+	entry.selectAll()
+	entry.TypedShortcut(&fyne.ShortcutCut{
+		Clipboard: clipboard,
+	})
+	entry.Undo()
+	assert.Equal(t, text, entry.Text)
+
+	// Pasting is undoable.
+	entry.SetText(text)
+	clipboard.SetContent("qwerty")
+	entry.CursorColumn = 7
+	entry.TypedShortcut(&fyne.ShortcutPaste{
+		Clipboard: clipboard,
+	})
+	entry.Undo()
+	assert.Equal(t, text, entry.Text)
+}
+
+func TestEntry_Undo(t *testing.T) {
+	text := "abc def"
+	entry, _ := newEntryWithFakeTimestamper()
+
+	// Empty action history should result in no changes (and no crashes).
+	entry.SetText(text)
+	assert.Equal(t, false, entry.IsUndoAvailable())
+	assert.Equal(t, false, entry.IsRedoAvailable())
+	entry.Undo()
+	entry.Undo()
+	entry.Redo()
+	assert.False(t, entry.IsUndoAvailable())
+	assert.False(t, entry.IsRedoAvailable())
+	assert.Equal(t, text, entry.Text)
+	assert.Equal(t, 0, entry.redoOffset)
+	assert.Equal(t, 0, len(entry.actionLog))
+
+	// Basic Undo operation.
+	entry.SetText(text)
+	entry.CursorRow = 0
+	entry.CursorColumn = 3
+	test.Type(entry, "Z")
+	entry.Undo()
+	assert.Equal(t, text, entry.Text)
+	assert.Equal(t, 1, entry.redoOffset)
+	assert.False(t, entry.IsUndoAvailable())
+	assert.True(t, entry.IsRedoAvailable())
+
+	// Basic Redo operation.
+	entry.Redo()
+	assert.Equal(t, "abcZ def", entry.Text)
+	assert.Equal(t, 0, entry.redoOffset)
+}
+
+func clickEntry(e *Entry, ev *fyne.PointEvent) {
+	mouseEvent := &desktop.MouseEvent{PointEvent: *ev, Button: desktop.MouseButtonPrimary}
+	e.MouseDown(mouseEvent)
+	e.MouseUp(mouseEvent)
+	e.Tapped(ev)
+}
+
+func typeToEntry(e *Entry, text string, fakeTime *fakeTime) {
+	for c := range text {
+		e.TypedRune(rune(text[c]))
+		if fakeTime != nil {
+			fakeTime.add(time.Millisecond)
+		}
+	}
+}
+
+type fakeTime struct {
+	now time.Time
+}
+
+func (ft *fakeTime) add(delta time.Duration) {
+	ft.now = ft.now.Add(delta)
+}
+
+func newEntryWithFakeTimestamper() (*Entry, *fakeTime) {
+	entry := NewEntry()
+	entry.Wrapping = fyne.TextWrapOff
+	entry.HistoryEnabled = true
+	entry.Refresh()
+
+	fakeTimestamper := fakeTime{
+		now: time.Unix(1633720000, 0),
+	}
+
+	entry.timestamper = func() time.Time {
+		return fakeTimestamper.now
+	}
+
+	return entry, &fakeTimestamper
+}

--- a/widget/entry_undo_internal_test.go
+++ b/widget/entry_undo_internal_test.go
@@ -99,13 +99,13 @@ func TestEntry_Undo(t *testing.T) {
 
 	// Empty action history should result in no changes (and no crashes).
 	entry.SetText(text)
-	assert.Equal(t, false, entry.IsUndoAvailable())
-	assert.Equal(t, false, entry.IsRedoAvailable())
+	assert.Equal(t, false, entry.CanUndo())
+	assert.Equal(t, false, entry.CanRedo())
 	entry.Undo()
 	entry.Undo()
 	entry.Redo()
-	assert.False(t, entry.IsUndoAvailable())
-	assert.False(t, entry.IsRedoAvailable())
+	assert.False(t, entry.CanUndo())
+	assert.False(t, entry.CanRedo())
 	assert.Equal(t, text, entry.Text)
 	assert.Equal(t, 0, entry.redoOffset)
 	assert.Equal(t, 0, len(entry.actionLog))
@@ -118,8 +118,8 @@ func TestEntry_Undo(t *testing.T) {
 	entry.Undo()
 	assert.Equal(t, text, entry.Text)
 	assert.Equal(t, 1, entry.redoOffset)
-	assert.False(t, entry.IsUndoAvailable())
-	assert.True(t, entry.IsRedoAvailable())
+	assert.False(t, entry.CanUndo())
+	assert.True(t, entry.CanRedo())
 
 	// Basic Redo operation.
 	entry.Redo()
@@ -154,7 +154,7 @@ func (ft *fakeTime) add(delta time.Duration) {
 func newEntryWithFakeTimestamper() (*Entry, *fakeTime) {
 	entry := NewEntry()
 	entry.Wrapping = fyne.TextWrapOff
-	entry.HistoryEnabled = true
+	entry.HistoryDisabled = false
 	entry.Refresh()
 
 	fakeTimestamper := fakeTime{

--- a/widget/entry_undo_internal_test.go
+++ b/widget/entry_undo_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -125,13 +124,6 @@ func TestEntry_Undo(t *testing.T) {
 	entry.Redo()
 	assert.Equal(t, "abcZ def", entry.Text)
 	assert.Equal(t, 0, entry.redoOffset)
-}
-
-func clickEntry(e *Entry, ev *fyne.PointEvent) {
-	mouseEvent := &desktop.MouseEvent{PointEvent: *ev, Button: desktop.MouseButtonPrimary}
-	e.MouseDown(mouseEvent)
-	e.MouseUp(mouseEvent)
-	e.Tapped(ev)
 }
 
 func typeToEntry(e *Entry, text string, fakeTime *fakeTime) {

--- a/widget/testdata/entry/focus_with_popup_initial.xml
+++ b/widget/testdata/entry/focus_with_popup_initial.xml
@@ -16,34 +16,48 @@
 	</content>
 	<overlay>
 		<widget size="150x200" type="*widget.OverlayContainer">
-			<widget pos="11,11" size="78x134" type="*widget.PopUpMenu">
-				<widget size="78x134" type="*widget.Shadow">
+			<widget pos="11,0" size="78x200" type="*widget.PopUpMenu">
+				<widget size="78x200" type="*widget.Shadow">
 					<radialGradient centerOffset="0.5,0.5" pos="-4,-4" size="4x4" startColor="shadow"/>
 					<linearGradient endColor="shadow" pos="0,-4" size="78x4"/>
 					<radialGradient centerOffset="-0.5,0.5" pos="78,-4" size="4x4" startColor="shadow"/>
-					<linearGradient angle="270" pos="78,0" size="4x134" startColor="shadow"/>
-					<radialGradient centerOffset="-0.5,-0.5" pos="78,134" size="4x4" startColor="shadow"/>
-					<linearGradient pos="0,134" size="78x4" startColor="shadow"/>
-					<radialGradient centerOffset="0.5,-0.5" pos="-4,134" size="4x4" startColor="shadow"/>
-					<linearGradient angle="270" endColor="shadow" pos="-4,0" size="4x134"/>
+					<linearGradient angle="270" pos="78,0" size="4x200" startColor="shadow"/>
+					<radialGradient centerOffset="-0.5,-0.5" pos="78,200" size="4x4" startColor="shadow"/>
+					<linearGradient pos="0,200" size="78x4" startColor="shadow"/>
+					<radialGradient centerOffset="0.5,-0.5" pos="-4,200" size="4x4" startColor="shadow"/>
+					<linearGradient angle="270" endColor="shadow" pos="-4,0" size="4x200"/>
 				</widget>
-				<widget size="78x134" type="*widget.Scroll">
-					<widget size="78x134" type="*widget.menuBox">
-						<rectangle fillColor="background" size="78x142"/>
-						<container pos="0,4" size="78x142">
+				<widget size="78x200" type="*widget.Scroll">
+					<widget size="78x200" type="*widget.menuBox">
+						<rectangle fillColor="background" size="78x208"/>
+						<container pos="0,4" size="78x208">
 							<widget size="78x28" type="*widget.menuItem">
-								<text pos="8,4" size="62x20">Cut</text>
+								<text pos="8,4" size="62x20">Undo</text>
 							</widget>
 							<widget pos="0,32" size="78x28" type="*widget.menuItem">
-								<text pos="8,4" size="62x20">Copy</text>
+								<text pos="8,4" size="62x20">Redo</text>
 							</widget>
 							<widget pos="0,65" size="78x28" type="*widget.menuItem">
-								<text pos="8,4" size="62x20">Paste</text>
+								<text pos="8,4" size="62x20">Cut</text>
 							</widget>
 							<widget pos="0,98" size="78x28" type="*widget.menuItem">
+								<text pos="8,4" size="62x20">Copy</text>
+							</widget>
+							<widget pos="0,130" size="78x28" type="*widget.menuItem">
+								<text pos="8,4" size="62x20">Paste</text>
+							</widget>
+							<widget pos="0,163" size="78x28" type="*widget.menuItem">
 								<text pos="8,4" size="62x20">Select all</text>
 							</widget>
 						</container>
+					</widget>
+					<widget pos="72,0" size="6x200" type="*widget.scrollBarArea">
+						<widget pos="3,0" size="3x199" type="*widget.scrollBar">
+							<rectangle fillColor="scrollbar" size="3x199"/>
+						</widget>
+					</widget>
+					<widget pos="0,200" size="78x0" type="*widget.Shadow">
+						<linearGradient endColor="shadow" pos="0,-8" size="78x8"/>
 					</widget>
 				</widget>
 			</widget>

--- a/widget/testdata/entry/tapped_secondary_full_menu.xml
+++ b/widget/testdata/entry/tapped_secondary_full_menu.xml
@@ -16,34 +16,48 @@
 	</content>
 	<overlay>
 		<widget size="150x200" type="*widget.OverlayContainer">
-			<widget pos="30,20" size="78x134" type="*widget.PopUpMenu">
-				<widget size="78x134" type="*widget.Shadow">
+			<widget pos="30,0" size="78x200" type="*widget.PopUpMenu">
+				<widget size="78x200" type="*widget.Shadow">
 					<radialGradient centerOffset="0.5,0.5" pos="-4,-4" size="4x4" startColor="shadow"/>
 					<linearGradient endColor="shadow" pos="0,-4" size="78x4"/>
 					<radialGradient centerOffset="-0.5,0.5" pos="78,-4" size="4x4" startColor="shadow"/>
-					<linearGradient angle="270" pos="78,0" size="4x134" startColor="shadow"/>
-					<radialGradient centerOffset="-0.5,-0.5" pos="78,134" size="4x4" startColor="shadow"/>
-					<linearGradient pos="0,134" size="78x4" startColor="shadow"/>
-					<radialGradient centerOffset="0.5,-0.5" pos="-4,134" size="4x4" startColor="shadow"/>
-					<linearGradient angle="270" endColor="shadow" pos="-4,0" size="4x134"/>
+					<linearGradient angle="270" pos="78,0" size="4x200" startColor="shadow"/>
+					<radialGradient centerOffset="-0.5,-0.5" pos="78,200" size="4x4" startColor="shadow"/>
+					<linearGradient pos="0,200" size="78x4" startColor="shadow"/>
+					<radialGradient centerOffset="0.5,-0.5" pos="-4,200" size="4x4" startColor="shadow"/>
+					<linearGradient angle="270" endColor="shadow" pos="-4,0" size="4x200"/>
 				</widget>
-				<widget size="78x134" type="*widget.Scroll">
-					<widget size="78x134" type="*widget.menuBox">
-						<rectangle fillColor="background" size="78x142"/>
-						<container pos="0,4" size="78x142">
+				<widget size="78x200" type="*widget.Scroll">
+					<widget size="78x200" type="*widget.menuBox">
+						<rectangle fillColor="background" size="78x208"/>
+						<container pos="0,4" size="78x208">
 							<widget size="78x28" type="*widget.menuItem">
-								<text pos="8,4" size="62x20">Cut</text>
+								<text pos="8,4" size="62x20">Undo</text>
 							</widget>
 							<widget pos="0,32" size="78x28" type="*widget.menuItem">
-								<text pos="8,4" size="62x20">Copy</text>
+								<text pos="8,4" size="62x20">Redo</text>
 							</widget>
 							<widget pos="0,65" size="78x28" type="*widget.menuItem">
-								<text pos="8,4" size="62x20">Paste</text>
+								<text pos="8,4" size="62x20">Cut</text>
 							</widget>
 							<widget pos="0,98" size="78x28" type="*widget.menuItem">
+								<text pos="8,4" size="62x20">Copy</text>
+							</widget>
+							<widget pos="0,130" size="78x28" type="*widget.menuItem">
+								<text pos="8,4" size="62x20">Paste</text>
+							</widget>
+							<widget pos="0,163" size="78x28" type="*widget.menuItem">
 								<text pos="8,4" size="62x20">Select all</text>
 							</widget>
 						</container>
+					</widget>
+					<widget pos="72,0" size="6x200" type="*widget.scrollBarArea">
+						<widget pos="3,0" size="3x199" type="*widget.scrollBar">
+							<rectangle fillColor="scrollbar" size="3x199"/>
+						</widget>
+					</widget>
+					<widget pos="0,200" size="78x0" type="*widget.Shadow">
+						<linearGradient endColor="shadow" pos="0,-8" size="78x8"/>
 					</widget>
 				</widget>
 			</widget>


### PR DESCRIPTION
### Description:
This pull request introduces a basic Undo/Redo functionality in the Entry widget, fixing issue #436 . The realization works as is for me, but I have some questions, presented slightly below. I am also working on writing tests for the new functionality.

### Basic description

If `Entry.HistoryDisabled` is false, whenever a user performs an action like, e.g., "typed rune", "paste from clipboard", or "erase selection by pressing backspace", the full state of the entry widget is saved and appended to an action log. The state includes full text, cursor position, and scroll position. When user calls "Undo" on a history-enabled widget, the state is restored from the action log. Redo is implemented in a similar way.

To improve user experience, a sequence of "typed rune" actions performed in a quick succession is considered a single action, so Undo does not cancel just one letter at a time. Same for a sequence of deletions (e.g., pressing backspace several times).

Calling SetText() erases the history, with a new SetTextUndoable() function that adds a new event to the history log instead.

For simplicity, undo action resets the current selection to empty.

### Justification for the crude mechanism
Better history implementation would store only user actions and roll them back in a smart way when requested. Saving the whole widget state is slower and wasteful in terms of memory, but this is the approach used here. Why?

- **Resistant to modifications of Entry internals.** RichText had just been introduced in Fyne 2.1, and I expect further changes to Entry internals to follow soon. A smarter approach working with diffs between RichText trees may become obsolete as RichText progresses.
- **This is a first draft.** Internal optimizations may follow later. Designing public APIs is separate from the implementation details.
- **Performance of undo is not a bottleneck.** For short texts or short-lived entry widgets, the overhead is negligeable. For a long-lived entry with long text, well, this would not be the only performance issue (see issue #1946 etc).

### Some requests for feedback

#### Design questions

1. As mentioned, selection is just reset during the undo. Is this OK?
2. When some text is selected and user types the rune "k", the selected text is replaced by the letter "k", and currently this is registered as a single action. Should it be split into two? Erasing the selection, then typing k.
3. I created fyne.ShortcutUndo and fyne.ShortcutRedo globally and on desktop bound them to Ctrl+Z and Ctrl+Y respectively. Is this OK? I'm not sure about Ctrl+Y.
4. I added "Undo" and "Redo" menu items to the right-click menu of an entry with history enabled. But I'm not sure how common this is. Should we only show "Undo" by default? Maybe show no items and rely on user implicit knowledge of Ctrl+Z? Should there be a separator line between undo and the clipboard actions?
5. Should history be disabled for password entries?
6. What should I do with scroll position? I'm currently saving Entry.scroll.Offset and Entry.content.scroll.Offset and restoring them. This is wrong if entry has been resized, for example. In terms of user experience, ideally the scroll position should not be modified if the part of the text modified by the Undo() is already visible to the user, but this is impossible to implement nicely with a crude history mechanism.
7. This pull request probably adds more data races. For example, `restoreHistorySnapshot()` would ideally restore the widget state completely while holding propertyLock(), but the current implementation of `updateText()` is not particularly conductive to this (and `setFieldsAndRefresh` in general). Someone should take a look if there are severe problems with concurrency in this code, I'm not very experienced with this.

#### Implementation questions

- Since the undo stack behavior changes based on the delay between successive TypedRune() events, for the purpose of testing I used kind of a "dependency injection": Entry.timestamper is usually a reference to time.Now function, but may be changed in internal tests. Is this acceptable?
- I've added some basic tests for Undo/Redo, but I don't know if that's enough.

### Public API changes

Added to widget.Entry:

- CanUndo(), CanRedo() `func() bool`: return true if entry history is enabled and the corresponding action can be performed. Can be used by applications for disabling menu items or toolbar buttons.
- Undo(), Redo() `func()`: perform undo/redo.
- SetTextUndoable `func(text string)`: sets the text of the entry to the provided string and saves this as a separate action in the action log.

Modified behavior in widget.Entry:

- SetText() now erases the action log if history is enabled.

New shortcuts:

- fyne.ShortcutUndo, fyne.ShortcutRedo: new shortcuts with no associated data (just `struct{}`). On desktop they are bound to Ctrl+Z and Ctrl+Y.


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
