### PR TITLE
Prefer ANDROID_NDK_HOME over the ANDROID_HOME ndk-bundle location

### DIFF
--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -234,17 +234,17 @@ func ndkRoot() (string, error) {
 		return "$NDK_PATH", nil
 	}
 
-	androidHome := os.Getenv("ANDROID_HOME")
-	if androidHome != "" {
-		ndkRoot := filepath.Join(androidHome, "ndk-bundle")
+	ndkRoot := os.Getenv("ANDROID_NDK_HOME")
+	if ndkRoot != "" {
 		_, err := os.Stat(ndkRoot)
 		if err == nil {
 			return ndkRoot, nil
 		}
 	}
 
-	ndkRoot := os.Getenv("ANDROID_NDK_HOME")
-	if ndkRoot != "" {
+	androidHome := os.Getenv("ANDROID_HOME")
+	if androidHome != "" {
+		ndkRoot := filepath.Join(androidHome, "ndk-bundle")
 		_, err := os.Stat(ndkRoot)
 		if err == nil {
 			return ndkRoot, nil


### PR DESCRIPTION
tidy order of operations to prefer more specific environment variable.

Fixes #2899

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
