### PR TITLE
Add a GitHub action to check license of dependencies

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,18 @@
+name: Check license of dependencies
+on: [push, pull_request]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: WillAbides/setup-go-faster@v1.7.0
+      with:      
+        go-version: '1.18beta2'
+
+    - name: install lian
+      run: go install lucor.dev/lian@latest
+
+    - name: Check license of dependencies against go.mod
+      run: lian -d --allowed="Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT"
+

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: WillAbides/setup-go-faster@v1.7.0
       with:      
-        go-version: '1.18beta2'
+        go-version: '1.18.x'
 
     - name: install lian
       run: go install lucor.dev/lian@latest


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR adds a GitHub action to check license of dependencies using the [lucor.dev/lian](https://lucor.dev/lian) tool.

It will check the licenses of dependencies listed into the go.mod against a set of allowed types.

Fixes #2767

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
