### PR TITLE
Disable check for pinned thread with gopherjs.

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -78,13 +78,6 @@ func (d *gLDriver) Quit() {
 	close(d.done)
 }
 
-func (d *gLDriver) Run() {
-	if goroutineID() != mainGoroutineID {
-		panic("Run() or ShowAndRun() must be called from main goroutine")
-	}
-	d.runGL()
-}
-
 func (d *gLDriver) addWindow(w *window) {
 	d.windowLock.Lock()
 	defer d.windowLock.Unlock()

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -1,0 +1,11 @@
+//go:build !js
+// +build !js
+
+package glfw
+
+func (d *gLDriver) Run() {
+	if goroutineID() != mainGoroutineID {
+		panic("Run() or ShowAndRun() must be called from main goroutine")
+	}
+	d.runGL()
+}

--- a/internal/driver/glfw/driver_goxjs.go
+++ b/internal/driver/glfw/driver_goxjs.go
@@ -1,0 +1,8 @@
+//go:build js
+// +build js
+
+package glfw
+
+func (d *gLDriver) Run() {
+	d.runGL()
+}


### PR DESCRIPTION
### Description:
gopherjs only does have one system thread, so checking for thread and
pinning to a system thread doesn't work.

### Checklist:
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
