### PR TITLE
Look up config dir using XDG_CONFIG_HOME

### DIFF
--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -46,9 +46,7 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 }
 
 func rootConfigDir() string {
-	homeDir, _ := os.UserHomeDir()
-
-	desktopConfig := filepath.Join(homeDir, ".config")
+	desktopConfig, _ := os.UserConfigDir()
 	return filepath.Join(desktopConfig, "fyne")
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This switches the config dir lookup from hardcoded `$HOME + /.config` to reading the $XDG_CONFIG_HOME environment variable using [os.UserConfigDir()](https://pkg.go.dev/os#UserConfigDir). This has one very big improvement. It means that Fyne apps running in flatpak don't need to pass though access to the cache directory to use the preference and document storage API. For everyone else, it's basically no change unless a custom `$XDG_CONFIG_HOME` is set in some situation (our old way is still the fallback).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
