### PR TITLE
Add a fyne build command.

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -13,6 +13,7 @@ import (
 // Builder generate the executables.
 type Builder struct {
 	os, srcdir, target string
+	goPackage          string
 	release            bool
 	tags               []string
 	tagsToParse        string
@@ -64,10 +65,7 @@ func Build() *cli.Command {
 				if argCount != 1 {
 					return fmt.Errorf("incorrect amount of path provided")
 				}
-				if b.srcdir != "" {
-					return fmt.Errorf("the directory to package is already specified")
-				}
-				b.srcdir = ctx.Args().First()
+				b.goPackage = ctx.Args().First()
 			}
 
 			return b.Build()
@@ -179,6 +177,10 @@ func (b *Builder) build() error {
 			args = append(args, "-tags")
 		}
 		args = append(args, strings.Join(tags, ","))
+	}
+
+	if b.goPackage != "" {
+		args = append(args, b.goPackage)
 	}
 
 	if goos != "ios" && goos != "android" && !isWeb(goos) {

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -28,7 +28,7 @@ func Build() *cli.Command {
 	return &cli.Command{
 		Name:        "build",
 		Usage:       "Build an application.",
-		Description: "You may specify the --executable to build, but --target will define the OS it is build for indiscriminate of the extention of the executable.",
+		Description: "You may specify the -o to build, but --target will define the OS it is build for indiscriminate of the extention of the output file.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "target",
@@ -54,7 +54,7 @@ func Build() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "o",
-				Usage:       "The path to the executable to build, default is the current dir main binary",
+				Usage:       "Specify a name for the output file, default is based on the current directory.",
 				Destination: &b.target,
 			},
 		},

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -28,7 +28,7 @@ func Build() *cli.Command {
 	return &cli.Command{
 		Name:        "build",
 		Usage:       "Build an application.",
-		Description: "You may specify the -o to build, but --target will define the OS it is build for indiscriminate of the extention of the output file.",
+		Description: "You can specify --target to define the OS to build for. The executable file will default to an appropriate name but can be overridden using -o.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "target",

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -53,12 +53,23 @@ func Build() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "executable",
-				Aliases:     []string{"exe"},
+				Aliases:     []string{"exe", "o"},
 				Usage:       "The path to the executable, default is the current dir main binary",
 				Destination: &b.target,
 			},
 		},
-		Action: func(_ *cli.Context) error {
+		Action: func(ctx *cli.Context) error {
+			argCount := ctx.Args().Len()
+			if argCount > 0 {
+				if argCount != 1 {
+					return fmt.Errorf("incorrect amount of path provided")
+				}
+				if b.srcdir != "" {
+					return fmt.Errorf("the directory to package is already specified")
+				}
+				b.srcdir = ctx.Args().First()
+			}
+
 			return b.Build()
 		},
 	}
@@ -66,6 +77,15 @@ func Build() *cli.Command {
 
 // Build parse the tags and start building
 func (b *Builder) Build() error {
+	if b.srcdir != "" {
+		dirStat, err := os.Stat(b.srcdir)
+		if err != nil {
+			return err
+		}
+		if !dirStat.IsDir() {
+			return fmt.Errorf("specified source directory is not a valid directory")
+		}
+	}
 	if b.tagsToParse != "" {
 		b.tags = strings.Split(b.tagsToParse, ",")
 	}

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -53,8 +53,7 @@ func Build() *cli.Command {
 				Destination: &b.release,
 			},
 			&cli.StringFlag{
-				Name:        "executable",
-				Aliases:     []string{"exe", "o"},
+				Name:        "o",
 				Usage:       "The path to the executable to build, default is the current dir main binary",
 				Destination: &b.target,
 			},

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -55,7 +55,7 @@ func Build() *cli.Command {
 			&cli.StringFlag{
 				Name:        "executable",
 				Aliases:     []string{"exe", "o"},
-				Usage:       "The path to the executable, default is the current dir main binary",
+				Usage:       "The path to the executable to build, default is the current dir main binary",
 				Destination: &b.target,
 			},
 		},

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -117,7 +117,7 @@ func Test_BuildWasmVersion(t *testing.T) {
 	}
 
 	wasmBuildTest := &testCommandRuns{runs: expected, t: t}
-	b := &builder{os: "wasm", srcdir: "myTest", runner: wasmBuildTest}
+	b := &Builder{os: "wasm", srcdir: "myTest", runner: wasmBuildTest}
 	err := b.build()
 	assert.Nil(t, err)
 	wasmBuildTest.verifyExpectation()
@@ -145,7 +145,7 @@ func Test_BuildWasmReleaseVersion(t *testing.T) {
 	}
 
 	wasmBuildTest := &testCommandRuns{runs: expected, t: t}
-	b := &builder{os: "wasm", srcdir: "myTest", release: true, runner: wasmBuildTest}
+	b := &Builder{os: "wasm", srcdir: "myTest", release: true, runner: wasmBuildTest}
 	err := b.build()
 	assert.Nil(t, err)
 	wasmBuildTest.verifyExpectation()
@@ -166,7 +166,7 @@ func Test_BuildGopherJSReleaseVersion(t *testing.T) {
 	}
 
 	gopherJSBuildTest := &testCommandRuns{runs: expected, t: t}
-	b := &builder{os: "gopherjs", srcdir: "myTest", release: true, runner: gopherJSBuildTest}
+	b := &Builder{os: "gopherjs", srcdir: "myTest", release: true, runner: gopherJSBuildTest}
 	err := b.build()
 	assert.Nil(t, err)
 	gopherJSBuildTest.verifyExpectation()
@@ -181,7 +181,7 @@ func Test_BuildWasmOldVersion(t *testing.T) {
 	}
 
 	wasmBuildTest := &testCommandRuns{runs: expected, t: t}
-	b := &builder{os: "wasm", srcdir: "myTest", runner: wasmBuildTest}
+	b := &Builder{os: "wasm", srcdir: "myTest", runner: wasmBuildTest}
 	err := b.build()
 	assert.NotNil(t, err)
 	wasmBuildTest.verifyExpectation()

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -189,7 +189,7 @@ func (p *Packager) buildPackage(runner runner) ([]string, error) {
 		tags = strings.Split(p.tags, ",")
 	}
 	if p.os != "web" {
-		b := &builder{
+		b := &Builder{
 			os:      p.os,
 			srcdir:  p.srcDir,
 			target:  p.exe,
@@ -201,7 +201,7 @@ func (p *Packager) buildPackage(runner runner) ([]string, error) {
 		return []string{p.exe}, b.build()
 	}
 
-	bWasm := &builder{
+	bWasm := &Builder{
 		os:      "wasm",
 		srcdir:  p.srcDir,
 		target:  p.exe + ".wasm",
@@ -215,7 +215,7 @@ func (p *Packager) buildPackage(runner runner) ([]string, error) {
 		return nil, err
 	}
 
-	bGopherJS := &builder{
+	bGopherJS := &Builder{
 		os:      "gopherjs",
 		srcdir:  p.srcDir,
 		target:  p.exe + ".js",

--- a/cmd/fyne/main.go
+++ b/cmd/fyne/main.go
@@ -24,6 +24,7 @@ func main() {
 			commands.Release(),
 			commands.Version(),
 			commands.Serve(),
+			commands.Build(),
 
 			// Deprecated: Use "go mod vendor" instead.
 			commands.Vendor(),


### PR DESCRIPTION
### Description:
The build stage done by fyne has grown a lot and definitively simplify the life of the developer even if manually calling go build does still work. This just expose the build() so that it is also accessible, not just hidden behind the fyne package command.

This is also going to be useful for avoiding duplicated code by tools that could use fyne build to gerenate gopherjs and wasm output for vscode extension for example.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Public APIs match existing style.
