### PR TITLE
Bugs/window locking

### DIFF
--- a/cmd/fyne_demo/tutorials/window.go
+++ b/cmd/fyne_demo/tutorials/window.go
@@ -10,10 +10,10 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
-var visibilityWindow fyne.Window = nil
-var visibilityState bool = false
-
 func windowScreen(_ fyne.Window) fyne.CanvasObject {
+	var visibilityWindow fyne.Window = nil
+	var visibilityState bool = false
+
 	windowGroup := container.NewVBox(
 		widget.NewButton("New window", func() {
 			w := fyne.CurrentApp().NewWindow("Hello")

--- a/cmd/fyne_demo/tutorials/window.go
+++ b/cmd/fyne_demo/tutorials/window.go
@@ -10,6 +10,9 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
+var visibilityWindow fyne.Window = nil
+var visibilityState bool = false
+
 func windowScreen(_ fyne.Window) fyne.CanvasObject {
 	windowGroup := container.NewVBox(
 		widget.NewButton("New window", func() {
@@ -41,6 +44,21 @@ func windowScreen(_ fyne.Window) fyne.CanvasObject {
 
 			w.CenterOnScreen()
 			w.Show()
+		}),
+		widget.NewButton("Show/Hide window", func() {
+			if visibilityWindow == nil {
+				visibilityWindow = fyne.CurrentApp().NewWindow("Hello")
+				visibilityWindow.SetContent(widget.NewLabel("Hello World!"))
+				visibilityWindow.SetOnClosed(func() {
+					visibilityWindow = nil
+				})
+			}
+			if visibilityState {
+				visibilityWindow.Hide()
+			} else {
+				visibilityWindow.Show()
+			}
+			visibilityState = !visibilityState
 		}))
 
 	drv := fyne.CurrentApp().Driver()

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -122,9 +122,12 @@ func (d *gLDriver) windowList() []fyne.Window {
 func (d *gLDriver) initFailed(msg string, err error) {
 	fyne.LogError(msg, err)
 
-	if running() {
+	run.Lock()
+	if !run.flag {
+		run.Unlock()
 		d.Quit()
 	} else {
+		run.Unlock()
 		os.Exit(1)
 	}
 }

--- a/internal/driver/glfw/glfw_test.go
+++ b/internal/driver/glfw/glfw_test.go
@@ -6,11 +6,14 @@ package glfw
 import "time"
 
 func repaintWindow(w *window) {
-	for !running() {
-		// Wait for GLFW loop to be running.
-		// If we try to paint windows before the context is created, we will end up on the wrong thread.
-		time.Sleep(time.Millisecond * 10)
+	// Wait for GLFW loop to be running.
+	// If we try to paint windows before the context is created, we will end up on the wrong thread.
+	run.RLock()
+	for !run.flag {
+		run.cond.Wait()
 	}
+	run.RUnlock()
+
 	runOnDraw(w, func() {
 		d.(*gLDriver).repaintWindow(w)
 	})

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -425,15 +425,18 @@ func (w *window) doShow() {
 }
 
 func (w *window) Hide() {
-	if w.isClosing() {
-		return
-	}
-
 	runOnMain(func() {
 		w.viewLock.Lock()
+		if w.closing || w.viewport == nil {
+			w.viewLock.Unlock()
+			return
+		}
+
 		w.visible = false
-		w.viewport.Hide()
+		v := w.viewport
 		w.viewLock.Unlock()
+
+		v.Hide()
 
 		// hide top canvas element
 		if w.canvas.Content() != nil {
@@ -452,7 +455,6 @@ func (w *window) Close() {
 		w.viewLock.Lock()
 		w.closing = true
 		w.viewLock.Unlock()
-		w.viewport.SetShouldClose(true)
 		cache.RangeTexturesFor(w.canvas, func(obj fyne.CanvasObject) {
 			w.canvas.Painter().Free(obj)
 		})

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -388,9 +388,12 @@ func (w *window) doShow() {
 		return
 	}
 
-	for !running() {
-		time.Sleep(time.Millisecond * 10)
+	run.RLock()
+	for !run.flag {
+		run.cond.Wait()
 	}
+	run.RUnlock()
+
 	w.createLock.Do(w.create)
 	if w.view() == nil {
 		return

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -40,9 +40,12 @@ func TestMain(m *testing.M) {
 	go func() {
 		// Wait for GLFW loop to be running.
 		// If we try to create windows before the context is created, this will fail with an exception.
-		for !running() {
-			time.Sleep(10 * time.Millisecond)
+		run.RLock()
+		for !run.flag {
+			run.cond.Wait()
 		}
+		run.RUnlock()
+
 		initMainMenu()
 		os.Exit(m.Run())
 	}()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This address locking/race condition issue I encountered while working on the WASM port. They are all around the creation/destruction/show/hide of a Window.

Before this patch, I would have random SEGV with access to a dead glfw internal pointer when testing with fyne_demo Windows tests. They are gone after this PR.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
