### PR TITLE
Updated roundToPixelCoords() function in draw.go

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -224,10 +224,13 @@ func roundToPixel(v float32, pixScale float32) float32 {
 }
 
 func roundToPixelCoords(size fyne.Size, pos fyne.Position, pixScale float32) (fyne.Size, fyne.Position) {
-	size.Width = roundToPixel(size.Width, pixScale)
-	size.Height = roundToPixel(size.Height, pixScale)
+	end := pos.Add(size)
+	end.X = roundToPixel(end.X, pixScale)
+	end.Y = roundToPixel(end.Y, pixScale)
 	pos.X = roundToPixel(pos.X, pixScale)
 	pos.Y = roundToPixel(pos.Y, pixScale)
+	size.Width = end.X - pos.X
+	size.Height = end.Y - pos.Y
 
 	return size, pos
 }


### PR DESCRIPTION
Precision improvement w.r.t rounding off for Rectangular co-ordinates.
Fix for #2471

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #2471 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
