### PR TITLE
Update go-gl/glfw for OpenBSD support and FreeBSD fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fredbi/uri v0.0.0-20181227131451-3dcfdacbaaf3
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-gl/gl v0.0.0-20210813123233-e4099ee2221f
-	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210410170116-ea3d685f79fb
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211024062804-40e447a793be
 	github.com/go-ole/go-ole v1.2.5
 	github.com/godbus/dbus/v5 v5.0.4
 	github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-gl/gl v0.0.0-20210813123233-e4099ee2221f h1:s0O46d8fPwk9kU4k1jj76wBquMVETx7uveQD9MCIQoU=
 github.com/go-gl/gl v0.0.0-20210813123233-e4099ee2221f/go.mod h1:wjpnOv6ONl2SuJSxqCPVaPZibGFdSci9HFocT9qtVYM=
-github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210410170116-ea3d685f79fb h1:T6gaWBvRzJjuOrdCtg8fXXjKai2xSDqWTcKFUPuw8Tw=
-github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210410170116-ea3d685f79fb/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211024062804-40e447a793be h1:Z28GdQBfKOL8tNHjvaDn3wHDO7AzTRkmAXvHvnopp98=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211024062804-40e447a793be/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-ole/go-ole v1.2.5 h1:t4MGB5xEDZvXI+0rMjjsfBsD7yAgp/s9ZDkL1JndXwY=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/GLFW_C_REVISION.txt
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/GLFW_C_REVISION.txt
@@ -1,1 +1,1 @@
-746cdea490a70dd6747272a171b19e5ec1fb9900
+b3e0aae393ef6c5cda7dcad0cba06bef23a1dda9

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/build.go
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/build.go
@@ -38,16 +38,16 @@ package glfw
 #cgo linux,!wayland LDFLAGS: -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama -ldl -lrt
 #cgo linux,wayland LDFLAGS: -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon -lm -ldl -lrt
 
-// FreeBSD Build Tags
+// BSD Build Tags
 // ----------------
 // GLFW Options:
-#cgo freebsd pkg-config: glfw3
-#cgo freebsd CFLAGS: -D_GLFW_HAS_DLOPEN
-#cgo freebsd,!wayland CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
+#cgo freebsd,!wayland openbsd pkg-config: x11 xau xcb xdmcp
+#cgo freebsd,wayland pkg-config: wayland-client wayland-cursor wayland-egl epoll-shim
+#cgo freebsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
+#cgo freebsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
 
 // Linker Options:
-#cgo freebsd,!wayland LDFLAGS: -lm -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lXinerama
-#cgo freebsd,wayland LDFLAGS: -lm -lGL -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
+#cgo freebsd openbsd LDFLAGS: -lm
 */
 import "C"

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/c_glfw_bsd.go
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/c_glfw_bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd
+// +build freebsd openbsd
 
 package glfw
 

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw.go
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw.go
@@ -34,7 +34,14 @@ const (
 // This function may only be called from the main thread.
 func Init() error {
 	C.glfwInit()
-	return acceptError(APIUnavailable)
+	// invalidValue can happen when specific joysticks are used. This issue
+	// will be fixed in GLFW 3.3.5. As a temporary fix, ignore this error.
+	// See go-gl/glfw#292, go-gl/glfw#324, and glfw/glfw#1763.
+	err := acceptError(APIUnavailable, invalidValue)
+	if e, ok := err.(*Error); ok && e.Code == invalidValue {
+		return nil
+	}
+	return err
 }
 
 // Terminate destroys all remaining windows, frees any allocated resources and

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw/include/GLFW/glfw3.h
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw/include/GLFW/glfw3.h
@@ -295,7 +295,7 @@ extern "C" {
  *  API changes.
  *  @ingroup init
  */
-#define GLFW_VERSION_REVISION       3
+#define GLFW_VERSION_REVISION       4
 /*! @} */
 
 /*! @brief One.

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw/src/win32_init.c
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw/src/win32_init.c
@@ -39,6 +39,10 @@ static const GUID _glfw_GUID_DEVINTERFACE_HID =
 
 #if defined(_GLFW_USE_HYBRID_HPG) || defined(_GLFW_USE_OPTIMUS_HPG)
 
+#if defined(_GLFW_BUILD_DLL)
+ #warning "These symbols must be exported by the executable and have no effect in a DLL"
+#endif
+
 // Executables (but not DLLs) exporting this symbol with this value will be
 // automatically directed to the high-performance GPU on Nvidia Optimus systems
 // with up-to-date drivers

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw/src/x11_window.c
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw/src/x11_window.c
@@ -2500,7 +2500,11 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
     }
 
     if (window->monitor)
+    {
+        _glfwPlatformSetWindowDecorated(window, window->decorated);
+        _glfwPlatformSetWindowFloating(window, window->floating);
         releaseMonitor(window);
+    }
 
     _glfwInputWindowMonitor(window, monitor);
     updateNormalHints(window, width, height);

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw_tree_rebuild.go
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/glfw_tree_rebuild.go
@@ -7,4 +7,4 @@ package glfw
 // generate` on this package. This exists to invalidate the build cache (see
 // https://github.com/go-gl/glfw/issues/269), which is unaffected by C source
 // inputs.
-const upstreamTreeSHA = "35599f5c137b48f8395629e686000729426bf966"
+const upstreamTreeSHA = "0d55f6838e16265b6ed4a10bec69d1f07e57ae39"

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/native_linbsd.go
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/native_linbsd.go
@@ -1,4 +1,4 @@
-// +build linux,!wayland freebsd,!wayland
+// +build linux,!wayland freebsd,!wayland openbsd
 
 package glfw
 

--- a/vendor/github.com/go-gl/glfw/v3.3/glfw/window.go
+++ b/vendor/github.com/go-gl/glfw/v3.3/glfw/window.go
@@ -936,6 +936,21 @@ func (w *Window) GetClipboardString() string {
 	return C.GoString(cs)
 }
 
+// panicErrorExceptForInvalidValue is the same as panicError but ignores
+// invalidValue.
+func panicErrorExceptForInvalidValue() {
+	// invalidValue can happen when specific joysticks are used. This issue
+	// will be fixed in GLFW 3.3.5. As a temporary fix, ignore this error.
+	// See go-gl/glfw#292, go-gl/glfw#324, and glfw/glfw#1763.
+	err := acceptError(invalidValue)
+	if e, ok := err.(*Error); ok && e.Code == invalidValue {
+		return
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+
 // PollEvents processes only those events that have already been received and
 // then returns immediately. Processing events will cause the window and input
 // callbacks associated with those events to be called.
@@ -947,7 +962,7 @@ func (w *Window) GetClipboardString() string {
 // This function may only be called from the main thread.
 func PollEvents() {
 	C.glfwPollEvents()
-	panicError()
+	panicErrorExceptForInvalidValue()
 }
 
 // WaitEvents puts the calling thread to sleep until at least one event has been
@@ -965,7 +980,7 @@ func PollEvents() {
 // This function may only be called from the main thread.
 func WaitEvents() {
 	C.glfwWaitEvents()
-	panicError()
+	panicErrorExceptForInvalidValue()
 }
 
 // WaitEventsTimeout puts the calling thread to sleep until at least one event is available in the
@@ -992,7 +1007,7 @@ func WaitEvents() {
 // Event processing is not required for joystick input to work.
 func WaitEventsTimeout(timeout float64) {
 	C.glfwWaitEventsTimeout(C.double(timeout))
-	panicError()
+	panicErrorExceptForInvalidValue()
 }
 
 // PostEmptyEvent posts an empty event from the current thread to the main

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -26,7 +26,7 @@ github.com/go-gl/gl/v3.1/gles2
 github.com/go-gl/gl/v3.1/gles2/KHR
 github.com/go-gl/gl/v3.2-core/gl
 github.com/go-gl/gl/v3.2-core/gl/KHR
-# github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210410170116-ea3d685f79fb
+# github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211024062804-40e447a793be
 ## explicit
 github.com/go-gl/glfw/v3.3/glfw
 github.com/go-gl/glfw/v3.3/glfw/glfw/deps


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This update adds support for building on OpenBSD, a fix to avoid using dynamically linked glfw on FreeBSD and updates glfw to 3.3.4 (contains just a fullscreen fix on X11).
Fixes #1928

Just opening as draft for now. Need to get docs on developer.fyne.io updated and I'm also currently having massive issues getting FreeBSD and OpenBSD running (many issues with using Gnome Boxes, trying out on hardware at the moment).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [-] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [-] Public APIs match existing style.
- [-] Any breaking changes have a deprecation path or have been discussed.
- [x] Updated the vendor folder (using `go mod vendor`).
