### PR TITLE
Add imaginary padding around the cursor

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1611,10 +1611,15 @@ func (r *entryContentRenderer) buildSelection() {
 }
 
 func (r *entryContentRenderer) ensureCursorVisible() {
-	cx1 := r.cursor.Position().X
-	cy1 := r.cursor.Position().Y
-	cx2 := cx1 + r.cursor.Size().Width
-	cy2 := cy1 + r.cursor.Size().Height
+	letter := fyne.MeasureText("e", theme.TextSize(), r.content.entry.TextStyle)
+	padX := letter.Width*2 + theme.Padding()
+	padY := letter.Height - theme.Padding()
+	cx := r.cursor.Position().X
+	cy := r.cursor.Position().Y
+	cx1 := cx - padX
+	cy1 := cy - padY
+	cx2 := cx + r.cursor.Size().Width + padX
+	cy2 := cy + r.cursor.Size().Height + padY
 	offset := r.content.scroll.Offset
 	size := r.content.scroll.Size()
 

--- a/widget/testdata/entry/wrap_multi_line_truncate.xml
+++ b/widget/testdata/entry/wrap_multi_line_truncate.xml
@@ -4,11 +4,19 @@
 			<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="120x96"/>
 			<rectangle fillColor="primary" pos="0,98" size="120x2"/>
 			<widget pos="0,2" size="120x96" type="*widget.Scroll">
-				<widget size="120x96" type="*widget.entryContent">
-					<widget size="120x96" type="*widget.RichText">
-						<text pos="8,6" size="104x20">A long text on short words w/o NLs or LFs.</text>
+				<widget size="316x96" type="*widget.entryContent">
+					<widget size="316x96" type="*widget.RichText">
+						<text pos="8,6" size="300x20">A long text on short words w/o NLs or LFs.</text>
 					</widget>
 					<rectangle fillColor="primary" pos="7,6" size="2x20"/>
+				</widget>
+				<widget pos="0,90" size="120x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="45x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" size="45x3"/>
+					</widget>
+				</widget>
+				<widget pos="120,0" size="0x96" type="*widget.Shadow">
+					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x96"/>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/entry/wrap_single_line_truncate.xml
+++ b/widget/testdata/entry/wrap_single_line_truncate.xml
@@ -10,6 +10,14 @@
 					</widget>
 					<rectangle fillColor="primary" pos="7,6" size="2x20"/>
 				</widget>
+				<widget pos="0,26" size="120x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="101x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" size="101x3"/>
+					</widget>
+				</widget>
+				<widget pos="120,0" size="0x32" type="*widget.Shadow">
+					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x32"/>
+				</widget>
 			</widget>
 		</widget>
 	</content>


### PR DESCRIPTION
so that when moving it brings content in around it

This changed an existing test, not really sure why - the change seems valid but not sure why the old sizes were that way...

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

