### PR TITLE
Add back special handling for last characters when compiling shaders …

### DIFF
--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -71,8 +71,8 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = p.createProgram("simple")
-	p.lineProgram = p.createProgram("line")
+	p.program = p.createProgram("simple", true)
+	p.lineProgram = p.createProgram("line", true)
 }
 
 type coreContext struct{}

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -78,8 +78,8 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = p.createProgram("simple_es")
-	p.lineProgram = p.createProgram("line_es")
+	p.program = p.createProgram("simple_es", true)
+	p.lineProgram = p.createProgram("line_es", true)
 }
 
 type esContext struct{}

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -68,8 +68,8 @@ func (p *painter) Init() {
 	p.ctx = &mobileContext{glContext: p.contextProvider.Context().(gl.Context)}
 	p.glctx().Disable(gl.DepthTest)
 	p.glctx().Enable(gl.Blend)
-	p.program = p.createProgram("simple_es")
-	p.lineProgram = p.createProgram("line_es")
+	p.program = p.createProgram("simple_es", false)
+	p.lineProgram = p.createProgram("line_es", false)
 }
 
 // f32Bytes returns the byte representation of float32 values in the given byte

--- a/internal/painter/gl/gl_goxjs.go
+++ b/internal/painter/gl/gl_goxjs.go
@@ -63,8 +63,8 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = p.createProgram("simple_es")
-	p.lineProgram = p.createProgram("line_es")
+	p.program = p.createProgram("simple_es", false)
+	p.lineProgram = p.createProgram("line_es", false)
 }
 
 type xjsContext struct{}

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -130,7 +130,7 @@ func (p *painter) createBuffer(points []float32) Buffer {
 	return vbo
 }
 
-func (p *painter) createProgram(shaderFilename string) Program {
+func (p *painter) createProgram(shaderFilename string, nullTerminated bool) Program {
 	// Why a switch over a filename?
 	// Because this allows for a minimal change, once we reach Go 1.16 and use go:embed instead of
 	// fyne bundle.
@@ -139,11 +139,17 @@ func (p *painter) createProgram(shaderFilename string) Program {
 	if vertexSrc == nil {
 		panic("shader not found: " + shaderFilename)
 	}
-	vertShader, err := p.compileShader(string(vertexSrc)+"\x00", vertexShader)
+
+	endChar := ""
+	if nullTerminated {
+		endChar = "\x00"
+	}
+
+	vertShader, err := p.compileShader(string(vertexSrc)+endChar, vertexShader)
 	if err != nil {
 		panic(err)
 	}
-	fragShader, err := p.compileShader(string(fragmentSrc)+"\x00", fragmentShader)
+	fragShader, err := p.compileShader(string(fragmentSrc)+endChar, fragmentShader)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Description:
Shader compilation for the Web driver got broken during latest refactor. This fixes the issues.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.