### PR TITLE
feat: create new folder from file/folder dialog

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -246,7 +246,7 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 			}
 
 			newFolderPath := filepath.Join(f.dir.Path(), newFolderEntry.Text)
-			createFolderErr := os.MkdirAll(newFolderPath, 0700)
+			createFolderErr := os.MkdirAll(newFolderPath, 0750)
 			if createFolderErr != nil {
 				fyne.LogError(
 					fmt.Sprintf("Failed to create folder with path %s", newFolderPath),

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -246,7 +246,7 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 			}
 
 			newFolderPath := filepath.Join(f.dir.Path(), newFolderEntry.Text)
-			createFolderErr := os.MkdirAll(newFolderPath, 0000)
+			createFolderErr := os.MkdirAll(newFolderPath, 0700)
 			if createFolderErr != nil {
 				fyne.LogError(
 					fmt.Sprintf("Failed to create folder with path %s", newFolderPath),

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -254,9 +254,9 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 	})
 
 	optionsbuttons := container.NewHBox(
+		newFolderButton,
 		toggleViewButton,
 		optionsButton,
-		newFolderButton,
 	)
 
 	header := container.NewBorder(nil, nil, nil, optionsbuttons,

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -233,9 +233,30 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 		}
 	})
 
+	newFolderButton := widget.NewButtonWithIcon("", theme.FolderNewIcon(), func() {
+		newFolderEntry := widget.NewEntry()
+		ShowForm("New Folder", "Create Folder", "Cancel", []*widget.FormItem{
+			{
+				Text:   "Name",
+				Widget: newFolderEntry,
+			},
+		}, func(s bool) {
+			if !s || newFolderEntry.Text == "" {
+				return
+			}
+
+			createFolderErr := os.MkdirAll(filepath.Join(f.dir.Path(), newFolderEntry.Text), 0700)
+			if createFolderErr != nil {
+				ShowInformation("Error", "Folder cannot be created", f.file.parent)
+			}
+			f.refreshDir(f.dir)
+		}, f.file.parent)
+	})
+
 	optionsbuttons := container.NewHBox(
 		toggleViewButton,
 		optionsButton,
+		newFolderButton,
 	)
 
 	header := container.NewBorder(nil, nil, nil, optionsbuttons,

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -245,9 +245,14 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 				return
 			}
 
-			createFolderErr := os.MkdirAll(filepath.Join(f.dir.Path(), newFolderEntry.Text), 0700)
+			newFolderPath := filepath.Join(f.dir.Path(), newFolderEntry.Text)
+			createFolderErr := os.MkdirAll(newFolderPath, 0000)
 			if createFolderErr != nil {
-				ShowInformation("Error", "Folder cannot be created", f.file.parent)
+				fyne.LogError(
+					fmt.Sprintf("Failed to create folder with path %s", newFolderPath),
+					createFolderErr,
+				)
+				ShowError(errors.New("folder cannot be created"), f.file.parent)
 			}
 			f.refreshDir(f.dir)
 		}, f.file.parent)

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -186,10 +186,13 @@ func TestShowFileOpen(t *testing.T) {
 	title := ui.Objects[1].(*fyne.Container).Objects[1].(*widget.Label)
 	assert.Equal(t, "Open File", title.Text)
 	//optionsbuttons
-	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)
+	createNewFolderButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)
+	assert.Equal(t, "", createNewFolderButton.Text)
+	assert.Equal(t, theme.FolderNewIcon(), createNewFolderButton.Icon)
+	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
 	assert.Equal(t, "", toggleViewButton.Text)
 	assert.Equal(t, theme.ListIcon(), toggleViewButton.Icon)
-	optionsButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
+	optionsButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[2].(*widget.Button)
 	assert.Equal(t, "", optionsButton.Text)
 	assert.Equal(t, theme.SettingsIcon(), optionsButton.Icon)
 	//footer
@@ -266,10 +269,10 @@ func TestHiddenFiles(t *testing.T) {
 
 	ui := popup.Content.(*fyne.Container)
 
-	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)
+	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
 	assert.Equal(t, "", toggleViewButton.Text)
 	assert.Equal(t, theme.ListIcon(), toggleViewButton.Icon)
-	optionsButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
+	optionsButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[2].(*widget.Button)
 	assert.Equal(t, "", optionsButton.Text)
 	assert.Equal(t, theme.SettingsIcon(), optionsButton.Icon)
 
@@ -440,7 +443,7 @@ func TestView(t *testing.T) {
 	assert.NotNil(t, popup)
 
 	ui := popup.Content.(*fyne.Container)
-	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)
+	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
 	files := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[1].(*container.Scroll).Content.(*fyne.Container).Objects[0].(*fyne.Container)
 
 	listLayout := layout.NewVBoxLayout()

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -269,6 +269,9 @@ func TestHiddenFiles(t *testing.T) {
 
 	ui := popup.Content.(*fyne.Container)
 
+	createNewFolderButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)
+	assert.Equal(t, "", createNewFolderButton.Text)
+	assert.Equal(t, theme.FolderNewIcon(), createNewFolderButton.Icon)
 	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
 	assert.Equal(t, "", toggleViewButton.Text)
 	assert.Equal(t, theme.ListIcon(), toggleViewButton.Icon)
@@ -560,4 +563,50 @@ func TestSetFileNameAfterShow(t *testing.T) {
 
 	assert.NotEqual(t, "testfile.zip", dOpen.dialog.fileName.(*widget.Label).Text)
 
+}
+
+func TestCreateNewFolderInDir(t *testing.T) {
+	win := test.NewWindow(widget.NewLabel("Content"))
+
+	folderDialog := NewFolderOpen(func(lu fyne.ListableURI, err error) {
+		assert.Nil(t, err)
+	}, win)
+	folderDialog.SetConfirmText("Choose")
+	folderDialog.SetDismissText("Cancel")
+	folderDialog.Show()
+
+	folderDialogPopup := win.Canvas().Overlays().Top().(*widget.PopUp)
+	defer win.Canvas().Overlays().Remove(folderDialogPopup)
+	assert.NotNil(t, folderDialogPopup)
+
+	folderDialogUi := folderDialogPopup.Content.(*fyne.Container)
+
+	createNewFolderButton := folderDialogUi.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)
+	assert.Equal(t, "", createNewFolderButton.Text)
+	assert.Equal(t, theme.FolderNewIcon(), createNewFolderButton.Icon)
+
+	// open folder name input dialog
+	test.Tap(createNewFolderButton)
+
+	inputPopup := win.Canvas().Overlays().Top().(*widget.PopUp)
+	defer win.Canvas().Overlays().Remove(inputPopup)
+	assert.NotNil(t, inputPopup)
+
+	folderNameInputUi := inputPopup.Content.(*fyne.Container)
+
+	folderNameInputTitle := folderNameInputUi.Objects[4].(*widget.Label)
+	assert.Equal(t, "New Folder", folderNameInputTitle.Text)
+
+	folderNameInputLabel := folderNameInputUi.Objects[2].(*fyne.Container).Objects[0].(*widget.Label)
+	assert.Equal(t, "Name", folderNameInputLabel.Text)
+
+	folderNameInputEntry := folderNameInputUi.Objects[2].(*fyne.Container).Objects[1].(*widget.Entry)
+	assert.Equal(t, "", folderNameInputEntry.Text)
+
+	folderNameInputCancel := folderNameInputUi.Objects[3].(*fyne.Container).Objects[1].(*widget.Button)
+	assert.Equal(t, "Cancel", folderNameInputCancel.Text)
+	assert.Equal(t, theme.CancelIcon(), folderNameInputCancel.Icon)
+
+	folderNameInputCreate := folderNameInputUi.Objects[3].(*fyne.Container).Objects[2].(*widget.Button)
+	assert.Equal(t, theme.ConfirmIcon(), folderNameInputCreate.Icon)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR introduces the ability to create new folder directly from the file/folder dialog. This is motivated by the hassle of having to create a folder separately before being able to select it via the folder dialog.

Changes were made to `makeUI()` to include a create folder button in the options container which would open up a entry form dialog for user to input the new folder name before executing the `mkdir` syscall. Directory is then refreshed to enable user to select the newly created folder. 

Fixes #3174 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
