### PR TITLE
Don't run change listeners if setting same value

### DIFF
--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -47,6 +47,11 @@ func (p *InMemoryPreferences) WriteValues(fn func(map[string]interface{})) {
 func (p *InMemoryPreferences) set(key string, value interface{}) {
 	p.lock.Lock()
 
+	if stored, ok := p.values[key]; ok && stored == value {
+		p.lock.Unlock()
+		return
+	}
+
 	p.values[key] = value
 	p.lock.Unlock()
 

--- a/internal/preferences_test.go
+++ b/internal/preferences_test.go
@@ -163,3 +163,24 @@ func TestRemoveValue(t *testing.T) {
 	assert.Equal(t, 0, p.Int("number"))
 	assert.Equal(t, "", p.String("month"))
 }
+
+func TestPrefs_SetSameValue(t *testing.T) {
+	p := NewInMemoryPreferences()
+	called := 0
+	p.AddChangeListener(func() {
+		called++
+	})
+
+	// We should not fire change when it hasn't changed.
+	for i := 0; i < 2; i++ {
+		p.SetBool("enabled", true)
+		time.Sleep(time.Millisecond * 100)
+
+		assert.Equal(t, 1, called)
+	}
+
+	p.SetBool("enabled", false)
+	time.Sleep(time.Millisecond * 100)
+
+	assert.Equal(t, 2, called)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This effectively makes sure that we don't write to the disk, or update/run any change listeners, when
trying to set the exact same value again. Does this make sense?
I noticed that I was writing just after reading the values in wormhole-gui, but does is happen in normal circumstances?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
