### PR TITLE
fixed show/hide window needed two clicks to open

### DIFF
--- a/cmd/fyne_demo/tutorials/window.go
+++ b/cmd/fyne_demo/tutorials/window.go
@@ -48,6 +48,7 @@ func windowScreen(_ fyne.Window) fyne.CanvasObject {
 			if visibilityWindow == nil {
 				visibilityWindow = fyne.CurrentApp().NewWindow("Hello")
 				visibilityWindow.SetContent(widget.NewLabel("Hello World!"))
+				visibilityWindow.Show()
 				visibilityWindow.SetOnClosed(func() {
 					visibilityWindow = nil
 				})


### PR DESCRIPTION
Just a small detail: in the demo app, windows section (cmd/fyne_demo/tutorials/window.go)), show/hide window had to be clicked two times to be opened after it was closed.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
