### PR TITLE
Add new colours to the theme. Plus more flexible ThemedResource

### DIFF
--- a/test/markup_renderer.go
+++ b/test/markup_renderer.go
@@ -137,7 +137,7 @@ func (r *markupRenderer) setResourceAttr(attrs map[string]*string, name string, 
 	}
 
 	var variant string
-	switch rsc.(type) {
+	switch t := rsc.(type) {
 	case *theme.DisabledResource:
 		variant = "disabled"
 	case *theme.ErrorThemedResource:
@@ -147,7 +147,10 @@ func (r *markupRenderer) setResourceAttr(attrs map[string]*string, name string, 
 	case *theme.PrimaryThemedResource:
 		variant = "primary"
 	case *theme.ThemedResource:
-		variant = "default"
+		variant = string(t.ColorName)
+		if variant == "" {
+			variant = "default"
+		}
 	default:
 		r.setStringAttr(attrs, name, rsc.Name())
 		return

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -569,6 +569,11 @@ func (t *builtinTheme) Icon(n fyne.ThemeIconName) fyne.Resource {
 // ThemedResource is a resource wrapper that will return a version of the resource with the main color changed
 // for the currently selected theme.
 type ThemedResource struct {
+	// ColorName specifies which theme colour should be used to theme the resource
+	//
+	// Since: 2.3
+	ColorName fyne.ThemeColorName
+
 	source fyne.Resource
 }
 
@@ -581,12 +586,22 @@ func NewThemedResource(src fyne.Resource) *ThemedResource {
 
 // Name returns the underlying resource name (used for caching).
 func (res *ThemedResource) Name() string {
-	return res.source.Name()
+	prefix := res.ColorName
+	if prefix != "" {
+		prefix += "_"
+	}
+
+	return string(prefix) + res.source.Name()
 }
 
 // Content returns the underlying content of the resource adapted to the current text color.
 func (res *ThemedResource) Content() []byte {
-	return svg.Colorize(res.source.Content(), ForegroundColor())
+	name := res.ColorName
+	if name == "" {
+		name = ColorNameForeground
+	}
+
+	return svg.Colorize(res.source.Content(), safeColorLookup(name, currentVariant()))
 }
 
 // Error returns a different resource for indicating an error.

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -569,12 +569,12 @@ func (t *builtinTheme) Icon(n fyne.ThemeIconName) fyne.Resource {
 // ThemedResource is a resource wrapper that will return a version of the resource with the main color changed
 // for the currently selected theme.
 type ThemedResource struct {
+	source fyne.Resource
+
 	// ColorName specifies which theme colour should be used to theme the resource
 	//
 	// Since: 2.3
 	ColorName fyne.ThemeColorName
-
-	source fyne.Resource
 }
 
 // NewThemedResource creates a resource that adapts to the current theme setting.

--- a/theme/icons_test.go
+++ b/theme/icons_test.go
@@ -139,6 +139,16 @@ func TestThemedResource_Success(t *testing.T) {
 	assert.Equal(t, name, fmt.Sprintf("success_%v", source.Name()))
 }
 
+func TestThemedResource_Warning(t *testing.T) {
+	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
+	source := helperNewStaticResource()
+	custom := NewThemedResource(source)
+	custom.ColorName = ColorNameWarning
+	name := custom.Name()
+
+	assert.Equal(t, name, fmt.Sprintf("warning_%v", source.Name()))
+}
+
 func TestDisabledResource_Name(t *testing.T) {
 	staticResource := helperLoadRes(t, "cancel_Paths.svg")
 	disabledResource := &DisabledResource{

--- a/theme/icons_test.go
+++ b/theme/icons_test.go
@@ -129,6 +129,16 @@ func TestThemedResource_Content_BlackFillIsUpdated(t *testing.T) {
 	assert.NotEqual(t, staticResource.Content(), themedResource.Content())
 }
 
+func TestThemedResource_Success(t *testing.T) {
+	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
+	source := helperNewStaticResource()
+	custom := NewThemedResource(source)
+	custom.ColorName = ColorNameSuccess
+	name := custom.Name()
+
+	assert.Equal(t, name, fmt.Sprintf("success_%v", source.Name()))
+}
+
 func TestDisabledResource_Name(t *testing.T) {
 	staticResource := helperLoadRes(t, "cancel_Paths.svg")
 	disabledResource := &DisabledResource{

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -469,7 +469,6 @@ func WarningColor() color.Color {
 	return safeColorLookup(ColorNameWarning, currentVariant())
 }
 
-
 var (
 	defaultTheme fyne.Theme
 

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -123,6 +123,11 @@ const (
 	// Since: 2.3
 	ColorNameSuccess fyne.ThemeColorName = "success"
 
+	// ColorNameWarning is the name of theme lookup for foreground warning color.
+	//
+	// Since: 2.3
+	ColorNameWarning fyne.ThemeColorName = "warning"
+
 	// SizeNameCaptionText is the name of theme lookup for helper text size, normally smaller than regular text size.
 	//
 	// Since: 2.0
@@ -274,7 +279,7 @@ func DisabledTextColor() color.Color {
 	return DisabledColor()
 }
 
-// ErrorColor returns the theme's error text color.
+// ErrorColor returns the theme's error foreground color.
 //
 // Since: 2.0
 func ErrorColor() color.Color {
@@ -399,7 +404,7 @@ func ShadowColor() color.Color {
 	return safeColorLookup(ColorNameShadow, currentVariant())
 }
 
-// SuccessColor returns the theme's success text color.
+// SuccessColor returns the theme's success foreground color.
 //
 // Since: 2.3
 func SuccessColor() color.Color {
@@ -457,11 +462,20 @@ func TextSubHeadingSize() float32 {
 	return current().Size(SizeNameSubHeadingText)
 }
 
+// WarningColor returns the theme's warning foreground color.
+//
+// Since: 2.3
+func WarningColor() color.Color {
+	return safeColorLookup(ColorNameWarning, currentVariant())
+}
+
+
 var (
 	defaultTheme fyne.Theme
 
 	errorColor   = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
 	successColor = color.NRGBA{R: 0x43, G: 0xf4, B: 0x36, A: 0xff}
+	warningColor = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
 	focusColors  = map[string]color.Color{
 		ColorRed:    color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f},
 		ColorOrange: color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f},
@@ -507,6 +521,7 @@ var (
 		ColorNameScrollBar:       color.NRGBA{A: 0x99},
 		ColorNameShadow:          color.NRGBA{A: 0x66},
 		ColorNameSuccess:         successColor,
+		ColorNameWarning:         warningColor,
 	}
 
 	lightPalette = map[fyne.ThemeColorName]color.Color{
@@ -523,6 +538,7 @@ var (
 		ColorNameScrollBar:       color.NRGBA{A: 0x99},
 		ColorNameShadow:          color.NRGBA{A: 0x33},
 		ColorNameSuccess:         successColor,
+		ColorNameWarning:         warningColor,
 	}
 )
 

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -118,6 +118,11 @@ const (
 	// Since: 2.0
 	ColorNameShadow fyne.ThemeColorName = "shadow"
 
+	// ColorNameSuccess is the name of theme lookup for foreground success color.
+	//
+	// Since: 2.3
+	ColorNameSuccess fyne.ThemeColorName = "success"
+
 	// SizeNameCaptionText is the name of theme lookup for helper text size, normally smaller than regular text size.
 	//
 	// Since: 2.0
@@ -394,6 +399,13 @@ func ShadowColor() color.Color {
 	return safeColorLookup(ColorNameShadow, currentVariant())
 }
 
+// SuccessColor returns the theme's success text color.
+//
+// Since: 2.3
+func SuccessColor() color.Color {
+	return safeColorLookup(ColorNameSuccess, currentVariant())
+}
+
 // TextBoldFont returns the font resource for the bold font style.
 func TextBoldFont() fyne.Resource {
 	return safeFontLookup(fyne.TextStyle{Bold: true})
@@ -448,8 +460,9 @@ func TextSubHeadingSize() float32 {
 var (
 	defaultTheme fyne.Theme
 
-	errorColor  = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
-	focusColors = map[string]color.Color{
+	errorColor   = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+	successColor = color.NRGBA{R: 0x43, G: 0xf4, B: 0x36, A: 0xff}
+	focusColors  = map[string]color.Color{
 		ColorRed:    color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f},
 		ColorOrange: color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f},
 		ColorYellow: color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x7f},
@@ -493,6 +506,7 @@ var (
 		ColorNamePressed:         color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0x66},
 		ColorNameScrollBar:       color.NRGBA{A: 0x99},
 		ColorNameShadow:          color.NRGBA{A: 0x66},
+		ColorNameSuccess:         successColor,
 	}
 
 	lightPalette = map[fyne.ThemeColorName]color.Color{
@@ -508,6 +522,7 @@ var (
 		ColorNamePressed:         color.NRGBA{A: 0x19},
 		ColorNameScrollBar:       color.NRGBA{A: 0x99},
 		ColorNameShadow:          color.NRGBA{A: 0x33},
+		ColorNameSuccess:         successColor,
 	}
 )
 


### PR DESCRIPTION
Added the new colour codes as suggested in the issue.
Skipped "Danger" as it is basically the same as Error. We could also have Pass/Fail but they too are just synonyms for Success and Error.

Fixes #1861

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
