### PR TITLE
Fix possible issue when un-fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * CenterOnScreen not working for FixedSize Window (#2550)
 * Panic in boundStringListItem.Get() (#2643)
 * Can't set an app/window icon to be an svg. (#1196)
+* SetFullScreen(false) can give error (#2588)
 
 
 ## 2.1.1 - 22 October 2021

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -136,6 +136,9 @@ func (w *window) SetFullScreen(full bool) {
 		if full {
 			w.viewport.SetMonitor(monitor, 0, 0, mode.Width, mode.Height, mode.RefreshRate)
 		} else {
+			if w.width == 0 && w.height == 0 { // if we were fullscreen on creation...
+				w.width, w.height = w.screenSize(w.canvas.Size())
+			}
 			w.viewport.SetMonitor(nil, w.xpos, w.ypos, w.width, w.height, 0)
 		}
 	})

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1647,6 +1647,24 @@ func TestWindow_SetContent_Twice(t *testing.T) {
 	assert.True(t, e1.Visible())
 }
 
+func TestWindow_SetFullScreen(t *testing.T) {
+	w := createWindow("Full").(*window)
+	w.SetFullScreen(true)
+	w.create()
+	w.doShow()
+	waitForMain()
+
+	// initial state - no window size set
+	assert.Zero(t, w.width)
+	assert.Zero(t, w.height)
+
+	w.SetFullScreen(false)
+	waitForMain()
+	// ensure we realised size now!
+	assert.NotZero(t, w.width)
+	assert.NotZero(t, w.height)
+}
+
 // This test makes our developer screens flash, let's not run it regularly...
 //func TestWindow_Shortcut(t *testing.T) {
 //	w := createWindow("Test")
@@ -1915,4 +1933,8 @@ func newDoubleTappableButton() *doubleTappableButton {
 	but.ExtendBaseWidget(but)
 
 	return but
+}
+
+func waitForMain() {
+	runOnMain(func() {}) // this blocks until processed
 }


### PR DESCRIPTION
Caused if the window has never had a resize event before.
Fixes #2588

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
