### PR TITLE
fix: cursor placement clicking inside Entry widget

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -819,7 +819,7 @@ func (e *Entry) getRowCol(p fyne.Position) (int, int) {
 		row = 0
 	} else if row >= e.textProvider().rows() {
 		row = e.textProvider().rows() - 1
-		col = 0
+		col = e.textProvider().rowLength(row)
 	} else {
 		col = e.cursorColAt(e.textProvider().row(row), p.Add(e.scroll.Offset))
 	}


### PR DESCRIPTION
### Description:
Reproducible in the fyne_demo app where clicking the empty space inside the multi-line entry widget causes the cursor to jump to the beginning of row instead of the end.

Before:
https://user-images.githubusercontent.com/15853349/165876725-6d6e9eda-6f07-4208-9d48-300dcefda69d.mov

After:
https://user-images.githubusercontent.com/15853349/165876757-0e5fed20-e22b-4acd-8ba1-a40602eb2c69.mov

Fixes #2877 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
