### PR TITLE
If FixedSize is set without a preferred size we should fall back to minimum

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -219,6 +219,10 @@ func (w *window) FixedSize() bool {
 func (w *window) SetFixedSize(fixed bool) {
 	w.fixedSize = fixed
 
+	if fixed && (w.requestedWidth == 0 || w.requestedHeight == 0) {
+		bigEnough := w.canvas.canvasSize(w.canvas.Content().MinSize())
+		w.Resize(bigEnough)
+	}
 	if w.view() != nil {
 		w.runOnMainWhenCreated(w.fitContent)
 	}
@@ -501,6 +505,11 @@ func (w *window) SetContent(content fyne.CanvasObject) {
 	}
 
 	w.canvas.SetContent(content)
+	if !visible && w.fixedSize && (w.requestedWidth == 0 || w.requestedHeight == 0) {
+		bigEnough := w.canvas.canvasSize(content.MinSize())
+		w.Resize(bigEnough)
+	}
+
 	// show new canvas element
 	if content != nil {
 		content.Show()

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -218,11 +218,7 @@ func (w *window) FixedSize() bool {
 
 func (w *window) SetFixedSize(fixed bool) {
 	w.fixedSize = fixed
-
-	if fixed && (w.requestedWidth == 0 || w.requestedHeight == 0) {
-		bigEnough := w.canvas.canvasSize(w.canvas.Content().MinSize())
-		w.Resize(bigEnough)
-	}
+	w.ensureFixedHasSize()
 	if w.view() != nil {
 		w.runOnMainWhenCreated(w.fitContent)
 	}
@@ -505,9 +501,8 @@ func (w *window) SetContent(content fyne.CanvasObject) {
 	}
 
 	w.canvas.SetContent(content)
-	if !visible && w.fixedSize && (w.requestedWidth == 0 || w.requestedHeight == 0) {
-		bigEnough := w.canvas.canvasSize(content.MinSize())
-		w.Resize(bigEnough)
+	if !visible {
+		w.ensureFixedHasSize()
 	}
 
 	// show new canvas element
@@ -541,6 +536,14 @@ func (w *window) destroy(d *gLDriver) {
 		d.Quit()
 	} else if runtime.GOOS == "darwin" {
 		go d.focusPreviousWindow()
+	}
+}
+
+// ensureFixedHasSize makes sure that if a window is fixed size it has a requested size, or is set to minimum
+func (w *window) ensureFixedHasSize() {
+	if w.FixedSize() && (w.requestedWidth == 0 || w.requestedHeight == 0) {
+		bigEnough := w.canvas.canvasSize(w.canvas.Content().MinSize())
+		w.Resize(bigEnough)
 	}
 }
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -78,6 +78,23 @@ func TestGLDriver_CreateSplashWindow(t *testing.T) {
 	assert.True(t, w.centered)
 }
 
+func TestWindow_MinSize_Fixed(t *testing.T) {
+	w := createWindow("Test").(*window)
+	r := canvas.NewRectangle(color.White)
+	r.SetMinSize(fyne.NewSize(100, 100))
+	w.SetContent(r)
+	w.SetFixedSize(true)
+
+	assert.Equal(t, float32(100)+theme.Padding()*2, w.Canvas().Size().Width)
+
+	w = createWindow("Test").(*window)
+	r.SetMinSize(fyne.NewSize(100, 100))
+	w.SetFixedSize(true)
+	w.SetContent(r)
+
+	assert.Equal(t, float32(100)+theme.Padding()*2, w.Canvas().Size().Width)
+}
+
 func TestWindow_ToggleMainMenuByKeyboard(t *testing.T) {
 	w := createWindow("Test").(*window)
 	c := w.Canvas().(*glCanvas)


### PR DESCRIPTION
Avoid crashes by being larger than 1x1

Fixes #2784

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
