### PR TITLE
Form validators

### DIFF
--- a/widget/form.go
+++ b/widget/form.go
@@ -147,7 +147,11 @@ func (f *Form) SetValidationError(err error) {
 	if (err == nil && f.validationError != nil) || (f.validationError == nil && err != nil) ||
 		err.Error() != f.validationError.Error() {
 		f.validationError = err
-		f.validationErrorText.Text = err.Error()
+		var errorText string
+		if err != nil {
+			errorText = err.Error()
+		}
+		f.validationErrorText.Text = errorText
 		if f.onValidationChanged != nil {
 			f.onValidationChanged(err)
 		}

--- a/widget/form.go
+++ b/widget/form.go
@@ -135,8 +135,10 @@ func (f *Form) SetOnValidationChanged(callback func(error)) {
 // SetValidationError manually updates the validation status until the next change in a child widget
 func (f *Form) SetValidationError(err error) {
 	if f.Validator == nil {
-		f.checkValidation(nil) // make sure the form get's enabled again if no widget inside it is invalid
 		return
+	}
+	if err == nil {
+		f.checkValidation(nil) // make sure the form get's enabled again if no widget inside it is invalid
 	}
 	if err == nil && f.validationError == nil {
 		return

--- a/widget/form.go
+++ b/widget/form.go
@@ -379,6 +379,7 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 	f.updateButtons()
 	f.updateLabels()
 	f.checkValidation(nil) // will trigger a validation check for correct intial validation status
+	f.Validate()           // will trigger a validation check with f.Validator
 	return renderer
 }
 

--- a/widget/form.go
+++ b/widget/form.go
@@ -138,6 +138,7 @@ func (f *Form) SetValidationError(err error) {
 		return
 	}
 	if err == nil {
+		f.Enable()
 		f.checkValidation(nil) // make sure the form get's enabled again if no widget inside it is invalid
 	}
 	if err == nil && f.validationError == nil {

--- a/widget/form.go
+++ b/widget/form.go
@@ -135,6 +135,7 @@ func (f *Form) SetOnValidationChanged(callback func(error)) {
 // SetValidationError manually updates the validation status until the next change in a child widget
 func (f *Form) SetValidationError(err error) {
 	if f.Validator == nil {
+		f.checkValidation(nil) // make sure the form get's enabled again if no widget inside it is invalid
 		return
 	}
 	if err == nil && f.validationError == nil {
@@ -148,8 +149,7 @@ func (f *Form) SetValidationError(err error) {
 		if f.onValidationChanged != nil {
 			f.onValidationChanged(err)
 		}
-
-		f.Refresh()
+		f.Disable()
 	}
 }
 

--- a/widget/form.go
+++ b/widget/form.go
@@ -377,11 +377,11 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 		validationErrorText = err.Error()
 	}
 	f.validationErrorText = &canvas.Text{Alignment: fyne.TextAlignLeading, Color: theme.ErrorColor(), Text: validationErrorText, TextSize: theme.TextSize(), TextStyle: fyne.TextStyle{Bold: true}}
-	buttons := &fyne.Container{Layout: layout.NewGridLayoutWithRows(1), Objects: []fyne.CanvasObject{f.cancelButton, f.submitButton}}
+	buttons := &fyne.Container{Layout: layout.NewGridLayoutWithRows(1), Objects: []fyne.CanvasObject{f.cancelButton, f.submitButton, f.validationErrorText}}
 	f.buttonBox = &fyne.Container{Layout: layout.NewBorderLayout(nil, nil, nil, buttons), Objects: []fyne.CanvasObject{buttons}}
 
 	f.itemGrid = &fyne.Container{Layout: layout.NewFormLayout()}
-	renderer := NewSimpleRenderer(fyne.NewContainerWithLayout(layout.NewVBoxLayout(), f.itemGrid, f.buttonBox, f.validationErrorText))
+	renderer := NewSimpleRenderer(fyne.NewContainerWithLayout(layout.NewVBoxLayout(), f.itemGrid, f.buttonBox))
 	f.ensureRenderItems()
 	f.updateButtons()
 	f.updateLabels()

--- a/widget/form.go
+++ b/widget/form.go
@@ -144,7 +144,7 @@ func (f *Form) SetValidationError(err error) {
 	if (err == nil && f.validationError != nil) || (f.validationError == nil && err != nil) ||
 		err.Error() != f.validationError.Error() {
 		f.validationError = err
-
+		f.validationErrorText.Text = err.Error()
 		if f.onValidationChanged != nil {
 			f.onValidationChanged(err)
 		}


### PR DESCRIPTION
### Description:
Adds the ability to add a form wide validator which get's run every time a widget inside the form get's changed. It has the following signature: `func(*widget.Form) error`, and if the returned error is not nil the error message get's displayed in red next to the submit button and the form get's disabled.

I am still working on the tests, since even the tests on the unchanged `develop` branch on the latest commit don't pass on macOS Monterey 12.3 arm64 go version go1.18 darwin/arm64: [output](https://pastebin.com/EV44qKbN).

Fixes #2562

### Checklist:

- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [X] Public APIs match existing style.