### PR TITLE
Add user installation in HOME directory

### DIFF
--- a/cmd/fyne/internal/templates/data/Makefile
+++ b/cmd/fyne/internal/templates/data/Makefile
@@ -6,6 +6,11 @@ LOCAL ?= $(shell test -d $(DESTDIR)/usr/local && echo "/local" || echo "")
 PREFIX ?= /usr$(LOCAL)
 
 default:
+	# Install for simple user
+	# Run "make user-install" to install in ~/.local/
+	# Run "make user-uninstall" to uninstall from ~/.local/
+	#
+	# System install
 	# Run "sudo make install" to install the application.
 	# Run "sudo make uninstall" to uninstall the application.
 
@@ -17,3 +22,14 @@ uninstall:
 	-rm $(DESTDIR)$(PREFIX)/share/applications/{{.Name}}.desktop
 	-rm $(DESTDIR)$(PREFIX)/bin/{{.Exec}}
 	-rm $(DESTDIR)$(PREFIX)/share/pixmaps/{{.Icon}}
+
+user-install:
+	install -Dm00644 usr/{{.Local}}share/applications/{{.Name}}.desktop $(DESTDIR)$(HOME)/.local/share/applications/{{.Name}}.desktop
+	install -Dm00755 usr/{{.Local}}bin/{{.Exec}} $(DESTDIR)$(HOME)/.local/bin/{{.Exec}}
+	install -Dm00644 usr/{{.Local}}share/pixmaps/{{.Icon}} $(DESTDIR)$(HOME)/.local/share/icons/{{.Icon}}
+	sed -i -e "s/Exec=.*/Exec=$(DESTDIR)$(HOME)/.local/bin/{{.Exec}}/g" $(DESTDIR)$(HOME)/.local/share/applications/{{.Name}}.desktop
+
+user-uninstall:
+	-rm $(DESTDIR)$(HOME)/.local/share/applications/{{.Name}}.desktop
+	-rm $(DESTDIR)$(HOME)/.local/bin/{{.Exec}}
+	-rm $(DESTDIR)$(HOME)/.local/share/icons/{{.Icon}}


### PR DESCRIPTION
### Description:

Append `user-install` and `user-uninstall` to make it possible to
install the application in the HOME directory respecting the freedesktop
recommendations.

Fixes #2909

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

There is no test for this it seems, but others tests are broken

