### PR TITLE
support controling visiblity of system tray menu items

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -88,6 +88,8 @@ func makeMenu(a fyne.App, w fyne.Window) *fyne.MainMenu {
 	checkedItem.Checked = true
 	disabledItem := fyne.NewMenuItem("Disabled", nil)
 	disabledItem.Disabled = true
+	visibleItem := fyne.NewMenuItem("Now you see me...", func() {})
+	hideShowItem := fyne.NewMenuItem("Hide", func() {})
 	otherItem := fyne.NewMenuItem("Other", nil)
 	mailItem := fyne.NewMenuItem("Mail", func() { fmt.Println("Menu New->Other->Mail") })
 	mailItem.Icon = theme.MailComposeIcon()
@@ -156,7 +158,7 @@ func makeMenu(a fyne.App, w fyne.Window) *fyne.MainMenu {
 		}))
 
 	// a quit item will be appended to our first (File) menu
-	file := fyne.NewMenu("File", newItem, checkedItem, disabledItem)
+	file := fyne.NewMenu("File", newItem, checkedItem, disabledItem, visibleItem, hideShowItem)
 	device := fyne.CurrentDevice()
 	if !device.IsMobile() && !device.IsBrowser() {
 		file.Items = append(file.Items, fyne.NewMenuItemSeparator(), settingsItem)
@@ -168,6 +170,15 @@ func makeMenu(a fyne.App, w fyne.Window) *fyne.MainMenu {
 	)
 	checkedItem.Action = func() {
 		checkedItem.Checked = !checkedItem.Checked
+		main.Refresh()
+	}
+	hideShowItem.Action = func() {
+		visibleItem.Hidden = !visibleItem.Hidden
+		if visibleItem.Hidden {
+			hideShowItem.Label = "Show"
+		} else {
+			hideShowItem.Label = "Hide"
+		}
 		main.Refresh()
 	}
 	return main

--- a/cmd/systray_demo/main.go
+++ b/cmd/systray_demo/main.go
@@ -1,0 +1,1 @@
+package systray_demo

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -73,7 +73,7 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 		if i.Disabled {
 			item.Disable()
 		}
-		if i.Visible {
+		if !i.Hidden {
 			item.Show()
 		} else {
 			item.Hide()

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -73,6 +73,11 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 		if i.Disabled {
 			item.Disable()
 		}
+		if i.Visible {
+			item.Show()
+		} else {
+			item.Hide()
+		}
 		if i.Icon != nil {
 			data := i.Icon.Content()
 			if painter.IsResourceSVG(i.Icon) {

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -93,6 +93,9 @@ func addNativeMenu(w *window, menu *fyne.Menu, nextItemID int, prepend bool) int
 
 	containsItems := false
 	for _, item := range menu.Items {
+		if item.Hidden {
+			continue
+		}
 		if !item.IsSeparator {
 			containsItems = true
 			break
@@ -120,6 +123,9 @@ func clearNativeMenu() {
 func createNativeMenu(w *window, menu *fyne.Menu, nextItemID int) (unsafe.Pointer, int) {
 	nsMenu := C.createDarwinMenu(C.CString(menu.Label))
 	for _, item := range menu.Items {
+		if item.Hidden {
+			continue
+		}
 		nsMenuItem := insertNativeMenuItem(nsMenu, item, nextItemID, -1)
 		nextItemID = registerCallback(w, item, nextItemID)
 		if item.ChildMenu != nil {
@@ -140,6 +146,9 @@ func exceptionCallback(e *C.char) {
 
 func handleSpecialItems(w *window, menu *fyne.Menu, nextItemID int, addSeparator bool) (*fyne.Menu, int) {
 	for i, item := range menu.Items {
+		if item.Hidden {
+			continue
+		}
 		if item.Label == "Settings" || item.Label == "Settings…" || item.Label == "Preferences" || item.Label == "Preferences…" {
 			items := make([]*fyne.MenuItem, 0, len(menu.Items)-1)
 			items = append(items, menu.Items[:i]...)

--- a/menu.go
+++ b/menu.go
@@ -57,7 +57,7 @@ type MenuItem struct {
 	Icon Resource
 	// Since: 2.2
 	Shortcut Shortcut
-	// Since: 2.2.2
+	// Since: 2.3
 	Hidden bool
 }
 

--- a/menu.go
+++ b/menu.go
@@ -57,11 +57,13 @@ type MenuItem struct {
 	Icon Resource
 	// Since: 2.2
 	Shortcut Shortcut
+	// Since: 2.2.2
+	Visible bool
 }
 
 // NewMenuItem creates a new menu item from the passed label and action parameters.
 func NewMenuItem(label string, action func()) *MenuItem {
-	return &MenuItem{Label: label, Action: action}
+	return &MenuItem{Label: label, Action: action, Visible: true}
 }
 
 // NewMenuItemSeparator creates a menu item that is to be used as a separator.

--- a/menu.go
+++ b/menu.go
@@ -58,12 +58,12 @@ type MenuItem struct {
 	// Since: 2.2
 	Shortcut Shortcut
 	// Since: 2.2.2
-	Visible bool
+	Hidden bool
 }
 
 // NewMenuItem creates a new menu item from the passed label and action parameters.
 func NewMenuItem(label string, action func()) *MenuItem {
-	return &MenuItem{Label: label, Action: action, Visible: true}
+	return &MenuItem{Label: label, Action: action}
 }
 
 // NewMenuItemSeparator creates a menu item that is to be used as a separator.

--- a/widget/menu_item.go
+++ b/widget/menu_item.go
@@ -55,7 +55,7 @@ func newMenuItem(item *fyne.MenuItem, parent *Menu) *menuItem {
 }
 
 func (i *menuItem) Child() *Menu {
-	if i.Item.ChildMenu != nil && i.child == nil {
+	if i.Item.ChildMenu != nil && (i.child == nil || i.Item.Hidden) {
 		child := NewMenu(i.Item.ChildMenu)
 		child.Hide()
 		child.OnDismiss = i.Parent.Dismiss
@@ -286,6 +286,11 @@ func (r *menuItemRenderer) MinSize() fyne.Size {
 }
 
 func (r *menuItemRenderer) Refresh() {
+	if r.i.Item.Hidden {
+		r.i.Hide()
+	} else {
+		r.i.Show()
+	}
 	if fyne.CurrentDevice().IsMobile() {
 		r.background.Hide()
 	} else if r.i.isActive() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Add a `Visible` attribute to `MenuItem`, evalute it in `refreshSystray` and call `Hide()` or `Show()` on the underlying `systray.MenuItem` accordingly.


Fixes #3095

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
