### PR TITLE
FYNE_FONT regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Resolve issue where macOS systray menu may not appear
 * Updated yaml dependency to fix CVE-2022-28948
 * Tab buttons stop working after removing a tab (#3050)
+* os.SetEnv("FYNE_FONT") doesn't work in v2.2.0 (#3056)
 
 
 ## 2.2.0 - 7 June 2022

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -243,6 +243,10 @@ func DefaultSymbolFont() fyne.Resource {
 //
 // Since: 2.0
 func DefaultTheme() fyne.Theme {
+	if defaultTheme == nil {
+		defaultTheme = setupDefaultTheme()
+	}
+
 	return defaultTheme
 }
 
@@ -442,7 +446,7 @@ func TextSubHeadingSize() float32 {
 }
 
 var (
-	defaultTheme = setupDefaultTheme()
+	defaultTheme fyne.Theme
 
 	errorColor  = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
 	focusColors = map[string]color.Color{


### PR DESCRIPTION
Order of init changed and broke application specified env setting

Fixes #3056

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

