### PR TITLE
Add flags to package cmd

### DIFF
--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -16,11 +16,31 @@ import (
 )
 
 func (p *Packager) packageAndroid(arch string) error {
-	return mobile.RunNewBuild(arch, p.appID, p.icon, p.name, p.appVersion, p.appBuild, p.release, "", "")
+	return mobile.RunNewBuild(
+		mobile.WithTarget(arch),
+		mobile.WithBundleID(p.appID),
+		mobile.WithIcon(p.icon),
+		mobile.WithName(p.name),
+		mobile.WithVersion(p.appVersion),
+		mobile.WithBuild(p.appBuild),
+		mobile.WithRelease(p.release),
+		mobile.WithAndroidAPI(p.androidAPI),
+	)
 }
 
 func (p *Packager) packageIOS(target string) error {
-	err := mobile.RunNewBuild(target, p.appID, p.icon, p.name, p.appVersion, p.appBuild, p.release, p.certificate, p.profile)
+	err := mobile.RunNewBuild(
+		mobile.WithTarget(target),
+		mobile.WithBundleID(p.appID),
+		mobile.WithIcon(p.icon),
+		mobile.WithName(p.name),
+		mobile.WithVersion(p.appVersion),
+		mobile.WithBuild(p.appBuild),
+		mobile.WithRelease(p.release),
+		mobile.WithCert(p.certificate),
+		mobile.WithProfile(p.profile),
+		mobile.WithIOSVersion(p.iosVersion),
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -106,6 +106,18 @@ func Package() *cli.Command {
 				Usage:       "Enable installation in release mode (disable debug etc).",
 				Destination: &p.release,
 			},
+			&cli.StringFlag{
+				Name:        "iosVersion",
+				Usage:       "The minimal version of the iOS SDK to compile against",
+				Destination: &p.iosVersion,
+				Value:       "7.0",
+			},
+			&cli.IntFlag{
+				Name:        "androidAPI",
+				Usage:       "The Android API version to compile against",
+				Destination: &p.androidAPI,
+				Value:       15,
+			},
 		},
 		Action: func(_ *cli.Context) error {
 			return p.Package()
@@ -120,6 +132,8 @@ type Packager struct {
 	install, release     bool
 	certificate, profile string // optional flags for releasing
 	tags, category       string
+	iosVersion                   string
+	androidAPI                   int
 }
 
 // AddFlags adds the flags for interacting with the package command.

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -132,8 +132,8 @@ type Packager struct {
 	install, release     bool
 	certificate, profile string // optional flags for releasing
 	tags, category       string
-	iosVersion                   string
-	androidAPI                   int
+	iosVersion           string
+	androidAPI           int
 }
 
 // AddFlags adds the flags for interacting with the package command.

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -268,20 +268,82 @@ var (
 	buildTags       stringsFlag // -tags
 )
 
+type BuildOption func()
+
+func WithTarget(v string) BuildOption {
+	return func() {
+		buildTarget = v
+	}
+}
+
+func WithBundleID(v string) BuildOption {
+	return func() {
+		buildBundleID = v
+	}
+}
+
+func WithRelease(v bool) BuildOption {
+	return func() {
+		buildRelease = v
+	}
+}
+
+func WithIcon(v string) BuildOption {
+	return func() {
+		cmdBuild.IconPath = v
+	}
+}
+
+func WithName(v string) BuildOption {
+	return func() {
+		cmdBuild.AppName = v
+	}
+}
+
+func WithVersion(v string) BuildOption {
+	return func() {
+		cmdBuild.Version = v
+	}
+}
+
+func WithBuild(v int) BuildOption {
+	return func() {
+		cmdBuild.Build = v
+	}
+}
+
+func WithCert(v string) BuildOption {
+	return func() {
+		cmdBuild.Cert = v
+	}
+}
+
+func WithProfile(v string) BuildOption {
+	return func() {
+		cmdBuild.Profile = v
+	}
+}
+
+func WithIOSVersion(v string) BuildOption {
+	return func() {
+		buildIOSVersion = v
+	}
+}
+
+func WithAndroidAPI(v int) BuildOption {
+	return func() {
+		buildAndroidAPI = v
+	}
+}
+
 // RunNewBuild executes a new mobile build for the specified configuration
-func RunNewBuild(target, appID, icon, name, version string, build int, release bool, cert, profile string) error {
-	buildTarget = target
-	buildBundleID = appID
-	buildRelease = release
+func RunNewBuild(opts ...BuildOption) error {
+	for _, v := range opts {
+		v()
+	}
 
 	cmd := cmdBuild
 	cmd.Flag = flag.FlagSet{}
-	cmd.IconPath = icon
-	cmd.AppName = name
-	cmd.Version = version
-	cmd.Build = build
-	cmd.Cert = cert
-	cmd.Profile = profile
 	return runBuild(cmd)
 }
 


### PR DESCRIPTION
### Description:
Add more flags to package command

- add `androidAPI` flag to set the Android API version
- add `iosVersion` flag to set the minimal version of the iOS SDK