### PR TITLE
[RFC] Bugs/reduce race condition

### DIFF
--- a/canvas/base.go
+++ b/canvas/base.go
@@ -8,8 +8,6 @@
 package canvas // import "fyne.io/fyne/v2/canvas"
 
 import (
-	"sync"
-
 	"fyne.io/fyne/v2"
 )
 
@@ -19,47 +17,30 @@ type baseObject struct {
 	Hidden   bool          // Is this object currently hidden
 
 	min fyne.Size // The minimum size this object can be
-
-	propertyLock sync.RWMutex
 }
 
 // CurrentSize returns the current size of this canvas object.
 func (r *baseObject) Size() fyne.Size {
-	r.propertyLock.RLock()
-	defer r.propertyLock.RUnlock()
-
 	return r.size
 }
 
 // Resize sets a new size for the canvas object.
 func (r *baseObject) Resize(size fyne.Size) {
-	r.propertyLock.Lock()
-	defer r.propertyLock.Unlock()
-
 	r.size = size
 }
 
 // CurrentPosition gets the current position of this canvas object, relative to its parent.
 func (r *baseObject) Position() fyne.Position {
-	r.propertyLock.RLock()
-	defer r.propertyLock.RUnlock()
-
 	return r.position
 }
 
 // Move the object to a new position, relative to its parent.
 func (r *baseObject) Move(pos fyne.Position) {
-	r.propertyLock.Lock()
-	defer r.propertyLock.Unlock()
-
 	r.position = pos
 }
 
 // MinSize returns the specified minimum size, if set, or {1, 1} otherwise.
 func (r *baseObject) MinSize() fyne.Size {
-	r.propertyLock.RLock()
-	defer r.propertyLock.RUnlock()
-
 	if r.min.Width == 0 && r.min.Height == 0 {
 		return fyne.NewSize(1, 1)
 	}
@@ -69,33 +50,21 @@ func (r *baseObject) MinSize() fyne.Size {
 
 // SetMinSize specifies the smallest size this object should be.
 func (r *baseObject) SetMinSize(size fyne.Size) {
-	r.propertyLock.Lock()
-	defer r.propertyLock.Unlock()
-
 	r.min = size
 }
 
 // IsVisible returns true if this object is visible, false otherwise.
 func (r *baseObject) Visible() bool {
-	r.propertyLock.RLock()
-	defer r.propertyLock.RUnlock()
-
 	return !r.Hidden
 }
 
 // Show will set this object to be visible.
 func (r *baseObject) Show() {
-	r.propertyLock.Lock()
-	defer r.propertyLock.Unlock()
-
 	r.Hidden = false
 }
 
 // Hide will set this object to not be visible.
 func (r *baseObject) Hide() {
-	r.propertyLock.Lock()
-	defer r.propertyLock.Unlock()
-
 	r.Hidden = true
 }
 

--- a/internal/async/gen.go
+++ b/internal/async/gen.go
@@ -30,9 +30,9 @@ func main() {
 	codes := map[*template.Template]map[string]data{
 		chanImpl: {
 			"chan_canvasobject.go": {
-				Type:    "fyne.CanvasObject",
-				Name:    "CanvasObject",
-				Imports: `import "fyne.io/fyne/v2"`,
+				Type:    "copy.CopyCanvasObject",
+				Name:    "CopyCanvasObject",
+				Imports: `import "fyne.io/fyne/v2/internal/driver/common/copy"`,
 			},
 			"chan_func.go": {
 				Type:    "func()",
@@ -47,34 +47,34 @@ func main() {
 		},
 		queueImpl: {
 			"queue_canvasobject.go": {
-				Type: "fyne.CanvasObject",
-				Name: "CanvasObject",
+				Type: "copy.CopyCanvasObject",
+				Name: "CopyCanvasObject",
 				Imports: `import (
 					"sync"
 					"sync/atomic"
 
-					"fyne.io/fyne/v2"
+					"fyne.io/fyne/v2/internal/driver/common/copy"
 				)`,
 			},
 		},
 		queueUnsafeStructImpl: {
 			"queue_unsafe_canvasobject.go": {
-				Type: "fyne.CanvasObject",
-				Name: "CanvasObject",
+				Type: "copy.CopyCanvasObject",
+				Name: "CopyCanvasObject",
 				Imports: `import (
 					"sync/atomic"
 					"unsafe"
 
-					"fyne.io/fyne/v2"
+					"fyne.io/fyne/v2/internal/driver/common/copy"
 				)`,
 			},
 		},
 		queuePureStructImpl: {
 			"queue_pure_canvasobject.go": {
-				Type: "fyne.CanvasObject",
-				Name: "CanvasObject",
+				Type: "copy.CopyCanvasObject",
+				Name: "CopyCanvasObject",
 				Imports: `import (
-					"fyne.io/fyne/v2"
+					"fyne.io/fyne/v2/internal/driver/common/copy"
 				)`,
 			},
 		},

--- a/internal/async/queue_pure_canvasobject.go
+++ b/internal/async/queue_pure_canvasobject.go
@@ -5,37 +5,37 @@
 package async
 
 import (
-	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/driver/common/copy"
 )
 
-// CanvasObjectQueue implements lock-free FIFO freelist based queue.
+// CopyCanvasObjectQueue implements lock-free FIFO freelist based queue.
 //
 // Reference: https://dl.acm.org/citation.cfm?doid=248052.248106
-type CanvasObjectQueue struct {
-	head *itemCanvasObject
-	tail *itemCanvasObject
+type CopyCanvasObjectQueue struct {
+	head *itemCopyCanvasObject
+	tail *itemCopyCanvasObject
 	len  uint64
 }
 
-// NewCanvasObjectQueue returns a queue for caching values.
-func NewCanvasObjectQueue() *CanvasObjectQueue {
-	head := &itemCanvasObject{next: nil, v: nil}
-	return &CanvasObjectQueue{
+// NewCopyCanvasObjectQueue returns a queue for caching values.
+func NewCopyCanvasObjectQueue() *CopyCanvasObjectQueue {
+	head := &itemCopyCanvasObject{next: nil, v: nil}
+	return &CopyCanvasObjectQueue{
 		tail: head,
 		head: head,
 	}
 }
 
-type itemCanvasObject struct {
-	next *itemCanvasObject
-	v    fyne.CanvasObject
+type itemCopyCanvasObject struct {
+	next *itemCopyCanvasObject
+	v    copy.CopyCanvasObject
 }
 
-func loadCanvasObjectItem(p **itemCanvasObject) *itemCanvasObject {
+func loadCopyCanvasObjectItem(p **itemCopyCanvasObject) *itemCopyCanvasObject {
 	return *p
 }
 
-func casCanvasObjectItem(p **itemCanvasObject, _, new *itemCanvasObject) bool {
+func casCopyCanvasObjectItem(p **itemCopyCanvasObject, _, new *itemCopyCanvasObject) bool {
 	*p = new
 	return true
 }

--- a/internal/async/queue_test.go
+++ b/internal/async/queue_test.go
@@ -7,25 +7,27 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/driver/common/copy"
 )
 
 func TestQueue(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		q := async.NewCanvasObjectQueue()
+		q := async.NewCopyCanvasObjectQueue()
 		if q.Out() != nil {
 			t.Fatalf("dequeue empty queue returns non-nil")
 		}
 	})
 
 	t.Run("length", func(t *testing.T) {
-		q := async.NewCanvasObjectQueue()
+		q := async.NewCopyCanvasObjectQueue()
 		if q.Len() != 0 {
 			t.Fatalf("empty queue has non-zero length")
 		}
 
 		obj := canvas.NewRectangle(color.Black)
+		copy := copy.NewCopyRectangle(obj)
 
-		q.In(obj)
+		q.In(copy)
 		if q.Len() != 1 {
 			t.Fatalf("count of enqueue wrong, want %d, got %d.", 1, q.Len())
 		}
@@ -37,16 +39,17 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("in-out", func(t *testing.T) {
-		q := async.NewCanvasObjectQueue()
+		q := async.NewCopyCanvasObjectQueue()
 
-		want := []fyne.CanvasObject{
+		want := []*canvas.Rectangle{
 			canvas.NewRectangle(color.Black),
 			canvas.NewRectangle(color.Black),
 			canvas.NewRectangle(color.Black),
 		}
 
 		for i := 0; i < len(want); i++ {
-			q.In(want[i])
+			copy := copy.NewCopyRectangle(want[i])
+			q.In(copy)
 		}
 
 		var x []fyne.CanvasObject

--- a/internal/async/queue_unsafe_canvasobject.go
+++ b/internal/async/queue_unsafe_canvasobject.go
@@ -8,36 +8,36 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/driver/common/copy"
 )
 
-// CanvasObjectQueue implements lock-free FIFO freelist based queue.
+// CopyCanvasObjectQueue implements lock-free FIFO freelist based queue.
 //
 // Reference: https://dl.acm.org/citation.cfm?doid=248052.248106
-type CanvasObjectQueue struct {
+type CopyCanvasObjectQueue struct {
 	head unsafe.Pointer
 	tail unsafe.Pointer
 	len  uint64
 }
 
-// NewCanvasObjectQueue returns a queue for caching values.
-func NewCanvasObjectQueue() *CanvasObjectQueue {
-	head := &itemCanvasObject{next: nil, v: nil}
-	return &CanvasObjectQueue{
+// NewCopyCanvasObjectQueue returns a queue for caching values.
+func NewCopyCanvasObjectQueue() *CopyCanvasObjectQueue {
+	head := &itemCopyCanvasObject{next: nil, v: nil}
+	return &CopyCanvasObjectQueue{
 		tail: unsafe.Pointer(head),
 		head: unsafe.Pointer(head),
 	}
 }
 
-type itemCanvasObject struct {
+type itemCopyCanvasObject struct {
 	next unsafe.Pointer
-	v    fyne.CanvasObject
+	v    copy.CopyCanvasObject
 }
 
-func loadCanvasObjectItem(p *unsafe.Pointer) *itemCanvasObject {
-	return (*itemCanvasObject)(atomic.LoadPointer(p))
+func loadCopyCanvasObjectItem(p *unsafe.Pointer) *itemCopyCanvasObject {
+	return (*itemCopyCanvasObject)(atomic.LoadPointer(p))
 }
 
-func casCanvasObjectItem(p *unsafe.Pointer, old, new *itemCanvasObject) bool {
+func casCopyCanvasObjectItem(p *unsafe.Pointer, old, new *itemCopyCanvasObject) bool {
 	return atomic.CompareAndSwapPointer(p, unsafe.Pointer(old), unsafe.Pointer(new))
 }

--- a/internal/driver/common/copy/copy_canvasobject.go
+++ b/internal/driver/common/copy/copy_canvasobject.go
@@ -1,0 +1,112 @@
+package copy
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+)
+
+type CopyCanvasObject interface {
+	fyne.CanvasObject
+
+	// Give a reference to the CanvasObject used as a source, should only be used for the pointer value, but not for any of its field
+	Ref() fyne.CanvasObject
+}
+
+type CopyReference struct {
+	ref fyne.CanvasObject
+}
+
+func (copy *CopyReference) Ref() fyne.CanvasObject {
+	return copy.ref
+}
+
+var _ CopyCanvasObject = (*CopyCircle)(nil)
+var _ CopyCanvasObject = (*CopyContainer)(nil)
+var _ CopyCanvasObject = (*CopyImage)(nil)
+var _ CopyCanvasObject = (*CopyLine)(nil)
+var _ CopyCanvasObject = (*CopyLinearGradient)(nil)
+var _ CopyCanvasObject = (*CopyRadialGradient)(nil)
+var _ CopyCanvasObject = (*CopyRaster)(nil)
+var _ CopyCanvasObject = (*CopyRectangle)(nil)
+var _ CopyCanvasObject = (*CopyText)(nil)
+
+type CopyCircle struct {
+	canvas.Circle
+	CopyReference
+}
+
+func NewCopyCircle(source *canvas.Circle) *CopyCircle {
+	return &CopyCircle{Circle: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyContainer struct {
+	fyne.Container
+	CopyReference
+}
+
+func NewCopyContainer(source *fyne.Container) *CopyContainer {
+	return &CopyContainer{Container: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyImage struct {
+	canvas.Image
+	CopyReference
+}
+
+func NewCopyImage(source *canvas.Image) *CopyImage {
+	return &CopyImage{Image: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyLine struct {
+	canvas.Line
+	CopyReference
+}
+
+func NewCopyLine(source *canvas.Line) *CopyLine {
+	return &CopyLine{Line: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyLinearGradient struct {
+	canvas.LinearGradient
+	CopyReference
+}
+
+func NewCopyLinearGradient(source *canvas.LinearGradient) *CopyLinearGradient {
+	return &CopyLinearGradient{LinearGradient: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyRadialGradient struct {
+	canvas.RadialGradient
+	CopyReference
+}
+
+func NewCopyRadialGradient(source *canvas.RadialGradient) *CopyRadialGradient {
+	return &CopyRadialGradient{RadialGradient: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyRaster struct {
+	canvas.Raster
+	CopyReference
+}
+
+func NewCopyRaster(source *canvas.Raster) *CopyRaster {
+	return &CopyRaster{Raster: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyRectangle struct {
+	canvas.Rectangle
+	CopyReference
+}
+
+func NewCopyRectangle(source *canvas.Rectangle) *CopyRectangle {
+	return &CopyRectangle{Rectangle: *source, CopyReference: CopyReference{source}}
+}
+
+type CopyText struct {
+	canvas.Text
+	CopyReference
+}
+
+func NewCopyText(source *canvas.Text) *CopyText {
+	return &CopyText{Text: *source, CopyReference: CopyReference{source}}
+}


### PR DESCRIPTION
### Description:
**THIS IS A REQUEST FOR COMMENT, DO NOT APPROVE/MERGE.**

This PR is just to show what I have in mind on how to address race condition in Fyne rendering logic. To make it simple, I think that the internal/* should only ever use a copy of the object and never access the object use by the user except during Refresh. For that purpose I introduce a new set of type which are Copy version of there public representation with all the data for rendering and locating them on screen.

The user duty is to lock things properly and synchronize his setting on the object and calling Refresh.

The current short coming of this PR:
- It has not switched all the type inside internal to be _CopyCanvasObject_, just the entry point of Refresh.
- It doesn't handle _baseWidget_ (I think it is doable, but require a bit of thinking in identifying what should be copied)
- It doesn't handle **canvas.SetContent** which should actually only ever use a Copy too. This one is harder to fix as the idea is that all the canvas call should only apply to the latest Refreshed content, not on the content that was set. For example, on a mouse click, it should walk the tree like it was when it was last **committed** to screen last, not like it is at that random point in time.
- All locks are gone right now, but it will need a lock for the rendering routine and the input routine to access the canvas content safely and avoid race there. Granularity of this is not clear at the moment (depends on the next point).
- This PR introduce a memory allocation per Refresh, which is a huge performance penalty. It is also not necessary as there is a need of **max 4 states** per _CanvasObject_ (1 for the modification by the user, 1 for the Copy in flight in Refresh, 1 for the Copy currently being processed by the Rendering routine, 1 for the Copy currently committed inside the content tree). Think of it like a triple buffer problem, each copy reduce the time a lock need to be held. The reason, we currently can't just have 4 copy created at structure allocation, is :
  - No link between _CanvasObject_ -> _CopyCanvasObject_
  - No idea at Refresh time if the last call to Refresh made it to the other side of the pipe or not. This could be solved by maintaining a map+lock of all the _CanvasObject_ that need rendering for next frame instead of using a queue. The lock could likely be held for a very short amount of time, just to switch the map, maybe?

Overall, I think the main problem to solve is how to quickly Copy and Match the object from the live tree with the one from the **Committed** tree. The easiest, fastest way, would be to have that information stored inside the _fyne.CanvasObject_ so that the lookup is a O(1), but I can not figure out how to do so without making a public API, which I find annoying (This would also solve the problem of to many allocation).

You can test this PR as long as there is no input that would interfere or Widget being used... This limit its usefulness, but hopefully it helps for the discussion.

Please share your idea and opinion.

Fixes #2895

Note: This is definitively not material for 2.2.