### PR TITLE
Mouse events3

### DIFF
--- a/internal/driver/glfw/testdata/windows_hover_object.xml
+++ b/internal/driver/glfw/testdata/windows_hover_object.xml
@@ -4,16 +4,16 @@
 			<widget size="192x292" type="*widget.Scroll">
 				<container size="192x292">
 					<widget size="192x36" type="*widget.listItem">
-						<widget pos="4,0" size="188x36" type="*widget.Entry">
-							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="188x32"/>
-							<rectangle fillColor="shadow" pos="0,34" size="188x2"/>
-							<widget pos="0,2" size="188x32" type="*widget.Scroll">
-								<widget size="188x32" type="*widget.entryContent">
-									<widget size="188x32" type="*widget.RichText">
-										<text color="placeholder" pos="8,6" size="172x20"></text>
+						<widget size="192x36" type="*widget.Entry">
+							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="192x32"/>
+							<rectangle fillColor="shadow" pos="0,34" size="192x2"/>
+							<widget pos="0,2" size="192x32" type="*widget.Scroll">
+								<widget size="192x32" type="*widget.entryContent">
+									<widget size="192x32" type="*widget.RichText">
+										<text color="placeholder" pos="8,6" size="176x20"></text>
 									</widget>
-									<widget size="188x32" type="*widget.RichText">
-										<text pos="8,6" size="172x20"></text>
+									<widget size="192x32" type="*widget.RichText">
+										<text pos="8,6" size="176x20"></text>
 									</widget>
 								</widget>
 							</widget>
@@ -21,16 +21,16 @@
 					</widget>
 					<widget pos="0,37" size="192x36" type="*widget.listItem">
 						<rectangle fillColor="hover" size="192x36"/>
-						<widget pos="4,0" size="188x36" type="*widget.Entry">
-							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="188x32"/>
-							<rectangle fillColor="shadow" pos="0,34" size="188x2"/>
-							<widget pos="0,2" size="188x32" type="*widget.Scroll">
-								<widget size="188x32" type="*widget.entryContent">
-									<widget size="188x32" type="*widget.RichText">
-										<text color="placeholder" pos="8,6" size="172x20"></text>
+						<widget size="192x36" type="*widget.Entry">
+							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="192x32"/>
+							<rectangle fillColor="shadow" pos="0,34" size="192x2"/>
+							<widget pos="0,2" size="192x32" type="*widget.Scroll">
+								<widget size="192x32" type="*widget.entryContent">
+									<widget size="192x32" type="*widget.RichText">
+										<text color="placeholder" pos="8,6" size="176x20"></text>
 									</widget>
-									<widget size="188x32" type="*widget.RichText">
-										<text pos="8,6" size="172x20"></text>
+									<widget size="192x32" type="*widget.RichText">
+										<text pos="8,6" size="176x20"></text>
 									</widget>
 								</widget>
 							</widget>

--- a/internal/driver/glfw/testdata/windows_no_hover_outside_object.xml
+++ b/internal/driver/glfw/testdata/windows_no_hover_outside_object.xml
@@ -4,32 +4,32 @@
 			<widget size="192x292" type="*widget.Scroll">
 				<container size="192x292">
 					<widget size="192x36" type="*widget.listItem">
-						<widget pos="4,0" size="188x36" type="*widget.Entry">
-							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="188x32"/>
-							<rectangle fillColor="shadow" pos="0,34" size="188x2"/>
-							<widget pos="0,2" size="188x32" type="*widget.Scroll">
-								<widget size="188x32" type="*widget.entryContent">
-									<widget size="188x32" type="*widget.RichText">
-										<text color="placeholder" pos="8,6" size="172x20"></text>
+						<widget size="192x36" type="*widget.Entry">
+							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="192x32"/>
+							<rectangle fillColor="shadow" pos="0,34" size="192x2"/>
+							<widget pos="0,2" size="192x32" type="*widget.Scroll">
+								<widget size="192x32" type="*widget.entryContent">
+									<widget size="192x32" type="*widget.RichText">
+										<text color="placeholder" pos="8,6" size="176x20"></text>
 									</widget>
-									<widget size="188x32" type="*widget.RichText">
-										<text pos="8,6" size="172x20"></text>
+									<widget size="192x32" type="*widget.RichText">
+										<text pos="8,6" size="176x20"></text>
 									</widget>
 								</widget>
 							</widget>
 						</widget>
 					</widget>
 					<widget pos="0,37" size="192x36" type="*widget.listItem">
-						<widget pos="4,0" size="188x36" type="*widget.Entry">
-							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="188x32"/>
-							<rectangle fillColor="shadow" pos="0,34" size="188x2"/>
-							<widget pos="0,2" size="188x32" type="*widget.Scroll">
-								<widget size="188x32" type="*widget.entryContent">
-									<widget size="188x32" type="*widget.RichText">
-										<text color="placeholder" pos="8,6" size="172x20"></text>
+						<widget size="192x36" type="*widget.Entry">
+							<rectangle fillColor="rgba(255,255,255,25)" pos="0,2" size="192x32"/>
+							<rectangle fillColor="shadow" pos="0,34" size="192x2"/>
+							<widget pos="0,2" size="192x32" type="*widget.Scroll">
+								<widget size="192x32" type="*widget.entryContent">
+									<widget size="192x32" type="*widget.RichText">
+										<text color="placeholder" pos="8,6" size="176x20"></text>
 									</widget>
-									<widget size="188x32" type="*widget.RichText">
-										<text pos="8,6" size="172x20"></text>
+									<widget size="192x32" type="*widget.RichText">
+										<text pos="8,6" size="176x20"></text>
 									</widget>
 								</widget>
 							</widget>

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -773,41 +773,41 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 	}
 
 	// find individual objects with clickable interfaces
-	var tappableO fyne.CanvasObject
-	var secondaryTappableO fyne.CanvasObject
-	var doubleTappableO fyne.CanvasObject
-	var focusableO fyne.CanvasObject
-	var mouseableO fyne.CanvasObject
-	var draggableO fyne.CanvasObject
+	var tappable fyne.CanvasObject
+	var secondaryTappable fyne.CanvasObject
+	var doubleTappable fyne.CanvasObject
+	var focusable fyne.CanvasObject
+	var mouseable fyne.CanvasObject
+	var draggable fyne.CanvasObject
 
 	_, pos, _ := w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) (ret bool) {
 		ret = false
 		// each Tappable, SecondaryTappable, DoubleTappable and Mouseable must receive appropriate event
 		if _, ok := object.(fyne.Tappable); ok {
-			tappableO = object
+			tappable = object
 			ret = true
 		}
 		if _, ok := object.(fyne.SecondaryTappable); ok {
-			secondaryTappableO = object
+			secondaryTappable = object
 			ret = true
 		}
 		if _, ok := object.(fyne.DoubleTappable); ok {
-			doubleTappableO = object
+			doubleTappable = object
 			ret = true
 		}
 		if _, ok := object.(desktop.Mouseable); ok {
-			mouseableO = object
+			mouseable = object
 			ret = true
 		}
 		// find fyne.Focusable to release focus when mouse clicked outside of currently focused object
 		if _, ok := object.(fyne.Focusable); ok {
-			focusableO = object
+			focusable = object
 			ret = true
 		}
 		// when drag started, we may need to know if mouse within the fyne.Draggable to ?
 		if mouseDragStarted {
 			if _, ok := object.(fyne.Draggable); ok {
-				draggableO = object
+				draggable = object
 				ret = true
 			}
 		}
@@ -820,17 +820,17 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 	button, modifiers := convertMouseButton(btn, mods)
 
 	// deliver Mouseable when one found
-	if mouseableO != nil {
+	if mouseable != nil {
 		mev := new(desktop.MouseEvent)
 		mev.Position = ev.Position
 		mev.AbsolutePosition = mousePos
 		mev.Button = button
 		mev.Modifier = modifiers
-		w.mouseClickedHandleMouseable(mev, action, mouseableO.(desktop.Mouseable))
+		w.mouseClickedHandleMouseable(mev, action, mouseable.(desktop.Mouseable))
 	}
 
 	// when click outside currently Focusable object, remove focus.
-	if focusableO, ok := focusableO.(fyne.Focusable); ok && w.canvas.Focused() != nil && focusableO != w.canvas.Focused() {
+	if focusable, ok := focusable.(fyne.Focusable); ok && w.canvas.Focused() != nil && focusable != w.canvas.Focused() {
 		w.canvas.Unfocus()
 	}
 
@@ -847,23 +847,23 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 
 	// button release must sent DragEnd during drag cycle
 	if action == glfw.Release && mouseDragged != nil {
-		w.mouseDragEnd(mouseDragged, draggableO)
+		w.mouseDragEnd(mouseDragged, draggable)
 	}
 
 	// trigger TappedSecondary on Secondary mouse release
-	if secondaryTappableO != nil && button == desktop.MouseButtonSecondary {
-		w.mouseClickedHandleButtonSecondary(ev, action, secondaryTappableO.(fyne.SecondaryTappable))
+	if secondaryTappable != nil && button == desktop.MouseButtonSecondary {
+		w.mouseClickedHandleButtonSecondary(ev, action, secondaryTappable.(fyne.SecondaryTappable))
 	}
 
 	if action == glfw.Release && button == desktop.MouseButtonPrimary {
-		if doubleTappableO != nil {
-			w.mouseClickedHandleTapDoubleTap(doubleTappableO, ev)
-			if doubleTappableO == tappableO {
-				tappableO = nil
+		if doubleTappable != nil {
+			w.mouseClickedHandleTapDoubleTap(doubleTappable, ev)
+			if doubleTappable == tappable {
+				tappable = nil
 			}
 		}
-		if tappableO != nil && mousePrimaryPressed == tappableO.(fyne.Tappable) {
-			w.QueueEvent(func() { tappableO.(fyne.Tappable).Tapped(ev) })
+		if tappable != nil && mousePrimaryPressed == tappable.(fyne.Tappable) {
+			w.QueueEvent(func() { tappable.(fyne.Tappable).Tapped(ev) })
 		}
 		w.mouseLock.Lock()
 		w.mousePrimaryPressed = nil
@@ -872,14 +872,14 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 	}
 
 	if action == glfw.Press {
-		if tappableO != nil {
+		if tappable != nil {
 			w.mouseLock.Lock()
-			w.mousePrimaryPressed = tappableO.(fyne.Tappable)
+			w.mousePrimaryPressed = tappable.(fyne.Tappable)
 			w.mouseLock.Unlock()
 		}
-		if doubleTappableO != nil {
+		if doubleTappable != nil {
 			w.mouseLock.Lock()
-			w.mouseDoublePressed = doubleTappableO
+			w.mouseDoublePressed = doubleTappable
 			w.mouseLock.Unlock()
 		}
 	}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -848,8 +848,6 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 	// button release must sent DragEnd during drag cycle
 	if action == glfw.Release && mouseDragged != nil {
 		w.mouseDragEnd(mouseDragged, draggableO)
-		// do not send clicked on drag end
-		tappableO = nil
 	}
 
 	// trigger TappedSecondary on Secondary mouse release

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -846,11 +846,14 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 
 	mouseDragged := w.mouseDragged
 	mousePrimaryPressed := w.mousePrimaryPressed
+	tappableObject := w.pointCache.tappable
 	w.mouseLock.Unlock()
 
 	// button release must sent DragEnd during drag cycle
 	if action == glfw.Release && mouseDragged != nil {
 		w.mouseDragEnd(mouseDragged, w.pointCache.draggable)
+		// do not send tap event when sending dragEnd
+		tappableObject = nil
 	}
 
 	// trigger TappedSecondary on Secondary mouse release
@@ -861,7 +864,6 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 		w.mouseClickedHandleButtonSecondary(ev, action, w.pointCache.secondaryTappable.(fyne.SecondaryTappable))
 	}
 
-	tappableObject := w.pointCache.tappable
 	if action == glfw.Release && button == desktop.MouseButtonPrimary {
 		if w.pointCache.doubleTappable != nil {
 			ev := new(fyne.PointEvent)

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -860,7 +860,7 @@ func TestWindow_HoverableOnDraggingOverHoverableAndBack(t *testing.T) {
 	assert.Nil(t, h.popMouseMovedEvent())
 }
 
-func TestWindow_DragEndWithinWidgetWithTappedEvent(t *testing.T) {
+func TestWindow_DragEndWithoutTappedEvent(t *testing.T) {
 	w := createWindow("Test").(*window)
 	do := &draggableTappableObject{Rectangle: canvas.NewRectangle(color.White)}
 	do.SetMinSize(fyne.NewSize(10, 10))
@@ -872,11 +872,16 @@ func TestWindow_DragEndWithinWidgetWithTappedEvent(t *testing.T) {
 	w.mouseMoved(w.viewport, 9, 9)
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
 	w.mouseMoved(w.viewport, 8, 8)
+
+	w.WaitForEvents()
+	assert.NotNil(t, do.popDragEvent())
+
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 
 	w.WaitForEvents()
 
-	assert.NotNil(t, do.popTapEvent())
+	assert.NotNil(t, do.popDragEndEvent())
+	assert.Nil(t, do.popTapEvent())
 }
 
 func TestWindow_Scrolled(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -627,237 +627,390 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.NotNil(t, dh.popMouseOutEvent())
 }
 
-func TestWindow_HoverableOnDraggingOverDraggable(t *testing.T) {
+func TestWindow_HoverableUnderDraggable(t *testing.T) {
 	w := createWindow("Test").(*window)
-	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
 	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
-	c := container.NewWithoutLayout(dh, d)
+	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+
+	c := container.NewWithoutLayout(h, d, dh)
+	h.Resize(fyne.NewSize(50, 50))
+	h.Move(fyne.NewPos(0, 0))
+	d.Resize(fyne.NewSize(30, 30))
+	d.Move(fyne.NewPos(10, 10))
 	dh.Resize(fyne.NewSize(10, 10))
-	d.Move(fyne.NewPos(10, 0))
-	d.Resize(fyne.NewSize(10, 10))
+	dh.Move(fyne.NewPos(20, 20))
+
 	w.SetContent(c)
 
 	repaintWindow(w)
-	w.mouseMoved(w.viewport, 8, 8)
+
+	// 1. move over to hoverableObject and verify
+	//  - mouseIn received by hoverableObject
+	//  - no events by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseMoved(w.viewport, 5, 5)
 	w.WaitForEvents()
-	assert.Equal(t,
-		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-			AbsolutePosition: fyne.NewPos(8, 8)}},
-		dh.popMouseInEvent(),
-	)
-	// start drag, on Move get the DragEvent
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 8, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&fyne.DragEvent{
-			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-				AbsolutePosition: fyne.NewPos(8, 8)},
-			Dragged: fyne.NewDelta(0, 0),
-		},
-		dh.popDragEvent(),
-	)
-	assert.Nil(t, dh.popDragEndEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
+		AbsolutePosition: fyne.NewPos(5, 5)}}, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-
-	// drag event going to another draggable widget area
-	// expected to get DragEvent (due to move) and loose hover
-	w.mouseMoved(w.viewport, 16, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&fyne.DragEvent{
-			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
-				AbsolutePosition: fyne.NewPos(16, 8)},
-			Dragged: fyne.NewDelta(8, 0),
-		},
-		dh.popDragEvent())
+	assert.Nil(t, dh.popDragEvent())
 	assert.Nil(t, dh.popDragEndEvent())
+
+	// 1.a test for drag in non-draggable
+	//  - move in hoverableObject
+	//  - no events by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 6, 6)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
+		AbsolutePosition: fyne.NewPos(6, 6)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 
-	// on release expect DragEng
-	// no hover events on end of drag event
-	// TODO the second draggable must get EndDrag as well
+	// 2. move over to draggableObject and verify
+	//  - mouseMoved by hoverableObject
+	//  - no events by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseMoved(w.viewport, 15, 15)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
+		AbsolutePosition: fyne.NewPos(15, 15)}}, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 2.a test for drag in draggable
+	//  - move in hoverableObject
+	//  - drag begin by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 16, 16)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 12),
+		AbsolutePosition: fyne.NewPos(16, 16)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
+		AbsolutePosition: fyne.NewPos(16, 16)}, Dragged: fyne.NewDelta(1, 1)}, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 2.b drag end
+	//  - no events by hoverableObject
+	//  - drag end by draggableObject
+	//  - no events by draggableHoverableObject
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 	w.WaitForEvents()
-	assert.Nil(t, dh.popDragEvent())
-	assert.NotNil(t, dh.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
 	assert.Nil(t, d.popDragEvent())
-}
-
-func TestWindow_HoverableOnDraggingOverHoverable(t *testing.T) {
-	w := createWindow("Test").(*window)
-	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	c := container.NewWithoutLayout(dh, h)
-	dh.Resize(fyne.NewSize(10, 10))
-	h.Move(fyne.NewPos(10, 0))
-	h.Resize(fyne.NewSize(10, 10))
-	w.SetContent(c)
-
-	repaintWindow(w)
-	w.mouseMoved(w.viewport, 8, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-			AbsolutePosition: fyne.NewPos(8, 8)}},
-		dh.popMouseInEvent(),
-	)
-	// start drag
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 8, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&fyne.DragEvent{
-			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-				AbsolutePosition: fyne.NewPos(8, 8)},
-			Dragged: fyne.NewDelta(0, 0),
-		},
-		dh.popDragEvent(),
-	)
-	assert.Nil(t, dh.popDragEndEvent())
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-
-	// drag event going outside the widget's area and over to second Hoverable
-	// second Hoverable get MouseIn
-	w.mouseMoved(w.viewport, 16, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&fyne.DragEvent{
-			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
-				AbsolutePosition: fyne.NewPos(16, 8)},
-			Dragged: fyne.NewDelta(8, 0),
-		},
-		dh.popDragEvent(),
-	)
-	assert.Nil(t, dh.popDragEndEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.NotNil(t, d.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
-	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Equal(t,
-		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 4),
-			AbsolutePosition: fyne.NewPos(16, 8)}, Button: 1},
-		h.popMouseInEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-
-	// no hover events on end of drag event
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
-	w.WaitForEvents()
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
 	assert.Nil(t, dh.popDragEvent())
-	assert.NotNil(t, dh.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-}
-
-func TestWindow_HoverableOnDraggingOverHoverableAndBack(t *testing.T) {
-	w := createWindow("Test").(*window)
-	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	c := container.NewWithoutLayout(dh, h)
-	dh.Resize(fyne.NewSize(10, 10))
-	h.Move(fyne.NewPos(10, 0))
-	h.Resize(fyne.NewSize(10, 10))
-	w.SetContent(c)
-
-	repaintWindow(w)
-	w.mouseMoved(w.viewport, 8, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-			AbsolutePosition: fyne.NewPos(8, 8)}},
-		dh.popMouseInEvent(),
-	)
-	// start drag
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 8, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&fyne.DragEvent{
-			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-				AbsolutePosition: fyne.NewPos(8, 8)},
-			Dragged: fyne.NewDelta(0, 0),
-		},
-		dh.popDragEvent(),
-	)
 	assert.Nil(t, dh.popDragEndEvent())
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
 
-	// drag event going outside the widget's area
-	// expected to get MouseOut
-	// Second Hoverable get MouseIn
-	w.mouseMoved(w.viewport, 16, 8)
+	// 3. move to draggableHoverableObject and verify
+	// - mouseOut received by hoverableObject
+	// - no events by draggableObject
+	// - mouseIn by draggableHoverableObject
+	w.mouseMoved(w.viewport, 25, 25)
 	w.WaitForEvents()
-	assert.Equal(t,
-		&fyne.DragEvent{
-			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
-				AbsolutePosition: fyne.NewPos(16, 8)},
-			Dragged: fyne.NewDelta(8, 0),
-		},
-		dh.popDragEvent(),
-	)
-	assert.Nil(t, dh.popDragEndEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Equal(t,
-		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 4),
-			AbsolutePosition: fyne.NewPos(16, 8)}, Button: 1},
-		h.popMouseInEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-
-	// drag event going back inside the widget's area again
-	// expected to get MouseOut for second object
-	// DragEvent and MoueIn for first object
-	w.mouseMoved(w.viewport, 8, 8)
-	w.WaitForEvents()
-	assert.Equal(t,
-		&fyne.DragEvent{
-			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-				AbsolutePosition: fyne.NewPos(8, 8)},
-			Dragged: fyne.NewDelta(-8, 0),
-		},
-		dh.popDragEvent(),
-	)
-	assert.Nil(t, dh.popDragEndEvent())
-	assert.Equal(t,
-		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
-			AbsolutePosition: fyne.NewPos(8, 8)}, Button: 1},
-		dh.popMouseInEvent(),
-	)
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
 	assert.NotNil(t, h.popMouseOutEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
+		AbsolutePosition: fyne.NewPos(25, 25)}}, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
 
-	// no hover events on end of drag event
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	// 4. move over to draggableObject and verify
+	// - mouseIn received by hoverableObject
+	// - no events by draggableObject
+	// - mouseOut by draggableHoverableObject
+	w.mouseMoved(w.viewport, 35, 35)
 	w.WaitForEvents()
-	assert.NotNil(t, dh.popDragEndEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(31, 31),
+		AbsolutePosition: fyne.NewPos(35, 35)}}, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 5. move to  hoverableObject and verify
+	//  - mouseMoved by hoverableObject
+	//  - no events by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseMoved(w.viewport, 45, 45)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(41, 41),
+		AbsolutePosition: fyne.NewPos(45, 45)}}, h.popMouseMovedEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 6. move ouside hoverableObject and verify
+	//  - mouseOut by hoverableObject
+	//  - no events by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseMoved(w.viewport, 55, 55)
+	w.WaitForEvents()
 	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseOutEvent())
 	assert.Nil(t, h.popMouseMovedEvent())
+	assert.NotNil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+}
+
+func TestWindow_HoverableUnderDraggable_DragAcross(t *testing.T) {
+	w := createWindow("Test").(*window)
+	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
+	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+
+	c := container.NewWithoutLayout(h, d, dh)
+	h.Resize(fyne.NewSize(50, 50))
+	h.Move(fyne.NewPos(0, 0))
+	d.Resize(fyne.NewSize(30, 30))
+	d.Move(fyne.NewPos(10, 10))
+	dh.Resize(fyne.NewSize(10, 10))
+	dh.Move(fyne.NewPos(20, 20))
+
+	w.SetContent(c)
+
+	repaintWindow(w)
+
+	// 1. drag across hoverable
+	//  - mouseIn by hoverableObject
+	//  - no events by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseMoved(w.viewport, 15, 15)
+	w.WaitForEvents()
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
+		AbsolutePosition: fyne.NewPos(15, 15)}}, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 2 start drag in draggable
+	//  - move in hoverableObject
+	//  - drag begin by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 16, 16)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 12),
+		AbsolutePosition: fyne.NewPos(16, 16)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
+		AbsolutePosition: fyne.NewPos(16, 16)}, Dragged: fyne.NewDelta(1, 1)}, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 3 drag to draggable+hoverable
+	//  - moveOut hoverableObject
+	//  - drag events by draggableObject
+	//  - moveIn by draggableHoverableObject
+	w.mouseMoved(w.viewport, 25, 25)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.NotNil(t, h.popMouseOutEvent())
+	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
+		AbsolutePosition: fyne.NewPos(25, 25)}, Dragged: fyne.NewDelta(9, 9)}, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
+		AbsolutePosition: fyne.NewPos(25, 25)}, Button: 1, Modifier: 0}, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 4 move over to draggableObject and verify
+	// - mouseIn received by hoverableObject
+	// - drag event by draggableObject
+	// - mouseOut by draggableHoverableObject
+	w.mouseMoved(w.viewport, 35, 35)
+	w.WaitForEvents()
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(31, 31),
+		AbsolutePosition: fyne.NewPos(35, 35)}, Button: 1, Modifier: 0}, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(21, 21),
+		AbsolutePosition: fyne.NewPos(35, 35)}, Dragged: fyne.NewDelta(10, 10)}, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 5 drag end
+	//  - no events by hoverableObject
+	//  - drag end by draggableObject
+	//  - no events by draggableHoverableObject
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.NotNil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+}
+
+func TestWindow_HoverableUnderDraggable_Drag_draggableHoverable(t *testing.T) {
+	w := createWindow("Test").(*window)
+	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
+	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+
+	c := container.NewWithoutLayout(h, d, dh)
+	h.Resize(fyne.NewSize(50, 50))
+	h.Move(fyne.NewPos(0, 0))
+	d.Resize(fyne.NewSize(30, 30))
+	d.Move(fyne.NewPos(10, 10))
+	dh.Resize(fyne.NewSize(10, 10))
+	dh.Move(fyne.NewPos(20, 20))
+
+	w.SetContent(c)
+
+	repaintWindow(w)
+
+	// 1. drag of draggableHoverable
+	//  - no event by hoverableObject
+	//  - no event by draggableObject
+	//  - moveIn event by draggableHoverableObject
+	w.mouseMoved(w.viewport, 25, 25)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
+		AbsolutePosition: fyne.NewPos(25, 25)}}, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 2. start drag in draggableHoverable
+	//  - no events by hoverableObject
+	//  - no events by draggableObject
+	//  - drag begin by draggableHoverableObject
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 26, 26)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
+		AbsolutePosition: fyne.NewPos(26, 26)}, Dragged: fyne.NewDelta(1, 1)}, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 3. drag to hoverable
+	//  - moveIn by hoverableObject
+	//  - no events by draggableObject
+	//  - drag and moveOut by draggableHoverableObject
+	w.mouseMoved(w.viewport, 45, 45)
+	w.WaitForEvents()
+	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(41, 41),
+		AbsolutePosition: fyne.NewPos(45, 45)}, Button: 1, Modifier: 0}, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
+	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(21, 21),
+		AbsolutePosition: fyne.NewPos(45, 45)}, Dragged: fyne.NewDelta(19, 19)}, dh.popDragEvent())
+	assert.Nil(t, dh.popDragEndEvent())
+
+	// 4. drag end
+	//  - no events by hoverableObject
+	//  - no events by draggableObject
+	//  - drag end by draggableHoverableObject
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.WaitForEvents()
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+	assert.Nil(t, d.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popDragEvent())
+	assert.NotNil(t, dh.popDragEndEvent())
 }
 
 func TestWindow_DragEndWithoutTappedEvent(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -580,6 +580,7 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	)
 
 	// drag event going outside the widget's area
+	// expected behavior is to keep hover and only get DragEvent without mouse move
 	w.mouseMoved(w.viewport, 16, 8)
 	w.WaitForEvents()
 	assert.Equal(t,
@@ -594,6 +595,7 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.Nil(t, dh.popMouseOutEvent())
 
 	// drag event going inside the widget's area again
+	// expected behavior is to keep hover and only get DragEvent without mouse move
 	w.mouseMoved(w.viewport, 8, 8)
 	w.WaitForEvents()
 	assert.Equal(t,
@@ -608,11 +610,13 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.Nil(t, dh.popMouseMovedEvent())
 
 	// no hover events on end of drag event
+	// only DragEnd
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 	w.WaitForEvents()
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.Nil(t, dh.popMouseOutEvent())
+	assert.NotNil(t, dh.popDragEndEvent())
 
 	// mouseOut on mouse release after dragging out of area
 	w.mouseMoved(w.viewport, 8, 8)
@@ -623,390 +627,237 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	assert.NotNil(t, dh.popMouseOutEvent())
 }
 
-func TestWindow_HoverableUnderDraggable(t *testing.T) {
+func TestWindow_HoverableOnDraggingOverDraggable(t *testing.T) {
 	w := createWindow("Test").(*window)
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
 	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-
-	c := container.NewWithoutLayout(h, d, dh)
-	h.Resize(fyne.NewSize(50, 50))
-	h.Move(fyne.NewPos(0, 0))
-	d.Resize(fyne.NewSize(30, 30))
-	d.Move(fyne.NewPos(10, 10))
+	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
+	c := container.NewWithoutLayout(dh, d)
 	dh.Resize(fyne.NewSize(10, 10))
-	dh.Move(fyne.NewPos(20, 20))
-
+	d.Move(fyne.NewPos(10, 0))
+	d.Resize(fyne.NewSize(10, 10))
 	w.SetContent(c)
 
 	repaintWindow(w)
-
-	// 1. move over to hoverableObject and verify
-	//  - mouseIn received by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 5, 5)
+	w.mouseMoved(w.viewport, 8, 8)
 	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(5, 5)}}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 1.a test for drag in non-draggable
-	//  - move in hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}},
+		dh.popMouseInEvent(),
+	)
+	// start drag, on Move get the DragEvent
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 6, 6)
+	w.mouseMoved(w.viewport, 8, 8)
 	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(6, 6)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(0, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
-
-	// 2. move over to draggableObject and verify
-	//  - mouseMoved by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 15, 15)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
-		AbsolutePosition: fyne.NewPos(15, 15)}}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
 	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
 
-	// 2.a test for drag in draggable
-	//  - move in hoverableObject
-	//  - drag begin by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 16, 16)
+	// drag event going to another draggable widget area
+	// expected to get DragEvent (due to move) and loose hover
+	w.mouseMoved(w.viewport, 16, 8)
 	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 12),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Dragged: fyne.NewDelta(1, 1)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
+				AbsolutePosition: fyne.NewPos(16, 8)},
+			Dragged: fyne.NewDelta(8, 0),
+		},
+		dh.popDragEvent())
 	assert.Nil(t, dh.popDragEndEvent())
-
-	// 2.b drag end
-	//  - no events by hoverableObject
-	//  - drag end by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.NotNil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 3. move to draggableHoverableObject and verify
-	// - mouseOut received by hoverableObject
-	// - no events by draggableObject
-	// - mouseIn by draggableHoverableObject
-	w.mouseMoved(w.viewport, 25, 25)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.NotNil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(25, 25)}}, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 4. move over to draggableObject and verify
-	// - mouseIn received by hoverableObject
-	// - no events by draggableObject
-	// - mouseOut by draggableHoverableObject
-	w.mouseMoved(w.viewport, 35, 35)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(31, 31),
-		AbsolutePosition: fyne.NewPos(35, 35)}}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
 	assert.Nil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 5. move to  hoverableObject and verify
-	//  - mouseMoved by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 45, 45)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(41, 41),
-		AbsolutePosition: fyne.NewPos(45, 45)}}, h.popMouseMovedEvent())
 	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
 
-	// 6. move ouside hoverableObject and verify
-	//  - mouseOut by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 55, 55)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.NotNil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-}
-
-func TestWindow_HoverableUnderDraggable_DragAcross(t *testing.T) {
-	w := createWindow("Test").(*window)
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
-	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-
-	c := container.NewWithoutLayout(h, d, dh)
-	h.Resize(fyne.NewSize(50, 50))
-	h.Move(fyne.NewPos(0, 0))
-	d.Resize(fyne.NewSize(30, 30))
-	d.Move(fyne.NewPos(10, 10))
-	dh.Resize(fyne.NewSize(10, 10))
-	dh.Move(fyne.NewPos(20, 20))
-
-	w.SetContent(c)
-
-	repaintWindow(w)
-
-	// 1. drag across hoverable
-	//  - mouseIn by hoverableObject
-	//  - no events by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseMoved(w.viewport, 15, 15)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
-		AbsolutePosition: fyne.NewPos(15, 15)}}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 2 start drag in draggable
-	//  - move in hoverableObject
-	//  - drag begin by draggableObject
-	//  - no events by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 16, 16)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 12),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Button: 1, Modifier: 0}, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(16, 16)}, Dragged: fyne.NewDelta(1, 1)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 3 drag to draggable+hoverable
-	//  - moveOut hoverableObject
-	//  - drag events by draggableObject
-	//  - moveIn by draggableHoverableObject
-	w.mouseMoved(w.viewport, 25, 25)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.NotNil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(11, 11),
-		AbsolutePosition: fyne.NewPos(25, 25)}, Dragged: fyne.NewDelta(9, 9)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(25, 25)}, Button: 1, Modifier: 0}, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 4 move over to draggableObject and verify
-	// - mouseIn received by hoverableObject
-	// - drag event by draggableObject
-	// - mouseOut by draggableHoverableObject
-	w.mouseMoved(w.viewport, 35, 35)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(31, 31),
-		AbsolutePosition: fyne.NewPos(35, 35)}, Button: 1, Modifier: 0}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(21, 21),
-		AbsolutePosition: fyne.NewPos(35, 35)}, Dragged: fyne.NewDelta(10, 10)}, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 5 drag end
-	//  - no events by hoverableObject
-	//  - drag end by draggableObject
-	//  - no events by draggableHoverableObject
+	// on release expect DragEng
+	// no hover events on end of drag event
+	// TODO the second draggable must get EndDrag as well
 	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.NotNil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-}
-
-func TestWindow_HoverableUnderDraggable_Drag_draggableHoverable(t *testing.T) {
-	w := createWindow("Test").(*window)
-	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-	d := &draggableObject{Rectangle: canvas.NewRectangle(color.White)}
-	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
-
-	c := container.NewWithoutLayout(h, d, dh)
-	h.Resize(fyne.NewSize(50, 50))
-	h.Move(fyne.NewPos(0, 0))
-	d.Resize(fyne.NewSize(30, 30))
-	d.Move(fyne.NewPos(10, 10))
-	dh.Resize(fyne.NewSize(10, 10))
-	dh.Move(fyne.NewPos(20, 20))
-
-	w.SetContent(c)
-
-	repaintWindow(w)
-
-	// 1. drag of draggableHoverable
-	//  - no event by hoverableObject
-	//  - no event by draggableObject
-	//  - moveIn event by draggableHoverableObject
-	w.mouseMoved(w.viewport, 25, 25)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(1, 1),
-		AbsolutePosition: fyne.NewPos(25, 25)}}, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Nil(t, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 2. start drag in draggableHoverable
-	//  - no events by hoverableObject
-	//  - no events by draggableObject
-	//  - drag begin by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
-	w.mouseMoved(w.viewport, 26, 26)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 2),
-		AbsolutePosition: fyne.NewPos(26, 26)}, Dragged: fyne.NewDelta(1, 1)}, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 3. drag to hoverable
-	//  - moveIn by hoverableObject
-	//  - no events by draggableObject
-	//  - drag and moveOut by draggableHoverableObject
-	w.mouseMoved(w.viewport, 45, 45)
-	w.WaitForEvents()
-	assert.Equal(t, &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(41, 41),
-		AbsolutePosition: fyne.NewPos(45, 45)}, Button: 1, Modifier: 0}, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.NotNil(t, dh.popMouseOutEvent())
-	assert.Equal(t, &fyne.DragEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(21, 21),
-		AbsolutePosition: fyne.NewPos(45, 45)}, Dragged: fyne.NewDelta(19, 19)}, dh.popDragEvent())
-	assert.Nil(t, dh.popDragEndEvent())
-
-	// 4. drag end
-	//  - no events by hoverableObject
-	//  - no events by draggableObject
-	//  - drag end by draggableHoverableObject
-	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
-	w.WaitForEvents()
-	assert.Nil(t, h.popMouseInEvent())
-	assert.Nil(t, h.popMouseMovedEvent())
-	assert.Nil(t, h.popMouseOutEvent())
-	assert.Nil(t, d.popDragEvent())
-	assert.Nil(t, d.popDragEndEvent())
-	assert.Nil(t, dh.popMouseInEvent())
-	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
 	assert.Nil(t, dh.popDragEvent())
 	assert.NotNil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, d.popDragEvent())
+}
+
+func TestWindow_HoverableOnDraggingOverHoverable(t *testing.T) {
+	w := createWindow("Test").(*window)
+	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	c := container.NewWithoutLayout(dh, h)
+	dh.Resize(fyne.NewSize(10, 10))
+	h.Move(fyne.NewPos(10, 0))
+	h.Resize(fyne.NewSize(10, 10))
+	w.SetContent(c)
+
+	repaintWindow(w)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}},
+		dh.popMouseInEvent(),
+	)
+	// start drag
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(0, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// drag event going outside the widget's area and over to second Hoverable
+	// second Hoverable get MouseIn
+	w.mouseMoved(w.viewport, 16, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
+				AbsolutePosition: fyne.NewPos(16, 8)},
+			Dragged: fyne.NewDelta(8, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 4),
+			AbsolutePosition: fyne.NewPos(16, 8)}, Button: 1},
+		h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// no hover events on end of drag event
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.WaitForEvents()
+	assert.Nil(t, dh.popDragEvent())
+	assert.NotNil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+}
+
+func TestWindow_HoverableOnDraggingOverHoverableAndBack(t *testing.T) {
+	w := createWindow("Test").(*window)
+	dh := &draggableHoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	h := &hoverableObject{Rectangle: canvas.NewRectangle(color.White)}
+	c := container.NewWithoutLayout(dh, h)
+	dh.Resize(fyne.NewSize(10, 10))
+	h.Move(fyne.NewPos(10, 0))
+	h.Resize(fyne.NewSize(10, 10))
+	w.SetContent(c)
+
+	repaintWindow(w)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}},
+		dh.popMouseInEvent(),
+	)
+	// start drag
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(0, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// drag event going outside the widget's area
+	// expected to get MouseOut
+	// Second Hoverable get MouseIn
+	w.mouseMoved(w.viewport, 16, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(12, 4),
+				AbsolutePosition: fyne.NewPos(16, 8)},
+			Dragged: fyne.NewDelta(8, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(2, 4),
+			AbsolutePosition: fyne.NewPos(16, 8)}, Button: 1},
+		h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// drag event going back inside the widget's area again
+	// expected to get MouseOut for second object
+	// DragEvent and MoueIn for first object
+	w.mouseMoved(w.viewport, 8, 8)
+	w.WaitForEvents()
+	assert.Equal(t,
+		&fyne.DragEvent{
+			PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+				AbsolutePosition: fyne.NewPos(8, 8)},
+			Dragged: fyne.NewDelta(-8, 0),
+		},
+		dh.popDragEvent(),
+	)
+	assert.Nil(t, dh.popDragEndEvent())
+	assert.Equal(t,
+		&desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(4, 4),
+			AbsolutePosition: fyne.NewPos(8, 8)}, Button: 1},
+		dh.popMouseInEvent(),
+	)
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.NotNil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
+
+	// no hover events on end of drag event
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+	w.WaitForEvents()
+	assert.NotNil(t, dh.popDragEndEvent())
+	assert.Nil(t, dh.popMouseInEvent())
+	assert.Nil(t, dh.popMouseMovedEvent())
+	assert.Nil(t, dh.popMouseOutEvent())
+	assert.Nil(t, h.popMouseInEvent())
+	assert.Nil(t, h.popMouseOutEvent())
+	assert.Nil(t, h.popMouseMovedEvent())
 }
 
 func TestWindow_DragEndWithoutTappedEvent(t *testing.T) {
@@ -1528,8 +1379,8 @@ func TestWindow_Clipboard(t *testing.T) {
 	text := "My content from test window"
 	cb := w.Clipboard()
 
-	cliboardContent := cb.Content()
-	if cliboardContent != "" {
+	clipboardContent := cb.Content()
+	if clipboardContent != "" {
 		// Current environment has some content stored in clipboard,
 		// set temporary to an empty string to allow test and restore later.
 		cb.SetContent("")
@@ -1541,7 +1392,7 @@ func TestWindow_Clipboard(t *testing.T) {
 	assert.Equal(t, text, cb.Content())
 
 	// Restore clipboardContent, if any
-	cb.SetContent(cliboardContent)
+	cb.SetContent(clipboardContent)
 }
 
 func TestWindow_ClipboardCopy_DisabledEntry(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -860,7 +860,7 @@ func TestWindow_HoverableOnDraggingOverHoverableAndBack(t *testing.T) {
 	assert.Nil(t, h.popMouseMovedEvent())
 }
 
-func TestWindow_DragEndWithoutTappedEvent(t *testing.T) {
+func TestWindow_DragEndWithinWidgetWithTappedEvent(t *testing.T) {
 	w := createWindow("Test").(*window)
 	do := &draggableTappableObject{Rectangle: canvas.NewRectangle(color.White)}
 	do.SetMinSize(fyne.NewSize(10, 10))
@@ -876,7 +876,7 @@ func TestWindow_DragEndWithoutTappedEvent(t *testing.T) {
 
 	w.WaitForEvents()
 
-	assert.Nil(t, do.popTapEvent())
+	assert.NotNil(t, do.popTapEvent())
 }
 
 func TestWindow_Scrolled(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -580,7 +580,7 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 	)
 
 	// drag event going outside the widget's area
-	// expected behavior is to keep hover and only get DragEvent without mouse move
+	// expected behavior is to loose hover, get DragEvent, and no mouse move
 	w.mouseMoved(w.viewport, 16, 8)
 	w.WaitForEvents()
 	assert.Equal(t,
@@ -592,10 +592,10 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 		dh.popDragEvent(),
 	)
 	assert.Nil(t, dh.popMouseMovedEvent())
-	assert.Nil(t, dh.popMouseOutEvent())
+	assert.NotNil(t, dh.popMouseOutEvent())
 
-	// drag event going inside the widget's area again
-	// expected behavior is to keep hover and only get DragEvent without mouse move
+	// drag event going back inside the widget's area again
+	// expected behavior is get hover, get DragEvent, and no mouse move
 	w.mouseMoved(w.viewport, 8, 8)
 	w.WaitForEvents()
 	assert.Equal(t,
@@ -606,7 +606,7 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 		},
 		dh.popDragEvent(),
 	)
-	assert.Nil(t, dh.popMouseInEvent())
+	assert.NotNil(t, dh.popMouseInEvent())
 	assert.Nil(t, dh.popMouseMovedEvent())
 
 	// no hover events on end of drag event

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -322,27 +322,38 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 		return
 	}
 
-	co, objPos, _ := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
+	var tappableO fyne.CanvasObject
+	var secondaryTappableO fyne.CanvasObject
+	var touchableO fyne.CanvasObject
+	var doubleTappableO fyne.CanvasObject
+
+	_, objPos, _ := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
+		ret := false
 		if _, ok := object.(fyne.Tappable); ok {
-			return true
-		} else if _, ok := object.(fyne.SecondaryTappable); ok {
-			return true
-		} else if _, ok := object.(mobile.Touchable); ok {
-			return true
-		} else if _, ok := object.(fyne.Focusable); ok {
-			return true
-		} else if _, ok := object.(fyne.DoubleTappable); ok {
-			return true
+			tappableO = object
+			ret = true
+		}
+		if _, ok := object.(fyne.SecondaryTappable); ok {
+			secondaryTappableO = object
+			ret = true
+		}
+		if _, ok := object.(mobile.Touchable); ok {
+			touchableO = object
+			ret = true
+		}
+		if _, ok := object.(fyne.DoubleTappable); ok {
+			doubleTappableO = object
+			ret = true
 		}
 
-		return false
+		return ret
 	})
 
-	if wid, ok := co.(mobile.Touchable); ok {
+	if touchableO != nil {
 		touchEv := &mobile.TouchEvent{}
 		touchEv.Position = objPos
 		touchEv.AbsolutePosition = pos
-		wid.TouchUp(touchEv)
+		touchableO.(mobile.Touchable).TouchUp(touchEv)
 		c.touched[tapID] = nil
 	}
 
@@ -351,23 +362,22 @@ func (c *mobileCanvas) tapUp(pos fyne.Position, tapID int,
 	ev.AbsolutePosition = pos
 
 	if duration < tapSecondaryDelay {
-		_, doubleTap := co.(fyne.DoubleTappable)
-		if doubleTap {
+		if doubleTappableO != nil {
 			c.touchTapCount++
-			c.touchLastTapped = co
+			c.touchLastTapped = doubleTappableO
 			if c.touchCancelFunc != nil {
 				c.touchCancelFunc()
 				return
 			}
-			go c.waitForDoubleTap(co, ev, tapCallback, doubleTapCallback)
+			go c.waitForDoubleTap(doubleTappableO, ev, tapCallback, doubleTapCallback)
 		} else {
-			if wid, ok := co.(fyne.Tappable); ok {
-				tapCallback(wid, ev)
+			if tappableO != nil {
+				tapCallback(tappableO.(fyne.Tappable), ev)
 			}
 		}
 	} else {
-		if wid, ok := co.(fyne.SecondaryTappable); ok {
-			tapAltCallback(wid, ev)
+		if secondaryTappableO != nil {
+			tapAltCallback(secondaryTappableO.(fyne.SecondaryTappable), ev)
 		}
 	}
 }


### PR DESCRIPTION
### Description:

This PR will allow deliver mouse events more precisely based on widget interfaces. Originally the topmost widget was intercepting unrelated events. I.e. hover events won't be delivered to widget with Hoverable interface when it is below of the topmost widget with Mousable interface.

The Hoverable and Draggable interfaces are for distinct and unrelated mechanisms.
When mouse leaves or enters a Hoverable Widget, the MouseOut/MouseIn events should be sent in order to remove/show the hover visual effect. 
These events now delivered and the test TestWindow_HoverableOnDragging was adjusted.
I would also argue that the MouseMove of Hoverable interface must be delivered as well. But this could interfere with drag logic and it is not in this PR.

Fixed test xml broken after recent list widget changes.

### Checklist:

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
