### PR TITLE
Don't forget about icons set before systray menu

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -13,7 +13,10 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-var setup sync.Once
+var (
+	iconSet fyne.Resource
+	setup   sync.Once
+)
 
 func goroutineID() (id uint64) {
 	var buf [30]byte
@@ -27,16 +30,12 @@ func goroutineID() (id uint64) {
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 	setup.Do(func() {
 		d.trayStart, d.trayStop = systray.RunWithExternalLoop(func() {
-			if fyne.CurrentApp().Icon() != nil {
-				img, err := toOSIcon(fyne.CurrentApp().Icon())
-				if err == nil {
-					systray.SetIcon(img)
-				}
+			if iconSet != nil {
+				d.SetSystemTrayIcon(iconSet)
+			} else if fyne.CurrentApp().Icon() != nil {
+				d.SetSystemTrayIcon(fyne.CurrentApp().Icon())
 			} else {
-				img, err := toOSIcon(theme.FyneLogo())
-				if err == nil {
-					systray.SetIcon(img)
-				}
+				d.SetSystemTrayIcon(theme.FyneLogo())
 			}
 
 			// it must be refreshed after init, so an earlier call would have been ineffective
@@ -86,7 +85,15 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 }
 
 func (d *gLDriver) SetSystemTrayIcon(resource fyne.Resource) {
-	systray.SetIcon(resource.Content())
+	iconSet = resource // in case we need it later
+
+	img, err := toOSIcon(resource)
+	if err != nil {
+		fyne.LogError("Failed to convert systray icon", err)
+		return
+	}
+
+	systray.SetIcon(img)
 }
 
 func (d *gLDriver) SystemTrayMenu() *fyne.Menu {

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	iconSet fyne.Resource
-	setup   sync.Once
+	systrayIcon fyne.Resource
+	setup       sync.Once
 )
 
 func goroutineID() (id uint64) {
@@ -30,8 +30,8 @@ func goroutineID() (id uint64) {
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 	setup.Do(func() {
 		d.trayStart, d.trayStop = systray.RunWithExternalLoop(func() {
-			if iconSet != nil {
-				d.SetSystemTrayIcon(iconSet)
+			if systrayIcon != nil {
+				d.SetSystemTrayIcon(systrayIcon)
 			} else if fyne.CurrentApp().Icon() != nil {
 				d.SetSystemTrayIcon(fyne.CurrentApp().Icon())
 			} else {
@@ -85,7 +85,7 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 }
 
 func (d *gLDriver) SetSystemTrayIcon(resource fyne.Resource) {
-	iconSet = resource // in case we need it later
+	systrayIcon = resource // in case we need it later
 
 	img, err := toOSIcon(resource)
 	if err != nil {


### PR DESCRIPTION
If it is set before the menu the init code overwrote it.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- this relates to the order of events in systray package
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

