### PR TITLE
widget: fix data race in progress bar

### DIFF
--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -104,8 +104,19 @@ func (p *ProgressBar) Bind(data binding.Float) {
 // SetValue changes the current value of this progress bar (from p.Min to p.Max).
 // The widget will be refreshed to indicate the change.
 func (p *ProgressBar) SetValue(v float64) {
+	p.propertyLock.Lock()
 	p.Value = v
+	p.propertyLock.Unlock()
 	p.Refresh()
+}
+
+// GetValue returns the current progress bar value.
+//
+// Since: 2.2
+func (p *ProgressBar) GetValue() float64 {
+	p.propertyLock.RLock()
+	defer p.propertyLock.RUnlock()
+	return p.Value
 }
 
 // MinSize returns the size that this widget should not shrink below

--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -14,28 +14,28 @@ func TestNewProgressBarWithData(t *testing.T) {
 	val := binding.NewFloat()
 	val.Set(0.4)
 
-	label := NewProgressBarWithData(val)
+	bar := NewProgressBarWithData(val)
 	waitForBinding()
-	assert.Equal(t, 0.4, label.Value)
+	assert.Equal(t, 0.4, bar.GetValue())
 }
 
 func TestProgressBar_Binding(t *testing.T) {
 	bar := NewProgressBar()
-	assert.Equal(t, 0.0, bar.Value)
+	assert.Equal(t, 0.0, bar.GetValue())
 
 	val := binding.NewFloat()
 	val.Set(0.1)
 	bar.Bind(val)
 	waitForBinding()
-	assert.Equal(t, 0.1, bar.Value)
+	assert.Equal(t, 0.1, bar.GetValue())
 
 	val.Set(0.4)
 	waitForBinding()
-	assert.Equal(t, 0.4, bar.Value)
+	assert.Equal(t, 0.4, bar.GetValue())
 
 	bar.Unbind()
 	waitForBinding()
-	assert.Equal(t, 0.4, bar.Value)
+	assert.Equal(t, 0.4, bar.GetValue())
 }
 
 func TestProgressBar_SetValue(t *testing.T) {
@@ -43,10 +43,10 @@ func TestProgressBar_SetValue(t *testing.T) {
 
 	assert.Equal(t, 0.0, bar.Min)
 	assert.Equal(t, 1.0, bar.Max)
-	assert.Equal(t, 0.0, bar.Value)
+	assert.Equal(t, 0.0, bar.GetValue())
 
 	bar.SetValue(.5)
-	assert.Equal(t, .5, bar.Value)
+	assert.Equal(t, .5, bar.GetValue())
 }
 
 func TestProgressBar_TextFormatter(t *testing.T) {
@@ -58,7 +58,7 @@ func TestProgressBar_TextFormatter(t *testing.T) {
 
 	formatter := func() string {
 		formatted = true
-		return fmt.Sprintf("%.2f out of %.2f", bar.Value, bar.Max)
+		return fmt.Sprintf("%.2f out of %.2f", bar.GetValue(), bar.Max)
 	}
 	bar.TextFormatter = formatter
 


### PR DESCRIPTION

### Description:
This PR resolves data races in the progress bar widget by introducing (*ProgressBar) GetValue() float64 method.

```
go test -v -race -run=ProgressBar
```

Updates #1028
Updates #2509

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
