### PR TITLE
Use basicBinder helper in Check, Entry, ProgressBar, and Slider widgets

### DIFF
--- a/widget/bind_helper.go
+++ b/widget/bind_helper.go
@@ -37,6 +37,15 @@ func (binder *basicBinder) Bind(data binding.DataItem) {
 	binder.dataListenerPairLock.Unlock()
 }
 
+// CallWithData passes the currently bound data item as an argument to the
+// provided function.
+func (binder *basicBinder) CallWithData(f func(data binding.DataItem)) {
+	binder.dataListenerPairLock.RLock()
+	data := binder.dataListenerPair.data
+	binder.dataListenerPairLock.RUnlock()
+	f(data)
+}
+
 // SetCallback replaces the function to be called when the data changes.
 func (binder *basicBinder) SetCallback(f func(data binding.DataItem)) {
 	binder.callbackLock.Lock()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1,6 +1,7 @@
 package widget
 
 import (
+	"fmt"
 	"image/color"
 	"math"
 	"strings"
@@ -85,9 +86,8 @@ type Entry struct {
 	// TODO: Add OnSelectChanged
 
 	// ActionItem is a small item which is displayed at the outer right of the entry (like a password revealer)
-	ActionItem   fyne.CanvasObject `json:"-"`
-	textSource   binding.String
-	textListener binding.DataListener
+	ActionItem fyne.CanvasObject `json:"-"`
+	binder     basicBinder
 }
 
 // NewEntry creates a new single line entry widget.
@@ -137,31 +137,11 @@ func (e *Entry) AcceptsTab() bool {
 //
 // Since: 2.0
 func (e *Entry) Bind(data binding.String) {
-	e.Unbind()
-	e.textSource = data
+	e.binder.SetCallback(e.updateFromData)
+	e.binder.Bind(data)
 
-	var convertErr error
-	e.Validator = func(string) error {
-		return convertErr
-	}
-	e.textListener = binding.NewDataListener(func() {
-		val, err := data.Get()
-		if err != nil {
-			convertErr = err
-			e.Validate()
-			return
-		}
-		e.Text = val
-		convertErr = nil
-		e.Refresh()
-		if cache.IsRendered(e) {
-			e.Refresh()
-		}
-	})
-	data.AddListener(e.textListener)
-
-	e.OnChanged = func(s string) {
-		convertErr = data.Set(s)
+	e.OnChanged = func(_ string) {
+		e.binder.CallWithData(e.writeData)
 		e.Validate()
 	}
 }
@@ -761,14 +741,7 @@ func (e *Entry) TypedShortcut(shortcut fyne.Shortcut) {
 // Since: 2.0
 func (e *Entry) Unbind() {
 	e.OnChanged = nil
-	if e.textSource == nil || e.textListener == nil {
-		return
-	}
-
-	e.Validator = nil
-	e.textSource.RemoveListener(e.textListener)
-	e.textListener = nil
-	e.textSource = nil
+	e.binder.Unbind()
 }
 
 // copyToClipboard copies the current selection to a given clipboard.
@@ -1127,6 +1100,23 @@ func (e *Entry) updateCursorAndSelection() {
 	e.selectRow, e.selectColumn = e.truncatePosition(e.selectRow, e.selectColumn)
 }
 
+func (e *Entry) updateFromData(data binding.DataItem) {
+	if data == nil {
+		return
+	}
+	textSource, ok := data.(binding.String)
+	if !ok {
+		return
+	}
+
+	val, err := textSource.Get()
+	if err != nil {
+		fyne.LogError("Error getting current data value", err)
+		return
+	}
+	e.SetText(val)
+}
+
 func (e *Entry) truncatePosition(row, col int) (int, int) {
 	if e.Text == "" {
 		return 0, 0
@@ -1180,6 +1170,27 @@ func (e *Entry) updateText(text string) {
 
 	if callback != nil {
 		callback(text)
+	}
+}
+
+func (e *Entry) writeData(data binding.DataItem) {
+	if data == nil {
+		return
+	}
+	textTarget, ok := data.(binding.String)
+	if !ok {
+		return
+	}
+	curValue, err := textTarget.Get()
+	if err != nil {
+		return
+	}
+
+	if curValue != e.Text {
+		err := textTarget.Set(e.Text)
+		if err != nil {
+			fyne.LogError(fmt.Sprintf("Failed to set binding value to %s", e.Text), err)
+		}
 	}
 }
 

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -89,8 +89,7 @@ type ProgressBar struct {
 	// Since: 1.4
 	TextFormatter func() string `json:"-"`
 
-	valueSource   binding.Float
-	valueListener binding.DataListener
+	binder basicBinder
 }
 
 // Bind connects the specified data source to this ProgressBar.
@@ -98,21 +97,8 @@ type ProgressBar struct {
 //
 // Since: 2.0
 func (p *ProgressBar) Bind(data binding.Float) {
-	p.Unbind()
-	p.valueSource = data
-
-	p.valueListener = binding.NewDataListener(func() {
-		val, err := data.Get()
-		if err != nil {
-			fyne.LogError("Error getting current data value", err)
-			return
-		}
-		p.Value = val
-		if cache.IsRendered(p) {
-			p.Refresh()
-		}
-	})
-	data.AddListener(p.valueListener)
+	p.binder.SetCallback(p.updateFromData)
+	p.binder.Bind(data)
 }
 
 // SetValue changes the current value of this progress bar (from p.Min to p.Max).
@@ -147,13 +133,7 @@ func (p *ProgressBar) CreateRenderer() fyne.WidgetRenderer {
 //
 // Since: 2.0
 func (p *ProgressBar) Unbind() {
-	if p.valueSource == nil || p.valueListener == nil {
-		return
-	}
-
-	p.valueSource.RemoveListener(p.valueListener)
-	p.valueListener = nil
-	p.valueSource = nil
+	p.binder.Unbind()
 }
 
 // NewProgressBar creates a new progress bar widget.
@@ -180,4 +160,21 @@ func progressBackgroundColor() color.Color {
 	r, g, b, a := col.ToNRGBA(theme.PrimaryColor())
 	faded := uint8(a) / 3
 	return &color.NRGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: faded}
+}
+
+func (p *ProgressBar) updateFromData(data binding.DataItem) {
+	if data == nil {
+		return
+	}
+	floatSource, ok := data.(binding.Float)
+	if !ok {
+		return
+	}
+
+	val, err := floatSource.Get()
+	if err != nil {
+		fyne.LogError("Error getting current data value", err)
+		return
+	}
+	p.SetValue(val)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

The current implementation of Bind/Unbind API in widgets such as Check, Entry, ProgressBar, and Slider is not thread-safe. As an example, all those widgets store the current data item and the registered listener in order to call `dataItem.RemoveListener(listener)` in Unbind(). If a concurrent call to `Bind(newDataItem)` is in progress, this may lead to RemoveListener being called on the `newDataItem`, but with the old listener value, which means that the previous listener will never be removed from the previous data item.

Previously Label widget had the same deficiencies, but they were fixed in #2566 by creating a helper type called "basicBinder" in the widget package which encapsulates basic bind logic. The same helper can be used in all other widgets. It prevents some concurrency issues like the one described above. Moreover, it simplifies the Bind/Unbind implementation. It is enough to define two callbacks:

* `thisWidget.updateFromData(data binding.DataItem)` that reads the current value from data and updates the widget to reflect it;
* `thisWidget.writeData(data binding.DataItem)` that writes the current state of the widget to the given data item.

As such, no direct manipulations with AddListener/RemoveListener are needed, which reduced the potential for concurrency bugs.

(Technical note: basicBinder is not an interface, the names are not relevant. Making basicBinder into an interface is possible, but that would expose methods like binder.SetCallback that should be private to the widget. I think storing a basicBinder as a field in the widget struct is a proper solution.)


As far as I know, the concurrency issues with those widgets aren't reported as bugs, but an issue like #2549 would occur as soon as someone creates a bound list with 1000 checkboxes instead of 1000 labels.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

