### PR TITLE
'Fix' the Sierra build error by adding -tags legacy

### DIFF
--- a/app/app_darwin.go
+++ b/app/app_darwin.go
@@ -4,7 +4,7 @@ package app
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Foundation -framework UserNotifications
+#cgo LDFLAGS: -framework Foundation
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/app/app_darwin.m
+++ b/app/app_darwin.m
@@ -1,11 +1,19 @@
 // +build !ci
 
+#import <Foundation/Foundation.h>
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
 #import <UserNotifications/UserNotifications.h>
+#endif
 
 static int notifyNum = 0;
 
 extern void fallbackSend(char *cTitle, char *cBody);
 
+bool isBundled() {
+    return [[NSBundle mainBundle] bundleIdentifier] != nil;
+}
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
 void doSendNotification(UNUserNotificationCenter *center, NSString *title, NSString *body) {
     UNMutableNotificationContent *content = [UNMutableNotificationContent new];
     [content autorelease];
@@ -22,10 +30,6 @@ void doSendNotification(UNUserNotificationCenter *center, NSString *title, NSStr
             NSLog(@"Could not send notification: %@", error);
         }
     }];
-}
-
-bool isBundled() {
-    return [[NSBundle mainBundle] bundleIdentifier] != nil;
 }
 
 void sendNotification(char *cTitle, char *cBody) {
@@ -49,3 +53,8 @@ void sendNotification(char *cTitle, char *cBody) {
             }
         }];
 }
+#else
+void sendNotification(char *cTitle, char *cBody) {
+	fallbackSend(cTitle, cBody);
+}
+#endif

--- a/app/app_notlegacy_darwin.go
+++ b/app/app_notlegacy_darwin.go
@@ -1,0 +1,9 @@
+// +build !ci
+// +build !legacy
+
+package app
+
+/*
+#cgo LDFLAGS: -framework Foundation -framework UserNotifications
+*/
+import "C"

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -9,8 +9,8 @@ const int menuTagMin = 5000;
 NSControlStateValue STATE_ON = NSControlStateValueOn;
 NSControlStateValue STATE_OFF = NSControlStateValueOff;
 #else
-NSControlStateValue STATE_ON = NSOnState;
-NSControlStateValue STATE_OFF = NSOffState;
+NSCellStateValue STATE_ON = NSOnState;
+NSCellStateValue STATE_OFF = NSOffState;
 #endif
 
 


### PR DESCRIPTION

### Description:
Cannot find a way to make this work automatically - we need to update cgo LDFLAGS based on OS version which seems to not be supported.
So add `legacy` tag that turns off the new notification center usage.

Fixes #2478

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- compile failure on old devices, but we don't have stuff that out-dated in CI
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
