### PR TITLE
Minor linear gradient generator optimization

### DIFF
--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -31,19 +31,19 @@ func (g *LinearGradient) Generate(iw, ih int) image.Image {
 		}
 	case 45: // diagonal negative flipped
 		generator = func(x, y float64) float64 {
-			return math.Abs((w+h)-(x+h-y)) / math.Abs(w+h)
+			return math.Abs((w - x + y) / (w + h)) // ((w+h)-(x+h-y)) / (w+h)
 		}
 	case 225: // diagonal negative
 		generator = func(x, y float64) float64 {
-			return math.Abs(x+h-y) / math.Abs(w+h)
+			return math.Abs((x + h - y) / (w + h))
 		}
 	case 135: // diagonal positive flipped
 		generator = func(x, y float64) float64 {
-			return math.Abs((w+h)-(x+y)) / math.Abs(w+h)
+			return math.Abs((w + h - (x + y)) / (w + h))
 		}
 	case 315: // diagonal positive
 		generator = func(x, y float64) float64 {
-			return math.Abs(x+y) / math.Abs(w+h)
+			return math.Abs((x + y) / (w + h))
 		}
 	case 180: // vertical flipped
 		generator = func(_, y float64) float64 {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This uses some math rules to simplify a few of the linear gradient generator functions.
It takes advantage of the fact that `|a| / |b| = |a / b|`, essentially avoiding one call to `math.Abs`.
For the 45 degree calculation, it also removes unnecessary additions and subtractions.

Benchmarking the whole `.Generate()` function shows at most 5% performance improvement (best case at 45 degrees).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
