### PR TITLE
Installation capability is deprecated from go get. Need to use go install instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ If you're not sure if that's all installed or you don't know how then check out 
 
 Using the standard go tools you can install Fyne's core library using:
 
-    $ go get fyne.io/fyne/v2
+    $ go install fyne.io/fyne/v2
 
 # Widget demo
 
 To run a showcase of the features of Fyne execute the following:
 
-    $ go get fyne.io/fyne/v2/cmd/fyne_demo/
+    $ go install fyne.io/fyne/v2/cmd/fyne_demo/
     $ fyne_demo
 
 And you should see something like this (after you click a few buttons):
@@ -120,7 +120,7 @@ Using `go install` will copy the executable into your go `bin` dir.
 To install the application with icons etc into your operating system's standard
 application location you can use the fyne utility and the "install" subcommand.
 
-    $ go get fyne.io/fyne/v2/cmd/fyne
+    $ go install fyne.io/fyne/v2/cmd/fyne
     $ fyne install
 
 # Packaging for mobile
@@ -163,7 +163,7 @@ However, if looking to support Fyne in a bigger way on your operating system the
 
 It is recommended that you install the following additional apps:
 
-| app | go get | description |
+| app | go install | description |
 | --- | ------ | ----------- |
 | fyne_settings | `fyne.io/fyne/v2/cmd/fyne_settings` | A GUI for managing your global Fyne settings like theme and scaling |
 | apps | `github.com/fyne-io/apps` | A graphical installer for the Fyne apps listed at https://apps.fyne.io |

--- a/internal/driver/mobile/app/doc.go
+++ b/internal/driver/mobile/app/doc.go
@@ -24,7 +24,7 @@ Apps written entirely in Go have a main function, and can be built
 with `gomobile build`, which directly produces runnable output for
 Android and iOS.
 
-The gomobile tool can get installed with go get. For reference, see
+The gomobile tool can get installed with go install. For reference, see
 https://golang.org/x/mobile/cmd/gomobile.
 
 For detailed instructions and documentation, see


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
"Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead."
Source: https://golang.org/doc/go-get-install-deprecation

The -i flag for go install is also deprecated and go install is enough.

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable: