### PR TITLE
Fix Random TestForm_Disabled Failure

### DIFF
--- a/internal/cache/widget.go
+++ b/internal/cache/widget.go
@@ -32,11 +32,7 @@ func Renderer(wid fyne.Widget) fyne.WidgetRenderer {
 	if !ok {
 		rinfo = &rendererInfo{renderer: wid.CreateRenderer()}
 		renderersLock.Lock()
-		if erinfo, ok := renderers[wid]; ok {
-			rinfo = erinfo
-		} else {
-			renderers[wid] = rinfo
-		}
+		renderers[wid] = rinfo
 		renderersLock.Unlock()
 	}
 

--- a/internal/cache/widget.go
+++ b/internal/cache/widget.go
@@ -32,7 +32,11 @@ func Renderer(wid fyne.Widget) fyne.WidgetRenderer {
 	if !ok {
 		rinfo = &rendererInfo{renderer: wid.CreateRenderer()}
 		renderersLock.Lock()
-		renderers[wid] = rinfo
+		if erinfo, ok := renderers[wid]; ok {
+			rinfo = erinfo
+		} else {
+			renderers[wid] = rinfo
+		}
 		renderersLock.Unlock()
 	}
 

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -148,9 +148,9 @@ func TestForm_ChangeTheme(t *testing.T) {
 }
 
 func TestForm_Disabled(t *testing.T) {
-	app := test.NewApp()
+	test.NewApp()
 	defer test.NewApp()
-	app.Settings().SetTheme(theme.LightTheme())
+	test.ApplyTheme(t, theme.LightTheme())
 
 	disabled := NewEntry()
 	disabled.Disable()


### PR DESCRIPTION
### Description:
This fixes the randomly-failing `TestForm_Disabled` test. I narrowed this down to a race with `cache.Renderer`. `test.NewApp()` spawns a goroutine that calls `app.ApplySettings` when settings are changed. This was racing with `app.NewWindow("")` to create the form's renderer, so `CreateRenderer` was occasionally being called on the form twice. This led to separate pointers for the `itemGrid` where the cached renderer didn't know about any of the form's objects.

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
