### PR TITLE
geometry addition helpers

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -99,6 +99,21 @@ func (s Size) Add(v Vector2) Size {
 	return Size{s.Width + w, s.Height + h}
 }
 
+// AddHeight returns a new Size by adding height to the current one.
+func (s Size) AddHeight(height float32) Size {
+	return Size{s.Width, s.Height + height}
+}
+
+// AddWidth returns a new Size by adding width to the current one.
+func (s Size) AddWidth(width float32) Size {
+	return Size{s.Width + width, s.Height}
+}
+
+// AddWidthAndHeight returns a new Size by adding width and height to the current one.
+func (s Size) AddWidthAndHeight(width, height float32) Size {
+	return Size{s.Width + width, s.Height + height}
+}
+
 // IsZero returns whether the Size has zero width and zero height.
 func (s Size) IsZero() bool {
 	return s.Width == 0.0 && s.Height == 0.0

--- a/geometry.go
+++ b/geometry.go
@@ -81,6 +81,21 @@ func (p Position) Subtract(v Vector2) Position {
 	return Position{p.X - x, p.Y - y}
 }
 
+// SubtractX returns a new Position by subtracting x from the current one.
+func (p Position) SubtractX(x float32) Position {
+	return Position{p.X - x, p.Y}
+}
+
+// SubtractXAndY returns a new Position by subtracting x and y from the current one.
+func (p Position) SubtractXAndY(x, y float32) Position {
+	return Position{p.X - x, p.Y - y}
+}
+
+// SubtractY returns a new Position by subtracting y from the current one.
+func (p Position) SubtractY(y float32) Position {
+	return Position{p.X, p.Y - y}
+}
+
 // Size describes something with width and height.
 type Size struct {
 	Width  float32 // The number of units along the X axis.

--- a/geometry.go
+++ b/geometry.go
@@ -49,19 +49,9 @@ func (p Position) Add(v Vector2) Position {
 	return Position{p.X + x, p.Y + y}
 }
 
-// AddX returns a new Position by adding x to the current one.
-func (p Position) AddX(x float32) Position {
-	return Position{p.X + x, p.Y}
-}
-
 // AddXAndY returns a new Position by adding x and y to the current one.
 func (p Position) AddXAndY(x, y float32) Position {
 	return Position{p.X + x, p.Y + y}
-}
-
-// AddY returns a new Position by adding y to the current one.
-func (p Position) AddY(y float32) Position {
-	return Position{p.X, p.Y + y}
 }
 
 // Components returns the X and Y elements of this Position
@@ -81,19 +71,9 @@ func (p Position) Subtract(v Vector2) Position {
 	return Position{p.X - x, p.Y - y}
 }
 
-// SubtractX returns a new Position by subtracting x from the current one.
-func (p Position) SubtractX(x float32) Position {
-	return Position{p.X - x, p.Y}
-}
-
 // SubtractXAndY returns a new Position by subtracting x and y from the current one.
 func (p Position) SubtractXAndY(x, y float32) Position {
 	return Position{p.X - x, p.Y - y}
-}
-
-// SubtractY returns a new Position by subtracting y from the current one.
-func (p Position) SubtractY(y float32) Position {
-	return Position{p.X, p.Y - y}
 }
 
 // Size describes something with width and height.
@@ -112,16 +92,6 @@ func NewSize(w float32, h float32) Size {
 func (s Size) Add(v Vector2) Size {
 	w, h := v.Components()
 	return Size{s.Width + w, s.Height + h}
-}
-
-// AddHeight returns a new Size by adding height to the current one.
-func (s Size) AddHeight(height float32) Size {
-	return Size{s.Width, s.Height + height}
-}
-
-// AddWidth returns a new Size by adding width to the current one.
-func (s Size) AddWidth(width float32) Size {
-	return Size{s.Width + width, s.Height}
 }
 
 // AddWidthAndHeight returns a new Size by adding width and height to the current one.
@@ -164,16 +134,6 @@ func (s Size) Components() (float32, float32) {
 func (s Size) Subtract(v Vector2) Size {
 	w, h := v.Components()
 	return Size{s.Width - w, s.Height - h}
-}
-
-// SubtractHeight returns a new Size by subtracting height from the current one.
-func (s Size) SubtractHeight(height float32) Size {
-	return Size{s.Width, s.Height - height}
-}
-
-// SubtractWidth returns a new Size by subtracting width from the current one.
-func (s Size) SubtractWidth(width float32) Size {
-	return Size{s.Width - width, s.Height}
 }
 
 // SubtractWidthAndHeight returns a new Size by subtracting width and height from the current one.

--- a/geometry.go
+++ b/geometry.go
@@ -165,3 +165,18 @@ func (s Size) Subtract(v Vector2) Size {
 	w, h := v.Components()
 	return Size{s.Width - w, s.Height - h}
 }
+
+// SubtractHeight returns a new Size by subtracting height from the current one.
+func (s Size) SubtractHeight(height float32) Size {
+	return Size{s.Width, s.Height - height}
+}
+
+// SubtractWidth returns a new Size by subtracting width from the current one.
+func (s Size) SubtractWidth(width float32) Size {
+	return Size{s.Width - width, s.Height}
+}
+
+// SubtractWidthAndHeight returns a new Size by subtracting width and height from the current one.
+func (s Size) SubtractWidthAndHeight(width, height float32) Size {
+	return Size{s.Width - width, s.Height - height}
+}

--- a/geometry.go
+++ b/geometry.go
@@ -49,6 +49,21 @@ func (p Position) Add(v Vector2) Position {
 	return Position{p.X + x, p.Y + y}
 }
 
+// AddX returns a new Position by adding x to the current one.
+func (p Position) AddX(x float32) Position {
+	return Position{p.X + x, p.Y}
+}
+
+// AddXAndY returns a new Position by adding x and y to the current one.
+func (p Position) AddXAndY(x, y float32) Position {
+	return Position{p.X + x, p.Y + y}
+}
+
+// AddY returns a new Position by adding y to the current one.
+func (p Position) AddY(y float32) Position {
+	return Position{p.X, p.Y + y}
+}
+
 // Components returns the X and Y elements of this Position
 func (p Position) Components() (float32, float32) {
 	return p.X, p.Y

--- a/geometry.go
+++ b/geometry.go
@@ -49,8 +49,8 @@ func (p Position) Add(v Vector2) Position {
 	return Position{p.X + x, p.Y + y}
 }
 
-// AddXAndY returns a new Position by adding x and y to the current one.
-func (p Position) AddXAndY(x, y float32) Position {
+// AddXY returns a new Position by adding x and y to the current one.
+func (p Position) AddXY(x, y float32) Position {
 	return Position{p.X + x, p.Y + y}
 }
 
@@ -71,8 +71,8 @@ func (p Position) Subtract(v Vector2) Position {
 	return Position{p.X - x, p.Y - y}
 }
 
-// SubtractXAndY returns a new Position by subtracting x and y from the current one.
-func (p Position) SubtractXAndY(x, y float32) Position {
+// SubtractXY returns a new Position by subtracting x and y from the current one.
+func (p Position) SubtractXY(x, y float32) Position {
 	return Position{p.X - x, p.Y - y}
 }
 
@@ -94,8 +94,8 @@ func (s Size) Add(v Vector2) Size {
 	return Size{s.Width + w, s.Height + h}
 }
 
-// AddWidthAndHeight returns a new Size by adding width and height to the current one.
-func (s Size) AddWidthAndHeight(width, height float32) Size {
+// AddWidthHeight returns a new Size by adding width and height to the current one.
+func (s Size) AddWidthHeight(width, height float32) Size {
 	return Size{s.Width + width, s.Height + height}
 }
 
@@ -136,7 +136,7 @@ func (s Size) Subtract(v Vector2) Size {
 	return Size{s.Width - w, s.Height - h}
 }
 
-// SubtractWidthAndHeight returns a new Size by subtracting width and height from the current one.
-func (s Size) SubtractWidthAndHeight(width, height float32) Size {
+// SubtractWidthHeight returns a new Size by subtracting width and height from the current one.
+func (s Size) SubtractWidthHeight(width, height float32) Size {
 	return Size{s.Width - width, s.Height - height}
 }

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -69,7 +69,7 @@ func TestPosition_Subtract_Speed(t *testing.T) {
 func TestSize_Add_Speed(t *testing.T) {
 	add := testing.Benchmark(benchmarkSizeAdd)
 	addHeight := testing.Benchmark(benchmarkSizeAddHeight)
-	addWidthAndHeight := testing.Benchmark(benchmarkSizeAddWidth)
+	addWidthAndHeight := testing.Benchmark(benchmarkSizeAddWidthAndHeight)
 	addWidth := testing.Benchmark(benchmarkSizeAddWidthAndHeight)
 	assert.Less(t, add.NsPerOp(), int64(5))
 	assert.Less(t, addHeight.NsPerOp(), int64(1))
@@ -82,7 +82,7 @@ func TestSize_Add_Speed(t *testing.T) {
 func TestSize_Subtract_Speed(t *testing.T) {
 	subtract := testing.Benchmark(benchmarkSizeSubtract)
 	subtractHeight := testing.Benchmark(benchmarkSizeSubtractHeight)
-	subtractWidthAndHeight := testing.Benchmark(benchmarkSizeSubtractWidth)
+	subtractWidthAndHeight := testing.Benchmark(benchmarkSizeSubtractWidthAndHeight)
 	subtractWidth := testing.Benchmark(benchmarkSizeSubtractWidthAndHeight)
 	assert.Less(t, subtract.NsPerOp(), int64(5))
 	assert.Less(t, subtractHeight.NsPerOp(), int64(1))

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -12,54 +12,54 @@ import (
 
 func BenchmarkPosition_Add(b *testing.B) {
 	b.Run("Add()", benchmarkPositionAdd)
-	b.Run("AddXAndY()", benchmarkPositionAddXAndY)
+	b.Run("AddXY()", benchmarkPositionAddXY)
 }
 
 func BenchmarkPosition_Subtract(b *testing.B) {
 	b.Run("Subtract()", benchmarkPositionSubtract)
-	b.Run("SubtractXAndY()", benchmarkPositionSubtractXAndY)
+	b.Run("SubtractXY()", benchmarkPositionSubtractXY)
 }
 
 func BenchmarkSize_Add(b *testing.B) {
 	b.Run("Add()", benchmarkSizeAdd)
-	b.Run("AddWidthAndHeight()", benchmarkSizeAddWidthAndHeight)
+	b.Run("AddWidthHeight()", benchmarkSizeAddWidthHeight)
 }
 
 func BenchmarkSize_Subtract(b *testing.B) {
 	b.Run("Subtract()", benchmarkSizeSubtract)
-	b.Run("SubtractWidthAndHeight()", benchmarkSizeSubtractWidthAndHeight)
+	b.Run("SubtractWidthHeight()", benchmarkSizeSubtractWidthHeight)
 }
 
-// This test prevents Position.Add to be simplified to `return p.AddXAndY(v.Components())`
+// This test prevents Position.Add to be simplified to `return p.AddXY(v.Components())`
 // because this slows down the speed by factor 10.
 func TestPosition_Add_Speed(t *testing.T) {
 	add := testing.Benchmark(benchmarkPositionAdd)
-	addXAndY := testing.Benchmark(benchmarkPositionAddXAndY)
-	assert.Less(t, add.NsPerOp()/addXAndY.NsPerOp(), int64(5))
+	addXY := testing.Benchmark(benchmarkPositionAddXY)
+	assert.Less(t, add.NsPerOp()/addXY.NsPerOp(), int64(5))
 }
 
-// This test prevents Position.Subtract to be simplified to `return p.SubtractXAndY(v.Components())`
+// This test prevents Position.Subtract to be simplified to `return p.SubtractXY(v.Components())`
 // because this slows down the speed by factor 10.
 func TestPosition_Subtract_Speed(t *testing.T) {
 	subtract := testing.Benchmark(benchmarkPositionSubtract)
-	subtractXAndY := testing.Benchmark(benchmarkPositionSubtractXAndY)
-	assert.Less(t, subtract.NsPerOp()/subtractXAndY.NsPerOp(), int64(5))
+	subtractXY := testing.Benchmark(benchmarkPositionSubtractXY)
+	assert.Less(t, subtract.NsPerOp()/subtractXY.NsPerOp(), int64(5))
 }
 
-// This test prevents Size.Add to be simplified to `return s.AddWidthAndHeight(v.Components())`
+// This test prevents Size.Add to be simplified to `return s.AddWidthHeight(v.Components())`
 // because this slows down the speed by factor 10.
 func TestSize_Add_Speed(t *testing.T) {
 	add := testing.Benchmark(benchmarkSizeAdd)
-	addWidthAndHeight := testing.Benchmark(benchmarkSizeAddWidthAndHeight)
-	assert.Less(t, add.NsPerOp()/addWidthAndHeight.NsPerOp(), int64(5))
+	addWidthHeight := testing.Benchmark(benchmarkSizeAddWidthHeight)
+	assert.Less(t, add.NsPerOp()/addWidthHeight.NsPerOp(), int64(5))
 }
 
-// This test prevents Size.Subtract to be simplified to `return s.SubtractWidthAndHeight(v.Components())`
+// This test prevents Size.Subtract to be simplified to `return s.SubtractWidthHeight(v.Components())`
 // because this slows down the speed by factor 10.
 func TestSize_Subtract_Speed(t *testing.T) {
 	subtract := testing.Benchmark(benchmarkSizeSubtract)
-	subtractWidthAndHeight := testing.Benchmark(benchmarkSizeSubtractWidthAndHeight)
-	assert.Less(t, subtract.NsPerOp()/subtractWidthAndHeight.NsPerOp(), int64(5))
+	subtractWidthHeight := testing.Benchmark(benchmarkSizeSubtractWidthHeight)
+	assert.Less(t, subtract.NsPerOp()/subtractWidthHeight.NsPerOp(), int64(5))
 }
 
 var benchmarkResult interface{}
@@ -72,10 +72,10 @@ func benchmarkPositionAdd(b *testing.B) {
 	benchmarkResult = pos
 }
 
-func benchmarkPositionAddXAndY(b *testing.B) {
+func benchmarkPositionAddXY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
-		pos = pos.AddXAndY(float32(n), float32(n))
+		pos = pos.AddXY(float32(n), float32(n))
 	}
 	benchmarkResult = pos
 }
@@ -88,10 +88,10 @@ func benchmarkPositionSubtract(b *testing.B) {
 	benchmarkResult = pos
 }
 
-func benchmarkPositionSubtractXAndY(b *testing.B) {
+func benchmarkPositionSubtractXY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
-		pos = pos.SubtractXAndY(float32(n), float32(n))
+		pos = pos.SubtractXY(float32(n), float32(n))
 	}
 	benchmarkResult = pos
 }
@@ -104,10 +104,10 @@ func benchmarkSizeAdd(b *testing.B) {
 	benchmarkResult = size
 }
 
-func benchmarkSizeAddWidthAndHeight(b *testing.B) {
+func benchmarkSizeAddWidthHeight(b *testing.B) {
 	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
-		size = size.AddWidthAndHeight(float32(n), float32(n))
+		size = size.AddWidthHeight(float32(n), float32(n))
 	}
 	benchmarkResult = size
 }
@@ -120,10 +120,10 @@ func benchmarkSizeSubtract(b *testing.B) {
 	benchmarkResult = size
 }
 
-func benchmarkSizeSubtractWidthAndHeight(b *testing.B) {
+func benchmarkSizeSubtractWidthHeight(b *testing.B) {
 	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
-		size = size.SubtractWidthAndHeight(float32(n), float32(n))
+		size = size.SubtractWidthHeight(float32(n), float32(n))
 	}
 	benchmarkResult = size
 }

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -12,29 +12,21 @@ import (
 
 func BenchmarkPosition_Add(b *testing.B) {
 	b.Run("Add()", benchmarkPositionAdd)
-	b.Run("AddX()", benchmarkPositionAddX)
 	b.Run("AddXAndY()", benchmarkPositionAddXAndY)
-	b.Run("AddY()", benchmarkPositionAddY)
 }
 
 func BenchmarkPosition_Subtract(b *testing.B) {
 	b.Run("Subtract()", benchmarkPositionSubtract)
-	b.Run("SubtractX()", benchmarkPositionSubtractX)
 	b.Run("SubtractXAndY()", benchmarkPositionSubtractXAndY)
-	b.Run("SubtractY()", benchmarkPositionSubtractY)
 }
 
 func BenchmarkSize_Add(b *testing.B) {
 	b.Run("Add()", benchmarkSizeAdd)
-	b.Run("AddHeight()", benchmarkSizeAddHeight)
-	b.Run("AddWidth()", benchmarkSizeAddWidth)
 	b.Run("AddWidthAndHeight()", benchmarkSizeAddWidthAndHeight)
 }
 
 func BenchmarkSize_Subtract(b *testing.B) {
 	b.Run("Subtract()", benchmarkSizeSubtract)
-	b.Run("SubtractHeight()", benchmarkSizeSubtractHeight)
-	b.Run("SubtractWidth()", benchmarkSizeSubtractWidth)
 	b.Run("SubtractWidthAndHeight()", benchmarkSizeSubtractWidthAndHeight)
 }
 
@@ -42,52 +34,36 @@ func BenchmarkSize_Subtract(b *testing.B) {
 // because this slows down the speed by factor 10.
 func TestPosition_Add_Speed(t *testing.T) {
 	add := testing.Benchmark(benchmarkPositionAdd)
-	addX := testing.Benchmark(benchmarkPositionAddX)
 	addXAndY := testing.Benchmark(benchmarkPositionAddXAndY)
-	addY := testing.Benchmark(benchmarkPositionAddY)
 	assert.Less(t, add.NsPerOp(), int64(5))
-	assert.Less(t, addX.NsPerOp(), int64(1))
 	assert.Less(t, addXAndY.NsPerOp(), int64(1))
-	assert.Less(t, addY.NsPerOp(), int64(1))
 }
 
 // This test prevents Position.Subtract to be simplified to `return p.SubtractXAndY(v.Components())`
 // because this slows down the speed by factor 10.
 func TestPosition_Subtract_Speed(t *testing.T) {
 	subtract := testing.Benchmark(benchmarkPositionSubtract)
-	subtractX := testing.Benchmark(benchmarkPositionSubtractX)
 	subtractXAndY := testing.Benchmark(benchmarkPositionSubtractXAndY)
-	subtractY := testing.Benchmark(benchmarkPositionSubtractY)
 	assert.Less(t, subtract.NsPerOp(), int64(5))
-	assert.Less(t, subtractX.NsPerOp(), int64(1))
 	assert.Less(t, subtractXAndY.NsPerOp(), int64(1))
-	assert.Less(t, subtractY.NsPerOp(), int64(1))
 }
 
 // This test prevents Size.Add to be simplified to `return s.AddWidthAndHeight(v.Components())`
 // because this slows down the speed by factor 10.
 func TestSize_Add_Speed(t *testing.T) {
 	add := testing.Benchmark(benchmarkSizeAdd)
-	addHeight := testing.Benchmark(benchmarkSizeAddHeight)
 	addWidthAndHeight := testing.Benchmark(benchmarkSizeAddWidthAndHeight)
-	addWidth := testing.Benchmark(benchmarkSizeAddWidthAndHeight)
 	assert.Less(t, add.NsPerOp(), int64(5))
-	assert.Less(t, addHeight.NsPerOp(), int64(1))
 	assert.Less(t, addWidthAndHeight.NsPerOp(), int64(1))
-	assert.Less(t, addWidth.NsPerOp(), int64(1))
 }
 
 // This test prevents Size.Subtract to be simplified to `return s.SubtractWidthAndHeight(v.Components())`
 // because this slows down the speed by factor 10.
 func TestSize_Subtract_Speed(t *testing.T) {
 	subtract := testing.Benchmark(benchmarkSizeSubtract)
-	subtractHeight := testing.Benchmark(benchmarkSizeSubtractHeight)
 	subtractWidthAndHeight := testing.Benchmark(benchmarkSizeSubtractWidthAndHeight)
-	subtractWidth := testing.Benchmark(benchmarkSizeSubtractWidthAndHeight)
 	assert.Less(t, subtract.NsPerOp(), int64(5))
-	assert.Less(t, subtractHeight.NsPerOp(), int64(1))
 	assert.Less(t, subtractWidthAndHeight.NsPerOp(), int64(1))
-	assert.Less(t, subtractWidth.NsPerOp(), int64(1))
 }
 
 func benchmarkPositionAdd(b *testing.B) {
@@ -98,24 +74,10 @@ func benchmarkPositionAdd(b *testing.B) {
 	}
 }
 
-func benchmarkPositionAddX(b *testing.B) {
-	pos := fyne.NewPos(10, 10)
-	for n := 0; n < b.N; n++ {
-		pos.AddX(25)
-	}
-}
-
 func benchmarkPositionAddXAndY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
 		pos.AddXAndY(25, 25)
-	}
-}
-
-func benchmarkPositionAddY(b *testing.B) {
-	pos := fyne.NewPos(10, 10)
-	for n := 0; n < b.N; n++ {
-		pos.AddY(25)
 	}
 }
 
@@ -127,24 +89,10 @@ func benchmarkPositionSubtract(b *testing.B) {
 	}
 }
 
-func benchmarkPositionSubtractX(b *testing.B) {
-	pos := fyne.NewPos(10, 10)
-	for n := 0; n < b.N; n++ {
-		pos.SubtractX(25)
-	}
-}
-
 func benchmarkPositionSubtractXAndY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
 		pos.SubtractXAndY(25, 25)
-	}
-}
-
-func benchmarkPositionSubtractY(b *testing.B) {
-	pos := fyne.NewPos(10, 10)
-	for n := 0; n < b.N; n++ {
-		pos.SubtractY(25)
 	}
 }
 
@@ -156,24 +104,10 @@ func benchmarkSizeAdd(b *testing.B) {
 	}
 }
 
-func benchmarkSizeAddWidth(b *testing.B) {
-	size := fyne.NewSize(10, 10)
-	for n := 0; n < b.N; n++ {
-		size.AddWidth(25)
-	}
-}
-
 func benchmarkSizeAddWidthAndHeight(b *testing.B) {
 	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
 		size.AddWidthAndHeight(25, 25)
-	}
-}
-
-func benchmarkSizeAddHeight(b *testing.B) {
-	size := fyne.NewSize(10, 10)
-	for n := 0; n < b.N; n++ {
-		size.AddHeight(25)
 	}
 }
 
@@ -185,23 +119,9 @@ func benchmarkSizeSubtract(b *testing.B) {
 	}
 }
 
-func benchmarkSizeSubtractWidth(b *testing.B) {
-	size := fyne.NewSize(10, 10)
-	for n := 0; n < b.N; n++ {
-		size.SubtractWidth(25)
-	}
-}
-
 func benchmarkSizeSubtractWidthAndHeight(b *testing.B) {
 	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
 		size.SubtractWidthAndHeight(25, 25)
-	}
-}
-
-func benchmarkSizeSubtractHeight(b *testing.B) {
-	size := fyne.NewSize(10, 10)
-	for n := 0; n < b.N; n++ {
-		size.SubtractHeight(25)
 	}
 }

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -17,6 +17,13 @@ func BenchmarkPosition_Add(b *testing.B) {
 	b.Run("AddY()", benchmarkPositionAddY)
 }
 
+func BenchmarkSize_Add(b *testing.B) {
+	b.Run("Add()", benchmarkSizeAdd)
+	b.Run("AddHeight()", benchmarkSizeAddHeight)
+	b.Run("AddWidth()", benchmarkSizeAddWidth)
+	b.Run("AddWidthAndHeight()", benchmarkSizeAddWidthAndHeight)
+}
+
 // This test prevents Position.Add to be simplified to `return p.AddXAndY(v.Components())`
 // because this slows down the speed by factor 10.
 func TestPosition_Add_Speed(t *testing.T) {
@@ -28,6 +35,19 @@ func TestPosition_Add_Speed(t *testing.T) {
 	assert.Less(t, addX.NsPerOp(), int64(1))
 	assert.Less(t, addXAndY.NsPerOp(), int64(1))
 	assert.Less(t, addY.NsPerOp(), int64(1))
+}
+
+// This test prevents Size.Add to be simplified to `return s.AddWidthAndHeight(v.Components())`
+// because this slows down the speed by factor 10.
+func TestSize_Add_Speed(t *testing.T) {
+	add := testing.Benchmark(benchmarkSizeAdd)
+	addHeight := testing.Benchmark(benchmarkSizeAddHeight)
+	addWidthAndHeight := testing.Benchmark(benchmarkSizeAddWidth)
+	addWidth := testing.Benchmark(benchmarkSizeAddWidthAndHeight)
+	assert.Less(t, add.NsPerOp(), int64(5))
+	assert.Less(t, addHeight.NsPerOp(), int64(1))
+	assert.Less(t, addWidthAndHeight.NsPerOp(), int64(1))
+	assert.Less(t, addWidth.NsPerOp(), int64(1))
 }
 
 func benchmarkPositionAdd(b *testing.B) {
@@ -56,5 +76,34 @@ func benchmarkPositionAddY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
 		pos.AddY(25)
+	}
+}
+
+func benchmarkSizeAdd(b *testing.B) {
+	size1 := fyne.NewSize(10, 10)
+	size2 := fyne.NewSize(25, 25)
+	for n := 0; n < b.N; n++ {
+		size1.Add(size2)
+	}
+}
+
+func benchmarkSizeAddWidth(b *testing.B) {
+	size := fyne.NewSize(10, 10)
+	for n := 0; n < b.N; n++ {
+		size.AddWidth(25)
+	}
+}
+
+func benchmarkSizeAddWidthAndHeight(b *testing.B) {
+	size := fyne.NewSize(10, 10)
+	for n := 0; n < b.N; n++ {
+		size.AddWidthAndHeight(25, 25)
+	}
+}
+
+func benchmarkSizeAddHeight(b *testing.B) {
+	size := fyne.NewSize(10, 10)
+	for n := 0; n < b.N; n++ {
+		size.AddHeight(25)
 	}
 }

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -1,0 +1,60 @@
+// +build !ci
+
+package fyne_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+)
+
+func BenchmarkPosition_Add(b *testing.B) {
+	b.Run("Add()", benchmarkPositionAdd)
+	b.Run("AddX()", benchmarkPositionAddX)
+	b.Run("AddXAndY()", benchmarkPositionAddXAndY)
+	b.Run("AddY()", benchmarkPositionAddY)
+}
+
+// This test prevents Position.Add to be simplified to `return p.AddXAndY(v.Components())`
+// because this slows down the speed by factor 10.
+func TestPosition_Add_Speed(t *testing.T) {
+	add := testing.Benchmark(benchmarkPositionAdd)
+	addX := testing.Benchmark(benchmarkPositionAddX)
+	addXAndY := testing.Benchmark(benchmarkPositionAddXAndY)
+	addY := testing.Benchmark(benchmarkPositionAddY)
+	assert.Less(t, add.NsPerOp(), int64(5))
+	assert.Less(t, addX.NsPerOp(), int64(1))
+	assert.Less(t, addXAndY.NsPerOp(), int64(1))
+	assert.Less(t, addY.NsPerOp(), int64(1))
+}
+
+func benchmarkPositionAdd(b *testing.B) {
+	pos1 := fyne.NewPos(10, 10)
+	pos2 := fyne.NewPos(25, 25)
+	for n := 0; n < b.N; n++ {
+		pos1.Add(pos2)
+	}
+}
+
+func benchmarkPositionAddX(b *testing.B) {
+	pos := fyne.NewPos(10, 10)
+	for n := 0; n < b.N; n++ {
+		pos.AddX(25)
+	}
+}
+
+func benchmarkPositionAddXAndY(b *testing.B) {
+	pos := fyne.NewPos(10, 10)
+	for n := 0; n < b.N; n++ {
+		pos.AddXAndY(25, 25)
+	}
+}
+
+func benchmarkPositionAddY(b *testing.B) {
+	pos := fyne.NewPos(10, 10)
+	for n := 0; n < b.N; n++ {
+		pos.AddY(25)
+	}
+}

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -31,6 +31,13 @@ func BenchmarkSize_Add(b *testing.B) {
 	b.Run("AddWidthAndHeight()", benchmarkSizeAddWidthAndHeight)
 }
 
+func BenchmarkSize_Subtract(b *testing.B) {
+	b.Run("Subtract()", benchmarkSizeSubtract)
+	b.Run("SubtractHeight()", benchmarkSizeSubtractHeight)
+	b.Run("SubtractWidth()", benchmarkSizeSubtractWidth)
+	b.Run("SubtractWidthAndHeight()", benchmarkSizeSubtractWidthAndHeight)
+}
+
 // This test prevents Position.Add to be simplified to `return p.AddXAndY(v.Components())`
 // because this slows down the speed by factor 10.
 func TestPosition_Add_Speed(t *testing.T) {
@@ -68,6 +75,19 @@ func TestSize_Add_Speed(t *testing.T) {
 	assert.Less(t, addHeight.NsPerOp(), int64(1))
 	assert.Less(t, addWidthAndHeight.NsPerOp(), int64(1))
 	assert.Less(t, addWidth.NsPerOp(), int64(1))
+}
+
+// This test prevents Size.Subtract to be simplified to `return s.SubtractWidthAndHeight(v.Components())`
+// because this slows down the speed by factor 10.
+func TestSize_Subtract_Speed(t *testing.T) {
+	subtract := testing.Benchmark(benchmarkSizeSubtract)
+	subtractHeight := testing.Benchmark(benchmarkSizeSubtractHeight)
+	subtractWidthAndHeight := testing.Benchmark(benchmarkSizeSubtractWidth)
+	subtractWidth := testing.Benchmark(benchmarkSizeSubtractWidthAndHeight)
+	assert.Less(t, subtract.NsPerOp(), int64(5))
+	assert.Less(t, subtractHeight.NsPerOp(), int64(1))
+	assert.Less(t, subtractWidthAndHeight.NsPerOp(), int64(1))
+	assert.Less(t, subtractWidth.NsPerOp(), int64(1))
 }
 
 func benchmarkPositionAdd(b *testing.B) {
@@ -154,5 +174,34 @@ func benchmarkSizeAddHeight(b *testing.B) {
 	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
 		size.AddHeight(25)
+	}
+}
+
+func benchmarkSizeSubtract(b *testing.B) {
+	size1 := fyne.NewSize(10, 10)
+	size2 := fyne.NewSize(25, 25)
+	for n := 0; n < b.N; n++ {
+		size1.Subtract(size2)
+	}
+}
+
+func benchmarkSizeSubtractWidth(b *testing.B) {
+	size := fyne.NewSize(10, 10)
+	for n := 0; n < b.N; n++ {
+		size.SubtractWidth(25)
+	}
+}
+
+func benchmarkSizeSubtractWidthAndHeight(b *testing.B) {
+	size := fyne.NewSize(10, 10)
+	for n := 0; n < b.N; n++ {
+		size.SubtractWidthAndHeight(25, 25)
+	}
+}
+
+func benchmarkSizeSubtractHeight(b *testing.B) {
+	size := fyne.NewSize(10, 10)
+	for n := 0; n < b.N; n++ {
+		size.SubtractHeight(25)
 	}
 }

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -35,8 +35,7 @@ func BenchmarkSize_Subtract(b *testing.B) {
 func TestPosition_Add_Speed(t *testing.T) {
 	add := testing.Benchmark(benchmarkPositionAdd)
 	addXAndY := testing.Benchmark(benchmarkPositionAddXAndY)
-	assert.Less(t, add.NsPerOp(), int64(5))
-	assert.Less(t, addXAndY.NsPerOp(), int64(1))
+	assert.Less(t, add.NsPerOp()/addXAndY.NsPerOp(), int64(5))
 }
 
 // This test prevents Position.Subtract to be simplified to `return p.SubtractXAndY(v.Components())`
@@ -44,8 +43,7 @@ func TestPosition_Add_Speed(t *testing.T) {
 func TestPosition_Subtract_Speed(t *testing.T) {
 	subtract := testing.Benchmark(benchmarkPositionSubtract)
 	subtractXAndY := testing.Benchmark(benchmarkPositionSubtractXAndY)
-	assert.Less(t, subtract.NsPerOp(), int64(5))
-	assert.Less(t, subtractXAndY.NsPerOp(), int64(1))
+	assert.Less(t, subtract.NsPerOp()/subtractXAndY.NsPerOp(), int64(5))
 }
 
 // This test prevents Size.Add to be simplified to `return s.AddWidthAndHeight(v.Components())`
@@ -53,8 +51,7 @@ func TestPosition_Subtract_Speed(t *testing.T) {
 func TestSize_Add_Speed(t *testing.T) {
 	add := testing.Benchmark(benchmarkSizeAdd)
 	addWidthAndHeight := testing.Benchmark(benchmarkSizeAddWidthAndHeight)
-	assert.Less(t, add.NsPerOp(), int64(5))
-	assert.Less(t, addWidthAndHeight.NsPerOp(), int64(1))
+	assert.Less(t, add.NsPerOp()/addWidthAndHeight.NsPerOp(), int64(5))
 }
 
 // This test prevents Size.Subtract to be simplified to `return s.SubtractWidthAndHeight(v.Components())`
@@ -62,66 +59,71 @@ func TestSize_Add_Speed(t *testing.T) {
 func TestSize_Subtract_Speed(t *testing.T) {
 	subtract := testing.Benchmark(benchmarkSizeSubtract)
 	subtractWidthAndHeight := testing.Benchmark(benchmarkSizeSubtractWidthAndHeight)
-	assert.Less(t, subtract.NsPerOp(), int64(5))
-	assert.Less(t, subtractWidthAndHeight.NsPerOp(), int64(1))
+	assert.Less(t, subtract.NsPerOp()/subtractWidthAndHeight.NsPerOp(), int64(5))
 }
 
+var benchmarkResult interface{}
+
 func benchmarkPositionAdd(b *testing.B) {
-	pos1 := fyne.NewPos(10, 10)
-	pos2 := fyne.NewPos(25, 25)
+	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
-		pos1.Add(pos2)
+		pos = pos.Add(fyne.NewPos(float32(n), float32(n)))
 	}
+	benchmarkResult = pos
 }
 
 func benchmarkPositionAddXAndY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
-		pos.AddXAndY(25, 25)
+		pos = pos.AddXAndY(float32(n), float32(n))
 	}
+	benchmarkResult = pos
 }
 
 func benchmarkPositionSubtract(b *testing.B) {
-	pos1 := fyne.NewPos(10, 10)
-	pos2 := fyne.NewPos(25, 25)
+	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
-		pos1.Subtract(pos2)
+		pos = pos.Subtract(fyne.NewPos(float32(n), float32(n)))
 	}
+	benchmarkResult = pos
 }
 
 func benchmarkPositionSubtractXAndY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
-		pos.SubtractXAndY(25, 25)
+		pos = pos.SubtractXAndY(float32(n), float32(n))
 	}
+	benchmarkResult = pos
 }
 
 func benchmarkSizeAdd(b *testing.B) {
-	size1 := fyne.NewSize(10, 10)
-	size2 := fyne.NewSize(25, 25)
+	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
-		size1.Add(size2)
+		size = size.Add(fyne.NewPos(float32(n), float32(n)))
 	}
+	benchmarkResult = size
 }
 
 func benchmarkSizeAddWidthAndHeight(b *testing.B) {
 	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
-		size.AddWidthAndHeight(25, 25)
+		size = size.AddWidthAndHeight(float32(n), float32(n))
 	}
+	benchmarkResult = size
 }
 
 func benchmarkSizeSubtract(b *testing.B) {
-	size1 := fyne.NewSize(10, 10)
-	size2 := fyne.NewSize(25, 25)
+	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
-		size1.Subtract(size2)
+		size = size.Subtract(fyne.NewSize(float32(n), float32(n)))
 	}
+	benchmarkResult = size
 }
 
 func benchmarkSizeSubtractWidthAndHeight(b *testing.B) {
 	size := fyne.NewSize(10, 10)
 	for n := 0; n < b.N; n++ {
-		size.SubtractWidthAndHeight(25, 25)
+		size = size.SubtractWidthAndHeight(float32(n), float32(n))
 	}
+	benchmarkResult = size
 }

--- a/geometry_benchmark_test.go
+++ b/geometry_benchmark_test.go
@@ -17,6 +17,13 @@ func BenchmarkPosition_Add(b *testing.B) {
 	b.Run("AddY()", benchmarkPositionAddY)
 }
 
+func BenchmarkPosition_Subtract(b *testing.B) {
+	b.Run("Subtract()", benchmarkPositionSubtract)
+	b.Run("SubtractX()", benchmarkPositionSubtractX)
+	b.Run("SubtractXAndY()", benchmarkPositionSubtractXAndY)
+	b.Run("SubtractY()", benchmarkPositionSubtractY)
+}
+
 func BenchmarkSize_Add(b *testing.B) {
 	b.Run("Add()", benchmarkSizeAdd)
 	b.Run("AddHeight()", benchmarkSizeAddHeight)
@@ -35,6 +42,19 @@ func TestPosition_Add_Speed(t *testing.T) {
 	assert.Less(t, addX.NsPerOp(), int64(1))
 	assert.Less(t, addXAndY.NsPerOp(), int64(1))
 	assert.Less(t, addY.NsPerOp(), int64(1))
+}
+
+// This test prevents Position.Subtract to be simplified to `return p.SubtractXAndY(v.Components())`
+// because this slows down the speed by factor 10.
+func TestPosition_Subtract_Speed(t *testing.T) {
+	subtract := testing.Benchmark(benchmarkPositionSubtract)
+	subtractX := testing.Benchmark(benchmarkPositionSubtractX)
+	subtractXAndY := testing.Benchmark(benchmarkPositionSubtractXAndY)
+	subtractY := testing.Benchmark(benchmarkPositionSubtractY)
+	assert.Less(t, subtract.NsPerOp(), int64(5))
+	assert.Less(t, subtractX.NsPerOp(), int64(1))
+	assert.Less(t, subtractXAndY.NsPerOp(), int64(1))
+	assert.Less(t, subtractY.NsPerOp(), int64(1))
 }
 
 // This test prevents Size.Add to be simplified to `return s.AddWidthAndHeight(v.Components())`
@@ -76,6 +96,35 @@ func benchmarkPositionAddY(b *testing.B) {
 	pos := fyne.NewPos(10, 10)
 	for n := 0; n < b.N; n++ {
 		pos.AddY(25)
+	}
+}
+
+func benchmarkPositionSubtract(b *testing.B) {
+	pos1 := fyne.NewPos(10, 10)
+	pos2 := fyne.NewPos(25, 25)
+	for n := 0; n < b.N; n++ {
+		pos1.Subtract(pos2)
+	}
+}
+
+func benchmarkPositionSubtractX(b *testing.B) {
+	pos := fyne.NewPos(10, 10)
+	for n := 0; n < b.N; n++ {
+		pos.SubtractX(25)
+	}
+}
+
+func benchmarkPositionSubtractXAndY(b *testing.B) {
+	pos := fyne.NewPos(10, 10)
+	for n := 0; n < b.N; n++ {
+		pos.SubtractXAndY(25, 25)
+	}
+}
+
+func benchmarkPositionSubtractY(b *testing.B) {
+	pos := fyne.NewPos(10, 10)
+	for n := 0; n < b.N; n++ {
+		pos.SubtractY(25)
 	}
 }
 

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -222,6 +222,33 @@ func TestSize_Subtract(t *testing.T) {
 	assert.Equal(t, float32(15), size3.Height)
 }
 
+func TestSize_SubtractHeight(t *testing.T) {
+	size1 := fyne.NewSize(25, 25)
+
+	size2 := size1.SubtractHeight(10)
+
+	assert.Equal(t, float32(25), size2.Width)
+	assert.Equal(t, float32(15), size2.Height)
+}
+
+func TestSize_SubtractWidth(t *testing.T) {
+	size1 := fyne.NewSize(25, 25)
+
+	size2 := size1.SubtractWidth(10)
+
+	assert.Equal(t, float32(15), size2.Width)
+	assert.Equal(t, float32(25), size2.Height)
+}
+
+func TestSize_SubtractWidthAndHeight(t *testing.T) {
+	size1 := fyne.NewSize(25, 25)
+
+	size2 := size1.SubtractWidthAndHeight(10, 10)
+
+	assert.Equal(t, float32(15), size2.Width)
+	assert.Equal(t, float32(15), size2.Height)
+}
+
 func TestVector_IsZero(t *testing.T) {
 	v := fyne.NewDelta(0, 0)
 

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -37,30 +37,12 @@ func TestPosition_Add_Vector(t *testing.T) {
 	assert.Equal(t, float32(35), pos2.Y)
 }
 
-func TestPosition_AddX(t *testing.T) {
-	pos1 := fyne.NewPos(10, 10)
-
-	pos2 := pos1.AddX(25)
-
-	assert.Equal(t, float32(35), pos2.X)
-	assert.Equal(t, float32(10), pos2.Y)
-}
-
 func TestPosition_AddXAndY(t *testing.T) {
 	pos1 := fyne.NewPos(10, 10)
 
 	pos2 := pos1.AddXAndY(25, 25)
 
 	assert.Equal(t, float32(35), pos2.X)
-	assert.Equal(t, float32(35), pos2.Y)
-}
-
-func TestPosition_AddY(t *testing.T) {
-	pos1 := fyne.NewPos(10, 10)
-
-	pos2 := pos1.AddY(25)
-
-	assert.Equal(t, float32(10), pos2.X)
 	assert.Equal(t, float32(35), pos2.Y)
 }
 
@@ -91,30 +73,12 @@ func TestPosition_Subtract(t *testing.T) {
 	assert.Equal(t, float32(15), pos3.Y)
 }
 
-func TestPosition_SubtractX(t *testing.T) {
-	pos1 := fyne.NewPos(25, 25)
-
-	pos2 := pos1.SubtractX(10)
-
-	assert.Equal(t, float32(15), pos2.X)
-	assert.Equal(t, float32(25), pos2.Y)
-}
-
 func TestPosition_SubtractXAndY(t *testing.T) {
 	pos1 := fyne.NewPos(25, 25)
 
 	pos2 := pos1.SubtractXAndY(10, 10)
 
 	assert.Equal(t, float32(15), pos2.X)
-	assert.Equal(t, float32(15), pos2.Y)
-}
-
-func TestPosition_SubtractY(t *testing.T) {
-	pos1 := fyne.NewPos(25, 25)
-
-	pos2 := pos1.SubtractY(10)
-
-	assert.Equal(t, float32(25), pos2.X)
 	assert.Equal(t, float32(15), pos2.Y)
 }
 
@@ -146,24 +110,6 @@ func TestSize_Add_Vector(t *testing.T) {
 
 	assert.Equal(t, float32(35), size2.Width)
 	assert.Equal(t, float32(35), size2.Height)
-}
-
-func TestSize_AddHeight(t *testing.T) {
-	size1 := fyne.NewSize(10, 10)
-
-	size2 := size1.AddHeight(25)
-
-	assert.Equal(t, float32(10), size2.Width)
-	assert.Equal(t, float32(35), size2.Height)
-}
-
-func TestSize_AddWidth(t *testing.T) {
-	size1 := fyne.NewSize(10, 10)
-
-	size2 := size1.AddWidth(25)
-
-	assert.Equal(t, float32(35), size2.Width)
-	assert.Equal(t, float32(10), size2.Height)
 }
 
 func TestSize_AddWidthAndHeight(t *testing.T) {
@@ -220,24 +166,6 @@ func TestSize_Subtract(t *testing.T) {
 
 	assert.Equal(t, float32(15), size3.Width)
 	assert.Equal(t, float32(15), size3.Height)
-}
-
-func TestSize_SubtractHeight(t *testing.T) {
-	size1 := fyne.NewSize(25, 25)
-
-	size2 := size1.SubtractHeight(10)
-
-	assert.Equal(t, float32(25), size2.Width)
-	assert.Equal(t, float32(15), size2.Height)
-}
-
-func TestSize_SubtractWidth(t *testing.T) {
-	size1 := fyne.NewSize(25, 25)
-
-	size2 := size1.SubtractWidth(10)
-
-	assert.Equal(t, float32(15), size2.Width)
-	assert.Equal(t, float32(25), size2.Height)
 }
 
 func TestSize_SubtractWidthAndHeight(t *testing.T) {

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -37,6 +37,33 @@ func TestPosition_Add_Vector(t *testing.T) {
 	assert.Equal(t, float32(35), pos2.Y)
 }
 
+func TestPosition_AddX(t *testing.T) {
+	pos1 := fyne.NewPos(10, 10)
+
+	pos2 := pos1.AddX(25)
+
+	assert.Equal(t, float32(35), pos2.X)
+	assert.Equal(t, float32(10), pos2.Y)
+}
+
+func TestPosition_AddXAndY(t *testing.T) {
+	pos1 := fyne.NewPos(10, 10)
+
+	pos2 := pos1.AddXAndY(25, 25)
+
+	assert.Equal(t, float32(35), pos2.X)
+	assert.Equal(t, float32(35), pos2.Y)
+}
+
+func TestPosition_AddY(t *testing.T) {
+	pos1 := fyne.NewPos(10, 10)
+
+	pos2 := pos1.AddY(25)
+
+	assert.Equal(t, float32(10), pos2.X)
+	assert.Equal(t, float32(35), pos2.Y)
+}
+
 func TestPosition_IsZero(t *testing.T) {
 	for name, tt := range map[string]struct {
 		p    fyne.Position

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -121,6 +121,33 @@ func TestSize_Add_Vector(t *testing.T) {
 	assert.Equal(t, float32(35), size2.Height)
 }
 
+func TestSize_AddHeight(t *testing.T) {
+	size1 := fyne.NewSize(10, 10)
+
+	size2 := size1.AddHeight(25)
+
+	assert.Equal(t, float32(10), size2.Width)
+	assert.Equal(t, float32(35), size2.Height)
+}
+
+func TestSize_AddWidth(t *testing.T) {
+	size1 := fyne.NewSize(10, 10)
+
+	size2 := size1.AddWidth(25)
+
+	assert.Equal(t, float32(35), size2.Width)
+	assert.Equal(t, float32(10), size2.Height)
+}
+
+func TestSize_AddWidthAndHeight(t *testing.T) {
+	size1 := fyne.NewSize(10, 10)
+
+	size2 := size1.AddWidthAndHeight(25, 25)
+
+	assert.Equal(t, float32(35), size2.Width)
+	assert.Equal(t, float32(35), size2.Height)
+}
+
 func TestSize_IsZero(t *testing.T) {
 	for name, tt := range map[string]struct {
 		s    fyne.Size

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -37,10 +37,10 @@ func TestPosition_Add_Vector(t *testing.T) {
 	assert.Equal(t, float32(35), pos2.Y)
 }
 
-func TestPosition_AddXAndY(t *testing.T) {
+func TestPosition_AddXY(t *testing.T) {
 	pos1 := fyne.NewPos(10, 10)
 
-	pos2 := pos1.AddXAndY(25, 25)
+	pos2 := pos1.AddXY(25, 25)
 
 	assert.Equal(t, float32(35), pos2.X)
 	assert.Equal(t, float32(35), pos2.Y)
@@ -73,10 +73,10 @@ func TestPosition_Subtract(t *testing.T) {
 	assert.Equal(t, float32(15), pos3.Y)
 }
 
-func TestPosition_SubtractXAndY(t *testing.T) {
+func TestPosition_SubtractXY(t *testing.T) {
 	pos1 := fyne.NewPos(25, 25)
 
-	pos2 := pos1.SubtractXAndY(10, 10)
+	pos2 := pos1.SubtractXY(10, 10)
 
 	assert.Equal(t, float32(15), pos2.X)
 	assert.Equal(t, float32(15), pos2.Y)
@@ -112,10 +112,10 @@ func TestSize_Add_Vector(t *testing.T) {
 	assert.Equal(t, float32(35), size2.Height)
 }
 
-func TestSize_AddWidthAndHeight(t *testing.T) {
+func TestSize_AddWidthHeight(t *testing.T) {
 	size1 := fyne.NewSize(10, 10)
 
-	size2 := size1.AddWidthAndHeight(25, 25)
+	size2 := size1.AddWidthHeight(25, 25)
 
 	assert.Equal(t, float32(35), size2.Width)
 	assert.Equal(t, float32(35), size2.Height)
@@ -168,10 +168,10 @@ func TestSize_Subtract(t *testing.T) {
 	assert.Equal(t, float32(15), size3.Height)
 }
 
-func TestSize_SubtractWidthAndHeight(t *testing.T) {
+func TestSize_SubtractWidthHeight(t *testing.T) {
 	size1 := fyne.NewSize(25, 25)
 
-	size2 := size1.SubtractWidthAndHeight(10, 10)
+	size2 := size1.SubtractWidthHeight(10, 10)
 
 	assert.Equal(t, float32(15), size2.Width)
 	assert.Equal(t, float32(15), size2.Height)

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -91,6 +91,33 @@ func TestPosition_Subtract(t *testing.T) {
 	assert.Equal(t, float32(15), pos3.Y)
 }
 
+func TestPosition_SubtractX(t *testing.T) {
+	pos1 := fyne.NewPos(25, 25)
+
+	pos2 := pos1.SubtractX(10)
+
+	assert.Equal(t, float32(15), pos2.X)
+	assert.Equal(t, float32(25), pos2.Y)
+}
+
+func TestPosition_SubtractXAndY(t *testing.T) {
+	pos1 := fyne.NewPos(25, 25)
+
+	pos2 := pos1.SubtractXAndY(10, 10)
+
+	assert.Equal(t, float32(15), pos2.X)
+	assert.Equal(t, float32(15), pos2.Y)
+}
+
+func TestPosition_SubtractY(t *testing.T) {
+	pos1 := fyne.NewPos(25, 25)
+
+	pos2 := pos1.SubtractY(10)
+
+	assert.Equal(t, float32(25), pos2.X)
+	assert.Equal(t, float32(15), pos2.Y)
+}
+
 func TestSize_Add(t *testing.T) {
 	size1 := fyne.NewSize(10, 10)
 	size2 := fyne.NewSize(25, 25)

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -1,14 +1,15 @@
-package fyne
+package fyne_test
 
 import (
 	"testing"
 
+	"fyne.io/fyne/v2"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPosition_Add(t *testing.T) {
-	pos1 := NewPos(10, 10)
-	pos2 := NewPos(25, 25)
+	pos1 := fyne.NewPos(10, 10)
+	pos2 := fyne.NewPos(25, 25)
 
 	pos3 := pos1.Add(pos2)
 
@@ -17,8 +18,8 @@ func TestPosition_Add(t *testing.T) {
 }
 
 func TestPosition_Add_Size(t *testing.T) {
-	pos1 := NewPos(10, 10)
-	s := NewSize(25, 25)
+	pos1 := fyne.NewPos(10, 10)
+	s := fyne.NewSize(25, 25)
 
 	pos2 := pos1.Add(s)
 
@@ -27,8 +28,8 @@ func TestPosition_Add_Size(t *testing.T) {
 }
 
 func TestPosition_Add_Vector(t *testing.T) {
-	pos1 := NewPos(10, 10)
-	v := NewDelta(25, 25)
+	pos1 := fyne.NewPos(10, 10)
+	v := fyne.NewDelta(25, 25)
 
 	pos2 := pos1.Add(v)
 
@@ -38,14 +39,14 @@ func TestPosition_Add_Vector(t *testing.T) {
 
 func TestPosition_IsZero(t *testing.T) {
 	for name, tt := range map[string]struct {
-		p    Position
+		p    fyne.Position
 		want bool
 	}{
-		"zero value":       {Position{}, true},
-		"0,0":              {NewPos(0, 0), true},
-		"zero X":           {NewPos(0, 42), false},
-		"zero Y":           {NewPos(17, 0), false},
-		"non-zero X and Y": {NewPos(6, 9), false},
+		"zero value":       {fyne.Position{}, true},
+		"0,0":              {fyne.NewPos(0, 0), true},
+		"zero X":           {fyne.NewPos(0, 42), false},
+		"zero Y":           {fyne.NewPos(17, 0), false},
+		"non-zero X and Y": {fyne.NewPos(6, 9), false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.p.IsZero())
@@ -54,8 +55,8 @@ func TestPosition_IsZero(t *testing.T) {
 }
 
 func TestPosition_Subtract(t *testing.T) {
-	pos1 := NewPos(25, 25)
-	pos2 := NewPos(10, 10)
+	pos1 := fyne.NewPos(25, 25)
+	pos2 := fyne.NewPos(10, 10)
 
 	pos3 := pos1.Subtract(pos2)
 
@@ -64,8 +65,8 @@ func TestPosition_Subtract(t *testing.T) {
 }
 
 func TestSize_Add(t *testing.T) {
-	size1 := NewSize(10, 10)
-	size2 := NewSize(25, 25)
+	size1 := fyne.NewSize(10, 10)
+	size2 := fyne.NewSize(25, 25)
 
 	size3 := size1.Add(size2)
 
@@ -74,8 +75,8 @@ func TestSize_Add(t *testing.T) {
 }
 
 func TestSize_Add_Position(t *testing.T) {
-	size1 := NewSize(10, 10)
-	p := NewSize(25, 25)
+	size1 := fyne.NewSize(10, 10)
+	p := fyne.NewSize(25, 25)
 
 	size2 := size1.Add(p)
 
@@ -84,8 +85,8 @@ func TestSize_Add_Position(t *testing.T) {
 }
 
 func TestSize_Add_Vector(t *testing.T) {
-	size1 := NewSize(10, 10)
-	v := NewDelta(25, 25)
+	size1 := fyne.NewSize(10, 10)
+	v := fyne.NewDelta(25, 25)
 
 	size2 := size1.Add(v)
 
@@ -95,14 +96,14 @@ func TestSize_Add_Vector(t *testing.T) {
 
 func TestSize_IsZero(t *testing.T) {
 	for name, tt := range map[string]struct {
-		s    Size
+		s    fyne.Size
 		want bool
 	}{
-		"zero value":    {Size{}, true},
-		"0x0":           {NewSize(0, 0), true},
-		"zero width":    {NewSize(0, 42), false},
-		"zero height":   {NewSize(17, 0), false},
-		"non-zero area": {NewSize(6, 9), false},
+		"zero value":    {fyne.Size{}, true},
+		"0x0":           {fyne.NewSize(0, 0), true},
+		"zero width":    {fyne.NewSize(0, 42), false},
+		"zero height":   {fyne.NewSize(17, 0), false},
+		"non-zero area": {fyne.NewSize(6, 9), false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.s.IsZero())
@@ -111,8 +112,8 @@ func TestSize_IsZero(t *testing.T) {
 }
 
 func TestSize_Max(t *testing.T) {
-	size1 := NewSize(10, 100)
-	size2 := NewSize(100, 10)
+	size1 := fyne.NewSize(10, 100)
+	size2 := fyne.NewSize(100, 10)
 
 	size3 := size1.Max(size2)
 
@@ -121,8 +122,8 @@ func TestSize_Max(t *testing.T) {
 }
 
 func TestSize_Min(t *testing.T) {
-	size1 := NewSize(10, 100)
-	size2 := NewSize(100, 10)
+	size1 := fyne.NewSize(10, 100)
+	size2 := fyne.NewSize(100, 10)
 
 	size3 := size1.Min(size2)
 
@@ -131,8 +132,8 @@ func TestSize_Min(t *testing.T) {
 }
 
 func TestSize_Subtract(t *testing.T) {
-	size1 := NewSize(25, 25)
-	size2 := NewSize(10, 10)
+	size1 := fyne.NewSize(25, 25)
+	size2 := fyne.NewSize(10, 10)
 
 	size3 := size1.Subtract(size2)
 
@@ -141,7 +142,7 @@ func TestSize_Subtract(t *testing.T) {
 }
 
 func TestVector_IsZero(t *testing.T) {
-	v := NewDelta(0, 0)
+	v := fyne.NewDelta(0, 0)
 
 	assert.True(t, v.IsZero())
 


### PR DESCRIPTION
### Description:

This PR introduces new `Add*` helpers to `fyne.Size` and `fyne.Position`.
With these helpers it is no longer necessary to create new  temporary vectors (`Size`, `Position`) just to add to an existing one. The benchmarks only cover the runtime of the methods themselves and do not consider the allocation time for the temporary vectors. The numbers would be even worse for the old approach then :).

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
