### PR TITLE
Fix build issue on mobile sim after upgrading from Fedora 34 to 35

### DIFF
--- a/internal/driver/mobile/app/x11.c
+++ b/internal/driver/mobile/app/x11.c
@@ -8,6 +8,7 @@
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Big thanks to @andydotxyz for coming up with this simple one-liner :)
This fixes some strange builds issues using -tags mobile on my Fedora installations after upgrading from 34 to 35.

Fixes #2625

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- hard to test since I seem to be the only one getting this issue.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
