### PR TITLE
Implement paragraph padding for RichText widget

### DIFF
--- a/cmd/fyne_demo/tutorials/theme.go
+++ b/cmd/fyne_demo/tutorials/theme.go
@@ -46,6 +46,8 @@ func (customTheme) Size(s fyne.ThemeSizeName) float32 {
 	switch s {
 	case theme.SizeNamePadding:
 		return 8
+	case theme.SizeNameParagraphPadding:
+		return 20
 	case theme.SizeNameInlineIcon:
 		return 20
 	case theme.SizeNameScrollBar:

--- a/test/testtheme.go
+++ b/test/testtheme.go
@@ -43,6 +43,7 @@ func NewTheme() fyne.Theme {
 		sizes: map[fyne.ThemeSizeName]float32{
 			theme.SizeNameInlineIcon:         float32(24),
 			theme.SizeNamePadding:            float32(10),
+			theme.SizeNameParagraphPadding:   float32(25),
 			theme.SizeNameScrollBar:          float32(10),
 			theme.SizeNameScrollBarSmall:     float32(2),
 			theme.SizeNameSeparatorThickness: float32(1),

--- a/test/theme.go
+++ b/test/theme.go
@@ -48,6 +48,7 @@ func Theme() fyne.Theme {
 			sizes: map[fyne.ThemeSizeName]float32{
 				theme.SizeNameInlineIcon:         float32(20),
 				theme.SizeNamePadding:            float32(4),
+				theme.SizeNameParagraphPadding:   float32(10),
 				theme.SizeNameScrollBar:          float32(16),
 				theme.SizeNameScrollBarSmall:     float32(3),
 				theme.SizeNameSeparatorThickness: float32(1),

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -133,6 +133,12 @@ const (
 	// Since: 2.0
 	SizeNamePadding fyne.ThemeSizeName = "padding"
 
+	// SizeNameParagraphPadding is the name of theme lookup for paragraph
+	// padding size.
+	//
+	// Since: 2.2
+	SizeNameParagraphPadding fyne.ThemeSizeName = "paragraphPadding"
+
 	// SizeNameScrollBar is the name of theme lookup for the scrollbar size.
 	//
 	// Since: 2.0
@@ -319,6 +325,13 @@ func LightTheme() fyne.Theme {
 // Padding is the standard gap between elements and the border around interface elements.
 func Padding() float32 {
 	return current().Size(SizeNamePadding)
+}
+
+// ParagraphPadding is the standard gap between paragraphs with rich text.
+//
+// Since: 2.2
+func ParagraphPadding() float32 {
+	return current().Size(SizeNameParagraphPadding)
 }
 
 // PlaceHolderColor returns the theme's standard text color.
@@ -586,6 +599,8 @@ func (t *builtinTheme) Size(s fyne.ThemeSizeName) float32 {
 		return 20
 	case SizeNamePadding:
 		return 4
+	case SizeNameParagraphPadding:
+		return 10
 	case SizeNameScrollBar:
 		return 16
 	case SizeNameScrollBarSmall:

--- a/theme/theme_test.go
+++ b/theme/theme_test.go
@@ -139,6 +139,11 @@ func Test_Padding(t *testing.T) {
 	assert.Equal(t, DarkTheme().Size(SizeNamePadding), Padding(), "wrong padding")
 }
 
+func Test_ParagraphPadding(t *testing.T) {
+	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
+	assert.Equal(t, DarkTheme().Size(SizeNameParagraphPadding), ParagraphPadding(), "wrong paragraph padding")
+}
+
 func Test_IconInlineSize(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	assert.Equal(t, DarkTheme().Size(SizeNameInlineIcon), IconInlineSize(), "wrong inline icon size")

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -78,7 +78,7 @@ func (m *markdownRenderer) Render(_ io.Writer, source []byte, n ast.Node) error 
 		case "Link":
 			link, _ := url.Parse(string(n.(*ast.Link).Destination))
 			m.nextSeg = &HyperlinkSegment{fyne.TextAlignLeading, "", link}
-		case "Paragraph":
+		case "Paragraph", "TextBlock":
 			m.nextSeg = &TextSegment{
 				Style: RichTextStyleInline, // we make it a paragraph at the end if there are no more elements
 			}
@@ -171,7 +171,7 @@ func (m *markdownRenderer) handleExitNode(n ast.Node) error {
 		m.segs = append(m.segs, &ParagraphSegment{Texts: itemSegs})
 	} else if !m.blockquote && !m.heading {
 		if len(m.segs) > 0 {
-			if text, ok := m.segs[len(m.segs)-1].(*TextSegment); ok && n.Kind().String() == "Paragraph" {
+			if text, ok := m.segs[len(m.segs)-1].(*TextSegment); ok && (n.Kind().String() == "Paragraph" || n.Kind().String() == "TextBlock") {
 				text.Style = RichTextStyleParagraph
 			}
 		}

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -487,7 +487,7 @@ func (r *textRenderer) Layout(size fyne.Size) {
 
 		lastSeg := bound.segments[len(bound.segments)-1]
 		if !lastSeg.Inline() && row < len(bounds)-1 && bounds[row+1].segments[0] != lastSeg { // ignore wrapped lines etc
-			yPos += theme.Padding()
+			yPos += theme.ParagraphPadding()
 		}
 	}
 }
@@ -533,7 +533,7 @@ func (r *textRenderer) MinSize() fyne.Size {
 
 		lastSeg := bound.segments[len(bound.segments)-1]
 		if !lastSeg.Inline() && row < len(bounds)-1 && bounds[row+1].segments[0] != lastSeg { // ignore wrapped lines etc
-			height += theme.Padding()
+			height += theme.ParagraphPadding()
 		}
 	}
 

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -175,14 +175,9 @@ func (l *ListSegment) Segments() []RichTextSegment {
 		}
 		bullet := &TextSegment{Text: txt + " ", Style: RichTextStyleStrong}
 		if para, ok := in.(*ParagraphSegment); ok {
-			seg := &ParagraphSegment{Texts: []RichTextSegment{bullet}}
-			seg.Texts = append(seg.Texts, para.Texts...)
-			out[i] = seg
+			out[i] = &ParagraphSegment{Texts: append([]RichTextSegment{bullet}, para.Texts...)}
 		} else {
-			out[i] = &ParagraphSegment{Texts: []RichTextSegment{
-				bullet,
-				in,
-			}}
+			out[i] = &ParagraphSegment{Texts: []RichTextSegment{bullet, in}}
 		}
 	}
 	return out


### PR DESCRIPTION
### Description:

~~_Opening as a draft as I'm having some issues getting the tests to run locally_~~

Introduces a new size name called `SizeNameParagraphPadding` and uses it in the rich text renderer to increase the padding between paragraphs.

Fixes #2912

![image](https://user-images.githubusercontent.com/3588652/162968452-88106263-2a44-4525-aa91-cbfa9c2d3025.png)

The padding around most elements looks much better imo. The only problem is that the padding does not seem to be applied after lists, so they end up being cuddled too closely to the following element. This can be seen in the above screenshot.

Any idea why this might be?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

