### PR TITLE
Use UIScreen bounds instead of nativeBounds for DisplayMetrics

### DIFF
--- a/internal/driver/mobile/app/darwin_ios.go
+++ b/internal/driver/mobile/app/darwin_ios.go
@@ -84,8 +84,8 @@ var DisplayMetrics struct {
 
 //export setDisplayMetrics
 func setDisplayMetrics(width, height int, scale int) {
-	DisplayMetrics.WidthPx = width
-	DisplayMetrics.HeightPx = height
+	DisplayMetrics.WidthPx = width * scale
+	DisplayMetrics.HeightPx = height * scale
 }
 
 //export setScreen
@@ -127,15 +127,14 @@ func updateConfig(width, height, orientation int32) {
 		o = size.OrientationPortrait
 	case C.UIDeviceOrientationLandscapeLeft, C.UIDeviceOrientationLandscapeRight:
 		o = size.OrientationLandscape
-		width, height = height, width
 	}
 	insets := C.getDevicePadding()
 
 	theApp.events.In() <- size.Event{
-		WidthPx:       int(width),
-		HeightPx:      int(height),
-		WidthPt:       float32(width) / pixelsPerPt,
-		HeightPt:      float32(height) / pixelsPerPt,
+		WidthPx:       int(width) * screenScale,
+		HeightPx:      int(height) * screenScale,
+		WidthPt:       float32(width),
+		HeightPt:      float32(height),
 		InsetTopPx:    int(float32(insets.top) * float32(screenScale)),
 		InsetBottomPx: int(float32(insets.bottom) * float32(screenScale)),
 		InsetLeftPx:   int(float32(insets.left) * float32(screenScale)),

--- a/internal/driver/mobile/app/darwin_ios.m
+++ b/internal/driver/mobile/app/darwin_ios.m
@@ -34,7 +34,7 @@ struct utsname sysInfo;
     if ([[UIScreen mainScreen] respondsToSelector:@selector(displayLinkWithTarget:selector:)]) {
 		scale = (int)[UIScreen mainScreen].scale; // either 1.0, 2.0, or 3.0.
 	}
-    CGSize size = [UIScreen mainScreen].nativeBounds.size;
+    CGSize size = [UIScreen mainScreen].bounds.size;
     setDisplayMetrics((int)size.width, (int)size.height, scale);
 
 	lifecycleAlive();
@@ -149,7 +149,7 @@ struct utsname sysInfo;
 		// TODO(crawshaw): come up with a plan to handle animations.
 	} completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
 		UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-		CGSize size = [UIScreen mainScreen].nativeBounds.size;
+		CGSize size = [UIScreen mainScreen].bounds.size;
 		updateConfig((int)size.width, (int)size.height, orientation);
 	}];
 }
@@ -194,7 +194,7 @@ static void sendTouches(int change, NSSet* touches) {
     [super traitCollectionDidChange: previousTraitCollection];
 
 	UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-	CGSize size = [UIScreen mainScreen].nativeBounds.size;
+	CGSize size = [UIScreen mainScreen].bounds.size;
 	updateConfig((int)size.width, (int)size.height, orientation);
 }
 @end


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #3122

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [] Tests included. <- I don't think tests applicable here.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass. <- Same tests that fail on master/develop for me, fail after my fix.


