### PR TITLE
Add support for OpenURL to the web drivers (GopherJS and Wasm).

### DIFF
--- a/app/app_goxjs.go
+++ b/app/app_goxjs.go
@@ -6,20 +6,12 @@
 package app
 
 import (
-	"errors"
-	"net/url"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
 )
 
 func defaultVariant() fyne.ThemeVariant {
 	return theme.VariantDark
-}
-
-func (app *fyneApp) OpenURL(url *url.URL) error {
-	// TODO #2736
-	return errors.New("OpenURL is not supported yet with GopherJS backend.")
 }
 
 func (app *fyneApp) SendNotification(_ *fyne.Notification) {

--- a/app/app_openurl_js.go
+++ b/app/app_openurl_js.go
@@ -1,0 +1,20 @@
+//go:build !ci && js && !wasm
+// +build !ci,js,!wasm
+
+package app
+
+import (
+	"fmt"
+	"net/url"
+
+	"honnef.co/go/js/dom"
+)
+
+func (app *fyneApp) OpenURL(url *url.URL) error {
+	window := dom.GetWindow().Open(url.String(), "_blank", "")
+	if window == nil {
+		return fmt.Errorf("Unable to open a new window/tab for URL: %v.", url)
+	}
+	window.Focus()
+	return nil
+}

--- a/app/app_openurl_wasm.go
+++ b/app/app_openurl_wasm.go
@@ -1,0 +1,19 @@
+//go:build !ci && wasm
+// +build !ci,wasm
+
+package app
+
+import (
+	"fmt"
+	"net/url"
+	"syscall/js"
+)
+
+func (app *fyneApp) OpenURL(url *url.URL) error {
+	window := js.Global().Call("open", url.String(), "_blank", "")
+	if window.Equal(js.Null()) {
+		return fmt.Errorf("Unable to open a new window/tab for URL: %v.", url)
+	}
+	window.Call("focus")
+	return nil
+}

--- a/app/app_openurl_web.go
+++ b/app/app_openurl_web.go
@@ -1,0 +1,13 @@
+//go:build !ci && !js && !wasm && test_web_driver
+// +build !ci,!js,!wasm,test_web_driver
+
+package app
+
+import (
+	"errors"
+	"net/url"
+)
+
+func (app *fyneApp) OpenURL(url *url.URL) error {
+	return errors.New("OpenURL is not supported with the test web driver.")
+}

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,5 @@ require (
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 	golang.org/x/tools v0.1.8-0.20211022200916-316ba0b74098
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,4 +171,5 @@ golang.org/x/xerrors/internal
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 gopkg.in/yaml.v3
 # honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2
+## explicit
 honnef.co/go/js/dom


### PR DESCRIPTION
### Description:
This make OpenURL work for both web drivers. This doesn't had any new dependencies, but make indirect one, direct.

Fixes #2736

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Updated the vendor folder (using `go mod vendor`).
