### PR TITLE
Completing Chrisbirster new string with format

### DIFF
--- a/data/binding/sprintf.go
+++ b/data/binding/sprintf.go
@@ -210,3 +210,16 @@ func (s *sprintfString) Set(str string) error {
 
 	return nil
 }
+
+// StringToStringWithFormat creates a binding that converts a string to another string using the specified format.
+// Changes to the returned String will be pushed to the passed in String and setting a new string value will parse and
+// set the underlying String if it matches the format and the parse was successful.
+//
+// Since: 2.2
+func StringToStringWithFormat(str String, format string) String {
+	if format == "%s" { // Same as not using custom formatting.
+		return str
+	}
+
+	return NewSprintf(format, str)
+}

--- a/data/binding/sprintf.go
+++ b/data/binding/sprintf.go
@@ -20,7 +20,7 @@ type sprintfString struct {
 // and will have all the same limitation as those function.
 //
 // Since: 2.2
-func NewSprintf(format string, b ...DataItem) (String, error) {
+func NewSprintf(format string, b ...DataItem) String {
 	ret := &sprintfString{
 		String: NewString(),
 		format: format,
@@ -31,14 +31,7 @@ func NewSprintf(format string, b ...DataItem) (String, error) {
 		value.AddListener(ret)
 	}
 
-	return ret, nil
-}
-
-// NewStringWithFormat is a wrapper over NewSprintf a String binding that format
-// its content using the format string and the provide additional parameter that
-// must be other data bindings.
-func NewStringWithFormat(format string, b ...DataItem) (String, error) {
-	return NewSprintf(format, b...)
+	return ret
 }
 
 func (s *sprintfString) DataChanged() {

--- a/data/binding/sprintf_test.go
+++ b/data/binding/sprintf_test.go
@@ -25,10 +25,8 @@ func TestSprintfConversionRead(t *testing.T) {
 	bu := BindURI(&u)
 
 	format := "Bool %v, Float %f, Int %i, Rune %v, String '%s', URI '%s'"
-	sp, err := NewSprintf(format, bb, bf, bi, br, bs, bu)
+	sp := NewSprintf(format, bb, bf, bi, br, bs, bu)
 	expected := fmt.Sprintf(format, b, f, i, r, s, u)
-
-	assert.Nil(t, err)
 	assert.NotNil(t, sp)
 
 	waitForItems()
@@ -73,10 +71,8 @@ func TestSprintfConversionReadWrite(t *testing.T) {
 	bu := BindURI(&u)
 
 	format := "Bool %v , Float %f , Int %v , Rune %v , String %s , URI %s"
-	sp, err := NewSprintf(format, bb, bf, bi, br, bs, bu)
+	sp := NewSprintf(format, bb, bf, bi, br, bs, bu)
 	expected := fmt.Sprintf(format, b, f, i, r, s, u)
-
-	assert.Nil(t, err)
 	assert.NotNil(t, sp)
 
 	waitForItems()

--- a/data/binding/sprintf_test.go
+++ b/data/binding/sprintf_test.go
@@ -111,25 +111,12 @@ func TestSprintfConversionReadWrite(t *testing.T) {
 }
 
 func TestNewStringWithFormat(t *testing.T) {
-	var b bool = true
-	var f float64 = 42
-	var i int = 7
-	var r rune = 'B'
 	var s string = "this is a string"
-	var u fyne.URI = storage.NewFileURI("/")
-
-	bb := BindBool(&b)
-	bf := BindFloat(&f)
-	bi := BindInt(&i)
-	br := BindRune(&r)
 	bs := BindString(&s)
-	bu := BindURI(&u)
 
-	format := "Bool %v , Float %f , Int %v , Rune %v , String %s , URI %s"
-	sp, err := NewStringWithFormat(format, bb, bf, bi, br, bs, bu)
-	expected := fmt.Sprintf(format, b, f, i, r, s, u)
-
-	assert.Nil(t, err)
+	format := "String %s"
+	sp := StringToStringWithFormat(bs, format)
+	expected := fmt.Sprintf(format, s)
 	assert.NotNil(t, sp)
 
 	waitForItems()
@@ -140,23 +127,16 @@ func TestNewStringWithFormat(t *testing.T) {
 	assert.NotNil(t, sGenerated)
 	assert.Equal(t, expected, sGenerated)
 
-	err = sp.Set("Bool false , Float 7.000000 , Int 42 , Rune 67 , String nospacestring , URI file:///var/")
+	err = sp.Set("String nospacestring")
 
 	assert.Nil(t, err)
 
 	waitForItems()
 
-	assert.Equal(t, b, false)
-	assert.Equal(t, f, float64(7))
-	assert.Equal(t, i, 42)
-	assert.Equal(t, r, 'C')
 	assert.Equal(t, s, "nospacestring")
-	assert.Equal(t, u.String(), "file:///var/")
-
-	expectedChange := fmt.Sprintf(format, b, f, i, r, s, u)
+	expectedChange := fmt.Sprintf(format, s)
 
 	sChange, err := sp.Get()
-
 	assert.Nil(t, err)
 	assert.NotNil(t, sChange)
 	assert.Equal(t, expectedChange, sChange)

--- a/data/binding/sprintf_test.go
+++ b/data/binding/sprintf_test.go
@@ -107,7 +107,7 @@ func TestSprintfConversionReadWrite(t *testing.T) {
 }
 
 func TestNewStringWithFormat(t *testing.T) {
-	var s string = "this is a string"
+	var s = "this is a string"
 	bs := BindString(&s)
 
 	format := "String %s"
@@ -118,23 +118,24 @@ func TestNewStringWithFormat(t *testing.T) {
 	waitForItems()
 
 	sGenerated, err := sp.Get()
-
 	assert.Nil(t, err)
 	assert.NotNil(t, sGenerated)
 	assert.Equal(t, expected, sGenerated)
 
 	err = sp.Set("String nospacestring")
-
 	assert.Nil(t, err)
 
 	waitForItems()
 
 	assert.Equal(t, s, "nospacestring")
 	expectedChange := fmt.Sprintf(format, s)
-
 	sChange, err := sp.Get()
 	assert.Nil(t, err)
 	assert.NotNil(t, sChange)
 	assert.Equal(t, expectedChange, sChange)
 	assert.NotEqual(t, sGenerated, sChange)
+
+	emptyFormat := "%s"
+	wrapped := StringToStringWithFormat(bs, emptyFormat)
+	assert.Equal(t, bs, wrapped)
 }


### PR DESCRIPTION
Wrap up the good work started in #2942, but match our naming and return style.

Fixes #2890

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style.
