### PR TITLE
android: listURI should return an empty []fyne.URI for empty folders

### DIFF
--- a/internal/driver/mobile/folder_android.go
+++ b/internal/driver/mobile/folder_android.go
@@ -66,6 +66,9 @@ func listURI(uri fyne.URI) ([]fyne.URI, error) {
 	parts := strings.Split(C.GoString(str), "|")
 	var list []fyne.URI
 	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
 		list = append(list, storage.NewURI(part))
 	}
 	return list, nil


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The listURI should return empty []fyne.URI for an empty folder.
This PR updates the listURI logic to behave like the implementation for iOS.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
