### PR TITLE
Insert metadata through a init method from generated code file

### DIFF
--- a/app/meta.go
+++ b/app/meta.go
@@ -9,12 +9,14 @@ import (
 )
 
 var meta = fyne.AppMetadata{
-	ID: "com.example",
-	Name: "Fyne App",
+	ID:      "com.example",
+	Name:    "Fyne App",
 	Version: "1.0.0",
-	Build: 1,
+	Build:   1,
 }
 
+// SetMetadata overrides the packaged application metadata.
+// This data can be used in many places like notifications and about screens.
 func SetMetadata(m fyne.AppMetadata) {
 	meta = m
 }

--- a/app/meta.go
+++ b/app/meta.go
@@ -3,30 +3,20 @@ package app
 import (
 	"encoding/base64"
 	"io/ioutil"
-	"strconv"
 	"strings"
 
 	"fyne.io/fyne/v2"
-	intapp "fyne.io/fyne/v2/internal/app"
 )
 
-var (
-	meta fyne.AppMetadata
-)
+var meta = fyne.AppMetadata{
+	ID: "com.example",
+	Name: "Fyne App",
+	Version: "1.0.0",
+	Build: 1,
+}
 
-func init() {
-	build, err := strconv.Atoi(intapp.MetaBuild)
-	if err != nil {
-		build = 1
-	}
-
-	meta = fyne.AppMetadata{
-		Icon:    convertIcon(intapp.MetaIcon),
-		ID:      intapp.MetaID,
-		Name:    intapp.MetaName,
-		Version: intapp.MetaVersion,
-		Build:   build,
-	}
+func SetMetadata(m fyne.AppMetadata) {
+	meta = m
 }
 
 func (a *fyneApp) Metadata() fyne.AppMetadata {

--- a/app/meta.go
+++ b/app/meta.go
@@ -1,10 +1,6 @@
 package app
 
 import (
-	"encoding/base64"
-	"io/ioutil"
-	"strings"
-
 	"fyne.io/fyne/v2"
 )
 
@@ -23,21 +19,4 @@ func SetMetadata(m fyne.AppMetadata) {
 
 func (a *fyneApp) Metadata() fyne.AppMetadata {
 	return meta
-}
-
-func convertIcon(bytes string) fyne.Resource {
-	if bytes == "" {
-		return nil
-	}
-	data := base64.NewDecoder(base64.StdEncoding, strings.NewReader(bytes))
-	img, err := ioutil.ReadAll(data)
-	if err != nil {
-		fyne.LogError("Failed to decode icon from embedded data", err)
-		return nil
-	}
-
-	return &fyne.StaticResource{
-		StaticName:    "FyneAppIcon",
-		StaticContent: img,
-	}
 }

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -8,17 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildGenerateMetaLDFlags(t *testing.T) {
-	b := &Builder{appData: &appData{}}
-	assert.Equal(t, "", b.generateMetaLDFlags())
-
-	b.appID = "com.example"
-	assert.Equal(t, "-X 'fyne.io/fyne/v2/internal/app.MetaID=com.example'", b.generateMetaLDFlags())
-
-	b.appVersion = "1.2.3"
-	assert.Equal(t, "-X 'fyne.io/fyne/v2/internal/app.MetaID=com.example' -X 'fyne.io/fyne/v2/internal/app.MetaVersion=1.2.3'", b.generateMetaLDFlags())
-}
-
 func Test_CheckGoVersionNoGo(t *testing.T) {
 	commandNil := &testCommandRuns{runs: []mockRunner{}, t: t}
 	assert.Nil(t, checkGoVersion(commandNil, nil))

--- a/cmd/fyne/internal/commands/get.go
+++ b/cmd/fyne/internal/commands/get.go
@@ -30,7 +30,7 @@ func Get() *cli.Command {
 				Name:        "appID",
 				Aliases:     []string{"id"},
 				Usage:       "For darwin and Windows targets an appID in the form of a reversed domain name is required, for ios this must match a valid provisioning profile",
-				Destination: &g.appID,
+				Destination: &g.AppID,
 			},
 		},
 		Action: func(ctx *cli.Context) error {
@@ -83,7 +83,7 @@ func (g *Getter) Get(pkg string) error {
 //
 // Since: 2.1
 func (g *Getter) SetAppID(id string) {
-	g.appID = id
+	g.AppID = id
 }
 
 // SetIcon allows you to set the app icon path that will be used for the next Get operation.

--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -47,7 +47,7 @@ func Install() *cli.Command {
 				Name:        "appID",
 				Aliases:     []string{"id"},
 				Usage:       "For Android, darwin, iOS and Windows targets an appID in the form of a reversed domain name is required, for ios this must match a valid provisioning profile",
-				Destination: &i.appID,
+				Destination: &i.AppID,
 			},
 			&cli.BoolFlag{
 				Name:        "release",
@@ -74,7 +74,7 @@ func (i *Installer) AddFlags() {
 	flag.StringVar(&i.os, "os", "", "The mobile platform to target (android, android/arm, android/arm64, android/amd64, android/386, ios)")
 	flag.StringVar(&i.installDir, "installDir", "", "A specific location to install to, rather than the OS default")
 	flag.StringVar(&i.icon, "icon", "Icon.png", "The name of the application icon file")
-	flag.StringVar(&i.appID, "appID", "", "For ios or darwin targets an appID is required, for ios this must \nmatch a valid provisioning profile")
+	flag.StringVar(&i.AppID, "appID", "", "For ios or darwin targets an appID is required, for ios this must \nmatch a valid provisioning profile")
 	flag.BoolVar(&i.release, "release", false, "Should this package be installed in release mode? (disable debug etc)")
 }
 
@@ -147,9 +147,9 @@ func (i *Installer) install() error {
 		case "linux", "openbsd", "freebsd", "netbsd":
 			i.installDir = "/" // the tarball contains the structure starting at usr/local
 		case "windows":
-			dirName := p.name
-			if filepath.Ext(p.name) == ".exe" {
-				dirName = p.name[:len(p.name)-4]
+			dirName := p.Name
+			if filepath.Ext(p.Name) == ".exe" {
+				dirName = p.Name[:len(p.Name)-4]
 			}
 			i.installDir = filepath.Join(os.Getenv("ProgramFiles"), dirName)
 			err := runAsAdminWindows("mkdir", "\"\""+i.installDir+"\"\"")
@@ -172,7 +172,7 @@ func (i *Installer) install() error {
 }
 
 func (i *Installer) installAndroid() error {
-	target := mobile.AppOutputName(i.os, i.Packager.name, i.release)
+	target := mobile.AppOutputName(i.os, i.Packager.Name, i.release)
 
 	_, err := os.Stat(target)
 	if os.IsNotExist(err) {
@@ -186,7 +186,7 @@ func (i *Installer) installAndroid() error {
 }
 
 func (i *Installer) installIOS() error {
-	target := mobile.AppOutputName(i.os, i.Packager.name, i.release)
+	target := mobile.AppOutputName(i.os, i.Packager.Name, i.release)
 
 	// Always redo the package because the codesign for ios and iossimulator
 	// must be different.
@@ -222,7 +222,7 @@ func (i *Installer) validate() error {
 		os = targetOS()
 	}
 	i.Packager = &Packager{appData: i.appData, os: os, install: true, srcDir: i.srcDir}
-	i.Packager.appID = i.appID
+	i.Packager.AppID = i.AppID
 	i.Packager.icon = i.icon
 	i.Packager.release = i.release
 	return i.Packager.validate()
@@ -242,7 +242,7 @@ func (i *Installer) installToIOSSimulator(target string) error {
 }
 
 func (i *Installer) runInIOSSimulator() error {
-	cmd := execabs.Command("xcrun", "simctl", "launch", "booted", i.Packager.appID)
+	cmd := execabs.Command("xcrun", "simctl", "launch", "booted", i.Packager.AppID)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		os.Stderr.Write(out)

--- a/cmd/fyne/internal/commands/install_windows.go
+++ b/cmd/fyne/internal/commands/install_windows.go
@@ -36,10 +36,10 @@ func linkToStartMenu(path, name string) error {
 
 func postInstall(i *Installer) error {
 	p := i.Packager
-	appName := p.name
-	appExe := p.name
-	if filepath.Ext(p.name) == ".exe" {
-		appName = p.name[:len(p.name)-4]
+	appName := p.Name
+	appExe := p.Name
+	if filepath.Ext(p.Name) == ".exe" {
+		appName = p.Name[:len(p.Name)-4]
 	} else {
 		appExe = appExe + ".exe"
 	}

--- a/cmd/fyne/internal/commands/package-darwin.go
+++ b/cmd/fyne/internal/commands/package-darwin.go
@@ -21,7 +21,7 @@ type darwinData struct {
 }
 
 func (p *Packager) packageDarwin() (err error) {
-	appDir := util.EnsureSubDir(p.dir, p.name+".app")
+	appDir := util.EnsureSubDir(p.dir, p.Name+".app")
 	exeName := filepath.Base(p.exe)
 
 	contentsDir := util.EnsureSubDir(appDir, "Contents")
@@ -36,7 +36,7 @@ func (p *Packager) packageDarwin() (err error) {
 		}
 	}()
 
-	tplData := darwinData{Name: p.name, ExeName: exeName, AppID: p.appID, Version: p.appVersion, Build: p.appBuild,
+	tplData := darwinData{Name: p.Name, ExeName: exeName, AppID: p.AppID, Version: p.AppVersion, Build: p.AppBuild,
 		Category: strings.ToLower(p.category)}
 	if err := templates.InfoPlistDarwin.Execute(infoFile, tplData); err != nil {
 		return fmt.Errorf("failed to write plist template: %w", err)

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -16,11 +16,11 @@ import (
 )
 
 func (p *Packager) packageAndroid(arch string) error {
-	return mobile.RunNewBuild(arch, p.appID, p.icon, p.name, p.appVersion, p.appBuild, p.release, "", "")
+	return mobile.RunNewBuild(arch, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, "", "")
 }
 
 func (p *Packager) packageIOS(target string) error {
-	err := mobile.RunNewBuild(target, p.appID, p.icon, p.name, p.appVersion, p.appBuild, p.release, p.certificate, p.profile)
+	err := mobile.RunNewBuild(target, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.certificate, p.profile)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (p *Packager) packageIOS(target string) error {
 		return err
 	}
 
-	appDir := filepath.Join(p.dir, mobile.AppOutputName(p.os, p.name, p.release))
+	appDir := filepath.Join(p.dir, mobile.AppOutputName(p.os, p.Name, p.release))
 	return runCmdCaptureOutput("xcrun", "actool", "Images.xcassets", "--compile", appDir, "--platform",
 		"iphoneos", "--target-device", "iphone", "--minimum-deployment-target", "9.0", "--app-icon", "AppIcon",
 		"--output-format", "human-readable-text", "--output-partial-info-plist", "/dev/null")

--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -42,17 +42,17 @@ func (p *Packager) packageUNIX() error {
 	}
 
 	iconDir := util.EnsureSubDir(shareDir, "pixmaps")
-	iconPath := filepath.Join(iconDir, p.name+filepath.Ext(p.icon))
+	iconPath := filepath.Join(iconDir, p.Name+filepath.Ext(p.icon))
 	err = util.CopyFile(p.icon, iconPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy icon: %w", err)
 	}
 
 	appsDir := util.EnsureSubDir(shareDir, "applications")
-	desktop := filepath.Join(appsDir, p.name+".desktop")
+	desktop := filepath.Join(appsDir, p.Name+".desktop")
 	deskFile, _ := os.Create(desktop)
 
-	tplData := unixData{Name: p.name, Exec: filepath.Base(p.exe), Icon: p.name + filepath.Ext(p.icon), Local: local}
+	tplData := unixData{Name: p.Name, Exec: filepath.Base(p.exe), Icon: p.Name + filepath.Ext(p.icon), Local: local}
 	err = templates.DesktopFileUNIX.Execute(deskFile, tplData)
 	if err != nil {
 		return fmt.Errorf("failed to write desktop entry string: %w", err)
@@ -68,7 +68,7 @@ func (p *Packager) packageUNIX() error {
 		}
 
 		var buf bytes.Buffer
-		tarCmd := execabs.Command("tar", "-Jcf", p.name+".tar.xz", "-C", tempDir, "usr", "Makefile")
+		tarCmd := execabs.Command("tar", "-Jcf", p.Name+".tar.xz", "-C", tempDir, "usr", "Makefile")
 		tarCmd.Stderr = &buf
 		if err = tarCmd.Run(); err != nil {
 			return fmt.Errorf("failed to create archive with tar: %s - %w", buf.String(), err)

--- a/cmd/fyne/internal/commands/package-web.go
+++ b/cmd/fyne/internal/commands/package-web.go
@@ -12,10 +12,10 @@ func (p *Packager) packageWeb() error {
 	appDir := util.EnsureSubDir(p.dir, "web")
 
 	tpl := webData{
-		AppName:      p.name,
-		AppVersion:   p.appVersion,
-		GopherJSFile: p.name + ".js",
-		WasmFile:     p.name + ".wasm",
+		AppName:      p.Name,
+		AppVersion:   p.AppVersion,
+		GopherJSFile: p.Name + ".js",
+		WasmFile:     p.Name + ".wasm",
 		IsReleased:   p.release,
 		HasGopherJS:  true,
 		HasWasm:      true,
@@ -28,9 +28,9 @@ func (p *Packager) packageWasm() error {
 	appDir := util.EnsureSubDir(p.dir, "wasm")
 
 	tpl := webData{
-		AppName:    p.name,
-		AppVersion: p.appVersion,
-		WasmFile:   p.name + ".wasm",
+		AppName:    p.Name,
+		AppVersion: p.AppVersion,
+		WasmFile:   p.Name + ".wasm",
 		IsReleased: p.release,
 		HasWasm:    true,
 	}
@@ -42,9 +42,9 @@ func (p *Packager) packageGopherJS() error {
 	appDir := util.EnsureSubDir(p.dir, "gopherjs")
 
 	tpl := webData{
-		AppName:      p.name,
-		AppVersion:   p.appVersion,
-		GopherJSFile: p.name + ".js",
+		AppName:      p.Name,
+		AppVersion:   p.AppVersion,
+		GopherJSFile: p.Name + ".js",
 		IsReleased:   p.release,
 		HasGopherJS:  true,
 	}

--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -32,7 +32,7 @@ func (p *Packager) packageWindows() error {
 		return fmt.Errorf("failed to decode source image: %w", err)
 	}
 
-	icoPath := filepath.Join(exePath, p.name+".ico")
+	icoPath := filepath.Join(exePath, p.Name+".ico")
 	file, err := os.Create(icoPath)
 	if err != nil {
 		return fmt.Errorf("failed to open image file: %w", err)
@@ -56,7 +56,7 @@ func (p *Packager) packageWindows() error {
 		manifestFile, _ := os.Create(manifest)
 
 		tplData := windowsData{
-			Name:            p.name,
+			Name:            p.Name,
 			CombinedVersion: p.combinedVersion(),
 		}
 		err := templates.ManifestWindows.Execute(manifestFile, tplData)
@@ -69,7 +69,7 @@ func (p *Packager) packageWindows() error {
 	outPath := filepath.Join(exePath, "fyne.syso")
 
 	vi := &goversioninfo.VersionInfo{}
-	vi.ProductName = p.name
+	vi.ProductName = p.Name
 	vi.IconPath = icoPath
 	vi.ManifestPath = manifest
 
@@ -104,9 +104,9 @@ func (p *Packager) packageWindows() error {
 
 	appPath := p.exe
 	appName := filepath.Base(p.exe)
-	if filepath.Base(p.exe) != p.name {
-		appName = p.name
-		if filepath.Ext(p.name) != ".exe" {
+	if filepath.Base(p.exe) != p.Name {
+		appName = p.Name
+		if filepath.Ext(p.Name) != ".exe" {
 			appName = appName + ".exe"
 		}
 		appPath = filepath.Join(filepath.Dir(p.exe), appName)

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -26,9 +26,9 @@ const (
 )
 
 type appData struct {
-	icon, name        string
-	appID, appVersion string
-	appBuild          int
+	icon, Name        string
+	AppID, AppVersion string
+	AppBuild          int
 }
 
 // Package returns the cli command for packaging fyne applications
@@ -55,7 +55,7 @@ func Package() *cli.Command {
 			&cli.StringFlag{
 				Name:        "name",
 				Usage:       "The name of the application, default is the executable file name",
-				Destination: &p.name,
+				Destination: &p.Name,
 			},
 			&cli.StringFlag{
 				Name:        "tags",
@@ -65,12 +65,12 @@ func Package() *cli.Command {
 			&cli.StringFlag{
 				Name:        "appVersion",
 				Usage:       "Version number in the form x, x.y or x.y.z semantic version",
-				Destination: &p.appVersion,
+				Destination: &p.AppVersion,
 			},
 			&cli.IntFlag{
 				Name:        "appBuild",
 				Usage:       "Build number, should be greater than 0 and incremented for each build",
-				Destination: &p.appBuild,
+				Destination: &p.AppBuild,
 			},
 			&cli.StringFlag{
 				Name:        "sourceDir",
@@ -88,7 +88,7 @@ func Package() *cli.Command {
 				Name:        "appID",
 				Aliases:     []string{"id"},
 				Usage:       "For Android, darwin, iOS and Windows targets an appID in the form of a reversed domain name is required, for ios this must match a valid provisioning profile",
-				Destination: &p.appID,
+				Destination: &p.AppID,
 			},
 			&cli.StringFlag{
 				Name:        "certificate",
@@ -129,11 +129,11 @@ func (p *Packager) AddFlags() {
 	flag.StringVar(&p.os, "os", "", "The operating system to target (android, android/arm, android/arm64, android/amd64, android/386, darwin, freebsd, ios, linux, netbsd, openbsd, windows, wasm)")
 	flag.StringVar(&p.exe, "executable", "", "Specify an existing binary instead of building before package")
 	flag.StringVar(&p.srcDir, "sourceDir", "", "The directory to package, if executable is not set")
-	flag.StringVar(&p.name, "name", "", "The name of the application, default is the executable file name")
+	flag.StringVar(&p.Name, "name", "", "The name of the application, default is the executable file name")
 	flag.StringVar(&p.icon, "icon", "", "The name of the application icon file")
-	flag.StringVar(&p.appID, "appID", "", "For ios or darwin targets an appID is required, for ios this must \nmatch a valid provisioning profile")
-	flag.StringVar(&p.appVersion, "appVersion", "", "Version number in the form x, x.y or x.y.z semantic version")
-	flag.IntVar(&p.appBuild, "appBuild", 0, "Build number, should be greater than 0 and incremented for each build")
+	flag.StringVar(&p.AppID, "appID", "", "For ios or darwin targets an appID is required, for ios this must \nmatch a valid provisioning profile")
+	flag.StringVar(&p.AppVersion, "appVersion", "", "Version number in the form x, x.y or x.y.z semantic version")
+	flag.IntVar(&p.AppBuild, "appBuild", 0, "Build number, should be greater than 0 and incremented for each build")
 	flag.BoolVar(&p.release, "release", false, "Should this package be prepared for release? (disable debug etc)")
 	flag.StringVar(&p.tags, "tags", "", "A comma-separated list of build tags")
 }
@@ -244,16 +244,16 @@ func (p *Packager) buildPackage(runner runner) ([]string, error) {
 }
 
 func (p *Packager) combinedVersion() string {
-	return fmt.Sprintf("%s.%d", p.appVersion, p.appBuild)
+	return fmt.Sprintf("%s.%d", p.AppVersion, p.AppBuild)
 }
 
 func (p *Packager) doPackage(runner runner) error {
 	// sensible defaults - validation deemed them optional
-	if p.appVersion == "" {
-		p.appVersion = defaultAppVersion
+	if p.AppVersion == "" {
+		p.AppVersion = defaultAppVersion
 	}
-	if p.appBuild <= 0 {
-		p.appBuild = defaultAppBuild
+	if p.AppBuild <= 0 {
+		p.AppBuild = defaultAppBuild
 	}
 
 	if !util.Exists(p.exe) && !util.IsMobile(p.os) {
@@ -338,8 +338,8 @@ func (p *Packager) validate() error {
 		_, _ = fmt.Fprint(os.Stderr, "Parameter -executable is ignored for mobile builds.\n")
 	}
 
-	if p.name == "" {
-		p.name = exeName
+	if p.Name == "" {
+		p.Name = exeName
 	}
 	if p.icon == "" || p.icon == "Icon.png" {
 		p.icon = filepath.Join(p.srcDir, "Icon.png")
@@ -348,11 +348,11 @@ func (p *Packager) validate() error {
 		return errors.New("Missing application icon at \"" + p.icon + "\"")
 	}
 
-	p.appID, err = validateAppID(p.appID, p.os, p.name, p.release)
+	p.AppID, err = validateAppID(p.AppID, p.os, p.Name, p.release)
 	if err != nil {
 		return err
 	}
-	if p.appVersion != "" && !isValidVersion(p.appVersion) {
+	if p.AppVersion != "" && !isValidVersion(p.AppVersion) {
 		return errors.New("invalid -appVersion parameter, integer and '.' characters only up to x.y.z")
 	}
 
@@ -398,17 +398,17 @@ func mergeMetadata(p *appData, data *metadata.FyneApp) {
 	if p.icon == "" {
 		p.icon = data.Details.Icon
 	}
-	if p.name == "" {
-		p.name = data.Details.Name
+	if p.Name == "" {
+		p.Name = data.Details.Name
 	}
-	if p.appID == "" {
-		p.appID = data.Details.ID
+	if p.AppID == "" {
+		p.AppID = data.Details.ID
 	}
-	if p.appVersion == "" {
-		p.appVersion = data.Details.Version
+	if p.AppVersion == "" {
+		p.AppVersion = data.Details.Version
 	}
-	if p.appBuild == 0 {
-		p.appBuild = data.Details.Build
+	if p.AppBuild == 0 {
+		p.AppBuild = data.Details.Build
 	}
 }
 

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -35,7 +35,7 @@ func Test_isValidVersion(t *testing.T) {
 
 func Test_MergeMetata(t *testing.T) {
 	p := &Packager{appData: &appData{}}
-	p.appVersion = "v0.1"
+	p.AppVersion = "v0.1"
 	data := &metadata.FyneApp{
 		Details: metadata.AppDetails{
 			Icon:    "test.png",
@@ -45,8 +45,8 @@ func Test_MergeMetata(t *testing.T) {
 	}
 
 	mergeMetadata(p.appData, data)
-	assert.Equal(t, "v0.1", p.appVersion)
-	assert.Equal(t, 3, p.appBuild)
+	assert.Equal(t, "v0.1", p.AppVersion)
+	assert.Equal(t, 3, p.AppBuild)
 	assert.Equal(t, "test.png", p.icon)
 }
 
@@ -121,9 +121,7 @@ func Test_PackageWasm(t *testing.T) {
 		},
 		{
 			expectedValue: expectedValue{
-				args: []string{"build", "-ldflags",
-					"-X 'fyne.io/fyne/v2/internal/app.MetaName=myTest' -X 'fyne.io/fyne/v2/internal/app.MetaVersion=1.0.0' -X 'fyne.io/fyne/v2/internal/app.MetaBuild=1'",
-					"-o", "myTest.wasm"},
+				args: []string{"build", "-o", "myTest.wasm"},
 				env:   []string{"GOARCH=wasm", "GOOS=js"},
 				osEnv: true,
 				dir:   "myTest",
@@ -136,7 +134,7 @@ func Test_PackageWasm(t *testing.T) {
 
 	p := &Packager{
 		appData: &appData{
-			name: "myTest",
+			Name: "myTest",
 			icon: "myTest.png",
 		},
 		os:     "wasm",
@@ -270,7 +268,7 @@ func Test_PackageGopherJS(t *testing.T) {
 
 	p := &Packager{
 		appData: &appData{
-			name: "myTest",
+			Name: "myTest",
 			icon: "myTest.png",
 		},
 		os:     "gopherjs",
@@ -403,9 +401,7 @@ func Test_PackageWeb(t *testing.T) {
 		},
 		{
 			expectedValue: expectedValue{
-				args: []string{"build", "-ldflags",
-					"-X 'fyne.io/fyne/v2/internal/app.MetaName=myTest' -X 'fyne.io/fyne/v2/internal/app.MetaVersion=1.0.0' -X 'fyne.io/fyne/v2/internal/app.MetaBuild=1'",
-					"-o", "myTest.wasm"},
+				args: []string{"build", "-o", "myTest.wasm"},
 				env:   []string{"GOARCH=wasm", "GOOS=js"},
 				osEnv: true,
 				dir:   "myTest",
@@ -444,7 +440,7 @@ func Test_PackageWeb(t *testing.T) {
 		dir:     "myTestTarget",
 		exe:     "myTest",
 	}
-	p.name = "myTest"
+	p.Name = "myTest"
 	p.icon = "myTest.png"
 	gopherjsBuildTest := &testCommandRuns{runs: expected, t: t}
 

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -121,7 +121,7 @@ func Test_PackageWasm(t *testing.T) {
 		},
 		{
 			expectedValue: expectedValue{
-				args: []string{"build", "-o", "myTest.wasm"},
+				args:  []string{"build", "-o", "myTest.wasm"},
 				env:   []string{"GOARCH=wasm", "GOOS=js"},
 				osEnv: true,
 				dir:   "myTest",
@@ -401,7 +401,7 @@ func Test_PackageWeb(t *testing.T) {
 		},
 		{
 			expectedValue: expectedValue{
-				args: []string{"build", "-o", "myTest.wasm"},
+				args:  []string{"build", "-o", "myTest.wasm"},
 				env:   []string{"GOARCH=wasm", "GOOS=js"},
 				osEnv: true,
 				dir:   "myTest",

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -64,7 +64,7 @@ func Release() *cli.Command {
 			&cli.StringFlag{
 				Name:        "name",
 				Usage:       "The name of the application, default is the executable file name",
-				Destination: &r.name,
+				Destination: &r.Name,
 			},
 			&cli.StringFlag{
 				Name:        "tags",
@@ -74,18 +74,18 @@ func Release() *cli.Command {
 			&cli.StringFlag{
 				Name:        "appVersion",
 				Usage:       "Version number in the form x, x.y or x.y.z semantic version",
-				Destination: &r.appVersion,
+				Destination: &r.AppVersion,
 			},
 			&cli.IntFlag{
 				Name:        "appBuild",
 				Usage:       "Build number, should be greater than 0 and incremented for each build",
-				Destination: &r.appBuild,
+				Destination: &r.AppBuild,
 			},
 			&cli.StringFlag{
 				Name:        "appID",
 				Aliases:     []string{"id"},
 				Usage:       "For Android, darwin, iOS and Windows targets an appID in the form of a reversed domain name is required, for ios this must match a valid provisioning profile",
-				Destination: &r.appID,
+				Destination: &r.AppID,
 			},
 			&cli.StringFlag{
 				Name:        "certificate",
@@ -143,11 +143,11 @@ type Releaser struct {
 // Deprecated: Access to the individual cli commands are being removed.
 func (r *Releaser) AddFlags() {
 	flag.StringVar(&r.os, "os", "", "The operating system to target (android, android/arm, android/arm64, android/amd64, android/386, darwin, freebsd, ios, linux, netbsd, openbsd, windows)")
-	flag.StringVar(&r.name, "name", "", "The name of the application, default is the executable file name")
+	flag.StringVar(&r.Name, "name", "", "The name of the application, default is the executable file name")
 	flag.StringVar(&r.icon, "icon", "", "The name of the application icon file")
-	flag.StringVar(&r.appID, "appID", "", "For ios or darwin targets an appID is required, for ios this must \nmatch a valid provisioning profile")
-	flag.StringVar(&r.appVersion, "appVersion", "", "Version number in the form x, x.y or x.y.z semantic version")
-	flag.IntVar(&r.appBuild, "appBuild", 0, "Build number, should be greater than 0 and incremented for each build")
+	flag.StringVar(&r.AppID, "appID", "", "For ios or darwin targets an appID is required, for ios this must \nmatch a valid provisioning profile")
+	flag.StringVar(&r.AppVersion, "appVersion", "", "Version number in the form x, x.y or x.y.z semantic version")
+	flag.IntVar(&r.AppBuild, "appBuild", 0, "Build number, should be greater than 0 and incremented for each build")
 	flag.StringVar(&r.keyStore, "keyStore", "", "Android: location of .keystore file containing signing information")
 	flag.StringVar(&r.keyStorePass, "keyStorePass", "", "Android: password for the .keystore file, default take the password from stdin")
 	flag.StringVar(&r.keyName, "keyName", "", "Android: alias for the signer's private key, which is needed when reading a .keystore file")
@@ -211,7 +211,7 @@ func (r *Releaser) releaseAction(_ *cli.Context) error {
 
 func (r *Releaser) afterPackage() error {
 	if util.IsAndroid(r.os) {
-		target := mobile.AppOutputName(r.os, r.Packager.name, r.release)
+		target := mobile.AppOutputName(r.os, r.Packager.Name, r.release)
 		apk := filepath.Join(r.dir, target)
 		if err := r.zipAlign(apk); err != nil {
 			return err
@@ -225,9 +225,9 @@ func (r *Releaser) afterPackage() error {
 		return r.packageIOSRelease()
 	}
 	if r.os == "windows" {
-		outName := r.name + ".appx"
-		if pos := strings.LastIndex(r.name, ".exe"); pos > 0 {
-			outName = r.name[:pos] + ".appx"
+		outName := r.Name + ".appx"
+		if pos := strings.LastIndex(r.Name, ".exe"); pos > 0 {
+			outName = r.Name[:pos] + ".appx"
 		}
 
 		outPath := filepath.Join(r.dir, outName)
@@ -271,7 +271,7 @@ func (r *Releaser) packageIOSRelease() error {
 	payload := filepath.Join(r.dir, "Payload")
 	_ = os.Mkdir(payload, 0750)
 	defer os.RemoveAll(payload)
-	appName := mobile.AppOutputName(r.os, r.name, r.release)
+	appName := mobile.AppOutputName(r.os, r.Name, r.release)
 	payloadAppDir := filepath.Join(payload, appName)
 	if err := os.Rename(filepath.Join(r.dir, appName), payloadAppDir); err != nil {
 		return err
@@ -279,7 +279,7 @@ func (r *Releaser) packageIOSRelease() error {
 
 	cleanup, err := r.writeEntitlements(templates.EntitlementsDarwinMobile, struct{ TeamID, AppID string }{
 		TeamID: team,
-		AppID:  r.appID,
+		AppID:  r.AppID,
 	})
 	if err != nil {
 		return errors.New("failed to write entitlements plist template")
@@ -300,9 +300,9 @@ func (r *Releaser) packageMacOSRelease() error {
 	// try to derive two certificates from one name (they will be consistent)
 	appCert := strings.Replace(r.certificate, "Installer", "Application", 1)
 	installCert := strings.Replace(r.certificate, "Application", "Installer", 1)
-	unsignedPath := r.name + "-unsigned.pkg"
+	unsignedPath := r.Name + "-unsigned.pkg"
 
-	defer os.RemoveAll(r.name + ".app") // this was the output of package and it can get in the way of future builds
+	defer os.RemoveAll(r.Name + ".app") // this was the output of package and it can get in the way of future builds
 
 	cleanup, err := r.writeEntitlements(templates.EntitlementsDarwin, nil)
 	if err != nil {
@@ -310,15 +310,15 @@ func (r *Releaser) packageMacOSRelease() error {
 	}
 	defer cleanup()
 
-	cmd := execabs.Command("codesign", "-vfs", appCert, "--entitlement", "entitlements.plist", r.name+".app")
+	cmd := execabs.Command("codesign", "-vfs", appCert, "--entitlement", "entitlements.plist", r.Name+".app")
 	err = cmd.Run()
 	if err != nil {
 		fyne.LogError("Codesign failed", err)
 		return errors.New("unable to codesign application bundle")
 	}
 
-	cmd = execabs.Command("productbuild", "--component", r.name+".app", "/Applications/",
-		"--product", r.name+".app/Contents/Info.plist", unsignedPath)
+	cmd = execabs.Command("productbuild", "--component", r.Name+".app", "/Applications/",
+		"--product", r.Name+".app/Contents/Info.plist", unsignedPath)
 	err = cmd.Run()
 	if err != nil {
 		fyne.LogError("Product build failed", err)
@@ -326,7 +326,7 @@ func (r *Releaser) packageMacOSRelease() error {
 	}
 	defer os.Remove(unsignedPath)
 
-	cmd = execabs.Command("productsign", "--sign", installCert, unsignedPath, r.name+".pkg")
+	cmd = execabs.Command("productsign", "--sign", installCert, unsignedPath, r.Name+".pkg")
 	return cmd.Run()
 }
 
@@ -341,11 +341,11 @@ func (r *Releaser) packageWindowsRelease(outFile string) error {
 		return err
 	}
 	manifestData := struct{ AppID, Developer, DeveloperName, Name, Version string }{
-		AppID: r.appID,
+		AppID: r.AppID,
 		// TODO read this info
 		Developer:     r.developer,
 		DeveloperName: r.nameFromCertInfo(r.developer),
-		Name:          r.name,
+		Name:          r.Name,
 		Version:       r.combinedVersion(),
 	}
 	err = templates.AppxManifestWindows.Execute(manifest, manifestData)
@@ -355,7 +355,7 @@ func (r *Releaser) packageWindowsRelease(outFile string) error {
 	}
 
 	util.CopyFile(r.icon, filepath.Join(payload, "Icon.png"))
-	util.CopyFile(r.name, filepath.Join(payload, r.name))
+	util.CopyFile(r.Name, filepath.Join(payload, r.Name))
 
 	binDir, err := findWindowsSDKBin()
 	if err != nil {
@@ -432,10 +432,10 @@ func (r *Releaser) validate() error {
 	}
 
 	if util.IsMobile(r.os) || r.os == "windows" {
-		if r.appVersion == "" { // Here it is required, if provided then package validate will check format
+		if r.AppVersion == "" { // Here it is required, if provided then package validate will check format
 			return errors.New("missing required -appVersion parameter")
 		}
-		if r.appBuild <= 0 {
+		if r.AppBuild <= 0 {
 			return errors.New("missing required -appBuild parameter")
 		}
 	}

--- a/cmd/fyne/internal/commands/serve.go
+++ b/cmd/fyne/internal/commands/serve.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 
@@ -84,7 +83,6 @@ func (s *Server) serve() error {
 
 	http.Handle("/", fileServer)
 
-	log.Println("AppData", s.appData)
 	fmt.Printf("Serving %s on HTTP port: %v\n", webDir, s.port)
 	err = http.ListenAndServe(":"+strconv.Itoa(s.port), nil)
 

--- a/cmd/fyne/internal/templates/bundled.go
+++ b/cmd/fyne/internal/templates/bundled.go
@@ -45,6 +45,11 @@ var resourceEntitlementsIosPlist = &fyne.StaticResource{
 	StaticContent: []byte(
 		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>application-identifier</key>\n    <string>{{.TeamID}}.{{.AppID}}</string>\n</dict>\n</plist>"),
 }
+var resourceFynemetadatainitGot = &fyne.StaticResource{
+	StaticName: "fyne_metadata_init.got",
+	StaticContent: []byte(
+		"package main\n\nimport (\n\t\"fyne.io/fyne/v2\"\n\t\"fyne.io/fyne/v2/app\"\n)\n\nfunc init() {\n\tapp.SetMetadata(fyne.AppMetadata{\n\t\tID: \"{{.AppID}}\",\n\t\tName: \"{{.Name}}\",\n\t\tVersion: \"{{.AppVersion}}\",\n\t\tBuild: {{.AppBuild}},\n\t\tIcon: fyneMetadataIcon,\n\t})\n}\n\n"),
+}
 var resourceIndexHtml = &fyne.StaticResource{
 	StaticName: "index.html",
 	StaticContent: []byte(

--- a/cmd/fyne/internal/templates/data/fyne_metadata_init.got
+++ b/cmd/fyne/internal/templates/data/fyne_metadata_init.got
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+)
+
+func init() {
+	app.SetMetadata(fyne.AppMetadata{
+		ID: "{{.AppID}}",
+		Name: "{{.Name}}",
+		Version: "{{.AppVersion}}",
+		Build: {{.AppBuild}},
+		Icon: fyneMetadataIcon,
+	})
+}
+

--- a/cmd/fyne/internal/templates/templates.go
+++ b/cmd/fyne/internal/templates/templates.go
@@ -17,6 +17,9 @@ var (
 	// EntitlementsDarwinMobile is a plist file that lists build entitlements for iOS releases
 	EntitlementsDarwinMobile = template.Must(template.New("EntitlementsMobile").Parse(string(resourceEntitlementsIosPlist.StaticContent)))
 
+	// FyneMetadataInit is the metadata injecting file for fyne metadata
+	FyneMetadataInit = template.Must(template.New("fyne_metadata_init.got").Parse(string(resourceFynemetadatainitGot.StaticContent)))
+
 	// ManifestWindows is the manifest file for windows packaging
 	ManifestWindows = template.Must(template.New("Manifest").Parse(string(resourceAppManifest.StaticContent)))
 


### PR DESCRIPTION
After build file is removed

Fixes windows compatibility
and adds metadata to the gopherJS build too :).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
