### PR TITLE
Fix os/exec that has gotten back in

### DIFF
--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -97,7 +96,7 @@ func envInit() (err error) {
 	// This is because go-list tries to analyze the module at the current directory if no packages are given,
 	// and if the module doesn't have any Go file, go-list fails. See golang/go#36668.
 
-	ver, err := exec.Command("go", "version").Output()
+	ver, err := execabs.Command("go", "version").Output()
 	if err == nil && string(ver) != "" {
 		fields := strings.Split(string(ver), " ")
 		if len(fields) >= 3 {

--- a/theme/gen.go
+++ b/theme/gen.go
@@ -10,13 +10,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
 
 	"fyne.io/fyne/v2"
+	"golang.org/x/sys/execabs"
 )
 
 const fontFace = "NotoSans"
@@ -226,7 +226,7 @@ func createFontByStripping(newFontFile, fontFile string, runes []rune) error {
 	for _, r := range runes {
 		unicodes = append(unicodes, fmt.Sprintf(`%04X`, r))
 	}
-	cmd := exec.Command(
+	cmd := execabs.Command(
 		"pyftsubset",
 		fontPath(fontFile),
 		"--output-file="+fontPath(newFontFile),


### PR DESCRIPTION


### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

It seems like the `os/exec` package has managed to get back into the code base. This just fixes up a few cases where it was being used. For anyone not sure why this is the case, see https://go.dev/blog/path-security.

We probably should do some sort of blacklist of the package but I don't know how to do so in a good way so we'll just have to do it like this for now. I would appreciate if people could take a little extra care to not introduce `os/exec` again next time :)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
