### PR TITLE
Correct mention of Go 1.12 as lowest supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and more news will follow in our news feeds and GitHub project.
 
 # Prerequisites
 
-To develop apps using Fyne you will need Go version 1.12 or later, a C compiler and your system's development tools.
+To develop apps using Fyne you will need Go version 1.14 or later, a C compiler and your system's development tools.
 If you're not sure if that's all installed or you don't know how then check out our
 [Getting Started](https://fyne.io/develop/) document.
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The issue #2559 made me aware that our documentation in the README never got updated to reflect Go 1.14 as the official lowest supported version. I am aiming this towards develop since 2.1.x (on master) actually had any changes made that would make the compile fail on Go 1.12 (those are only in 2.2.0 afaik). If people feels like this should be on master as well (which might or might not be necessary), we can simply cherry-pick it over.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
