### PR TITLE
This handle now live detection of dark/light mode setup by the browse…

### DIFF
--- a/app/app_goxjs.go
+++ b/app/app_goxjs.go
@@ -7,12 +7,7 @@ package app
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 )
-
-func defaultVariant() fyne.ThemeVariant {
-	return theme.VariantDark
-}
 
 func (app *fyneApp) SendNotification(_ *fyne.Notification) {
 	// TODO #2735
@@ -21,8 +16,4 @@ func (app *fyneApp) SendNotification(_ *fyne.Notification) {
 
 func rootConfigDir() string {
 	return "/data/"
-}
-
-func defaultTheme() fyne.Theme {
-	return theme.DarkTheme()
 }

--- a/app/app_theme_js.go
+++ b/app/app_theme_js.go
@@ -1,0 +1,29 @@
+//go:build !ci && js && !wasm
+// +build !ci,js,!wasm
+
+package app
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func defaultVariant() fyne.ThemeVariant {
+	if matchMedia := js.Global.Call("matchMedia", "(prefers-color-scheme: dark)"); matchMedia != js.Undefined {
+		if matches := matchMedia.Get("matches"); matches != js.Undefined && matches.Bool() {
+			return theme.VariantDark
+		}
+		return theme.VariantLight
+	}
+	return theme.VariantDark
+}
+
+func init() {
+	if matchMedia := js.Global.Call("matchMedia", "(prefers-color-scheme: dark)"); matchMedia != js.Undefined {
+		matchMedia.Call("addEventListener", "change", func(o *js.Object) {
+			fyne.CurrentApp().Settings().(*settings).setupTheme()
+		})
+	}
+}

--- a/app/app_theme_wasm.go
+++ b/app/app_theme_wasm.go
@@ -1,0 +1,31 @@
+//go:build !ci && wasm
+// +build !ci,wasm
+
+package app
+
+import (
+	"syscall/js"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+func defaultVariant() fyne.ThemeVariant {
+	matches := js.Global().Call("matchMedia", "(prefers-color-scheme: dark)")
+	if matches.Truthy() {
+		if matches.Get("matches").Bool() {
+			return theme.VariantDark
+		}
+		return theme.VariantLight
+	}
+	return theme.VariantDark
+}
+
+func init() {
+	if matchMedia := js.Global().Call("matchMedia", "(prefers-color-scheme: dark)"); matchMedia.Truthy() {
+		matchMedia.Call("addEventListener", "change", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+			fyne.CurrentApp().Settings().(*settings).setupTheme()
+			return nil
+		}))
+	}
+}

--- a/app/app_theme_web.go
+++ b/app/app_theme_web.go
@@ -1,0 +1,13 @@
+//go:build !ci && !js && !wasm && test_web_driver
+// +build !ci,!js,!wasm,test_web_driver
+
+package app
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+func defaultVariant() fyne.ThemeVariant {
+	return theme.VariantDark
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
+	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/jackmordaunt/icns/v2 v2.2.1
 	github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca
 	github.com/lucor/goinfo v0.0.0-20210802170112-c078a2b0f08b

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
-	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/gopherjs/gopherjs v1.17.2
 	github.com/jackmordaunt/icns/v2 v2.2.1
 	github.com/josephspurrier/goversioninfo v0.0.0-20200309025242-14b0ab84c6ca
 	github.com/lucor/goinfo v0.0.0-20210802170112-c078a2b0f08b

--- a/go.sum
+++ b/go.sum
@@ -166,7 +166,6 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60 h1:btMZK5oA0NpSAOOE7zRfq2UEuPC9apJ2UBackURyaTU=
 github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60/go.mod h1:cz9oNYuRUWGdHmLF2IodMLkAhcPtXeULvcBNagUrxTI=
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60 h1:btMZK5oA0NpSAOOE7zRfq2UEuPC9apJ2UBackURyaTU=
 github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60/go.mod h1:cz9oNYuRUWGdHmLF2IodMLkAhcPtXeULvcBNagUrxTI=
+github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
+github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/goxjs/gl v0.0.0-20210104184919-e3fafc6f8f2a/go.mod h1:dy/f2gjY09hwVfIyATps4G2ai7/hLwLkc5TrPqONuXY=
 github.com/goxjs/glfw v0.0.0-20191126052801-d2efb5f20838/go.mod h1:oS8P8gVOT4ywTcjV6wZlOU4GuVFQ8F5328KY3MJ79CY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -258,6 +260,7 @@ github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
@@ -429,6 +432,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/gopherjs/gopherjs/js/js.go
+++ b/vendor/github.com/gopherjs/gopherjs/js/js.go
@@ -1,6 +1,6 @@
 // Package js provides functions for interacting with native JavaScript APIs. Calls to these functions are treated specially by GopherJS and translated directly to their corresponding JavaScript syntax.
 //
-// Use MakeWrapper to expose methods to JavaScript. When passing values directly, the following type conversions are performed:
+// Use MakeWrapper to expose methods to JavaScript. Use MakeFullWrapper to expose methods AND fields to JavaScript. When passing values directly, the following type conversions are performed:
 //
 //  | Go type               | JavaScript type       | Conversions back to interface{} |
 //  | --------------------- | --------------------- | ------------------------------- |
@@ -97,7 +97,13 @@ func (err *Error) Stack() string {
 // Global gives JavaScript's global object ("window" for browsers and "GLOBAL" for Node.js).
 var Global *Object
 
-// Module gives the value of the "module" variable set by Node.js. Hint: Set a module export with 'js.Module.Get("exports").Set("exportName", ...)'.
+// Module gives the value of the "module" variable set by Node.js. Hint: Set a
+// module export with 'js.Module.Get("exports").Set("exportName", ...)'.
+//
+// Note that js.Module is only defined in runtimes which support CommonJS
+// modules (https://nodejs.org/api/modules.html). NodeJS supports it natively,
+// but in browsers it can only be used if GopherJS output is passed through a
+// bundler which implements CommonJS (for example, webpack or esbuild).
 var Module *Object
 
 // Undefined gives the JavaScript value "undefined".
@@ -147,6 +153,99 @@ func MakeWrapper(i interface{}) *Object {
 	return o
 }
 
+// MakeFullWrapper creates a JavaScript object which has wrappers for the exported
+// methods of i, and, where i is a (pointer to a) struct value, wrapped getters
+// and setters
+// (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty)
+// for the non-embedded exported fields of i. Values accessed via these methods
+// and getters are themsevles wrapped when accessed, but an important point to
+// note is that a new wrapped value is created on each access.
+func MakeFullWrapper(i interface{}) *Object {
+	internalObj := InternalObject(i)
+	constructor := internalObj.Get("constructor")
+
+	wrapperObj := Global.Get("Object").New()
+
+	defineProperty := func(key string, descriptor M) {
+		Global.Get("Object").Call("defineProperty", wrapperObj, key, descriptor)
+	}
+
+	defineProperty("__internal_object__", M{
+		"value": internalObj,
+	})
+
+	{
+		// Calculate a sensible type string.
+
+		// We don't want to import any packages in this package,
+		// so we do some string operations by hand.
+
+		typ := constructor.Get("string").String()
+		pkg := constructor.Get("pkg").String()
+
+		ptr := ""
+		if typ[0] == '*' {
+			ptr = "*"
+		}
+
+		for i := 0; i < len(typ); i++ {
+			if typ[i] == '.' {
+				typ = typ[i+1:]
+				break
+			}
+		}
+
+		pkgTyp := pkg + "." + ptr + typ
+		defineProperty("$type", M{
+			"value": pkgTyp,
+		})
+	}
+
+	var fields *Object
+	methods := Global.Get("Array").New()
+	if ms := constructor.Get("methods"); ms != Undefined {
+		methods = methods.Call("concat", ms)
+	}
+	// If we are a pointer value then add fields from element,
+	// else the constructor itself will have them.
+	if e := constructor.Get("elem"); e != Undefined {
+		fields = e.Get("fields")
+		methods = methods.Call("concat", e.Get("methods"))
+	} else {
+		fields = constructor.Get("fields")
+	}
+	for i := 0; i < methods.Length(); i++ {
+		m := methods.Index(i)
+		if m.Get("pkg").String() != "" { // not exported
+			continue
+		}
+		defineProperty(m.Get("prop").String(), M{
+			"value": func(args ...*Object) *Object {
+				return Global.Call("$externalizeFunction", internalObj.Get(m.Get("prop").String()), m.Get("typ"), true, InternalObject(MakeFullWrapper)).Call("apply", internalObj, args)
+			},
+		})
+	}
+	if fields != Undefined {
+		for i := 0; i < fields.Length(); i++ {
+			f := fields.Index(i)
+			if !f.Get("exported").Bool() {
+				continue
+			}
+			defineProperty(f.Get("prop").String(), M{
+				"get": func() *Object {
+					vc := Global.Call("$copyIfRequired", internalObj.Get("$val").Get(f.Get("prop").String()), f.Get("typ"))
+					return Global.Call("$externalize", vc, f.Get("typ"), InternalObject(MakeFullWrapper))
+				},
+				"set": func(jv *Object) {
+					gv := Global.Call("$internalize", jv, f.Get("typ"), InternalObject(MakeFullWrapper))
+					internalObj.Get("$val").Set(f.Get("prop").String(), gv)
+				},
+			})
+		}
+	}
+	return wrapperObj
+}
+
 // NewArrayBuffer creates a JavaScript ArrayBuffer from a byte slice.
 func NewArrayBuffer(b []byte) *Object {
 	slice := InternalObject(b)
@@ -162,7 +261,7 @@ type M map[string]interface{}
 type S []interface{}
 
 func init() {
-	// avoid dead code elimination
+	// Avoid dead code elimination.
 	e := Error{}
 	_ = e
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,8 @@ github.com/godbus/dbus/v5/prop
 github.com/goki/freetype
 github.com/goki/freetype/raster
 github.com/goki/freetype/truetype
-# github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60
+# github.com/gopherjs/gopherjs v1.17.2
+## explicit
 github.com/gopherjs/gopherjs/js
 # github.com/jackmordaunt/icns/v2 v2.2.1
 ## explicit


### PR DESCRIPTION
### Description:
This add support for detecting dark/light theme setup coming from the web browser when using the web drivers. Work for both JS and WASM driver. There was no issue for it, but it was fairly easy to add once I looked at it.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
