### PR TITLE
Fix: DocTabItem update text doesn't update the underline select bar

### DIFF
--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -372,11 +372,17 @@ func (r *docTabsRenderer) updateIndicator(animate bool) {
 		if a := r.action; a != nil {
 			selectedPos = a.Position()
 			selectedSize = a.Size()
+			if a.MinSize().Width > selectedSize.Width {
+				selectedSize = a.MinSize()
+			}
 		}
 	} else {
 		selected := buttons[r.docTabs.current]
 		selectedPos = selected.Position()
 		selectedSize = selected.Size()
+		if selected.MinSize().Width > selectedSize.Width {
+			selectedSize = selected.MinSize()
+		}
 	}
 
 	scrollOffset := r.scroller.Offset

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -372,16 +372,18 @@ func (r *docTabsRenderer) updateIndicator(animate bool) {
 		if a := r.action; a != nil {
 			selectedPos = a.Position()
 			selectedSize = a.Size()
-			if a.MinSize().Width > selectedSize.Width {
-				selectedSize = a.MinSize()
+			minSize := a.MinSize()
+			if minSize.Width > selectedSize.Width {
+				selectedSize = minSize
 			}
 		}
 	} else {
 		selected := buttons[r.docTabs.current]
 		selectedPos = selected.Position()
 		selectedSize = selected.Size()
-		if selected.MinSize().Width > selectedSize.Width {
-			selectedSize = selected.MinSize()
+		minSize := selected.MinSize()
+		if minSize.Width > selectedSize.Width {
+			selectedSize = minSize
 		}
 	}
 

--- a/container/doctabs_desktop_test.go
+++ b/container/doctabs_desktop_test.go
@@ -105,6 +105,12 @@ func TestDocTabs_ChangeItemText(t *testing.T) {
 	item2.Text = "New 2"
 	tabs.Refresh()
 	test.AssertRendersToMarkup(t, "doctabs/desktop/change_label_change_unselected.xml", c)
+
+	// use bigger window to have indicator be based on tab size
+	w.Resize(fyne.NewSize(500, 150))
+	item1.Text = "New longer text 1"
+	tabs.Refresh()
+	test.AssertRendersToMarkup(t, "doctabs/desktop/change_label_to_longer_text_selected.xml", c)
 }
 
 func TestDocTabs_DynamicTabs(t *testing.T) {

--- a/container/testdata/doctabs/desktop/change_label_to_longer_text_selected.xml
+++ b/container/testdata/doctabs/desktop/change_label_to_longer_text_selected.xml
@@ -1,0 +1,30 @@
+<canvas size="500x150">
+	<content>
+		<widget size="500x150" type="*container.DocTabs">
+			<container size="500x36">
+				<widget size="460x36" type="*widget.Scroll">
+					<container size="460x36">
+						<widget size="86x36" type="*container.tabButton">
+							<text bold color="primary" pos="8,8" size="70x20">New longer text 1</text>
+						</widget>
+						<widget pos="90,0" size="86x36" type="*container.tabButton">
+							<text bold pos="8,8" size="70x20">New 2</text>
+						</widget>
+					</container>
+				</widget>
+				<container pos="464,0" size="36x36">
+					<widget size="36x36" type="*widget.Button">
+						<rectangle size="36x36"/>
+						<rectangle size="0x0"/>
+						<image fillMode="contain" pos="8,8" rsc="more-horizontal.svg" size="iconInlineSize" themed="default"/>
+					</widget>
+				</container>
+			</container>
+			<rectangle fillColor="shadow" pos="0,36" size="500x4"/>
+			<rectangle fillColor="primary" pos="0,36" size="175x4"/>
+			<widget pos="0,40" size="500x109" type="*widget.Label">
+				<text pos="8,8" size="484x20">Text1</text>
+			</widget>
+		</widget>
+	</content>
+</canvas>

--- a/container/testdata/doctabs/desktop/dynamic_appended_and_removed.xml
+++ b/container/testdata/doctabs/desktop/dynamic_appended_and_removed.xml
@@ -18,7 +18,7 @@
 				</container>
 			</container>
 			<rectangle fillColor="shadow" pos="0,36" size="300x4"/>
-			<rectangle fillColor="primary" pos="0,36" size="0x4"/>
+			<rectangle fillColor="primary" pos="0,36" size="80x4"/>
 			<widget pos="0,40" size="300x109" type="*widget.Label">
 				<text pos="8,8" size="284x20">Text 2</text>
 			</widget>

--- a/container/testdata/doctabs/mobile/dynamic_appended_and_removed.xml
+++ b/container/testdata/doctabs/mobile/dynamic_appended_and_removed.xml
@@ -21,7 +21,7 @@
 				</container>
 			</container>
 			<rectangle fillColor="shadow" pos="0,36" size="300x4"/>
-			<rectangle fillColor="primary" pos="0,36" size="0x4"/>
+			<rectangle fillColor="primary" pos="0,36" size="72x4"/>
 			<widget pos="0,40" size="300x109" type="*widget.Label">
 				<text pos="8,8" size="284x20">Text 2</text>
 			</widget>


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #3106

I had to change `dynamic_appended_and_removed.xml` expected size of rectangle indicator bar for tests to pass due to a new logic.


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
