### PR TITLE
Add SetComparator to ExternalUntypedList

### DIFF
--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -222,7 +222,7 @@ type boundExternalBoolListItem struct {
 }
 
 func (b *boundExternalBoolListItem) setIfChanged(val bool) error {
-	if reflect.DeepEqual(val, b.old) {
+	if val == b.old {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -666,7 +666,7 @@ type boundExternalFloatListItem struct {
 }
 
 func (b *boundExternalFloatListItem) setIfChanged(val float64) error {
-	if reflect.DeepEqual(val, b.old) {
+	if val == b.old {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -888,7 +888,7 @@ type boundExternalIntListItem struct {
 }
 
 func (b *boundExternalIntListItem) setIfChanged(val int) error {
-	if reflect.DeepEqual(val, b.old) {
+	if val == b.old {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -1110,7 +1110,7 @@ type boundExternalRuneListItem struct {
 }
 
 func (b *boundExternalRuneListItem) setIfChanged(val rune) error {
-	if reflect.DeepEqual(val, b.old) {
+	if val == b.old {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -1332,7 +1332,7 @@ type boundExternalStringListItem struct {
 }
 
 func (b *boundExternalStringListItem) setIfChanged(val string) error {
-	if reflect.DeepEqual(val, b.old) {
+	if val == b.old {
 		return nil
 	}
 	(*b.val)[b.index] = val

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -1,10 +1,10 @@
 // auto-generated
 // **** THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT IT **** //
-
 package binding
 
 import (
 	"bytes"
+	"reflect"
 
 	"fyne.io/fyne/v2"
 )
@@ -1553,7 +1553,7 @@ type boundExternalUntypedListItem struct {
 }
 
 func (b *boundExternalUntypedListItem) setIfChanged(val interface{}) error {
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -1,5 +1,6 @@
 // auto-generated
 // **** THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT IT **** //
+
 package binding
 
 import (
@@ -221,7 +222,7 @@ type boundExternalBoolListItem struct {
 }
 
 func (b *boundExternalBoolListItem) setIfChanged(val bool) error {
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -665,7 +666,7 @@ type boundExternalFloatListItem struct {
 }
 
 func (b *boundExternalFloatListItem) setIfChanged(val float64) error {
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -887,7 +888,7 @@ type boundExternalIntListItem struct {
 }
 
 func (b *boundExternalIntListItem) setIfChanged(val int) error {
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -1109,7 +1110,7 @@ type boundExternalRuneListItem struct {
 }
 
 func (b *boundExternalRuneListItem) setIfChanged(val rune) error {
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val
@@ -1331,7 +1332,7 @@ type boundExternalStringListItem struct {
 }
 
 func (b *boundExternalStringListItem) setIfChanged(val string) error {
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	(*b.val)[b.index] = val

--- a/data/binding/bindlists_test.go
+++ b/data/binding/bindlists_test.go
@@ -1,16 +1,18 @@
 package binding
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeepItems(t *testing.T) {
-	type DeepItem struct {
-		name     string
-		subArray []string
-	}
+type DeepItem struct {
+	name     string
+	subArray []string
+}
+
+func setupDeepItemArray() ExternalUntypedList {
 	deepItemArray := []DeepItem{
 		{
 			name:     "first",
@@ -24,7 +26,21 @@ func TestDeepItems(t *testing.T) {
 	for index, deepItem := range deepItemArray {
 		interfaceArray[index] = deepItem
 	}
-	untypedList := BindUntypedList(&interfaceArray)
+	return BindUntypedList(&interfaceArray)
+}
+
+func TestDeepItemsWithPanic(t *testing.T) {
+	untypedList := setupDeepItemArray()
+	defer func() {
+		recover()
+	}()
+	untypedList.Append(DeepItem{name: "third", subArray: []string{"sub-item-3"}})
+	t.Errorf("should have panicked")
+}
+
+func TestDeepItemsWithDeepEqual(t *testing.T) {
+	untypedList := setupDeepItemArray()
+	untypedList.SetItemComparator(reflect.DeepEqual)
 	untypedList.Append(DeepItem{name: "third", subArray: []string{"sub-item-3"}})
 	assert.Equal(t, 3, untypedList.Length())
 }

--- a/data/binding/bindlists_test.go
+++ b/data/binding/bindlists_test.go
@@ -6,6 +6,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDeepItems(t *testing.T) {
+	type DeepItem struct {
+		name     string
+		subArray []string
+	}
+	deepItemArray := []DeepItem{
+		{
+			name:     "first",
+			subArray: []string{"sub-item-1"},
+		}, {
+			name:     "second",
+			subArray: []string{"sub-item-2"},
+		},
+	}
+	interfaceArray := make([]interface{}, 2)
+	for index, deepItem := range deepItemArray {
+		interfaceArray[index] = deepItem
+	}
+	untypedList := BindUntypedList(&interfaceArray)
+	untypedList.Append(DeepItem{name: "third", subArray: []string{"sub-item-3"}})
+	assert.Equal(t, 3, untypedList.Length())
+}
+
 func TestBindFloatList(t *testing.T) {
 	l := []float64{1.0, 5.0, 2.3}
 	f := BindFloatList(&l)

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -584,7 +584,7 @@ type boundExternal{{ .Name }}ListItem struct {
 
 func (b *boundExternal{{ .Name }}ListItem) setIfChanged(val {{ .Type }}) error {
 	{{- if eq .Comparator "" }}
-	if val == b.old {
+	if reflect.DeepEqual(val, b.old) {
 		return nil
 	}
 	{{- else }}
@@ -680,6 +680,7 @@ const keyTypeMismatchError = "A previous preference binding exists with differen
 	listFile.WriteString(`
 import (
 	"bytes"
+	"reflect"
 
 	"fyne.io/fyne/v2"
 )

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -487,7 +487,6 @@ func (l *bound{{ .Name }}List) Set(v []{{ .Type }}) error {
 }
 
 {{- if eq .Name "Untyped" }}
-
 // Sets the internal function to use when comparing items in the list. This comparison occurs e.g. on Append.
 //
 // Since: {{ .Since }}

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -584,7 +584,7 @@ type boundExternal{{ .Name }}ListItem struct {
 
 func (b *boundExternal{{ .Name }}ListItem) setIfChanged(val {{ .Type }}) error {
 	{{- if eq .Comparator "" }}
-	if reflect.DeepEqual(val, b.old) {
+	if val == b.old {
 		return nil
 	}
 	{{- else }}
@@ -698,7 +698,7 @@ import (
 		bindValues{Name: "Int", Type: "int", Default: "0", Format: "%d", SupportsPreferences: true},
 		bindValues{Name: "Rune", Type: "rune", Default: "rune(0)"},
 		bindValues{Name: "String", Type: "string", Default: "\"\"", SupportsPreferences: true},
-		bindValues{Name: "Untyped", Type: "interface{}", Default: "nil", Since: "2.1"},
+		bindValues{Name: "Untyped", Type: "interface{}", Default: "nil", Since: "2.1", Comparator: "reflect.DeepEqual"},
 		bindValues{Name: "URI", Type: "fyne.URI", Default: "fyne.URI(nil)", Since: "2.1",
 			FromString: "uriFromString", ToString: "uriToString", Comparator: "compareURI"},
 	}


### PR DESCRIPTION
### Description:
With this change ExternalUntypedList gets a new function: `SetComparator`. This way one can provide a custom comparator to be used in the package internal function `setIfChanged`. Such a comparator function could be `reflect.DeepEqual`.

This came up in my app where I have an array of items containing not only primitive fields, but also an array of strings. When I appended an item to that array, my Fine app promptly crashed with panic: runtime error: comparing uncomparable type.

p.s. This PR is a re-run of my incorrect one from the previous day. This time the change is in the string template that is used in generating the code, and the change is in the correct branch.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
