### PR TITLE
Make the example code field mandatory

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
   attributes:
     label: Example code
     description: |
-      If applicable, add a short code snippet to help explain and simplify reproduction of the problem.
+      Add a short code snippet to help explain and simplify reproduction of the problem.
       Please refrain from adding screenshots of code, links to other projects or very long code examples.
       A good code example should be runnable and contain no more code than is necessary to reproduce the bug.
     placeholder: |
@@ -47,7 +47,7 @@ body:
       Write your code here.
       ```
   validations:
-    required: false
+    required: true
 - type: input
   attributes:
     label: Fyne version


### PR DESCRIPTION


### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I have noticed that a lot fewer bug reports actually contain the example code now.
Now that there is a clear distinction between mandatory and not, people don't see to use it at all.
Let's make it required. Those that don't need it can point to fyne_demo instead.

Again, this is targeting master as that's where GitHub is pulling the templates from.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [] Tests included.
- [] Lint and formatter run with no errors.
- [] Tests all pass.