### PR TITLE
fix: top Table items were invisible after window resize

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -512,7 +512,13 @@ func (c *tableCells) Resize(s fyne.Size) {
 	if s == c.size {
 		return
 	}
+	cSizeBeforeResize := c.size
 	c.BaseWidget.Resize(s)
+	if c.size.Height > cSizeBeforeResize.Height {
+		// table height has increased.
+		// call ScrollToTop() otherwise empty rows will appear at the top of the table.
+		c.t.ScrollToTop()
+	}
 	c.Refresh() // trigger a redraw
 }
 

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -585,42 +585,30 @@ func TestTable_ScrollToBottomThenResize(t *testing.T) {
 		height  float32 = 10
 	)
 
-	const labelText = "a"
-
-	data := make([][]string, 0)
-	for i := 0; i < maxRows; i++ {
-		row := []string{}
-		for j := 0; j < maxCols; j++ {
-			row = append(row, labelText)
-		}
-		data = append(data, row)
-	}
-
-	createdLabels := make([]*Label, 0)
+	createdCells := make([]*canvas.Rectangle, 0)
 
 	table := NewTable(
 		func() (int, int) { return maxRows, maxCols },
 		func() fyne.CanvasObject {
-			l := NewLabel("")
-			createdLabels = append(createdLabels, l)
-			return l
+			templ := canvas.NewRectangle(color.Gray16{})
+			templ.SetMinSize(fyne.Size{Width: width, Height: height})
+			createdCells = append(createdCells, templ)
+			return templ
 		},
-		func(cellID TableCellID, o fyne.CanvasObject) {
-			o.(*Label).SetText(data[cellID.Row][cellID.Col])
-		})
+		func(cellID TableCellID, o fyne.CanvasObject) {})
 
 	w := test.NewWindow(table)
 	defer w.Close()
 
-	// choose a size small enough that there is vertical scroll
-	w.Resize(fyne.NewSize(100, 50))
+	// choose a size small enough that less than half of the rows are visible
+	w.Resize(fyne.NewSize(200, float32(maxRows/2-2)*(table.cells.cellSize.Height+theme.SeparatorThicknessSize())+2*theme.Padding()))
 	table.ScrollToBottom()
-	table.Select(TableCellID{Row: maxRows - 1, Col: 1})
-	// increase size big enough that there is no scroll
-	w.Resize(fyne.NewSize(1000, 1000))
+	// increase size enough so that there is no scroll
+	w.Resize(fyne.NewSize(200, float32(maxRows)*(table.cells.cellSize.Height+theme.SeparatorThicknessSize())+2*theme.Padding()))
 	var visibleCount int
-	for _, l := range createdLabels {
-		if l.Text == labelText {
+	var zeroSize = fyne.Size{Width: 0, Height: 0}
+	for _, c := range createdCells {
+		if c.Size() != zeroSize {
 			visibleCount++
 		}
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Fixes #3034 

This appears to be working.

Unfortunately I couldn't write tests for this one because I don't know how to check for visible elements, but I decided to send the PR now hoping it will be merged before the next release.

The issue was happening only when the size of the table increased as a result of the window size increasing. So in that case only I call ScrollToTop().

Losing scroll position doesn't seem to be a problem. The top row appears anyway, by calling ScrollToTop() I make it visible. But there might be cases where it causes a small inconvenience.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
