### PR TITLE
Changed boundExternalUntypedListItem::setIfChanged to use DeepEqual...

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,4 +1,4 @@
-sackage fyne
+package fyne
 
 import (
 	"net/url"

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -1,9 +1,12 @@
 // auto-generated
 // **** THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT IT **** //
-
 package binding
 
-import "fyne.io/fyne/v2"
+import (
+	"reflect"
+
+	"fyne.io/fyne/v2"
+)
 
 // BoolList supports binding a list of bool values.
 //
@@ -1327,7 +1330,7 @@ type boundExternalUntypedListItem struct {
 }
 
 func (b *boundExternalUntypedListItem) setIfChanged(val interface{}) error {
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val

--- a/data/binding/bindlists_test.go
+++ b/data/binding/bindlists_test.go
@@ -6,6 +6,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDeepItems(t *testing.T) {
+	type DeepItem struct {
+		name     string
+		subArray []string
+	}
+	deepItemArray := []DeepItem{
+		{
+			name:     "first",
+			subArray: []string{"sub-item-1"},
+		}, {
+			name:     "second",
+			subArray: []string{"sub-item-2"},
+		},
+	}
+	interfaceArray := make([]interface{}, 2)
+	for index, deepItem := range deepItemArray {
+		interfaceArray[index] = deepItem
+	}
+	untypedList := BindUntypedList(&interfaceArray)
+	untypedList.Append(DeepItem{name: "third", subArray: []string{"sub-item-3"}})
+	assert.Equal(t, 3, untypedList.Length())
+}
+
 func TestBindFloatList(t *testing.T) {
 	l := []float64{1.0, 5.0, 2.3}
 	f := BindFloatList(&l)


### PR DESCRIPTION
…  to be able to cope with structs that have embedded arrays in them.

### Description:
With this change one can use an array of structs containing embedded arrays in various operations, e.g. Append.

This came up in my app where I have an array of items containing not only primitive fields, but also an array of strings. When I appended an item to that array, my Fine app promptly crashed with `panic: runtime error: comparing uncomparable type`.

Fixes #(issue)

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
