### PR TITLE
Ci cleanup

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,16 +1,20 @@
 name: Check license of dependencies
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
-  checks:
+  licenses:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - uses: WillAbides/setup-go-faster@v1.7.0
       with:      
         go-version: '1.18.x'
 
-    - name: install lian
+    - name: Install lian
       run: go install lucor.dev/lian@latest
 
     - name: Check license of dependencies against go.mod

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 jobs:
-  checks:
+  static_analysis:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -22,11 +22,7 @@ jobs:
         sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-        go install golang.org/x/lint/golint@latest
         go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
-
-    - name: Cleanup repository
-      run: rm -rf vendor/
 
     - name: Vet
       run: go vet -tags ci ./...
@@ -37,8 +33,5 @@ jobs:
     - name: Gocyclo
       run: gocyclo -over 30 .
 
-    - name: Golint
-      run: golint -set_exit_status $(go list -tags ci ./...)
-
     - name: Staticcheck
-      run: staticcheck -go 1.14 ./...
+      run: staticcheck ./...

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -22,7 +22,10 @@ jobs:
         sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
+        go install honnef.co/go/tools/cmd/staticcheck@v0.3.0
+
+    - name: Cleanup repository
+      run: rm -rf vendor/
 
     - name: Vet
       run: go vet -tags ci ./...

--- a/dialog/color_wheel.go
+++ b/dialog/color_wheel.go
@@ -176,13 +176,11 @@ type colorWheelRenderer struct {
 }
 
 func (r *colorWheelRenderer) Layout(size fyne.Size) {
-	if f := r.area.selection; f != nil {
-		x, y := f(size.Width, size.Height)
-		r.x.Position1 = fyne.NewPos(0, y)
-		r.x.Position2 = fyne.NewPos(size.Width, y)
-		r.y.Position1 = fyne.NewPos(x, 0)
-		r.y.Position2 = fyne.NewPos(x, size.Height)
-	}
+	x, y := r.area.selection(size.Width, size.Height)
+	r.x.Position1 = fyne.NewPos(0, y)
+	r.x.Position2 = fyne.NewPos(size.Width, y)
+	r.y.Position1 = fyne.NewPos(x, 0)
+	r.y.Position2 = fyne.NewPos(x, size.Height)
 	r.raster.Move(fyne.NewPos(0, 0))
 	r.raster.Resize(size)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Golint has been deprecated and frozen. Go vet and staticcheck should have us covered.
After some fixes upstream in gocyclo, we can also stop removing the vendor folder now.
The workflow has also been renamed to not be called "checks".

Added in the stricter security permissions and renamed the license workflow to not be called "checks".



### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
