### PR TITLE
Switch to milliseconds now that we no longer support Go 1.12

### DIFF
--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -21,7 +21,7 @@ type anim struct {
 
 func newAnim(a *fyne.Animation) *anim {
 	animate := &anim{a: a, start: time.Now(), end: time.Now().Add(a.Duration)}
-	animate.total = animate.end.Sub(animate.start).Nanoseconds() / 1000000 // TODO change this to Milliseconds() when we drop Go 1.12
+	animate.total = animate.end.Sub(animate.start).Milliseconds()
 	animate.repeatsLeft = a.RepeatCount
 	return animate
 }

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -118,7 +118,7 @@ func (r *Runner) tickAnimation(a *anim) bool {
 		return true
 	}
 
-	delta := time.Since(a.start).Nanoseconds() / 1000000 // TODO change this to Milliseconds() when we drop Go 1.12
+	delta := time.Since(a.start).Milliseconds()
 
 	val := float32(delta) / float32(a.total)
 	curve := a.a.Curve


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This now moves to use the milliseconds support in Go 1.13 and later.
I think this might be the first change that actually makes it not compile with Go 1.12 (even though Go 1.14 is the official minimum).

There might be more changes that we can do now that we have upgraded our minimum, but this is the only one that I'm aware of.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
