### PR TITLE
internal/driver/glfw: window close regression

### DIFF
--- a/internal/driver/glfw/glfw_test.go
+++ b/internal/driver/glfw/glfw_test.go
@@ -8,11 +8,11 @@ import "time"
 func repaintWindow(w *window) {
 	// Wait for GLFW loop to be running.
 	// If we try to paint windows before the context is created, we will end up on the wrong thread.
-	run.RLock()
+	run.Lock()
 	for !run.flag {
 		run.cond.Wait()
 	}
-	run.RUnlock()
+	run.Unlock()
 
 	runOnDraw(w, func() {
 		d.(*gLDriver).repaintWindow(w)

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -27,7 +27,7 @@ type drawData struct {
 }
 
 type runFlag struct {
-	sync.RWMutex
+	sync.Mutex
 	flag bool
 	cond *sync.Cond
 }
@@ -58,12 +58,12 @@ func init() {
 func runOnMain(f func()) {
 	// If we are on main just execute - otherwise add it to the main queue and wait.
 	// The "running" variable is normally false when we are on the main thread.
-	run.RLock()
+	run.Lock()
 	if !run.flag {
 		f()
-		run.RUnlock()
+		run.Unlock()
 	} else {
-		run.RUnlock()
+		run.Unlock()
 
 		done := donePool.Get().(chan struct{})
 		defer donePool.Put(done)

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -388,11 +388,11 @@ func (w *window) doShow() {
 		return
 	}
 
-	run.RLock()
+	run.Lock()
 	for !run.flag {
 		run.cond.Wait()
 	}
-	run.RUnlock()
+	run.Unlock()
 
 	w.createLock.Do(w.create)
 	if w.view() == nil {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -458,6 +458,7 @@ func (w *window) Close() {
 		w.viewLock.Lock()
 		w.closing = true
 		w.viewLock.Unlock()
+		w.viewport.SetShouldClose(true)
 		cache.RangeTexturesFor(w.canvas, func(obj fyne.CanvasObject) {
 			w.canvas.Painter().Free(obj)
 		})

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1607,6 +1607,7 @@ func TestWindow_CloseInterception(t *testing.T) {
 	w.WaitForEvents()
 	assert.False(t, onIntercepted) // The interceptor is not called by the Close.
 	assert.True(t, onClosed)
+	assert.True(t, w.viewport.ShouldClose()) // For #2694
 
 	w.closing = false // fake a fresh window
 	onIntercepted = false

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -40,11 +40,11 @@ func TestMain(m *testing.M) {
 	go func() {
 		// Wait for GLFW loop to be running.
 		// If we try to create windows before the context is created, this will fail with an exception.
-		run.RLock()
+		run.Lock()
 		for !run.flag {
 			run.cond.Wait()
 		}
-		run.RUnlock()
+		run.Unlock()
 
 		initMainMenu()
 		os.Exit(m.Run())


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

This PR fixes a regression introduced in #2687.

With PR#2687, a window cannot be closed because an additional line was removed.
Add it back.

cc @Bluebugs 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
