### PR TITLE
Fix build error when using 'fyne build' and no icon

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -275,8 +275,15 @@ func createMetadataInitFile(srcdir string, app *appData, icon string) (func(), e
 
 	err = templates.FyneMetadataInit.Execute(metadataInitFile, app)
 	if err == nil {
+		iconResName := "fyneMetadataIcon"
 		if icon != "" {
-			writeResource(icon, "fyneMetadataIcon", metadataInitFile)
+			writeResource(icon, iconResName, metadataInitFile)
+		} else {
+			v := fmt.Sprintf("var %s = (fyne.Resource)(nil)\n", iconResName)
+			_, err = metadataInitFile.Write([]byte(v))
+			if err != nil {
+				fyne.LogError("Error writing icon placeholder", err)
+			}
 		}
 	}
 

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -244,8 +244,8 @@ func Test_FyneGoMod(t *testing.T) {
 		called := false
 
 		fyneGoModTest := &testCommandRuns{runs: expected, t: t}
-		injectMetadataIfPossible(fyneGoModTest, "myTest", &appData{}, "",
-			func(string, *appData, string) (func(), error) {
+		injectMetadataIfPossible(fyneGoModTest, "myTest", &appData{},
+			func(string, *appData) (func(), error) {
 				called = true
 				return func() {}, nil
 			})

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -104,7 +104,7 @@ func Test_BuildWasmVersion(t *testing.T) {
 		{
 			expectedValue: expectedValue{args: []string{"mod", "edit", "-json"}},
 			mockReturn: mockReturn{
-				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"}"),
+				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"} }"),
 			},
 		},
 		{
@@ -134,7 +134,7 @@ func Test_BuildWasmReleaseVersion(t *testing.T) {
 		{
 			expectedValue: expectedValue{args: []string{"mod", "edit", "-json"}},
 			mockReturn: mockReturn{
-				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"}"),
+				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"} }"),
 			},
 		},
 		{
@@ -168,7 +168,7 @@ func Test_BuildGopherJSReleaseVersion(t *testing.T) {
 		{
 			expectedValue: expectedValue{args: []string{"mod", "edit", "-json"}},
 			mockReturn: mockReturn{
-				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"}"),
+				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"} }"),
 			},
 		},
 		{
@@ -205,7 +205,7 @@ func Test_BuildWasmOldVersion(t *testing.T) {
 		{
 			expectedValue: expectedValue{args: []string{"mod", "edit", "-json"}},
 			mockReturn: mockReturn{
-				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"}"),
+				ret: []byte("{ \"Module\": { \"Path\": \"fyne.io/fyne/v2\"} }"),
 			},
 		},
 		{

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -276,7 +276,7 @@ func (p *Packager) doPackage(runner runner) error {
 		}
 	}
 	if util.IsMobile(p.os) { // we don't use the normal build command for mobile so inject before gomobile...
-		close, err := injectMetadataIfPossible(newCommand("go"), p.dir, p.appData, p.icon, createMetadataInitFile)
+		close, err := injectMetadataIfPossible(newCommand("go"), p.dir, p.appData, createMetadataInitFile)
 		if err != nil {
 			fyne.LogError("Failed to inject metadata init file, omitting metadata", err)
 		} else if close != nil {

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -270,6 +270,9 @@ func Test_buildPackageGopherJS(t *testing.T) {
 			{"myTest.wasm", true},
 		},
 	}
+	if runtime.GOOS == "windows" {
+		expectedExistRuns.expected[0].path = "myTest\\Icon.png"
+	}
 	utilExistsMock = func(path string) bool {
 		return expectedExistRuns.verifyExpectation(t, path)
 	}

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -450,8 +450,8 @@ func Test_BuildPackageWeb(t *testing.T) {
 		},
 	}
 	if runtime.GOOS == "windows" {
-		expectedExistRuns.expected[0].path = "myText\\Icon.png"
-		expectedExistRuns.expected[1].path = "myText\\Icon.png"
+		expectedExistRuns.expected[0].path = "myTest\\Icon.png"
+		expectedExistRuns.expected[1].path = "myTest\\Icon.png"
 	}
 	utilExistsMock = func(path string) bool {
 		return expectedExistRuns.verifyExpectation(t, path)

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -449,6 +449,10 @@ func Test_BuildPackageWeb(t *testing.T) {
 			{"myTest", false},
 		},
 	}
+	if runtime.GOOS == "windows" {
+		expectedExistRuns.expected[0].path = "myText\\Icon.png"
+		expectedExistRuns.expected[1].path = "myText\\Icon.png"
+	}
 	utilExistsMock = func(path string) bool {
 		return expectedExistRuns.verifyExpectation(t, path)
 	}

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -263,6 +263,17 @@ func Test_buildPackageGopherJS(t *testing.T) {
 		},
 	}
 
+	expectedExistRuns := mockExistRuns{
+		expected: []mockExist{
+			{"myTest/Icon.png", false},
+			{"myTest.wasm", false},
+			{"myTest.wasm", true},
+		},
+	}
+	utilExistsMock = func(path string) bool {
+		return expectedExistRuns.verifyExpectation(t, path)
+	}
+
 	p := &Packager{
 		appData: &appData{},
 		os:      "gopherjs",
@@ -429,6 +440,17 @@ func Test_BuildPackageWeb(t *testing.T) {
 				ret: []byte(""),
 			},
 		},
+	}
+
+	expectedExistRuns := mockExistRuns{
+		expected: []mockExist{
+			{"myTest/Icon.png", false},
+			{"myTest/Icon.png", false},
+			{"myTest", false},
+		},
+	}
+	utilExistsMock = func(path string) bool {
+		return expectedExistRuns.verifyExpectation(t, path)
 	}
 
 	p := &Packager{


### PR DESCRIPTION
Turns out that icon can be missing because "fyne build" does not require metadata.
This change fixes the resulting compile error for that case

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- "fyne build" any fyne app with no icon file of FyneApp.toml
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
