### PR TITLE
Update jackmordaunt/icns/v2 to v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
-	github.com/jackmordaunt/icns/v2 v2.1.3
+	github.com/jackmordaunt/icns/v2 v2.2.0
 	github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca
 	github.com/lucor/goinfo v0.0.0-20210802170112-c078a2b0f08b
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,6 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jackmordaunt/icns/v2 v2.1.3 h1:LBBT9k6Rvnbx+peHFNVQU9klGs0jGol/pTd0EJf0+l8=
-github.com/jackmordaunt/icns/v2 v2.1.3/go.mod h1:6aYIB9eSzyfHHMKqDf17Xrs1zetQPReAkiUSHzdw4cI=
 github.com/jackmordaunt/icns/v2 v2.2.0 h1:Q+V+6c09VNTfRK1cQpBHC4qBkoLiHkxGXOKAQQSLGSw=
 github.com/jackmordaunt/icns/v2 v2.2.0/go.mod h1:6aYIB9eSzyfHHMKqDf17Xrs1zetQPReAkiUSHzdw4cI=
 github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca h1:ozPUX9TKQZVek4lZWYRsQo7uS8vJ+q4OOHvRhHiCLfU=

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackmordaunt/icns/v2 v2.1.3 h1:LBBT9k6Rvnbx+peHFNVQU9klGs0jGol/pTd0EJf0+l8=
 github.com/jackmordaunt/icns/v2 v2.1.3/go.mod h1:6aYIB9eSzyfHHMKqDf17Xrs1zetQPReAkiUSHzdw4cI=
+github.com/jackmordaunt/icns/v2 v2.2.0 h1:Q+V+6c09VNTfRK1cQpBHC4qBkoLiHkxGXOKAQQSLGSw=
+github.com/jackmordaunt/icns/v2 v2.2.0/go.mod h1:6aYIB9eSzyfHHMKqDf17Xrs1zetQPReAkiUSHzdw4cI=
 github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca h1:ozPUX9TKQZVek4lZWYRsQo7uS8vJ+q4OOHvRhHiCLfU=
 github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca h1:ozPUX9TKQZVek4lZWYRsQo7uS8vJ+q4OOHvRhHiCLfU=
 github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca/go.mod h1:eJTEwMjXb7kZ633hO3Ln9mBUCOjX2+FlTljvpl9SYdE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/goki/freetype/raster
 github.com/goki/freetype/truetype
 # github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60
 github.com/gopherjs/gopherjs/js
-# github.com/jackmordaunt/icns/v2 v2.1.3
+# github.com/jackmordaunt/icns/v2 v2.2.0
 ## explicit
 github.com/jackmordaunt/icns/v2
 # github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

[jackmordaunt/icns](https://github.com/JackMordaunt/icns) is a library that can convert *.png file to *.icns file, and it releases a new version with [tag v2.2.0](https://github.com/JackMordaunt/icns/tree/v2.2.0).  This latest release fixes [some bugs](https://github.com/JackMordaunt/icns/pull/10) and  can make generated icons' edges on macOS smooth.

Please consider merging it to Fyne's develop branch and hope it will help Fyne to be better.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
- [x] Any breaking changes have a deprecation path or have been discussed.
- [x] Updated the vendor folder (using `go mod vendor`).
- [x] Check for binary size increases when importing new modules.
