### PR TITLE
Fix shortcuts not working in non-ASCII keyboard layouts

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1292,8 +1292,10 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key glfw.Key, m
 	// User pressing physical keys Ctrl+V while using a Russian (or any non-ASCII) keyboard layout
 	// is reported as a fyne.KeyUnknown key with Control modifier. We should still consider this
 	// as a "Paste" shortcut.
+	// See https://github.com/fyne-io/fyne/pull/2587 for discussion.
 	keyName := localizedKeyName
-	if (localizedKeyName == fyne.KeyUnknown) && (modifier == ctrlMod) {
+	resemblesShortcut := (modifier&(desktop.ControlModifier|desktop.SuperModifier) != 0)
+	if (localizedKeyName == fyne.KeyUnknown) && resemblesShortcut {
 		if asciiKey, ok := keyCodeMapASCII[key]; ok {
 			keyName = asciiKey
 		}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1293,9 +1293,8 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key glfw.Key, m
 	// is reported as a fyne.KeyUnknown key with Control modifier. We should still consider this
 	// as a "Paste" shortcut.
 	keyName := localizedKeyName
-	if (localizedKeyName == fyne.KeyUnknown) && (modifier&(desktop.ControlModifier|desktop.AltModifier|desktop.SuperModifier) != 0) {
-		asciiKey, ok := keyCodeMapASCII[key]
-		if ok {
+	if (localizedKeyName == fyne.KeyUnknown) && (modifier == ctrlMod) {
+		if asciiKey, ok := keyCodeMapASCII[key]; ok {
 			keyName = asciiKey
 		}
 	}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1052,6 +1052,35 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyCapsLock:     desktop.KeyCapsLock,
 }
 
+var keyCodeMapASCII = map[glfw.Key]fyne.KeyName{
+	glfw.KeyA: fyne.KeyA,
+	glfw.KeyB: fyne.KeyB,
+	glfw.KeyC: fyne.KeyC,
+	glfw.KeyD: fyne.KeyD,
+	glfw.KeyE: fyne.KeyE,
+	glfw.KeyF: fyne.KeyF,
+	glfw.KeyG: fyne.KeyG,
+	glfw.KeyH: fyne.KeyH,
+	glfw.KeyI: fyne.KeyI,
+	glfw.KeyJ: fyne.KeyJ,
+	glfw.KeyK: fyne.KeyK,
+	glfw.KeyL: fyne.KeyL,
+	glfw.KeyM: fyne.KeyM,
+	glfw.KeyN: fyne.KeyN,
+	glfw.KeyO: fyne.KeyO,
+	glfw.KeyP: fyne.KeyP,
+	glfw.KeyQ: fyne.KeyQ,
+	glfw.KeyR: fyne.KeyR,
+	glfw.KeyS: fyne.KeyS,
+	glfw.KeyT: fyne.KeyT,
+	glfw.KeyU: fyne.KeyU,
+	glfw.KeyV: fyne.KeyV,
+	glfw.KeyW: fyne.KeyW,
+	glfw.KeyX: fyne.KeyX,
+	glfw.KeyY: fyne.KeyY,
+	glfw.KeyZ: fyne.KeyZ,
+}
+
 var keyNameMap = map[string]fyne.KeyName{
 	"'": fyne.KeyApostrophe,
 	",": fyne.KeyComma,
@@ -1187,7 +1216,7 @@ func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action g
 		// key repeat will fall through to TypedKey and TypedShortcut
 	}
 
-	if (keyName == fyne.KeyTab && !w.capturesTab(keyDesktopModifier)) || w.triggersShortcut(keyName, keyDesktopModifier) {
+	if (keyName == fyne.KeyTab && !w.capturesTab(keyDesktopModifier)) || w.triggersShortcut(keyName, key, keyDesktopModifier) {
 		return
 	}
 
@@ -1254,11 +1283,21 @@ func (w *window) focused(_ *glfw.Window, focus bool) {
 	}
 }
 
-func (w *window) triggersShortcut(keyName fyne.KeyName, modifier desktop.Modifier) bool {
+func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key glfw.Key, modifier desktop.Modifier) bool {
 	var shortcut fyne.Shortcut
 	ctrlMod := desktop.ControlModifier
 	if runtime.GOOS == "darwin" {
 		ctrlMod = desktop.SuperModifier
+	}
+	// User pressing physical keys Ctrl+V while using a Russian (or any non-ASCII) keyboard layout
+	// is reported as a fyne.KeyUnknown key with Control modifier. We should still consider this
+	// as a "Paste" shortcut.
+	keyName := localizedKeyName
+	if (localizedKeyName == fyne.KeyUnknown) && (modifier&(desktop.ControlModifier|desktop.AltModifier|desktop.SuperModifier) != 0) {
+		asciiKey, ok := keyCodeMapASCII[key]
+		if ok {
+			keyName = asciiKey
+		}
 	}
 	if modifier == ctrlMod {
 		switch keyName {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

People who use Russian language (or many other languages with primarily non-ASCII symbols) typically switch between several keyboard layouts throughout the day, for example between English layout and a Russian layout. The same physical key will correspond to both English symbol (e.g., "V") and Russian symbol ("М" for the most common Cyrillic layout; that's not the same symbol as English M, it just looks the same). Normally, people expect the physical key combination corresponding to "Ctrl+V" in English to also work in Russian (otherwise muscle memory goes haywire if you switch between the keyboard layouts often). This is how it usually works in Windows, Mac, and well-developed graphical toolkits on Linux. Note that this is not what people with AZERTY do, since they usually stick to a single keyboard layout and type both French and English with it.

This used not to work in Fyne, and this pull request fixes it: when a user presses an unknown-to-fyne key (like Russian "Ф") with a Control/Alt modifier, the `triggersShortcut` function will try to replace the unknown key with the equivalent ASCII symbol. I'm not sure if the method I use for translation actually works on all platforms, but at least it seems to work on my Mac OS Sierra.

Fixes #1220 .

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
