### PR TITLE
Make 'web' the default output for `fyne serve` with added messaging t…

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -202,6 +202,12 @@ func (b *Builder) build() error {
 		versionConstraint = version.NewConstrainGroupFromString(">=1.17")
 		env = append(env, "GOARCH=wasm")
 		env = append(env, "GOOS=js")
+	} else if goos == "gopherjs" {
+		_, err := b.runner.runOutput("version")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Can not execute `gopherjs version`. Please do `go install github.com/gopherjs/gopherjs@latest`.\n")
+			return err
+		}
 	}
 
 	if err := checkGoVersion(b.runner, versionConstraint); err != nil {

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -166,6 +166,16 @@ func Test_BuildGopherJSReleaseVersion(t *testing.T) {
 	expected := []mockRunner{
 		{
 			expectedValue: expectedValue{
+				args:  []string{"version"},
+				osEnv: true,
+			},
+			mockReturn: mockReturn{
+				ret: []byte(""),
+				err: nil,
+			},
+		},
+		{
+			expectedValue: expectedValue{
 				args:  []string{"build", "--tags", "release"},
 				osEnv: true,
 				dir:   "myTest",

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -204,6 +204,16 @@ func Test_buildPackageGopherJS(t *testing.T) {
 	expected := []mockRunner{
 		{
 			expectedValue: expectedValue{
+				args:  []string{"version"},
+				osEnv: true,
+			},
+			mockReturn: mockReturn{
+				ret: []byte(""),
+				err: nil,
+			},
+		},
+		{
+			expectedValue: expectedValue{
 				args:  []string{"build", "-o", "myTest.js", "--tags", "release"},
 				osEnv: true,
 				dir:   "myTest",
@@ -230,6 +240,16 @@ func Test_buildPackageGopherJS(t *testing.T) {
 
 func Test_PackageGopherJS(t *testing.T) {
 	expected := []mockRunner{
+		{
+			expectedValue: expectedValue{
+				args:  []string{"version"},
+				osEnv: true,
+			},
+			mockReturn: mockReturn{
+				ret: []byte(""),
+				err: nil,
+			},
+		},
 		{
 			expectedValue: expectedValue{
 				args: []string{"build",
@@ -329,6 +349,16 @@ func Test_BuildPackageWeb(t *testing.T) {
 		},
 		{
 			expectedValue: expectedValue{
+				args:  []string{"version"},
+				osEnv: true,
+			},
+			mockReturn: mockReturn{
+				ret: []byte(""),
+				err: nil,
+			},
+		},
+		{
+			expectedValue: expectedValue{
 				args:  []string{"build", "-o", "myTest.js", "--tags", "release"},
 				osEnv: true,
 				dir:   "myTest",
@@ -372,6 +402,16 @@ func Test_PackageWeb(t *testing.T) {
 			},
 			mockReturn: mockReturn{
 				ret: []byte(""),
+			},
+		},
+		{
+			expectedValue: expectedValue{
+				args:  []string{"version"},
+				osEnv: true,
+			},
+			mockReturn: mockReturn{
+				ret: []byte(""),
+				err: nil,
 			},
 		},
 		{

--- a/cmd/fyne/internal/commands/serve.go
+++ b/cmd/fyne/internal/commands/serve.go
@@ -47,7 +47,7 @@ func Serve() *cli.Command {
 				Name:        "target",
 				Aliases:     []string{"os"},
 				Usage:       "The web runtime to target (wasm, gopherjs, web).",
-				Value:       "wasm",
+				Value:       "web",
 				Destination: &s.os,
 			},
 		},


### PR DESCRIPTION
### Description:
This switch `fyne serve` to use the `web` output, instead of just wasm. As this require gopherjs to be installed, this also add an explicit warning for the user to install gopherjs if not available.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.