### PR TITLE
internal/driver/glfw: correct handle goroutineID

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -21,7 +21,11 @@ import (
 	"fyne.io/fyne/v2/storage/repository"
 )
 
-const mainGoroutineID = 1
+// mainGoroutineID stores the main goroutine ID.
+// This ID must be initialized in main.init because
+// a main goroutine may not equal to 1 due to the
+// influence of a garbage collector.
+var mainGoroutineID uint64
 
 var (
 	curWindow *window

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -5,8 +5,6 @@ package glfw
 
 import (
 	"runtime"
-	"strconv"
-	"strings"
 
 	"fyne.io/systray"
 
@@ -14,14 +12,13 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-func goroutineID() int {
-	b := make([]byte, 64)
-	b = b[:runtime.Stack(b, false)]
-	// string format expects "goroutine X [running..."
-	id := strings.Split(strings.TrimSpace(string(b)), " ")[1]
-
-	num, _ := strconv.Atoi(id)
-	return num
+func goroutineID() (id uint64) {
+	var buf [30]byte
+	runtime.Stack(buf[:], false)
+	for i := 10; buf[i] != ' '; i++ {
+		id = id*10 + uint64(buf[i]&15)
+	}
+	return id
 }
 
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {

--- a/internal/driver/glfw/driver_goxjs.go
+++ b/internal/driver/glfw/driver_goxjs.go
@@ -3,6 +3,6 @@
 
 package glfw
 
-func goroutineID() int {
+func goroutineID() uint64 {
 	return mainGoroutineID
 }

--- a/internal/driver/glfw/driver_test.go
+++ b/internal/driver/glfw/driver_test.go
@@ -119,7 +119,7 @@ func Test_gLDriver_AbsolutePositionForObject(t *testing.T) {
 	}
 }
 
-var mainRoutineID int
+var mainRoutineID uint64
 
 func init() {
 	mainRoutineID = goroutineID()
@@ -128,7 +128,7 @@ func init() {
 func TestGoroutineID(t *testing.T) {
 	assert.Equal(t, 1, mainRoutineID)
 
-	var childID1, childID2 int
+	var childID1, childID2 uint64
 	testID1 := goroutineID()
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -47,6 +47,7 @@ func newRun() *runFlag {
 // Arrange that main.main runs on main thread.
 func init() {
 	runtime.LockOSThread()
+	mainGoroutineID = goroutineID()
 
 	run = newRun()
 }


### PR DESCRIPTION
### Description:

The current goroutine ID is handled with two issues:

1. main goroutine is assumed to be 1, but it may not be true;
2. goroutine ID is typed as int rather than uin64; this may cause overflow.

Let's handle them gracefully.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
