### PR TITLE
widget: fix data races in label

### DIFF
--- a/widget/label.go
+++ b/widget/label.go
@@ -111,8 +111,19 @@ func (l *Label) Resize(s fyne.Size) {
 
 // SetText sets the text of the label
 func (l *Label) SetText(text string) {
+	l.propertyLock.Lock()
 	l.Text = text
+	l.propertyLock.Unlock()
 	l.Refresh()
+}
+
+// GetText returns the text of the label
+//
+// Since: 2.1
+func (l *Label) GetText() string {
+	l.propertyLock.RLock()
+	defer l.propertyLock.RUnlock()
+	return l.Text
 }
 
 // Unbind disconnects any configured data source from this Label.

--- a/widget/label.go
+++ b/widget/label.go
@@ -119,7 +119,7 @@ func (l *Label) SetText(text string) {
 
 // GetText returns the text of the label
 //
-// Since: 2.1
+// Since: 2.2
 func (l *Label) GetText() string {
 	l.propertyLock.RLock()
 	defer l.propertyLock.RUnlock()

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -15,20 +15,20 @@ import (
 
 func TestLabel_Binding(t *testing.T) {
 	label := NewLabel("Init")
-	assert.Equal(t, "Init", label.Text)
+	assert.Equal(t, "Init", label.GetText())
 
 	str := binding.NewString()
 	label.Bind(str)
 	waitForBinding()
-	assert.Equal(t, "", label.Text)
+	assert.Equal(t, "", label.GetText())
 
 	str.Set("Updated")
 	waitForBinding()
-	assert.Equal(t, "Updated", label.Text)
+	assert.Equal(t, "Updated", label.GetText())
 
 	label.Unbind()
 	waitForBinding()
-	assert.Equal(t, "Updated", label.Text)
+	assert.Equal(t, "Updated", label.GetText())
 }
 
 func TestLabel_Hide(t *testing.T) {
@@ -55,8 +55,7 @@ func TestLabel_MinSize(t *testing.T) {
 	minB := label.MinSize()
 	assert.Less(t, minA.Width, minB.Width)
 
-	label.Text = "."
-	label.Refresh()
+	label.SetText(".")
 	minC := label.MinSize()
 	assert.Greater(t, minB.Width, minC.Width)
 }
@@ -79,19 +78,18 @@ func TestLabel_Text(t *testing.T) {
 	label := &Label{Text: "Test"}
 	label.Refresh()
 
-	assert.Equal(t, "Test", label.Text)
+	assert.Equal(t, "Test", label.GetText())
 	assert.Equal(t, "Test", textRenderTexts(label)[0].Text)
 }
 
 func TestLabel_Text_Refresh(t *testing.T) {
 	label := &Label{Text: ""}
 
-	assert.Equal(t, "", label.Text)
+	assert.Equal(t, "", label.GetText())
 	assert.Equal(t, "", textRenderTexts(label)[0].Text)
 
-	label.Text = "Test"
-	label.Refresh()
-	assert.Equal(t, "Test", label.Text)
+	label.SetText("Test")
+	assert.Equal(t, "Test", label.GetText())
 	assert.Equal(t, "Test", textRenderTexts(label)[0].Text)
 }
 
@@ -101,7 +99,7 @@ func TestLabel_SetText(t *testing.T) {
 	label.Refresh()
 	label.SetText("New")
 
-	assert.Equal(t, "New", label.Text)
+	assert.Equal(t, "New", label.GetText())
 	assert.Equal(t, "New", textRenderTexts(label)[0].Text)
 }
 
@@ -202,5 +200,5 @@ func TestNewLabelWithData(t *testing.T) {
 
 	label := NewLabelWithData(str)
 	waitForBinding()
-	assert.Equal(t, "Init", label.Text)
+	assert.Equal(t, "Init", label.GetText())
 }


### PR DESCRIPTION
### Description:

This PR resolves data races in the check widget by introducing (*Label) GetText() string method.

```
go test -v -race -run=Label
```

Updates #1028
Updates #2509

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
