### PR TITLE
Fix preference test seeming fails

### DIFF
--- a/app/app_other.go
+++ b/app/app_other.go
@@ -6,6 +6,8 @@ package app
 import (
 	"errors"
 	"net/url"
+	"os"
+	"path/filepath"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
@@ -16,7 +18,7 @@ func defaultVariant() fyne.ThemeVariant {
 }
 
 func rootConfigDir() string {
-	return "/tmp/fyne-test/"
+	return filepath.Join(os.TempDir(), "fyne-test")
 }
 
 func (a *fyneApp) OpenURL(_ *url.URL) error {

--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -25,9 +25,10 @@ func TestPreferences_Save(t *testing.T) {
 		val["keyBool"] = true
 	})
 
-	path := filepath.Join(os.TempDir(), "fynePrefs.json")
+	path := p.storagePath()
 	defer os.Remove(path)
-	p.saveToFile(path)
+	err := p.saveToFile(path)
+	assert.Nil(t, err)
 
 	expected, err := ioutil.ReadFile(filepath.Join("testdata", "preferences.json"))
 	if err != nil {


### PR DESCRIPTION
With the "CI" flag set a new test was failing due to temp file locations.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

