### PR TITLE
Add workaround to use just 1 thread on Apple M1

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -37,6 +37,8 @@ type gLDriver struct {
 	drawDone   chan interface{}
 
 	animation *animation.Runner
+
+	drawOnMainThread bool // A workaround on Apple M1, just use 1 thread until fixed upstream
 }
 
 func (d *gLDriver) RenderedTextSize(text string, textSize float32, style fyne.TextStyle) (size fyne.Size, baseline float32) {

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -244,7 +244,7 @@ func (d *gLDriver) startDrawThread() {
 					c.applyThemeOutOfTreeObjects()
 					go c.reloadScale()
 				})
-			case <-draw.C:
+			case <-drawCh:
 				d.drawSingleFrame()
 			}
 		}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -214,9 +214,9 @@ func (d *gLDriver) repaintWindow(w *window) {
 func (d *gLDriver) startDrawThread() {
 	settingsChange := make(chan fyne.Settings)
 	fyne.CurrentApp().Settings().AddChangeListener(settingsChange)
-	var drawCh chan Time
+	var drawCh <-chan time.Time
 	if d.drawOnMainThread {
-		drawCh = make(chan Time) // don't tick when on M1
+		drawCh = make(chan time.Time) // don't tick when on M1
 	} else {
 		drawCh = time.NewTicker(time.Second / 60).C
 	}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -214,11 +214,11 @@ func (d *gLDriver) repaintWindow(w *window) {
 func (d *gLDriver) startDrawThread() {
 	settingsChange := make(chan fyne.Settings)
 	fyne.CurrentApp().Settings().AddChangeListener(settingsChange)
-	var draw *time.Ticker
+	var drawCh chan Time
 	if d.drawOnMainThread {
-		draw = time.NewTicker(time.Hour * 24 * 365 * 100) // don't tick when on M1
+		drawCh = make(chan Time) // don't tick when on M1
 	} else {
-		draw = time.NewTicker(time.Second / 60)
+		drawCh = time.NewTicker(time.Second / 60).C
 	}
 
 	go func() {


### PR DESCRIPTION
Downsize is resize is not as smooth, but upside does not crash.

Fixes #2188

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- run and resize a lot on M1
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
