### PR TITLE
Add setters to dialogs

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -22,11 +22,11 @@ const (
 type Dialog interface {
 	Show()
 	Hide()
-	SetDismissText(label string)
-	SetOnClosed(closed func())
+	SetDismissText(string)
+	SetOnClosed(func())
 	SetTitle(string)
 	Refresh()
-	Resize(size fyne.Size)
+	Resize(fyne.Size)
 
 	// Since: 2.1
 	MinSize() fyne.Size
@@ -152,6 +152,7 @@ func (d *dialog) SetOnClosed(closed func()) {
 	}
 }
 
+// SetTitle allows developers to set a new title for this dialog.
 func (d *dialog) SetTitle(title string) {
 	d.title = title
 	d.label.SetText(title)

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -24,6 +24,7 @@ type Dialog interface {
 	Hide()
 	SetDismissText(label string)
 	SetOnClosed(closed func())
+	SetTitle(string)
 	Refresh()
 	Resize(size fyne.Size)
 
@@ -40,12 +41,13 @@ type dialog struct {
 	icon        fyne.Resource
 	desiredSize fyne.Size
 
-	win            *widget.PopUp
-	bg             *themedBackground
-	content, label fyne.CanvasObject
-	dismiss        *widget.Button
-	parent         fyne.Window
-	layout         *dialogLayout
+	win     *widget.PopUp
+	bg      *themedBackground
+	content fyne.CanvasObject
+	dismiss *widget.Button
+	label   *widget.Label
+	parent  fyne.Window
+	layout  *dialogLayout
 }
 
 // NewCustom creates and returns a dialog over the specified application using custom
@@ -148,6 +150,11 @@ func (d *dialog) SetOnClosed(closed func()) {
 			originalCallback(response)
 		}
 	}
+}
+
+func (d *dialog) SetTitle(title string) {
+	d.title = title
+	d.label.SetText(title)
 }
 
 func (d *dialog) hideWithResponse(resp bool) {

--- a/dialog/base_test.go
+++ b/dialog/base_test.go
@@ -49,6 +49,20 @@ func TestShowCustom_Resize(t *testing.T) {
 	assert.Equal(t, size, d.(*dialog).win.Content.Size().Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
 }
 
+func TestShowCustom_SetTitle(t *testing.T) {
+	w := test.NewWindow(canvas.NewRectangle(color.Transparent))
+	w.Resize(fyne.NewSize(300, 300))
+
+	label := widget.NewLabel("Content")
+	label.Alignment = fyne.TextAlignCenter
+	d := NewCustom("Title", "OK", label, w)
+	d.Show()
+	assert.Equal(t, "Title", d.(*dialog).label.Text)
+
+	d.SetTitle("New title")
+	assert.Equal(t, "New title", d.(*dialog).label.Text)
+}
+
 func TestCustom_ApplyThemeOnShow(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -54,6 +54,7 @@ type fileDialog struct {
 	dir      fyne.ListableURI
 	// this will be the initial filename in a FileDialog in save mode
 	initialFileName string
+	title           *widget.Label
 }
 
 // FileDialog is a dialog containing a file picker for use in opening or saving files.
@@ -234,8 +235,9 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 		optionsButton,
 	)
 
+	f.title = widget.NewLabelWithStyle(title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 	header := container.NewBorder(nil, nil, nil, optionsbuttons,
-		optionsbuttons, widget.NewLabelWithStyle(title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		optionsbuttons, f.title,
 	)
 
 	footer := container.NewBorder(nil, nil, nil, buttons,
@@ -659,6 +661,10 @@ func (f *FileDialog) SetFileName(fileName string) {
 			f.dialog.fileName.SetText(fileName)
 		}
 	}
+}
+
+func (f *FileDialog) SetTitle(title string) {
+	f.dialog.title.SetText(title)
 }
 
 // NewFileOpen creates a file dialog allowing the user to choose a file to open.

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -663,6 +663,7 @@ func (f *FileDialog) SetFileName(fileName string) {
 	}
 }
 
+// SetTitle allows developers to set a new title for this dialog.
 func (f *FileDialog) SetTitle(title string) {
 	f.dialog.title.SetText(title)
 }

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -551,3 +551,13 @@ func TestSetFileNameAfterShow(t *testing.T) {
 	assert.NotEqual(t, "testfile.zip", dOpen.dialog.fileName.(*widget.Label).Text)
 
 }
+
+func TestFileDialog_SetTitle(t *testing.T) {
+	win := test.NewWindow(widget.NewLabel("Content"))
+	dOpen := NewFileOpen(func(f fyne.URIReadCloser, e error) {}, win)
+	dOpen.Show()
+	assert.Equal(t, "Open File", dOpen.dialog.title.Text)
+
+	dOpen.SetTitle("New title")
+	assert.Equal(t, "New title", dOpen.dialog.title.Text)
+}


### PR DESCRIPTION
Allowing dialogs to have content updated when shown.
First pass is SetTitle - easy because it applies to all.

Next has been requested `SetMessage` which applies to some.
Happy to get feedback about how we should expose this and if other setters should be added too

Fixes #1566

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
