### PR TITLE
Fix incorrect size and position for radio focus indicator

### DIFF
--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -98,12 +98,10 @@ func (i *radioItem) MouseOut() {
 
 // SetSelected sets whether this radio item is selected or not.
 func (i *radioItem) SetSelected(selected bool) {
-	if i.Disabled() {
+	if i.Disabled() || i.Selected == selected {
 		return
 	}
-	if i.Selected == selected {
-		return
-	}
+
 	i.Selected = selected
 	i.Refresh()
 }
@@ -138,10 +136,7 @@ func (i *radioItem) TypedRune(r rune) {
 }
 
 func (i *radioItem) toggle() {
-	if i.Disabled() {
-		return
-	}
-	if i.onTap == nil {
+	if i.Disabled() || i.onTap == nil {
 		return
 	}
 

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -153,12 +153,12 @@ type radioItemRenderer struct {
 }
 
 func (r *radioItemRenderer) Layout(size fyne.Size) {
-	labelSize := fyne.NewSize(size.Width, size.Height)
-	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.Padding()*2, theme.IconInlineSize()+theme.Padding())
-
+	pad2 := 2 * theme.Padding()
+	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+pad2, theme.IconInlineSize()+pad2)
 	r.focusIndicator.Resize(focusIndicatorSize)
-	r.focusIndicator.Move(fyne.NewPos(theme.Padding()*0.5, (size.Height-focusIndicatorSize.Height)/2))
+	r.focusIndicator.Move(fyne.NewPos(theme.Padding()/2, (size.Height-focusIndicatorSize.Height)/2))
 
+	labelSize := fyne.NewSize(size.Width, size.Height)
 	r.label.Resize(labelSize)
 	r.label.Move(fyne.NewPos(focusIndicatorSize.Width+theme.Padding(), 0))
 

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -15,7 +15,7 @@ func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
 	render := test.WidgetRenderer(item).(*radioItemRenderer)
 	render.Layout(fyne.NewSize(200, 100))
 
-	focusIndicatorSize := theme.IconInlineSize() + theme.Padding()
+	focusIndicatorSize := theme.IconInlineSize() + 2*theme.Padding()
 	heightCenterOffset := (100 - focusIndicatorSize) / 2
 	assert.Equal(t, fyne.NewPos(theme.Padding()/2, heightCenterOffset), render.focusIndicator.Position1)
 }

--- a/widget/testdata/radio_group/disabled_append_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_append_none_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,59" size="102x73" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/disabled_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_none_selected.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,59" size="102x73" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option B</text>
 				</widget>

--- a/widget/testdata/radio_group/focus_a_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_b_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,40" size="102x110" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,6" size="28x24"/>
+					<circle fillColor="focus" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<text pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/focus_a_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_none_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,40" size="102x110" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,6" size="28x24"/>
+					<circle fillColor="focus" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/focus_b_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_b_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,40" size="102x110" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,6" size="28x24"/>
+					<circle fillColor="focus" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<text pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/focus_b_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_none_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,40" size="102x110" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,6" size="28x24"/>
+					<circle fillColor="focus" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/focus_disabled_none_selected.xml
+++ b/widget/testdata/radio_group/focus_disabled_none_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,40" size="102x110" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/focus_none_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_b_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,40" size="102x110" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<text pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/focus_none_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_none_selected.xml
@@ -3,17 +3,17 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="19,40" size="102x110" type="*widget.RadioGroup">
 				<widget size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option A</text>
 				</widget>
 				<widget pos="0,36" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option B</text>
 				</widget>
 				<widget pos="0,73" size="102x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="102x36">Option C</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple.xml
+++ b/widget/testdata/radio_group/layout_multiple.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,59" size="66x73" type="*widget.RadioGroup">
 				<widget size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="66x36">Foo</text>
 				</widget>
 				<widget pos="0,36" size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="66x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_disabled.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,59" size="66x73" type="*widget.RadioGroup">
 				<widget size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="66x36">Foo</text>
 				</widget>
 				<widget pos="0,36" size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="66x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="5,77" size="130x36" type="*widget.RadioGroup">
 				<widget size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="65x36">Foo</text>
 				</widget>
 				<widget pos="65,0" size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="65x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="5,77" size="130x36" type="*widget.RadioGroup">
 				<widget size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="65x36">Foo</text>
 				</widget>
 				<widget pos="65,0" size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="65x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple_selected.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,59" size="66x73" type="*widget.RadioGroup">
 				<widget size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<text pos="32,0" size="66x36">Foo</text>
 				</widget>
 				<widget pos="0,36" size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="66x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,59" size="66x73" type="*widget.RadioGroup">
 				<widget size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="66x36">Foo</text>
 				</widget>
 				<widget pos="0,36" size="66x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="66x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="5,77" size="130x36" type="*widget.RadioGroup">
 				<widget size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<text pos="32,0" size="65x36">Foo</text>
 				</widget>
 				<widget pos="65,0" size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="65x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
@@ -3,12 +3,12 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="5,77" size="130x36" type="*widget.RadioGroup">
 				<widget size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="65x36">Foo</text>
 				</widget>
 				<widget pos="65,0" size="65x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="65x36">Bar</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single.xml
+++ b/widget/testdata/radio_group/layout_single.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="69x36">Test</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="69x36">Test</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize"/>
 					<text pos="32,0" size="69x36">Test</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="69x36">Test</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single_selected.xml
+++ b/widget/testdata/radio_group/layout_single_selected.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<text pos="32,0" size="69x36">Test</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="69x36">Test</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<text pos="32,0" size="69x36">Test</text>
 				</widget>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="36,77" size="69x36" type="*widget.RadioGroup">
 				<widget size="69x36" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,6" size="28x24"/>
+					<circle fillColor="background" pos="2,4" size="28x28"/>
 					<image pos="6,8" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="69x36">Test</text>
 				</widget>


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This fixes an issue where the incorrect amount of padding was added to the focus indicator in `radioItem`.

#### Before:
![image](https://user-images.githubusercontent.com/25466657/178793107-3346553b-92b8-476a-a1d8-f40040b41957.png)

#### After:
![image](https://user-images.githubusercontent.com/25466657/178793767-a1cc6ea0-fa94-4f30-ac3b-8ccec0ce3c85.png)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.