### PR TITLE
data/binding: use atomics

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -56,41 +56,27 @@ func (l *listener) DataChanged() {
 }
 
 type base struct {
-	listeners []DataListener
-	lock      sync.RWMutex
+	listeners sync.Map // map[DataListener]bool
+
+	lock sync.RWMutex
 }
 
 // AddListener allows a data listener to be informed of changes to this item.
 func (b *base) AddListener(l DataListener) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	b.listeners = append(b.listeners, l)
+	b.listeners.Store(l, true)
 	queueItem(l.DataChanged)
 }
 
 // RemoveListener should be called if the listener is no longer interested in being informed of data change events.
 func (b *base) RemoveListener(l DataListener) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	for i, listen := range b.listeners {
-		if listen != l {
-			continue
-		}
-
-		if i == len(b.listeners)-1 {
-			b.listeners = b.listeners[:len(b.listeners)-1]
-		} else {
-			b.listeners = append(b.listeners[:i], b.listeners[i+1:]...)
-		}
-	}
+	b.listeners.Delete(l)
 }
 
 func (b *base) trigger() {
-	for _, listen := range b.listeners {
-		queueItem(listen.DataChanged)
-	}
+	b.listeners.Range(func(key, _ interface{}) bool {
+		queueItem(key.(DataListener).DataChanged)
+		return true
+	})
 }
 
 // Untyped supports binding a interface{} value.

--- a/data/binding/binding_test.go
+++ b/data/binding/binding_test.go
@@ -1,10 +1,19 @@
 package binding
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func syncMapLen(m *sync.Map) (n int) {
+	m.Range(func(_, _ interface{}) bool {
+		n++
+		return true
+	})
+	return
+}
 
 type simpleItem struct {
 	base
@@ -12,14 +21,14 @@ type simpleItem struct {
 
 func TestBase_AddListener(t *testing.T) {
 	data := &simpleItem{}
-	assert.Equal(t, 0, len(data.listeners))
+	assert.Equal(t, 0, syncMapLen(&data.listeners))
 
 	called := false
 	fn := NewDataListener(func() {
 		called = true
 	})
 	data.AddListener(fn)
-	assert.Equal(t, 1, len(data.listeners))
+	assert.Equal(t, 1, syncMapLen(&data.listeners))
 
 	waitForItems()
 	assert.True(t, called)
@@ -31,11 +40,13 @@ func TestBase_RemoveListener(t *testing.T) {
 		called = true
 	})
 	data := &simpleItem{}
-	data.listeners = []DataListener{fn}
+	m := sync.Map{}
+	m.Store(fn, true)
+	data.listeners = m
 
-	assert.Equal(t, 1, len(data.listeners))
+	assert.Equal(t, 1, syncMapLen(&data.listeners))
 	data.RemoveListener(fn)
-	assert.Equal(t, 0, len(data.listeners))
+	assert.Equal(t, 0, syncMapLen(&data.listeners))
 
 	waitForItems()
 	data.trigger()

--- a/data/binding/binding_test.go
+++ b/data/binding/binding_test.go
@@ -40,9 +40,7 @@ func TestBase_RemoveListener(t *testing.T) {
 		called = true
 	})
 	data := &simpleItem{}
-	m := sync.Map{}
-	m.Store(fn, true)
-	data.listeners = m
+	data.listeners.Store(fn, true)
 
 	assert.Equal(t, 1, syncMapLen(&data.listeners))
 	data.RemoveListener(fn)

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -120,11 +120,9 @@ func (b *boundExternal{{ .Name }}) Reload() error {
 const prefTemplate = `
 type prefBound{{ .Name }} struct {
 	base
-	key string
-	p   fyne.Preferences
-
-	cacheLock sync.RWMutex
-	cache     {{ .Type }}
+	key   string
+	p     fyne.Preferences
+	cache atomic.Value // {{ .Type }}
 }
 
 // BindPreference{{ .Name }} returns a bindable {{ .Type }} value that is managed by the application preferences.
@@ -150,10 +148,8 @@ func BindPreference{{ .Name }}(key string, p fyne.Preferences) {{ .Name }} {
 
 func (b *prefBound{{ .Name }}) Get() ({{ .Type }}, error) {
 	cache := b.p.{{ .Name }}(b.key)
-	b.cacheLock.Lock()
-	b.cache = cache
-	b.cacheLock.Unlock()
-	return b.cache, nil
+	b.cache.Store(cache)
+	return cache, nil
 }
 
 func (b *prefBound{{ .Name }}) Set(v {{ .Type }}) error {
@@ -166,13 +162,13 @@ func (b *prefBound{{ .Name }}) Set(v {{ .Type }}) error {
 }
 
 func (b *prefBound{{ .Name }}) checkForChange() {
-	b.cacheLock.RLock()
-	cache := b.cache
-	b.cacheLock.RUnlock()
-	if b.p.{{ .Name }}(b.key) == cache {
-		return
+	val := b.cache.Load()
+	if val != nil {
+		cache := val.({{ .Type }})
+		if b.p.{{ .Name }}(b.key) == cache {
+			return
+		}
 	}
-
 	b.trigger()
 }
 `
@@ -649,7 +645,7 @@ import (
 	defer prefFile.Close()
 	prefFile.WriteString(`
 import (
-	"sync"
+	"sync/atomic"
 
 	"fyne.io/fyne/v2"
 )

--- a/data/binding/listbinding_test.go
+++ b/data/binding/listbinding_test.go
@@ -1,6 +1,7 @@
 package binding
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,14 +13,14 @@ type simpleList struct {
 
 func TestListBase_AddListener(t *testing.T) {
 	data := &simpleList{}
-	assert.Equal(t, 0, len(data.listeners))
+	assert.Equal(t, 0, syncMapLen(&data.listeners))
 
 	called := false
 	fn := NewDataListener(func() {
 		called = true
 	})
 	data.AddListener(fn)
-	assert.Equal(t, 1, len(data.listeners))
+	assert.Equal(t, 1, syncMapLen(&data.listeners))
 
 	data.trigger()
 	waitForItems()
@@ -56,11 +57,13 @@ func TestListBase_RemoveListener(t *testing.T) {
 		called = true
 	})
 	data := &simpleList{}
-	data.listeners = []DataListener{fn}
+	m := sync.Map{}
+	m.Store(fn, true)
+	data.listeners = m
 
-	assert.Equal(t, 1, len(data.listeners))
+	assert.Equal(t, 1, syncMapLen(&data.listeners))
 	data.RemoveListener(fn)
-	assert.Equal(t, 0, len(data.listeners))
+	assert.Equal(t, 0, syncMapLen(&data.listeners))
 
 	data.trigger()
 	waitForItems()

--- a/data/binding/listbinding_test.go
+++ b/data/binding/listbinding_test.go
@@ -1,7 +1,6 @@
 package binding
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,9 +56,7 @@ func TestListBase_RemoveListener(t *testing.T) {
 		called = true
 	})
 	data := &simpleList{}
-	m := sync.Map{}
-	m.Store(fn, true)
-	data.listeners = m
+	data.listeners.Store(fn, true)
 
 	assert.Equal(t, 1, syncMapLen(&data.listeners))
 	data.RemoveListener(fn)

--- a/data/binding/preference.go
+++ b/data/binding/preference.go
@@ -4,7 +4,7 @@
 package binding
 
 import (
-	"sync"
+	"sync/atomic"
 
 	"fyne.io/fyne/v2"
 )
@@ -13,11 +13,9 @@ const keyTypeMismatchError = "A previous preference binding exists with differen
 
 type prefBoundBool struct {
 	base
-	key string
-	p   fyne.Preferences
-
-	cacheLock sync.RWMutex
-	cache     bool
+	key   string
+	p     fyne.Preferences
+	cache atomic.Value // bool
 }
 
 // BindPreferenceBool returns a bindable bool value that is managed by the application preferences.
@@ -43,10 +41,8 @@ func BindPreferenceBool(key string, p fyne.Preferences) Bool {
 
 func (b *prefBoundBool) Get() (bool, error) {
 	cache := b.p.Bool(b.key)
-	b.cacheLock.Lock()
-	b.cache = cache
-	b.cacheLock.Unlock()
-	return b.cache, nil
+	b.cache.Store(cache)
+	return cache, nil
 }
 
 func (b *prefBoundBool) Set(v bool) error {
@@ -59,23 +55,21 @@ func (b *prefBoundBool) Set(v bool) error {
 }
 
 func (b *prefBoundBool) checkForChange() {
-	b.cacheLock.RLock()
-	cache := b.cache
-	b.cacheLock.RUnlock()
-	if b.p.Bool(b.key) == cache {
-		return
+	val := b.cache.Load()
+	if val != nil {
+		cache := val.(bool)
+		if b.p.Bool(b.key) == cache {
+			return
+		}
 	}
-
 	b.trigger()
 }
 
 type prefBoundFloat struct {
 	base
-	key string
-	p   fyne.Preferences
-
-	cacheLock sync.RWMutex
-	cache     float64
+	key   string
+	p     fyne.Preferences
+	cache atomic.Value // float64
 }
 
 // BindPreferenceFloat returns a bindable float64 value that is managed by the application preferences.
@@ -101,10 +95,8 @@ func BindPreferenceFloat(key string, p fyne.Preferences) Float {
 
 func (b *prefBoundFloat) Get() (float64, error) {
 	cache := b.p.Float(b.key)
-	b.cacheLock.Lock()
-	b.cache = cache
-	b.cacheLock.Unlock()
-	return b.cache, nil
+	b.cache.Store(cache)
+	return cache, nil
 }
 
 func (b *prefBoundFloat) Set(v float64) error {
@@ -117,23 +109,21 @@ func (b *prefBoundFloat) Set(v float64) error {
 }
 
 func (b *prefBoundFloat) checkForChange() {
-	b.cacheLock.RLock()
-	cache := b.cache
-	b.cacheLock.RUnlock()
-	if b.p.Float(b.key) == cache {
-		return
+	val := b.cache.Load()
+	if val != nil {
+		cache := val.(float64)
+		if b.p.Float(b.key) == cache {
+			return
+		}
 	}
-
 	b.trigger()
 }
 
 type prefBoundInt struct {
 	base
-	key string
-	p   fyne.Preferences
-
-	cacheLock sync.RWMutex
-	cache     int
+	key   string
+	p     fyne.Preferences
+	cache atomic.Value // int
 }
 
 // BindPreferenceInt returns a bindable int value that is managed by the application preferences.
@@ -159,10 +149,8 @@ func BindPreferenceInt(key string, p fyne.Preferences) Int {
 
 func (b *prefBoundInt) Get() (int, error) {
 	cache := b.p.Int(b.key)
-	b.cacheLock.Lock()
-	b.cache = cache
-	b.cacheLock.Unlock()
-	return b.cache, nil
+	b.cache.Store(cache)
+	return cache, nil
 }
 
 func (b *prefBoundInt) Set(v int) error {
@@ -175,23 +163,21 @@ func (b *prefBoundInt) Set(v int) error {
 }
 
 func (b *prefBoundInt) checkForChange() {
-	b.cacheLock.RLock()
-	cache := b.cache
-	b.cacheLock.RUnlock()
-	if b.p.Int(b.key) == cache {
-		return
+	val := b.cache.Load()
+	if val != nil {
+		cache := val.(int)
+		if b.p.Int(b.key) == cache {
+			return
+		}
 	}
-
 	b.trigger()
 }
 
 type prefBoundString struct {
 	base
-	key string
-	p   fyne.Preferences
-
-	cacheLock sync.RWMutex
-	cache     string
+	key   string
+	p     fyne.Preferences
+	cache atomic.Value // string
 }
 
 // BindPreferenceString returns a bindable string value that is managed by the application preferences.
@@ -217,10 +203,8 @@ func BindPreferenceString(key string, p fyne.Preferences) String {
 
 func (b *prefBoundString) Get() (string, error) {
 	cache := b.p.String(b.key)
-	b.cacheLock.Lock()
-	b.cache = cache
-	b.cacheLock.Unlock()
-	return b.cache, nil
+	b.cache.Store(cache)
+	return cache, nil
 }
 
 func (b *prefBoundString) Set(v string) error {
@@ -233,12 +217,12 @@ func (b *prefBoundString) Set(v string) error {
 }
 
 func (b *prefBoundString) checkForChange() {
-	b.cacheLock.RLock()
-	cache := b.cache
-	b.cacheLock.RUnlock()
-	if b.p.String(b.key) == cache {
-		return
+	val := b.cache.Load()
+	if val != nil {
+		cache := val.(string)
+		if b.p.String(b.key) == cache {
+			return
+		}
 	}
-
 	b.trigger()
 }


### PR DESCRIPTION
### Description:
Use `sync/atomic.*` and `sync.Map` to optimize the following two cases:

1. atomic access on an individual variable
2. read-heavy cases, such as preference maps

Existing benchmarks:

```
name             old time/op  new time/op  delta
BoolToString-8   1.12µs ± 2%  1.10µs ± 2%    ~     (p=0.095 n=5+5)
FloatToString-8  1.42µs ± 0%  1.37µs ± 0%  -3.08%  (p=0.016 n=4+5)
IntToString-8    1.13µs ± 0%  1.12µs ± 2%    ~     (p=0.159 n=4+5)
StringToBool-8   1.46µs ± 2%  1.39µs ± 0%  -5.04%  (p=0.008 n=5+5)
StringToFloat-8  1.60µs ± 1%  1.51µs ± 0%  -5.62%  (p=0.000 n=5+4)
StringToInt-8    1.47µs ± 2%  1.41µs ± 0%  -4.17%  (p=0.008 n=5+5)
```

The actual performance gain might be even higher, but concerning new benchmarks would be another story.

Fixes #2359

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
