### PR TITLE
Correctly transition cloud providers in the test app

### DIFF
--- a/test/testapp.go
+++ b/test/testapp.go
@@ -132,7 +132,7 @@ func (a *testApp) transitionCloud(p fyne.CloudProvider) {
 	}
 
 	// after transition ensure settings listener is fired
-	a.settings.apply() //just a test - "cedric"
+	a.settings.apply()
 }
 
 // NewApp returns a new dummy app used for testing.

--- a/test/testapp_test.go
+++ b/test/testapp_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"testing"
 
+	"fyne.io/fyne/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,4 +13,19 @@ func TestTestApp_CloudProvider(t *testing.T) {
 	a.SetCloudProvider(c)
 
 	assert.Equal(t, c, a.CloudProvider())
+}
+
+func TestFyneApp_transitionCloud(t *testing.T) {
+	a := NewApp()
+	p := &mockCloud{}
+	preferenceChanged := false
+	settingsChan := make(chan fyne.Settings)
+	a.Preferences().AddChangeListener(func() {
+		preferenceChanged = true
+	})
+	a.Settings().AddChangeListener(settingsChan)
+	a.SetCloudProvider(p)
+
+	<-settingsChan // settings were updated
+	assert.True(t, preferenceChanged)
 }


### PR DESCRIPTION
This was missed in the test app so it did not behave consistently on provider switching out.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

