### PR TITLE
Various minor validation improvements

### DIFF
--- a/data/validation/regexp.go
+++ b/data/validation/regexp.go
@@ -19,9 +19,10 @@ func NewRegexp(regexpstr, reason string) fyne.StringValidator {
 		return nil
 	}
 
+	err = errors.New(reason)
 	return func(text string) error {
 		if expression != nil && !expression.MatchString(text) {
-			return errors.New(reason)
+			return err
 		}
 
 		return nil // Nothing to validate with, same as having no validator.

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -1,6 +1,8 @@
 package widget
 
 import (
+	"errors"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/theme"
@@ -36,8 +38,7 @@ func (e *Entry) SetValidationError(err error) {
 		return
 	}
 
-	if (err == nil && e.validationError != nil) || (e.validationError == nil && err != nil) ||
-		err.Error() != e.validationError.Error() {
+	if !errors.Is(err, e.validationError) {
 		e.validationError = err
 
 		if e.onValidationChanged != nil {

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -24,9 +24,7 @@ func (e *Entry) Validate() error {
 // SetOnValidationChanged is intended for parent widgets or containers to hook into the validation.
 // The function might be overwritten by a parent that cares about child validation (e.g. widget.Form).
 func (e *Entry) SetOnValidationChanged(callback func(error)) {
-	if callback != nil {
-		e.onValidationChanged = callback
-	}
+	e.onValidationChanged = callback
 }
 
 // SetValidationError manually updates the validation status until the next input change

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -119,4 +119,9 @@ func TestEntry_SetOnValidationChanged(t *testing.T) {
 	modified = false
 	test.Type(entry, "-01-01")
 	assert.True(t, modified)
+
+	modified = false
+	entry.SetOnValidationChanged(nil)
+	test.Type(entry, "invalid")
+	assert.False(t, modified)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This rips out some of the changes in https://github.com/fyne-io/fyne/pull/2765 that I feel doesn't belong with the other changes in the PR. The changes are as follows (separated into one commit each):
- Avoid recreating the regexp error each time we get an invalid state. This should decrease the allocations and be faster over time when you write in an entry.
- We now use the `errors.Is` function that was added in Go 1.13. We can thus remove the hacky error checking and use something a bit more robust. This technically also allows wrapped errors to be correctly handled (if anyone even uses those for validation).
- Allow the onValidationChanged function to be removed in the entry. If we can remove the validator, we should be able to remove the function that runs when validation changes.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
