### PR TITLE
Fix custom font derivative lookups

### DIFF
--- a/theme/theme.go
+++ b/theme/theme.go
@@ -516,9 +516,15 @@ func (t *builtinTheme) initFonts() {
 	font := os.Getenv("FYNE_FONT")
 	if font != "" {
 		t.regular = loadCustomFont(font, "Regular", regular)
-		t.bold = loadCustomFont(font, "Bold", bold)
-		t.italic = loadCustomFont(font, "Italic", italic)
-		t.boldItalic = loadCustomFont(font, "BoldItalic", bolditalic)
+		if t.regular == regular { // failed to load
+			t.bold = loadCustomFont(font, "Bold", bold)
+			t.italic = loadCustomFont(font, "Italic", italic)
+			t.boldItalic = loadCustomFont(font, "BoldItalic", boldItalic)
+		} else { // first custom font loaded, fall back to that
+			t.bold = loadCustomFont(font, "Bold", t.regular)
+			t.italic = loadCustomFont(font, "Italic", t.regular)
+			t.boldItalic = loadCustomFont(font, "BoldItalic", t.regular)
+		}
 	}
 	font = os.Getenv("FYNE_FONT_MONOSPACE")
 	if font != "" {

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -519,7 +519,7 @@ func (t *builtinTheme) initFonts() {
 		if t.regular == regular { // failed to load
 			t.bold = loadCustomFont(font, "Bold", bold)
 			t.italic = loadCustomFont(font, "Italic", italic)
-			t.boldItalic = loadCustomFont(font, "BoldItalic", boldItalic)
+			t.boldItalic = loadCustomFont(font, "BoldItalic", bolditalic)
 		} else { // first custom font loaded, fall back to that
 			t.bold = loadCustomFont(font, "Bold", t.regular)
 			t.italic = loadCustomFont(font, "Italic", t.regular)


### PR DESCRIPTION
If we load the first custom font use it as fallback instead
This means that other languages can provide just regular font

Fixes #2512

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
