### PR TITLE
Optimize the goroutineID function

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -4,9 +4,9 @@
 package glfw
 
 import (
+	"bytes"
 	"runtime"
 	"strconv"
-	"strings"
 
 	"fyne.io/systray"
 
@@ -17,11 +17,13 @@ import (
 func goroutineID() int {
 	b := make([]byte, 64)
 	b = b[:runtime.Stack(b, false)]
-	// string format expects "goroutine X [running..."
-	id := strings.Split(strings.TrimSpace(string(b)), " ")[1]
 
-	num, _ := strconv.Atoi(id)
-	return num
+	// String format expects "goroutine X [running...".
+	b = b[bytes.IndexByte(b, ' ')+1:]
+	b = b[:bytes.IndexByte(b, ' ')]
+
+	id, _ := strconv.Atoi(string(b))
+	return id
 }
 
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

It is not a lot faster but it does allocate about 60% less memory.

```
BenchmarkGoroutineIDnew-8   	  385348	      2847 ns/op	      66 B/op	       2 allocs/op
BenchmarkGoroutineIDold-8   	  400776	      2960 ns/op	     176 B/op	       3 allocs/op
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
