### PR TITLE
Resolve multiple data races (for discussion)

### DIFF
--- a/canvas/text.go
+++ b/canvas/text.go
@@ -25,12 +25,30 @@ type Text struct {
 // MinSize returns the minimum size of this text object based on its font size and content.
 // This is normally determined by the render implementation.
 func (t *Text) MinSize() fyne.Size {
-	return fyne.MeasureText(t.Text, t.TextSize, t.TextStyle)
+	t.propertyLock.Lock()
+	text := t.Text
+	t.propertyLock.Unlock()
+	return fyne.MeasureText(text, t.TextSize, t.TextStyle)
 }
 
 // SetMinSize has no effect as the smallest size this canvas object can be is based on its font size and content.
 func (t *Text) SetMinSize(size fyne.Size) {
 	// no-op
+}
+
+// SetText sets the string text.
+func (t *Text) SetText(s string) {
+	t.propertyLock.Lock()
+	defer t.propertyLock.Unlock()
+	t.Text = s
+}
+
+// GetText gets the string text.
+func (t *Text) GetText() (s string) {
+	t.propertyLock.Lock()
+	defer t.propertyLock.Unlock()
+	s = t.Text
+	return
 }
 
 // Refresh causes this object to be redrawn in it's current state

--- a/container.go
+++ b/container.go
@@ -1,17 +1,23 @@
 package fyne
 
+import (
+	"sync"
+	"sync/atomic"
+)
+
 // Declare conformity to CanvasObject
 var _ CanvasObject = (*Container)(nil)
 
 // Container is a CanvasObject that contains a collection of child objects.
 // The layout of the children is set by the specified Layout.
 type Container struct {
-	size     Size     // The current size of the Container
-	position Position // The current position of the Container
-	Hidden   bool     // Is this Container hidden
+	size     Size         // The current size of the Container
+	position atomic.Value // Position // The current position of the Container
+	Hidden   bool         // Is this Container hidden
 
 	Layout  Layout         // The Layout algorithm for arranging child CanvasObjects
 	Objects []CanvasObject // The set of CanvasObjects this container holds
+	sync.Mutex
 }
 
 // NewContainer returns a new Container instance holding the specified CanvasObjects.
@@ -44,6 +50,7 @@ func NewContainerWithLayout(layout Layout, objects ...CanvasObject) *Container {
 		Layout:  layout,
 	}
 
+	ret.position.Store(Position{})
 	ret.size = layout.MinSize(objects)
 	ret.layout()
 	return ret
@@ -68,7 +75,10 @@ func (c *Container) AddObject(o CanvasObject) {
 // This is delegated to the Layout, if specified, otherwise it will mimic MaxLayout.
 func (c *Container) MinSize() Size {
 	if c.Layout != nil {
-		return c.Layout.MinSize(c.Objects)
+		c.Lock()
+		siz := c.Layout.MinSize(c.Objects)
+		c.Unlock()
+		return siz
 	}
 
 	minSize := NewSize(1, 1)
@@ -81,12 +91,12 @@ func (c *Container) MinSize() Size {
 
 // Move the container (and all its children) to a new position, relative to its parent.
 func (c *Container) Move(pos Position) {
-	c.position = pos
+	c.position.Store(pos)
 }
 
 // Position gets the current position of this Container, relative to its parent.
 func (c *Container) Position() Position {
-	return c.position
+	return c.position.Load().(Position)
 }
 
 // Resize sets a new size for the Container.

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -530,7 +530,11 @@ func updateLayout(objToLayout fyne.CanvasObject) {
 	switch cont := objToLayout.(type) {
 	case *fyne.Container:
 		if cont.Layout != nil {
-			cont.Layout.Layout(cont.Objects, cont.Size())
+			cont.Lock()
+			objs := cont.Objects
+			cont.Unlock()
+
+			cont.Layout.Layout(objs, cont.Size())
 		}
 	case fyne.Widget:
 		cache.Renderer(cont).Layout(cont.Size())

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -155,7 +155,9 @@ func walkObjectTree(
 	var children []fyne.CanvasObject
 	switch co := obj.(type) {
 	case *fyne.Container:
+		co.Lock()
 		children = co.Objects
+		co.Unlock()
 	case fyne.Widget:
 		children = cache.Renderer(co).Objects()
 	}

--- a/internal/painter/gl/gl_common.go
+++ b/internal/painter/gl/gl_common.go
@@ -85,7 +85,7 @@ func (p *glPainter) newGlTextTexture(obj fyne.CanvasObject) Texture {
 	d.Src = &image.Uniform{C: color}
 	d.Face = face
 	d.Dot = freetype.Pt(0, height-face.Metrics().Descent.Ceil())
-	d.DrawString(text.Text, text.TextStyle.TabWidth)
+	d.DrawString(text.GetText(), text.TextStyle.TabWidth)
 
 	return p.imgToTexture(img, canvas.ImageScaleSmooth)
 }


### PR DESCRIPTION
### Description:

The rendering thread and the user thread can race on the properties of widgets. This PR shows a very basic draft of fixing all potential data races in a basic example provided in #2548, and demonstrates potential new APIs or changes (not only from fyne side but also from user side) that might be needed to address the long observed data races for all APIs reported in #2509 and #1028. 

For instance, with this PR, users should update their code in this way:

```
package main

import (
	"fmt"

	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/canvas"
	"fyne.io/fyne/v2/theme"
	"fyne.io/fyne/v2/widget"
)

func main() {
	w := app.New().NewWindow("List with many lines")
	ts := []string{"aaaaaaaaa", "bb", "NNNNNNNNNNNNNNN"}

	w.SetContent(widget.NewList(
		func() int { return 1000 },
		func() fyne.CanvasObject {
			return canvas.NewText("", theme.ForegroundColor())
		},
		func(id widget.ListItemID, o fyne.CanvasObject) {
			// o.(*canvas.Text).Text = fmt.Sprintf("%s %d", ts[id%3], id) // Data race!
			o.(*canvas.Text).SetText(fmt.Sprintf("%s %d", ts[id%3], id))  // OK
			o.Refresh()
		},
	))
	w.Resize(fyne.NewSize(float32(500), float32(300)))
	w.ShowAndRun()
}

```

Updates #1028
Updates #2509 
Updates #2548 
