### PR TITLE
Windows mobile simulator

### DIFF
--- a/internal/driver/mobile/gl/dll_windows.go
+++ b/internal/driver/mobile/gl/dll_windows.go
@@ -203,31 +203,43 @@ func findDLLs() (err error) {
 		return false, nil
 	}
 
+	var savedError error = nil
+
 	// Look in the system directory.
-	if ok, err := load(""); ok || err != nil {
-		return err
+	if ok, err := load(""); ok {
+		return nil
+	} else {
+		savedError = fmt.Errorf("System load error: %v.\n\r", err)
 	}
 
 	// Look in the AppData directory.
-	if ok, err := load(appdataPath()); ok || err != nil {
-		return err
+	if ok, err := load(appdataPath()); ok {
+		return nil
+	} else {
+		savedError = fmt.Errorf("%vAppData load error: %v.\n\r", savedError, err)
 	}
 
 	// Look for a Chrome installation
 	if dir := chromePath(); dir != "" {
-		if ok, err := load(dir); ok || err != nil {
-			return err
+		if ok, err := load(dir); ok {
+			return nil
+		} else {
+			savedError = fmt.Errorf("%vChrome load error: %v.\n\r", savedError, err)
 		}
 	}
 
 	// Look in GOPATH/pkg.
-	if ok, err := load(filepath.Join(os.Getenv("GOPATH"), "pkg")); ok || err != nil {
-		return err
+	if ok, err := load(filepath.Join(os.Getenv("GOPATH"), "pkg")); ok {
+		return nil
+	} else {
+		savedError = fmt.Errorf("%vGOPATH load error: %v.\n\r", savedError, err)
 	}
 
 	// Look in temporary directory.
-	if ok, err := load(os.TempDir()); ok || err != nil {
-		return err
+	if ok, err := load(os.TempDir()); ok {
+		return nil
+	} else {
+		savedError = fmt.Errorf("%vTemp directory load error: %v.\n\r", savedError, err)
 	}
 
 	// Download the DLL binary.
@@ -237,7 +249,9 @@ func findDLLs() (err error) {
 	}
 	debug.Printf("DLLs written to %s", path)
 	if ok, err := load(path); !ok || err != nil {
-		return fmt.Errorf("gl: unable to load ANGLE after installation: %v", err)
+		savedError = fmt.Errorf("%vDLL Binary download (ANGLE) load error: %v", savedError, err)
+	} else if ok {
+		return nil
 	}
-	return nil
+	return savedError
 }


### PR DESCRIPTION
### Description:
Currently under windows depending on the location of DLLS the mobile simulator will cause a 'panic' to occur due to not being able to find (or download) the respective DLLS. Currently caused because if there is an error at any of the steps it short circuits and stops looking. Now the load DLL code will try every option and only if none of them worked will throw a combined error reflecting that.

Fixes #2454

### Checklist:
- [ ] Tests included. (There doesn't seem to be tests for this type of thing)
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

#### Where applicable:
Non applicable for change.
