### PR TITLE
internal/async: prevent unbounded channel may not be close properly

### DIFF
--- a/internal/async/chan_canvasobject.go
+++ b/internal/async/chan_canvasobject.go
@@ -91,10 +91,13 @@ func (ch *UnboundedCanvasObjectChan) closed() {
 	for len(ch.q) > 0 {
 		select {
 		case ch.out <- ch.q[0]:
-			ch.q[0] = nil // de-reference earlier to help GC
-			ch.q = ch.q[1:]
+		// The default branch exists because we need guarantee
+		// the loop can terminate. If there is a receiver, the
+		// first case will ways be selected.
 		default:
 		}
+		ch.q[0] = nil // de-reference earlier to help GC
+		ch.q = ch.q[1:]
 	}
 	close(ch.out)
 	close(ch.close)

--- a/internal/async/chan_func.go
+++ b/internal/async/chan_func.go
@@ -89,10 +89,13 @@ func (ch *UnboundedFuncChan) closed() {
 	for len(ch.q) > 0 {
 		select {
 		case ch.out <- ch.q[0]:
-			ch.q[0] = nil // de-reference earlier to help GC
-			ch.q = ch.q[1:]
+		// The default branch exists because we need guarantee
+		// the loop can terminate. If there is a receiver, the
+		// first case will ways be selected.
 		default:
 		}
+		ch.q[0] = nil // de-reference earlier to help GC
+		ch.q = ch.q[1:]
 	}
 	close(ch.out)
 	close(ch.close)

--- a/internal/async/chan_interface.go
+++ b/internal/async/chan_interface.go
@@ -89,10 +89,13 @@ func (ch *UnboundedInterfaceChan) closed() {
 	for len(ch.q) > 0 {
 		select {
 		case ch.out <- ch.q[0]:
-			ch.q[0] = nil // de-reference earlier to help GC
-			ch.q = ch.q[1:]
+		// The default branch exists because we need guarantee
+		// the loop can terminate. If there is a receiver, the
+		// first case will ways be selected.
 		default:
 		}
+		ch.q[0] = nil // de-reference earlier to help GC
+		ch.q = ch.q[1:]
 	}
 	close(ch.out)
 	close(ch.close)

--- a/internal/async/chan_test.go
+++ b/internal/async/chan_test.go
@@ -216,3 +216,18 @@ func BenchmarkUnboundedChann(b *testing.B) {
 		})
 	})
 }
+
+func TestUnboundedChannCloseStatus(t *testing.T) {
+	ch := async.NewUnboundedStructChan()
+	for i := 0; i < 100; i++ {
+		ch.In() <- struct{}{}
+	}
+	ch.Close()
+
+	// Theoretically, this is not a dead loop. If the channel
+	// is closed, this loop will terminate soon. Otherwise, we will meet
+	// timeout in the test which indicates a failure and a potential bug.
+	for !async.IsClosed(ch) {
+		t.Log("unbounded channel is still not entirely closed")
+	}
+}

--- a/internal/async/export_test.go
+++ b/internal/async/export_test.go
@@ -1,0 +1,12 @@
+package async
+
+// IsClosed checks if a channel is entirely closed or not.
+// This function is only exported for testing.
+func IsClosed(ch *UnboundedStructChan) bool {
+	select {
+	case <-ch.close:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/async/gen.go
+++ b/internal/async/gen.go
@@ -191,10 +191,13 @@ func (ch *Unbounded{{.Name}}Chan) closed() {
 	for len(ch.q) > 0 {
 		select {
 		case ch.out <- ch.q[0]:
-			ch.q[0] = nil // de-reference earlier to help GC
-			ch.q = ch.q[1:]
+		// The default branch exists because we need guarantee
+		// the loop can terminate. If there is a receiver, the
+		// first case will ways be selected.
 		default:
 		}
+		ch.q[0] = nil // de-reference earlier to help GC
+		ch.q = ch.q[1:]
 	}
 	close(ch.out)
 	close(ch.close)


### PR DESCRIPTION
### Description:

If there are more than 16 unprocessed objects, the unbounded channel may
not be closed gracefully because the existing close branch can lead to a
spin loop.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.