### PR TITLE
Implement NewStringWithFormat method

### DIFF
--- a/data/binding/sprintf.go
+++ b/data/binding/sprintf.go
@@ -32,6 +32,13 @@ func NewSprintf(format string, b ...DataItem) (String, error) {
 	return ret, nil
 }
 
+// NewStringWithFormat is a wrapper over NewSprintf a String binding that format
+// its content using the format string and the provide additional parameter that
+// must be other data bindings.
+func NewStringWithFormat(format string, b ...DataItem) (String, error) {
+	return NewSprintf(format, b...)
+}
+
 func (s *sprintfString) DataChanged() {
 	data := make([]interface{}, 0, len(s.source))
 

--- a/data/binding/sprintf_test.go
+++ b/data/binding/sprintf_test.go
@@ -109,3 +109,56 @@ func TestSprintfConversionReadWrite(t *testing.T) {
 	assert.Equal(t, expectedChange, sChange)
 	assert.NotEqual(t, sGenerated, sChange)
 }
+
+func TestNewStringWithFormat(t *testing.T) {
+	var b bool = true
+	var f float64 = 42
+	var i int = 7
+	var r rune = 'B'
+	var s string = "this is a string"
+	var u fyne.URI = storage.NewFileURI("/")
+
+	bb := BindBool(&b)
+	bf := BindFloat(&f)
+	bi := BindInt(&i)
+	br := BindRune(&r)
+	bs := BindString(&s)
+	bu := BindURI(&u)
+
+	format := "Bool %v , Float %f , Int %v , Rune %v , String %s , URI %s"
+	sp, err := NewStringWithFormat(format, bb, bf, bi, br, bs, bu)
+	expected := fmt.Sprintf(format, b, f, i, r, s, u)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, sp)
+
+	waitForItems()
+
+	sGenerated, err := sp.Get()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, sGenerated)
+	assert.Equal(t, expected, sGenerated)
+
+	err = sp.Set("Bool false , Float 7.000000 , Int 42 , Rune 67 , String nospacestring , URI file:///var/")
+
+	assert.Nil(t, err)
+
+	waitForItems()
+
+	assert.Equal(t, b, false)
+	assert.Equal(t, f, float64(7))
+	assert.Equal(t, i, 42)
+	assert.Equal(t, r, 'C')
+	assert.Equal(t, s, "nospacestring")
+	assert.Equal(t, u.String(), "file:///var/")
+
+	expectedChange := fmt.Sprintf(format, b, f, i, r, s, u)
+
+	sChange, err := sp.Get()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, sChange)
+	assert.Equal(t, expectedChange, sChange)
+	assert.NotEqual(t, sGenerated, sChange)
+}


### PR DESCRIPTION
### Description:
Adds a new binding.NewStringWithFormat which is a wrapper over existing binding.NewSprintf. 

Fixes #2890 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
