### PR TITLE
dialog: show file extension in list view

### DIFF
--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -63,15 +63,6 @@ func (i *fileDialogItem) CreateRenderer() fyne.WidgetRenderer {
 	}
 }
 
-func fileName(path fyne.URI) (name string) {
-	pathstr := path.String()[len(path.Scheme())+3:]
-	name = filepath.Base(pathstr)
-	ext := filepath.Ext(name[1:])
-	name = name[:len(name)-len(ext)]
-
-	return
-}
-
 func (i *fileDialogItem) isDirectory() bool {
 	return i.dir
 }
@@ -80,13 +71,13 @@ func (f *fileDialog) newFileItem(location fyne.URI, dir bool) *fileDialogItem {
 	item := &fileDialogItem{
 		picker:   f,
 		location: location,
+		name:     location.Name(),
 		dir:      dir,
 	}
 
-	if dir {
-		item.name = location.Name()
-	} else {
-		item.name = fileName(location)
+	if f.view == gridView {
+		ext := filepath.Ext(item.name[1:])
+		item.name = item.name[:len(item.name)-len(ext)]
 	}
 
 	item.ExtendBaseWidget(item)

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -22,6 +22,24 @@ func TestFileItem_Name(t *testing.T) {
 
 	item = f.newFileItem(storage.NewFileURI("/path/to/.maybeHidden.txt"), false)
 	assert.Equal(t, ".maybeHidden", item.name)
+
+	item = f.newFileItem(storage.NewFileURI("/path/to/noext"), false)
+	assert.Equal(t, "noext", item.name)
+
+	// Test that the extension remains for the list view.
+	f.view = listView
+
+	item = f.newFileItem(storage.NewFileURI("/path/to/filename.txt"), false)
+	assert.Equal(t, "filename.txt", item.name)
+
+	item = f.newFileItem(storage.NewFileURI("/path/to/MyFile.jpeg"), false)
+	assert.Equal(t, "MyFile.jpeg", item.name)
+
+	item = f.newFileItem(storage.NewFileURI("/path/to/.maybeHidden.txt"), false)
+	assert.Equal(t, ".maybeHidden.txt", item.name)
+
+	item = f.newFileItem(storage.NewFileURI("/path/to/noext"), false)
+	assert.Equal(t, "noext", item.name)
 }
 
 func TestFileItem_FolderName(t *testing.T) {

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -50,10 +50,15 @@ func TestFileItem_FolderName(t *testing.T) {
 	assert.Equal(t, "foldername", item.name)
 
 	item = f.newFileItem(storage.NewFileURI("/path/to/myapp.app/"), true)
-	assert.Equal(t, "myapp.app", item.name)
+	assert.Equal(t, "myapp", item.name)
 
 	item = f.newFileItem(storage.NewFileURI("/path/to/.maybeHidden/"), true)
 	assert.Equal(t, ".maybeHidden", item.name)
+
+	// Test that the extension remains for the list view.
+	f.view = listView
+	item = f.newFileItem(storage.NewFileURI("/path/to/myapp.app/"), true)
+	assert.Equal(t, "myapp.app", item.name)
 }
 
 func TestNewFileItem(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Due to icons being a lot smaller for the list view, we should show the file extension to make it more clear to the user what file they are seeing. This PR makes that change and manages to clean up and optimize the code a bit in the process.

Fixes https://github.com/Jacalz/rymdport/issues/39 but should be superseded by #3032 for a future release.

![image](https://user-images.githubusercontent.com/25466657/171871269-0cd260cc-4ad7-4fd0-87d6-ae8aa6eea134.png)
![image](https://user-images.githubusercontent.com/25466657/171871340-e432dd6c-906e-4161-8b8d-7ac16c36e4f8.png)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
