### PR TITLE
internal/painter/gl: use correct shader program

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -27,8 +27,8 @@ func (p *painter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canva
 	points := p.rectCoords(size, pos, frame, fill, aspect, pad)
 	p.ctx.UseProgram(p.program)
 	vbo := p.createBuffer(points)
-	p.defineVertexArray("vert", 3, 5*4, 0)
-	p.defineVertexArray("vertTexCoord", 2, 5*4, 12)
+	p.defineVertexArray(p.program, "vert", 3, 5*4, 0)
+	p.defineVertexArray(p.program, "vertTexCoord", 2, 5*4, 12)
 
 	// here we have to choose between blending the image alpha or fading it...
 	// TODO find a way to support both
@@ -62,8 +62,8 @@ func (p *painter) drawLine(line *canvas.Line, pos fyne.Position, frame fyne.Size
 	points, halfWidth, feather := p.lineCoords(pos, line.Position1, line.Position2, line.StrokeWidth, 0.5, frame)
 	p.ctx.UseProgram(p.lineProgram)
 	vbo := p.createBuffer(points)
-	p.defineVertexArray("vert", 2, 4*4, 0)
-	p.defineVertexArray("normal", 2, 4*4, 2*4)
+	p.defineVertexArray(p.lineProgram, "vert", 2, 4*4, 0)
+	p.defineVertexArray(p.lineProgram, "normal", 2, 4*4, 2*4)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -171,8 +171,8 @@ func (p *painter) createProgram(shaderFilename string) Program {
 	return prog
 }
 
-func (p *painter) defineVertexArray(name string, size, stride, offset int) {
-	vertAttrib := p.ctx.GetAttribLocation(p.program, name)
+func (p *painter) defineVertexArray(prog Program, name string, size, stride, offset int) {
+	vertAttrib := p.ctx.GetAttribLocation(prog, name)
 	p.ctx.EnableVertexAttribArray(vertAttrib)
 	p.ctx.VertexAttribPointerWithOffset(vertAttrib, size, float, false, stride, offset)
 	p.logError()


### PR DESCRIPTION
### Description:

https://github.com/fyne-io/fyne/pull/2939 is a nice refactor, but the PR somehow forgot to use the correct shader program when defining a VBO. For line drawing, one must use a line shader program other than the simple shader program.

Small reproducer:

```go
package main

import (
	"image/color"

	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/canvas"
	"fyne.io/fyne/v2/container"
)

func main() {
	w := app.New().NewWindow("fyne")
	w.SetContent(container.NewVSplit(
		container.NewMax(&canvas.Rectangle{}),
		container.NewMax(&canvas.Line{StrokeColor: color.RGBA{0, 0, 0x80, 0xff}, StrokeWidth: 5}),
	))
	w.ShowAndRun()
}
```

- Before this PR: crash
- After this PR: OK

Fixes #2962

### Checklist:


- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
