### PR TITLE
Support creating a transparent software canvas

### DIFF
--- a/driver/software/softwarecanvas.go
+++ b/driver/software/softwarecanvas.go
@@ -5,7 +5,14 @@ import (
 	"fyne.io/fyne/v2/test"
 )
 
-// NewCanvas creates a new canvas in memory that can render without hardware support
+// NewCanvas creates a new canvas in memory that can render without hardware support.
 func NewCanvas() test.WindowlessCanvas {
 	return test.NewCanvasWithPainter(software.NewPainter())
+}
+
+// NewTransparentCanvas creates a new canvas in memory that can render without hardware support without a background color.
+//
+// Since: 2.2
+func NewTransparentCanvas() test.WindowlessCanvas {
+	return test.NewTransparentCanvasWithPainter(software.NewPainter())
 }

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -30,11 +30,12 @@ type testCanvas struct {
 	size  fyne.Size
 	scale float32
 
-	content  fyne.CanvasObject
-	overlays *internal.OverlayStack
-	focusMgr *app.FocusManager
-	hovered  desktop.Hoverable
-	padded   bool
+	content     fyne.CanvasObject
+	overlays    *internal.OverlayStack
+	focusMgr    *app.FocusManager
+	hovered     desktop.Hoverable
+	padded      bool
+	transparent bool
 
 	onTypedRune func(rune)
 	onTypedKey  func(*fyne.KeyEvent)
@@ -74,10 +75,23 @@ func NewCanvasWithPainter(painter SoftwarePainter) WindowlessCanvas {
 	return canvas
 }
 
+// NewTransparentCanvasWithPainter allows creation of an in-memory canvas with a specific painter without a background color.
+// The painter will be used to render in the Capture() call.
+//
+// Since: 2.2
+func NewTransparentCanvasWithPainter(painter SoftwarePainter) WindowlessCanvas {
+	canvas := NewCanvasWithPainter(painter).(*testCanvas)
+	canvas.transparent = true
+
+	return canvas
+}
+
 func (c *testCanvas) Capture() image.Image {
 	bounds := image.Rect(0, 0, internal.ScaleInt(c, c.Size().Width), internal.ScaleInt(c, c.Size().Height))
 	img := image.NewNRGBA(bounds)
-	draw.Draw(img, bounds, image.NewUniform(theme.BackgroundColor()), image.Point{}, draw.Src)
+	if !c.transparent {
+		draw.Draw(img, bounds, image.NewUniform(theme.BackgroundColor()), image.Point{}, draw.Src)
+	}
 
 	if c.painter != nil {
 		draw.Draw(img, bounds, c.painter.Paint(c), image.Point{}, draw.Over)

--- a/test/testcanvas_test.go
+++ b/test/testcanvas_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"image/color"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,22 @@ func TestTestCanvas_Capture(t *testing.T) {
 	assert.True(t, img.Bounds().Size().Y > 0)
 
 	r1, g1, b1, a1 := theme.BackgroundColor().RGBA()
+	r2, g2, b2, a2 := img.At(1, 1).RGBA()
+	assert.Equal(t, r1, r2)
+	assert.Equal(t, g1, g2)
+	assert.Equal(t, b1, b2)
+	assert.Equal(t, a1, a2)
+}
+
+func TestTestCanvas_TransparentCapture(t *testing.T) {
+	c := NewTransparentCanvasWithPainter(nil)
+	c.Size()
+
+	img := c.Capture()
+	assert.True(t, img.Bounds().Size().X > 0)
+	assert.True(t, img.Bounds().Size().Y > 0)
+
+	r1, g1, b1, a1 := color.Transparent.RGBA()
 	r2, g2, b2, a2 := img.At(1, 1).RGBA()
 	assert.Equal(t, r1, r2)
 	assert.Equal(t, g1, g2)


### PR DESCRIPTION
Super useful to capture a partial canvas and embed with transparency as most widgets are transparent.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style.
