### PR TITLE
fix: Use nativeScale to calculate touch location on IOS

### DIFF
--- a/internal/driver/mobile/app/darwin_ios.m
+++ b/internal/driver/mobile/app/darwin_ios.m
@@ -167,7 +167,7 @@ struct utsname sysInfo;
 #define TOUCH_TYPE_END   2 // touch.TypeEnd
 
 static void sendTouches(int change, NSSet* touches) {
-	CGFloat scale = [UIScreen mainScreen].scale;
+	CGFloat scale = [UIScreen mainScreen].nativeScale;
 	for (UITouch* touch in touches) {
 		CGPoint p = [touch locationInView:touch.view];
 		sendTouch((GoUintptr)touch, (GoUintptr)change, p.x*scale, p.y*scale);


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #3122

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [] Tests included. <- I don't think tests applicable here.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass. <- Same tests that fail on master/develop for me, fail after my fix.


