### PR TITLE
Specialize goroutineID instead of Run.

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -7,8 +7,6 @@ import (
 	"image"
 	"os"
 	"runtime"
-	"strconv"
-	"strings"
 	"sync"
 
 	ico "github.com/Kodeworks/golang-image-ico"
@@ -151,14 +149,11 @@ func (d *gLDriver) initFailed(msg string, err error) {
 	}
 }
 
-func goroutineID() int {
-	b := make([]byte, 64)
-	b = b[:runtime.Stack(b, false)]
-	// string format expects "goroutine X [running..."
-	id := strings.Split(strings.TrimSpace(string(b)), " ")[1]
-
-	num, _ := strconv.Atoi(id)
-	return num
+func (d *gLDriver) Run() {
+	if goroutineID() != mainGoroutineID {
+		panic("Run() or ShowAndRun() must be called from main goroutine")
+	}
+	d.runGL()
 }
 
 // NewGLDriver sets up a new Driver instance implemented using the GLFW Go library and OpenGL bindings.

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -4,17 +4,24 @@
 package glfw
 
 import (
+	"runtime"
+	"strconv"
+	"strings"
+
 	"fyne.io/systray"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
 )
 
-func (d *gLDriver) Run() {
-	if goroutineID() != mainGoroutineID {
-		panic("Run() or ShowAndRun() must be called from main goroutine")
-	}
-	d.runGL()
+func goroutineID() int {
+	b := make([]byte, 64)
+	b = b[:runtime.Stack(b, false)]
+	// string format expects "goroutine X [running..."
+	id := strings.Split(strings.TrimSpace(string(b)), " ")[1]
+
+	num, _ := strconv.Atoi(id)
+	return num
 }
 
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {

--- a/internal/driver/glfw/driver_goxjs.go
+++ b/internal/driver/glfw/driver_goxjs.go
@@ -3,6 +3,6 @@
 
 package glfw
 
-func (d *gLDriver) Run() {
-	d.runGL()
+func goroutineID() int {
+	return mainGoroutineID
 }


### PR DESCRIPTION
### Description:
Change how the Go RoutineID check is done without duplicating Run for gopherjs backend.

Fixes #2780

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.