### PR TITLE
Add `Bytes` for a `[]byte` binding

### DIFF
--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -96,6 +96,97 @@ func (b *boundExternalBool) Reload() error {
 	return b.Set(*b.val)
 }
 
+// Bytes supports binding a []byte value.
+//
+// Since: 2.2
+type Bytes interface {
+	DataItem
+	Get() ([]byte, error)
+	Set([]byte) error
+}
+
+// ExternalBytes supports binding a []byte value to an external value.
+//
+// Since: 2.2
+type ExternalBytes interface {
+	Bytes
+	Reload() error
+}
+
+// NewBytes returns a bindable []byte value that is managed internally.
+//
+// Since: 2.2
+func NewBytes() Bytes {
+	var blank []byte = nil
+	return &boundBytes{val: &blank}
+}
+
+// BindBytes returns a new bindable value that controls the contents of the provided []byte variable.
+// If your code changes the content of the variable this refers to you should call Reload() to inform the bindings.
+//
+// Since: 2.2
+func BindBytes(v *[]byte) ExternalBytes {
+	if v == nil {
+		var blank []byte = nil
+		v = &blank // never allow a nil value pointer
+	}
+	b := &boundExternalBytes{}
+	b.val = v
+	b.old = *v
+	return b
+}
+
+type boundBytes struct {
+	base
+
+	val *[]byte
+}
+
+func (b *boundBytes) Get() ([]byte, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	if b.val == nil {
+		return nil, nil
+	}
+	return *b.val, nil
+}
+
+func (b *boundBytes) Set(val []byte) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if compareBytes(*b.val, val) {
+		return nil
+	}
+	*b.val = val
+
+	b.trigger()
+	return nil
+}
+
+type boundExternalBytes struct {
+	boundBytes
+
+	old []byte
+}
+
+func (b *boundExternalBytes) Set(val []byte) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if compareBytes(b.old, val) {
+		return nil
+	}
+	*b.val = val
+	b.old = val
+
+	b.trigger()
+	return nil
+}
+
+func (b *boundExternalBytes) Reload() error {
+	return b.Set(*b.val)
+}
+
 // Float supports binding a float64 value.
 //
 // Since: 2.0

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -3,7 +3,11 @@
 
 package binding
 
-import "fyne.io/fyne/v2"
+import (
+	"bytes"
+
+	"fyne.io/fyne/v2"
+)
 
 // Bool supports binding a bool value.
 //
@@ -155,7 +159,7 @@ func (b *boundBytes) Get() ([]byte, error) {
 func (b *boundBytes) Set(val []byte) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	if compareBytes(*b.val, val) {
+	if bytes.Equal(*b.val, val) {
 		return nil
 	}
 	*b.val = val
@@ -173,7 +177,7 @@ type boundExternalBytes struct {
 func (b *boundExternalBytes) Set(val []byte) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	if compareBytes(b.old, val) {
+	if bytes.Equal(b.old, val) {
 		return nil
 	}
 	*b.val = val

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -3,7 +3,11 @@
 
 package binding
 
-import "fyne.io/fyne/v2"
+import (
+	"bytes"
+
+	"fyne.io/fyne/v2"
+)
 
 // BoolList supports binding a list of bool values.
 //
@@ -439,7 +443,7 @@ type boundExternalBytesListItem struct {
 }
 
 func (b *boundExternalBytesListItem) setIfChanged(val []byte) error {
-	if compareBytes(val, b.old) {
+	if bytes.Equal(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -227,6 +227,228 @@ func (b *boundExternalBoolListItem) setIfChanged(val bool) error {
 	return nil
 }
 
+// BytesList supports binding a list of []byte values.
+//
+// Since: 2.2
+type BytesList interface {
+	DataList
+
+	Append(value []byte) error
+	Get() ([][]byte, error)
+	GetValue(index int) ([]byte, error)
+	Prepend(value []byte) error
+	Set(list [][]byte) error
+	SetValue(index int, value []byte) error
+}
+
+// ExternalBytesList supports binding a list of []byte values from an external variable.
+//
+// Since: 2.2
+type ExternalBytesList interface {
+	BytesList
+
+	Reload() error
+}
+
+// NewBytesList returns a bindable list of []byte values.
+//
+// Since: 2.2
+func NewBytesList() BytesList {
+	return &boundBytesList{val: &[][]byte{}}
+}
+
+// BindBytesList returns a bound list of []byte values, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
+//
+// Since: 2.2
+func BindBytesList(v *[][]byte) ExternalBytesList {
+	if v == nil {
+		return NewBytesList().(ExternalBytesList)
+	}
+
+	b := &boundBytesList{val: v, updateExternal: true}
+
+	for i := range *v {
+		b.appendItem(bindBytesListItem(v, i, b.updateExternal))
+	}
+
+	return b
+}
+
+type boundBytesList struct {
+	listBase
+
+	updateExternal bool
+	val            *[][]byte
+}
+
+func (l *boundBytesList) Append(val []byte) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	*l.val = append(*l.val, val)
+
+	return l.doReload()
+}
+
+func (l *boundBytesList) Get() ([][]byte, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	return *l.val, nil
+}
+
+func (l *boundBytesList) GetValue(i int) ([]byte, error) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	if i < 0 || i >= l.Length() {
+		return nil, errOutOfBounds
+	}
+
+	return (*l.val)[i], nil
+}
+
+func (l *boundBytesList) Prepend(val []byte) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	*l.val = append([][]byte{val}, *l.val...)
+
+	return l.doReload()
+}
+
+func (l *boundBytesList) Reload() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	return l.doReload()
+}
+
+func (l *boundBytesList) Set(v [][]byte) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	*l.val = v
+
+	return l.doReload()
+}
+
+func (l *boundBytesList) doReload() (retErr error) {
+	oldLen := len(l.items)
+	newLen := len(*l.val)
+	if oldLen > newLen {
+		for i := oldLen - 1; i >= newLen; i-- {
+			l.deleteItem(i)
+		}
+		l.trigger()
+	} else if oldLen < newLen {
+		for i := oldLen; i < newLen; i++ {
+			l.appendItem(bindBytesListItem(l.val, i, l.updateExternal))
+		}
+		l.trigger()
+	}
+
+	for i, item := range l.items {
+		if i > oldLen || i > newLen {
+			break
+		}
+
+		var err error
+		if l.updateExternal {
+			item.(*boundExternalBytesListItem).lock.Lock()
+			err = item.(*boundExternalBytesListItem).setIfChanged((*l.val)[i])
+			item.(*boundExternalBytesListItem).lock.Unlock()
+		} else {
+			item.(*boundBytesListItem).lock.Lock()
+			err = item.(*boundBytesListItem).doSet((*l.val)[i])
+			item.(*boundBytesListItem).lock.Unlock()
+		}
+		if err != nil {
+			retErr = err
+		}
+	}
+	return
+}
+
+func (l *boundBytesList) SetValue(i int, v []byte) error {
+	l.lock.RLock()
+	len := l.Length()
+	l.lock.RUnlock()
+
+	if i < 0 || i >= len {
+		return errOutOfBounds
+	}
+
+	l.lock.Lock()
+	(*l.val)[i] = v
+	l.lock.Unlock()
+
+	item, err := l.GetItem(i)
+	if err != nil {
+		return err
+	}
+	return item.(Bytes).Set(v)
+}
+
+func bindBytesListItem(v *[][]byte, i int, external bool) Bytes {
+	if external {
+		ret := &boundExternalBytesListItem{old: (*v)[i]}
+		ret.val = v
+		ret.index = i
+		return ret
+	}
+
+	return &boundBytesListItem{val: v, index: i}
+}
+
+type boundBytesListItem struct {
+	base
+
+	val   *[][]byte
+	index int
+}
+
+func (b *boundBytesListItem) Get() ([]byte, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if b.index < 0 || b.index >= len(*b.val) {
+		return nil, errOutOfBounds
+	}
+
+	return (*b.val)[b.index], nil
+}
+
+func (b *boundBytesListItem) Set(val []byte) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return b.doSet(val)
+}
+
+func (b *boundBytesListItem) doSet(val []byte) error {
+	(*b.val)[b.index] = val
+
+	b.trigger()
+	return nil
+}
+
+type boundExternalBytesListItem struct {
+	boundBytesListItem
+
+	old []byte
+}
+
+func (b *boundExternalBytesListItem) setIfChanged(val []byte) error {
+	if compareBytes(val, b.old) {
+		return nil
+	}
+	(*b.val)[b.index] = val
+	b.old = val
+
+	b.trigger()
+	return nil
+}
+
 // FloatList supports binding a list of float64 values.
 //
 // Since: 2.0
@@ -1549,7 +1771,7 @@ type boundExternalURIListItem struct {
 }
 
 func (b *boundExternalURIListItem) setIfChanged(val fyne.URI) error {
-	if val == b.old {
+	if compareURI(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val

--- a/data/binding/comparator_helper.go
+++ b/data/binding/comparator_helper.go
@@ -1,8 +1,6 @@
 package binding
 
 import (
-	"bytes"
-
 	"fyne.io/fyne/v2"
 )
 
@@ -14,8 +12,4 @@ func compareURI(v1, v2 fyne.URI) bool {
 		return false
 	}
 	return v1.String() == v2.String()
-}
-
-func compareBytes(v1, v2 []byte) bool {
-	return bytes.Equal(v1, v2)
 }

--- a/data/binding/comparator_helper.go
+++ b/data/binding/comparator_helper.go
@@ -1,8 +1,6 @@
 package binding
 
-import (
-	"fyne.io/fyne/v2"
-)
+import "fyne.io/fyne/v2"
 
 func compareURI(v1, v2 fyne.URI) bool {
 	if v1 == nil && v1 == v2 {

--- a/data/binding/comparator_helper.go
+++ b/data/binding/comparator_helper.go
@@ -17,5 +17,5 @@ func compareURI(v1, v2 fyne.URI) bool {
 }
 
 func compareBytes(v1, v2 []byte) bool {
-	return bytes.Compare(v1, v2) == 0
+	return bytes.Equal(v1, v2)
 }

--- a/data/binding/comparator_helper.go
+++ b/data/binding/comparator_helper.go
@@ -1,6 +1,10 @@
 package binding
 
-import "fyne.io/fyne/v2"
+import (
+	"bytes"
+
+	"fyne.io/fyne/v2"
+)
 
 func compareURI(v1, v2 fyne.URI) bool {
 	if v1 == nil && v1 == v2 {
@@ -10,4 +14,8 @@ func compareURI(v1, v2 fyne.URI) bool {
 		return false
 	}
 	return v1.String() == v2.String()
+}
+
+func compareBytes(v1, v2 []byte) bool {
+	return bytes.Compare(v1, v2) == 0
 }

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -583,9 +583,15 @@ type boundExternal{{ .Name }}ListItem struct {
 }
 
 func (b *boundExternal{{ .Name }}ListItem) setIfChanged(val {{ .Type }}) error {
+	{{- if eq .Comparator "" }}
 	if val == b.old {
 		return nil
 	}
+	{{- else }}
+	if {{ .Comparator }}(val, b.old) {
+		return nil
+	}
+	{{- end }}
 	(*b.val)[b.index] = val
 	b.old = val
 
@@ -678,6 +684,7 @@ import "fyne.io/fyne/v2"
 	list := template.Must(template.New("list").Parse(listBindTemplate))
 	binds := []bindValues{
 		bindValues{Name: "Bool", Type: "bool", Default: "false", Format: "%t", SupportsPreferences: true},
+		bindValues{Name: "Bytes", Type: "[]byte", Default: "nil", Since: "2.2", Comparator: "compareBytes"},
 		bindValues{Name: "Float", Type: "float64", Default: "0.0", Format: "%f", SupportsPreferences: true},
 		bindValues{Name: "Int", Type: "int", Default: "0", Format: "%d", SupportsPreferences: true},
 		bindValues{Name: "Rune", Type: "rune", Default: "rune(0)"},

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -639,7 +639,11 @@ func main() {
 	}
 	defer itemFile.Close()
 	itemFile.WriteString(`
-import "fyne.io/fyne/v2"
+import (
+	"bytes"
+
+	"fyne.io/fyne/v2"
+)
 `)
 	convertFile, err := newFile("convert")
 	if err != nil {
@@ -674,7 +678,11 @@ const keyTypeMismatchError = "A previous preference binding exists with differen
 	}
 	defer listFile.Close()
 	listFile.WriteString(`
-import "fyne.io/fyne/v2"
+import (
+	"bytes"
+
+	"fyne.io/fyne/v2"
+)
 `)
 
 	item := template.Must(template.New("item").Parse(itemBindTemplate))
@@ -684,7 +692,7 @@ import "fyne.io/fyne/v2"
 	list := template.Must(template.New("list").Parse(listBindTemplate))
 	binds := []bindValues{
 		bindValues{Name: "Bool", Type: "bool", Default: "false", Format: "%t", SupportsPreferences: true},
-		bindValues{Name: "Bytes", Type: "[]byte", Default: "nil", Since: "2.2", Comparator: "compareBytes"},
+		bindValues{Name: "Bytes", Type: "[]byte", Default: "nil", Since: "2.2", Comparator: "bytes.Equal"},
 		bindValues{Name: "Float", Type: "float64", Default: "0.0", Format: "%f", SupportsPreferences: true},
 		bindValues{Name: "Int", Type: "int", Default: "0", Format: "%d", SupportsPreferences: true},
 		bindValues{Name: "Rune", Type: "rune", Default: "rune(0)"},


### PR DESCRIPTION
Just adding `[]byte` to the types generated

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

