### PR TITLE
data/binding: do not add DataItem and Listener on the fly

### DIFF
--- a/data/binding/sprintf.go
+++ b/data/binding/sprintf.go
@@ -21,12 +21,14 @@ type sprintfString struct {
 //
 // Since: 2.2
 func NewSprintf(format string, b ...DataItem) (String, error) {
-	ret := &sprintfString{String: NewString(), format: format, source: make([]DataItem, 0, len(b))}
+	ret := &sprintfString{
+		String: NewString(),
+		format: format,
+		source: append(make([]DataItem, 0, len(b)), b...),
+	}
 
 	for _, value := range b {
 		value.AddListener(ret)
-
-		ret.source = append(ret.source, value)
 	}
 
 	return ret, nil


### PR DESCRIPTION
### Description:
DataChanged() may looping s.source (read) while NewSprintf is still
AddListener and append items to ret.source (write).

Just a tiny step towards data race free.

Update #2509

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
