### PR TITLE
Don't try to focus windows that are not made

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -166,7 +166,7 @@ func (w *window) doCenterOnScreen() {
 }
 
 func (w *window) RequestFocus() {
-	if isWayland {
+	if isWayland || w.view() == nil {
 		return
 	}
 


### PR DESCRIPTION
This is safe as we try to focus when windows are created (OS specific).

Fixes #2875

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

