### PR TITLE
More valid version field for metadata load test

### DIFF
--- a/cmd/fyne/internal/metadata/load_test.go
+++ b/cmd/fyne/internal/metadata/load_test.go
@@ -16,6 +16,6 @@ func TestLoadAppMetadata(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "https://apps.fyne.io", data.Website)
 	assert.Equal(t, "io.fyne.fyne", data.Details.ID)
-	assert.Equal(t, "v1.0", data.Details.Version)
+	assert.Equal(t, "1.0.0", data.Details.Version)
 	assert.Equal(t, 1, data.Details.Build)
 }

--- a/cmd/fyne/internal/metadata/testdata/FyneApp.toml
+++ b/cmd/fyne/internal/metadata/testdata/FyneApp.toml
@@ -4,6 +4,6 @@ Website = "https://apps.fyne.io"
 Name = "Fyne App"
 ID = "io.fyne.fyne"
 Icon = "https://conf.fyne.io/assets/img/fyne.png"
-Version = "v1.0"
+Version = "1.0.0"
 Build = 1
 


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The metadata takes a version of "x.y.z" but the test made it seem as if it takes "vx.y" instead.
Fix up the test to be more representative of the real world usage.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
