### PR TITLE
Fix setting style for middle rows

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -269,7 +269,7 @@ func (t *TextGrid) SetStyleRange(startRow, startCol, endRow, endCol int, style T
 	}
 
 	// possible middle rows
-	for rowNum := startRow + 1; rowNum < endRow-1; rowNum++ {
+	for rowNum := startRow + 1; rowNum < endRow; rowNum++ {
 		for col := 0; col < len(t.Rows[rowNum].Cells); col++ {
 			t.SetStyle(rowNum, col, style)
 		}

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -92,15 +92,19 @@ func TestTextGrid_SetStyle(t *testing.T) {
 }
 
 func TestTextGrid_SetStyleRange(t *testing.T) {
-	grid := NewTextGridFromString("Ab\ncd")
-	grid.SetStyleRange(0, 1, 1, 0, &CustomTextGridStyle{FGColor: color.White, BGColor: color.Black})
+	grid := NewTextGridFromString("Ab\ncd\nef")
+	grid.SetStyleRange(0, 1, 2, 0, &CustomTextGridStyle{FGColor: color.White, BGColor: color.Black})
 
 	assert.Nil(t, grid.Rows[0].Cells[0].Style)
 	assert.Equal(t, color.White, grid.Rows[0].Cells[1].Style.TextColor())
 	assert.Equal(t, color.Black, grid.Rows[0].Cells[1].Style.BackgroundColor())
 	assert.Equal(t, color.White, grid.Rows[1].Cells[0].Style.TextColor())
 	assert.Equal(t, color.Black, grid.Rows[1].Cells[0].Style.BackgroundColor())
-	assert.Nil(t, grid.Rows[1].Cells[1].Style)
+	assert.Equal(t, color.White, grid.Rows[1].Cells[1].Style.TextColor())
+	assert.Equal(t, color.Black, grid.Rows[1].Cells[1].Style.BackgroundColor())
+	assert.Equal(t, color.White, grid.Rows[2].Cells[0].Style.TextColor())
+	assert.Equal(t, color.Black, grid.Rows[2].Cells[0].Style.BackgroundColor())
+	assert.Nil(t, grid.Rows[2].Cells[1].Style)
 }
 
 func TestTextGrid_SetStyleRange_Overflow(t *testing.T) {


### PR DESCRIPTION
### Description:

Due to common off by one error last row in the middle was not set to
proper style. This trivial fix sets style of all middle rows consistently including last middle one.

Fixes #2957

### Checklist:

- [X] Tests included. // extended existing test in most straightforward way to cover for discovered issue - this test fails for develop but passes in my branch
- [X] Lint and formatter run with no errors. // `gofmt` reports multiple issues for develop; none in the code I've changed though; same for golangci-lint run - no issues with code I've touched
- [X] Tests all pass. // textgrid_test.go only - there is no use of TextGrid in other tests I believe and both `develop` and my branch consistently fail some tests unrelated to TextGrid
