### PR TITLE
widget: fix data race in check

### DIFF
--- a/widget/check.go
+++ b/widget/check.go
@@ -102,9 +102,7 @@ func (c *checkRenderer) updateFocusIndicator() {
 // Check widget has a text label and a checked (or unchecked) icon and triggers an event func when toggled
 type Check struct {
 	DisableableWidget
-	Text string
-
-	// Deprecated: Use SetChecked and IsChecked instead.
+	Text      string
 	Checked   bool
 	OnChanged func(bool) `json:"-"`
 
@@ -154,7 +152,7 @@ func (c *Check) SetChecked(checked bool) {
 
 // IsChecked checks if the given Check is checked.
 //
-// Since: 2.0
+// Since: 2.2
 func (c *Check) IsChecked() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/widget/check_test.go
+++ b/widget/check_test.go
@@ -15,17 +15,17 @@ import (
 func TestCheck_Binding(t *testing.T) {
 	c := widget.NewCheck("", nil)
 	c.SetChecked(true)
-	assert.Equal(t, true, c.Checked)
+	assert.Equal(t, true, c.IsChecked())
 
 	val := binding.NewBool()
 	c.Bind(val)
 	waitForBinding()
-	assert.Equal(t, false, c.Checked)
+	assert.Equal(t, false, c.IsChecked())
 
 	err := val.Set(true)
 	assert.Nil(t, err)
 	waitForBinding()
-	assert.Equal(t, true, c.Checked)
+	assert.Equal(t, true, c.IsChecked())
 
 	c.SetChecked(false)
 	v, err := val.Get()
@@ -34,7 +34,7 @@ func TestCheck_Binding(t *testing.T) {
 
 	c.Unbind()
 	waitForBinding()
-	assert.Equal(t, false, c.Checked)
+	assert.Equal(t, false, c.IsChecked())
 }
 
 func TestCheck_Layout(t *testing.T) {
@@ -89,7 +89,7 @@ func TestNewCheckWithData(t *testing.T) {
 
 	c := widget.NewCheckWithData("", val)
 	waitForBinding()
-	assert.Equal(t, true, c.Checked)
+	assert.Equal(t, true, c.IsChecked())
 
 	c.SetChecked(false)
 	v, err := val.Get()


### PR DESCRIPTION
### Description:

This PR resolves data races in the check widget by introducing `(*Check) IsChecked() bool` method. The majority of the races that appear in the tests are about Check and OnChange. However, we cannot really resolve public property being accessed if it is exposed to the user. Hence, a new method `(*Check) IsChecked() bool` that complements the `SetChecked` then deprecates the `Check` public property.

```
go test -v -race -run=TestCheck
```

Updates #1028
Updates #2509

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
