### PR TITLE
avoid layouts in Canvas.EnsureMinSize

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -65,6 +65,8 @@ func (c *Canvas) EnsureMinSize() bool {
 	}
 	var lastParent fyne.CanvasObject
 
+	seenObj := map[fyne.CanvasObject]struct{}{}
+
 	windowNeedsMinSizeUpdate := false
 	csize := c.impl.Size()
 	min := c.impl.MinSize()
@@ -93,8 +95,9 @@ func (c *Canvas) EnsureMinSize() bool {
 				}
 			}
 
-			if objToLayout != lastParent {
-				updateLayout(lastParent)
+			if _, hasSeen := seenObj[objToLayout]; !hasSeen {
+				updateLayout(objToLayout)
+				seenObj[objToLayout] = struct{}{}
 				lastParent = objToLayout
 			}
 		}

--- a/internal/driver/common/canvas_perf_test.go
+++ b/internal/driver/common/canvas_perf_test.go
@@ -1,0 +1,62 @@
+package common_test
+
+import (
+	"fmt"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/widget"
+)
+
+const sizeTree = 1_000
+
+func Example() {
+	a := app.New()
+	w := a.NewWindow("Perf tree")
+
+	w.Resize(fyne.NewSize(600, 600))
+	content := tree()
+	w.SetContent(content)
+	time.AfterFunc(200*time.Millisecond, w.Close)
+	w.ShowAndRun()
+	fmt.Println("Number of isBranch calls:", count/100*100) // rounding
+
+	// with master version of Canvas.EnsureMinSize : 1028000
+	// with patched version of Canvas.EnsureMinSize : 29000
+
+	// Output: Number of isBranch calls: 1028000
+}
+
+var count int
+
+func tree() fyne.CanvasObject {
+	childUIDs := func(uid widget.TreeNodeID) (c []widget.TreeNodeID) {
+		if uid == "" {
+			out := make([]string, sizeTree)
+			for i := range out {
+				out[i] = fmt.Sprintf("node_%d", i)
+			}
+			return out
+		} else if uid[0] == 'n' {
+			return []string{"kid" + uid}
+		} else {
+			return nil
+		}
+	}
+	// Return a CanvasObject that can represent a Branch (if branch is true), or a Leaf (if branch is false)
+	createNode := func(branch bool) (o fyne.CanvasObject) {
+		return widget.NewLabel("")
+	}
+	// Return true if the given widget.TreeNodeID represents a Branch
+	isBranch := func(uid widget.TreeNodeID) (ok bool) {
+		count++
+		return uid == "" || uid[0] != 'k'
+	}
+	// Called to update the given CanvasObject to represent the data at the given widget.TreeNodeID
+	updateNode := func(uid widget.TreeNodeID, _ bool, node fyne.CanvasObject) {
+		node.(*widget.Label).SetText(uid)
+	}
+
+	return widget.NewTree(childUIDs, isBranch, createNode, updateNode)
+}

--- a/internal/driver/common/canvas_perf_test.go
+++ b/internal/driver/common/canvas_perf_test.go
@@ -25,7 +25,7 @@ func Example() {
 	// with master version of Canvas.EnsureMinSize : 1028000
 	// with patched version of Canvas.EnsureMinSize : 29000
 
-	// Output: Number of isBranch calls: 1028000
+	// Output: Number of isBranch calls: 29000
 }
 
 var count int


### PR DESCRIPTION
### Description:
Try to avoid too many layouts in Canvas.EnsureMinSize by using a cache.

Fixes  #1655 : performance of the widget tree are then very decent 

I do not pretend this is a good solution, but the tests are passing. 

I don't really understand the logic of this function, but it seems strange to me that it is the parent which must be laid out instead of the current node CanvasObject (`objToLayout = node.parent.obj`).

 Wouldn't be possible to change this so that this behavior won't happen anymore ? (I mean, that the parent has to layout itself for each of its children)

Feel free to close if it seems to rash, or to guide me towards a better solution/understanding of the problem !