### PR TITLE
Fix regression where OriginalFill images would never show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Emphasis in Markdown gives erroneous output in RichText (#2974)
 * When last visible window is closed, hidden window is set visible (#3059)
 * Do not close app when last window is closed but systrayMenu exists (#3092)
+* Image with ImageFillOriginal not showing (#3102)
 
 
 ## 2.2.1 - 12 June 2022

--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -46,8 +46,8 @@ func PaintImage(img *canvas.Image, c fyne.Canvas, width, height int) image.Image
 	var wantOrigW, wantOrigH int
 	wantOrigSize := false
 	if img.FillMode == canvas.ImageFillOriginal && c != nil {
-		wantOrigW = internal.ScaleInt(c, img.Size().Width)
-		wantOrigH = internal.ScaleInt(c, img.Size().Height)
+		wantOrigW = internal.ScaleInt(c, img.MinSize().Width)
+		wantOrigH = internal.ScaleInt(c, img.MinSize().Height)
 		wantOrigSize = true
 	}
 
@@ -124,12 +124,14 @@ func paintImage(img *canvas.Image, width, height int, wantOrigSize bool, wantOri
 			}
 
 			origSize := pixels.Bounds().Size()
+			origW, origH = origSize.X, origSize.Y
 			if checkSize(origSize.X, origSize.Y) {
 				dst = scaleImage(pixels, width, height, img.ScaleMode)
 			}
 		}
 	case img.Image != nil:
 		origSize := img.Image.Bounds().Size()
+		origW, origH = origSize.X, origSize.Y
 		if checkSize(origSize.X, origSize.Y) {
 			dst = scaleImage(img.Image, width, height, img.ScaleMode)
 		}

--- a/internal/painter/image_test.go
+++ b/internal/painter/image_test.go
@@ -5,9 +5,28 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/painter/software"
 	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestPaintImage_MinSize(t *testing.T) {
+	img := canvas.NewImageFromFile("testdata/svg-stroke-default.png")
+	img.FillMode = canvas.ImageFillOriginal
+	c := test.NewCanvasWithPainter(software.NewPainter())
+	c.SetScale(1.0)
+	c.SetContent(img)
+
+	// check fallback min
+	assert.Equal(t, float32(1), img.MinSize().Width)
+	assert.Equal(t, float32(1), img.MinSize().Height)
+
+	// render it with original will set min
+	painter.PaintImage(img, c, 100, 100)
+	assert.Equal(t, float32(480), img.MinSize().Width)
+	assert.Equal(t, float32(240), img.MinSize().Height)
+}
 
 func TestPaintImage_SVG(t *testing.T) {
 	test.NewApp()


### PR DESCRIPTION
Fixes #3102

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
