### PR TITLE
fix clipping of large scrollable content

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -276,14 +276,6 @@ func (c *glCanvas) paint(size fyne.Size) {
 			inner := clips.Push(pos, obj.Size())
 			c.Painter().StartClipping(inner.Rect())
 		}
-
-		if visibleArea := clips.Top(); visibleArea != nil {
-			_, paintArea := visibleArea.Intersect(pos, size).Rect()
-			if paintArea.Width <= 0 || paintArea.Height <= 0 {
-				return
-			}
-		}
-
 		c.Painter().Paint(obj, pos, size)
 	}
 	afterPaint := func(node *common.RenderCacheNode) {
@@ -293,11 +285,9 @@ func (c *glCanvas) paint(size fyne.Size) {
 				c.Painter().StartClipping(top.Rect())
 			} else {
 				c.Painter().StopClipping()
-
 			}
 		}
 	}
-
 	c.WalkTrees(paint, afterPaint)
 }
 


### PR DESCRIPTION
### Description:

PR #2893 included an optimization to not paint an object if the intersection of the visible area and the object’s current position and size was empty. This computation does not consider that the object might have been scrolled. In effect, the background of large pop-ups (like the icon list in the demo app) vanished when scrolling down too much.

The optimization is removed for now. If it will ever be re-introduced, it has to consider scrolling and there have to be tests, of course.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
