### PR TITLE
Cleanup of glfw driver window files

### DIFF
--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -6,6 +6,26 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
+// Cursor mode values.
+const (
+	CursorNormal   int = glfw.CursorNormal
+	CursorHidden   int = glfw.CursorHidden
+	CursorDisabled int = glfw.CursorDisabled
+)
+
+var cursorMap map[desktop.StandardCursor]*glfw.Cursor
+
+// Input modes.
+const (
+	CursorMode             glfw.InputMode = glfw.CursorMode
+	StickyKeysMode         glfw.InputMode = glfw.StickyKeysMode
+	StickyMouseButtonsMode glfw.InputMode = glfw.StickyMouseButtonsMode
+	LockKeyMods            glfw.InputMode = glfw.LockKeyMods
+	RawMouseMotion         glfw.InputMode = glfw.RawMouseMotion
+)
+
+const defaultTitle = "Fyne Application"
+
 var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	// non-printable
 	glfw.KeyEscape:    fyne.KeyEscape,

--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -1,10 +1,5 @@
 package glfw
 
-import (
-	"fyne.io/fyne/v2"
-	"github.com/go-gl/glfw/v3.3/glfw"
-)
-
 const defaultTitle = "Fyne Application"
 
 func unknownKey(key string) bool {
@@ -38,13 +33,4 @@ var keyKnownRuneMap = map[byte]struct{}{
 	'[':  {},
 	'\\': {},
 	']':  {},
-}
-
-func convertASCII(key glfw.Key) fyne.KeyName {
-	keyRune := rune('A' + key - glfw.KeyA)
-	if keyRune < 'A' || keyRune > 'Z' {
-		return fyne.KeyUnknown
-	}
-
-	return fyne.KeyName(keyRune)
 }

--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -8,29 +8,19 @@ func unknownKey(key string) bool {
 	}
 
 	keyRune := key[0]
-	if keyRune >= 'a' || keyRune <= 'z' {
+	if keyRune >= 'a' && keyRune <= 'z' {
 		return false
 	}
 
-	_, ok := keyKnownRuneMap[keyRune]
-	return !ok
-}
+	// This catches [ \ ] per ASCII table.
+	if keyRune >= '[' && keyRune <= ']' {
+		return false
+	}
 
-// keyKnownRuneMap does not contain 'a' to 'z'. They are handled outside.
-var keyKnownRuneMap = map[byte]struct{}{
-	'\'': {},
-	',':  {},
-	'-':  {},
-	'.':  {},
-	'/':  {},
-	'*':  {},
-	'`':  {},
+	// This catches * + , - . / per ASCII table.
+	if keyRune >= '*' && keyRune <= '/' {
+		return false
+	}
 
-	';': {},
-	'+': {},
-	'=': {},
-
-	'[':  {},
-	'\\': {},
-	']':  {},
+	return keyRune == '\'' || keyRune == '`'
 }

--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -6,26 +6,6 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
-// Cursor mode values.
-const (
-	CursorNormal   int = glfw.CursorNormal
-	CursorHidden   int = glfw.CursorHidden
-	CursorDisabled int = glfw.CursorDisabled
-)
-
-var cursorMap map[desktop.StandardCursor]*glfw.Cursor
-
-// Input modes.
-const (
-	CursorMode             glfw.InputMode = glfw.CursorMode
-	StickyKeysMode         glfw.InputMode = glfw.StickyKeysMode
-	StickyMouseButtonsMode glfw.InputMode = glfw.StickyMouseButtonsMode
-	LockKeyMods            glfw.InputMode = glfw.LockKeyMods
-	RawMouseMotion         glfw.InputMode = glfw.RawMouseMotion
-)
-
-const defaultTitle = "Fyne Application"
-
 var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	// non-printable
 	glfw.KeyEscape:    fyne.KeyEscape,

--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -22,5 +22,5 @@ func unknownKey(key string) bool {
 		return false
 	}
 
-	return keyRune == '\'' || keyRune == '`'
+	return keyRune != '\'' && keyRune != '`'
 }

--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -2,81 +2,10 @@ package glfw
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/driver/desktop"
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
 const defaultTitle = "Fyne Application"
-
-var keyCodeMap = map[glfw.Key]fyne.KeyName{
-	// non-printable
-	glfw.KeyEscape:    fyne.KeyEscape,
-	glfw.KeyEnter:     fyne.KeyReturn,
-	glfw.KeyTab:       fyne.KeyTab,
-	glfw.KeyBackspace: fyne.KeyBackspace,
-	glfw.KeyInsert:    fyne.KeyInsert,
-	glfw.KeyDelete:    fyne.KeyDelete,
-	glfw.KeyRight:     fyne.KeyRight,
-	glfw.KeyLeft:      fyne.KeyLeft,
-	glfw.KeyDown:      fyne.KeyDown,
-	glfw.KeyUp:        fyne.KeyUp,
-	glfw.KeyPageUp:    fyne.KeyPageUp,
-	glfw.KeyPageDown:  fyne.KeyPageDown,
-	glfw.KeyHome:      fyne.KeyHome,
-	glfw.KeyEnd:       fyne.KeyEnd,
-
-	glfw.KeySpace:   fyne.KeySpace,
-	glfw.KeyKPEnter: fyne.KeyEnter,
-
-	// functions
-	glfw.KeyF1:  fyne.KeyF1,
-	glfw.KeyF2:  fyne.KeyF2,
-	glfw.KeyF3:  fyne.KeyF3,
-	glfw.KeyF4:  fyne.KeyF4,
-	glfw.KeyF5:  fyne.KeyF5,
-	glfw.KeyF6:  fyne.KeyF6,
-	glfw.KeyF7:  fyne.KeyF7,
-	glfw.KeyF8:  fyne.KeyF8,
-	glfw.KeyF9:  fyne.KeyF9,
-	glfw.KeyF10: fyne.KeyF10,
-	glfw.KeyF11: fyne.KeyF11,
-	glfw.KeyF12: fyne.KeyF12,
-
-	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	glfw.Key0:   fyne.Key0,
-	glfw.KeyKP0: fyne.Key0,
-	glfw.Key1:   fyne.Key1,
-	glfw.KeyKP1: fyne.Key1,
-	glfw.Key2:   fyne.Key2,
-	glfw.KeyKP2: fyne.Key2,
-	glfw.Key3:   fyne.Key3,
-	glfw.KeyKP3: fyne.Key3,
-	glfw.Key4:   fyne.Key4,
-	glfw.KeyKP4: fyne.Key4,
-	glfw.Key5:   fyne.Key5,
-	glfw.KeyKP5: fyne.Key5,
-	glfw.Key6:   fyne.Key6,
-	glfw.KeyKP6: fyne.Key6,
-	glfw.Key7:   fyne.Key7,
-	glfw.KeyKP7: fyne.Key7,
-	glfw.Key8:   fyne.Key8,
-	glfw.KeyKP8: fyne.Key8,
-	glfw.Key9:   fyne.Key9,
-	glfw.KeyKP9: fyne.Key9,
-
-	// desktop
-	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
-	glfw.KeyRightShift:   desktop.KeyShiftRight,
-	glfw.KeyLeftControl:  desktop.KeyControlLeft,
-	glfw.KeyRightControl: desktop.KeyControlRight,
-	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
-	glfw.KeyRightAlt:     desktop.KeyAltRight,
-	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
-	glfw.KeyRightSuper:   desktop.KeySuperRight,
-	glfw.KeyMenu:         desktop.KeyMenu,
-	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
-	glfw.KeyCapsLock:     desktop.KeyCapsLock,
-}
 
 func unknownKey(key string) bool {
 	if len(key) != 1 {

--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
+const defaultTitle = "Fyne Application"
+
 var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	// non-printable
 	glfw.KeyEscape:    fyne.KeyEscape,

--- a/internal/driver/glfw/window_common.go
+++ b/internal/driver/glfw/window_common.go
@@ -1,0 +1,119 @@
+package glfw
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/driver/desktop"
+	"github.com/go-gl/glfw/v3.3/glfw"
+)
+
+var keyCodeMap = map[glfw.Key]fyne.KeyName{
+	// non-printable
+	glfw.KeyEscape:    fyne.KeyEscape,
+	glfw.KeyEnter:     fyne.KeyReturn,
+	glfw.KeyTab:       fyne.KeyTab,
+	glfw.KeyBackspace: fyne.KeyBackspace,
+	glfw.KeyInsert:    fyne.KeyInsert,
+	glfw.KeyDelete:    fyne.KeyDelete,
+	glfw.KeyRight:     fyne.KeyRight,
+	glfw.KeyLeft:      fyne.KeyLeft,
+	glfw.KeyDown:      fyne.KeyDown,
+	glfw.KeyUp:        fyne.KeyUp,
+	glfw.KeyPageUp:    fyne.KeyPageUp,
+	glfw.KeyPageDown:  fyne.KeyPageDown,
+	glfw.KeyHome:      fyne.KeyHome,
+	glfw.KeyEnd:       fyne.KeyEnd,
+
+	glfw.KeySpace:   fyne.KeySpace,
+	glfw.KeyKPEnter: fyne.KeyEnter,
+
+	// functions
+	glfw.KeyF1:  fyne.KeyF1,
+	glfw.KeyF2:  fyne.KeyF2,
+	glfw.KeyF3:  fyne.KeyF3,
+	glfw.KeyF4:  fyne.KeyF4,
+	glfw.KeyF5:  fyne.KeyF5,
+	glfw.KeyF6:  fyne.KeyF6,
+	glfw.KeyF7:  fyne.KeyF7,
+	glfw.KeyF8:  fyne.KeyF8,
+	glfw.KeyF9:  fyne.KeyF9,
+	glfw.KeyF10: fyne.KeyF10,
+	glfw.KeyF11: fyne.KeyF11,
+	glfw.KeyF12: fyne.KeyF12,
+
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	glfw.Key0:   fyne.Key0,
+	glfw.KeyKP0: fyne.Key0,
+	glfw.Key1:   fyne.Key1,
+	glfw.KeyKP1: fyne.Key1,
+	glfw.Key2:   fyne.Key2,
+	glfw.KeyKP2: fyne.Key2,
+	glfw.Key3:   fyne.Key3,
+	glfw.KeyKP3: fyne.Key3,
+	glfw.Key4:   fyne.Key4,
+	glfw.KeyKP4: fyne.Key4,
+	glfw.Key5:   fyne.Key5,
+	glfw.KeyKP5: fyne.Key5,
+	glfw.Key6:   fyne.Key6,
+	glfw.KeyKP6: fyne.Key6,
+	glfw.Key7:   fyne.Key7,
+	glfw.KeyKP7: fyne.Key7,
+	glfw.Key8:   fyne.Key8,
+	glfw.KeyKP8: fyne.Key8,
+	glfw.Key9:   fyne.Key9,
+	glfw.KeyKP9: fyne.Key9,
+
+	// desktop
+	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
+	glfw.KeyRightShift:   desktop.KeyShiftRight,
+	glfw.KeyLeftControl:  desktop.KeyControlLeft,
+	glfw.KeyRightControl: desktop.KeyControlRight,
+	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
+	glfw.KeyRightAlt:     desktop.KeyAltRight,
+	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
+	glfw.KeyRightSuper:   desktop.KeySuperRight,
+	glfw.KeyMenu:         desktop.KeyMenu,
+	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
+	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+}
+
+func unknownKey(key string) bool {
+	if len(key) != 1 {
+		return true
+	}
+
+	keyRune := key[0]
+	if keyRune >= 'a' || keyRune <= 'z' {
+		return false
+	}
+
+	_, ok := keyKnownRuneMap[keyRune]
+	return !ok
+}
+
+// keyKnownRuneMap does not contain 'a' to 'z'. They are handled outside.
+var keyKnownRuneMap = map[byte]struct{}{
+	'\'': {},
+	',':  {},
+	'-':  {},
+	'.':  {},
+	'/':  {},
+	'*':  {},
+	'`':  {},
+
+	';': {},
+	'+': {},
+	'=': {},
+
+	'[':  {},
+	'\\': {},
+	']':  {},
+}
+
+func convertASCII(key glfw.Key) fyne.KeyName {
+	keyRune := rune('A' + key - glfw.KeyA)
+	if keyRune < 'A' || keyRune > 'Z' {
+		return fyne.KeyUnknown
+	}
+
+	return fyne.KeyName(keyRune)
+}

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -22,6 +22,26 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
+// Input modes.
+const (
+	CursorMode             glfw.InputMode = glfw.CursorMode
+	StickyKeysMode         glfw.InputMode = glfw.StickyKeysMode
+	StickyMouseButtonsMode glfw.InputMode = glfw.StickyMouseButtonsMode
+	LockKeyMods            glfw.InputMode = glfw.LockKeyMods
+	RawMouseMotion         glfw.InputMode = glfw.RawMouseMotion
+)
+
+// Cursor mode values.
+const (
+	CursorNormal   int = glfw.CursorNormal
+	CursorHidden   int = glfw.CursorHidden
+	CursorDisabled int = glfw.CursorDisabled
+)
+
+const defaultTitle = "Fyne Application"
+
+var cursorMap map[desktop.StandardCursor]*glfw.Cursor
+
 func initCursors() {
 	cursorMap = map[desktop.StandardCursor]*glfw.Cursor{
 		desktop.DefaultCursor:   glfw.CreateStandardCursor(glfw.ArrowCursor),

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -38,8 +38,6 @@ const (
 	CursorDisabled int = glfw.CursorDisabled
 )
 
-const defaultTitle = "Fyne Application"
-
 var cursorMap map[desktop.StandardCursor]*glfw.Cursor
 
 func initCursors() {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -388,121 +388,6 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-var keyCodeMap = map[glfw.Key]fyne.KeyName{
-	// non-printable
-	glfw.KeyEscape:    fyne.KeyEscape,
-	glfw.KeyEnter:     fyne.KeyReturn,
-	glfw.KeyTab:       fyne.KeyTab,
-	glfw.KeyBackspace: fyne.KeyBackspace,
-	glfw.KeyInsert:    fyne.KeyInsert,
-	glfw.KeyDelete:    fyne.KeyDelete,
-	glfw.KeyRight:     fyne.KeyRight,
-	glfw.KeyLeft:      fyne.KeyLeft,
-	glfw.KeyDown:      fyne.KeyDown,
-	glfw.KeyUp:        fyne.KeyUp,
-	glfw.KeyPageUp:    fyne.KeyPageUp,
-	glfw.KeyPageDown:  fyne.KeyPageDown,
-	glfw.KeyHome:      fyne.KeyHome,
-	glfw.KeyEnd:       fyne.KeyEnd,
-
-	glfw.KeySpace:   fyne.KeySpace,
-	glfw.KeyKPEnter: fyne.KeyEnter,
-
-	// functions
-	glfw.KeyF1:  fyne.KeyF1,
-	glfw.KeyF2:  fyne.KeyF2,
-	glfw.KeyF3:  fyne.KeyF3,
-	glfw.KeyF4:  fyne.KeyF4,
-	glfw.KeyF5:  fyne.KeyF5,
-	glfw.KeyF6:  fyne.KeyF6,
-	glfw.KeyF7:  fyne.KeyF7,
-	glfw.KeyF8:  fyne.KeyF8,
-	glfw.KeyF9:  fyne.KeyF9,
-	glfw.KeyF10: fyne.KeyF10,
-	glfw.KeyF11: fyne.KeyF11,
-	glfw.KeyF12: fyne.KeyF12,
-
-	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	glfw.Key0:   fyne.Key0,
-	glfw.KeyKP0: fyne.Key0,
-	glfw.Key1:   fyne.Key1,
-	glfw.KeyKP1: fyne.Key1,
-	glfw.Key2:   fyne.Key2,
-	glfw.KeyKP2: fyne.Key2,
-	glfw.Key3:   fyne.Key3,
-	glfw.KeyKP3: fyne.Key3,
-	glfw.Key4:   fyne.Key4,
-	glfw.KeyKP4: fyne.Key4,
-	glfw.Key5:   fyne.Key5,
-	glfw.KeyKP5: fyne.Key5,
-	glfw.Key6:   fyne.Key6,
-	glfw.KeyKP6: fyne.Key6,
-	glfw.Key7:   fyne.Key7,
-	glfw.KeyKP7: fyne.Key7,
-	glfw.Key8:   fyne.Key8,
-	glfw.KeyKP8: fyne.Key8,
-	glfw.Key9:   fyne.Key9,
-	glfw.KeyKP9: fyne.Key9,
-
-	// desktop
-	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
-	glfw.KeyRightShift:   desktop.KeyShiftRight,
-	glfw.KeyLeftControl:  desktop.KeyControlLeft,
-	glfw.KeyRightControl: desktop.KeyControlRight,
-	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
-	glfw.KeyRightAlt:     desktop.KeyAltRight,
-	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
-	glfw.KeyRightSuper:   desktop.KeySuperRight,
-	glfw.KeyMenu:         desktop.KeyMenu,
-	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
-	glfw.KeyCapsLock:     desktop.KeyCapsLock,
-}
-
-var keyNameMap = map[string]fyne.KeyName{
-	"'": fyne.KeyApostrophe,
-	",": fyne.KeyComma,
-	"-": fyne.KeyMinus,
-	".": fyne.KeyPeriod,
-	"/": fyne.KeySlash,
-	"*": fyne.KeyAsterisk,
-	"`": fyne.KeyBackTick,
-
-	";": fyne.KeySemicolon,
-	"+": fyne.KeyPlus,
-	"=": fyne.KeyEqual,
-
-	"a": fyne.KeyA,
-	"b": fyne.KeyB,
-	"c": fyne.KeyC,
-	"d": fyne.KeyD,
-	"e": fyne.KeyE,
-	"f": fyne.KeyF,
-	"g": fyne.KeyG,
-	"h": fyne.KeyH,
-	"i": fyne.KeyI,
-	"j": fyne.KeyJ,
-	"k": fyne.KeyK,
-	"l": fyne.KeyL,
-	"m": fyne.KeyM,
-	"n": fyne.KeyN,
-	"o": fyne.KeyO,
-	"p": fyne.KeyP,
-	"q": fyne.KeyQ,
-	"r": fyne.KeyR,
-	"s": fyne.KeyS,
-	"t": fyne.KeyT,
-	"u": fyne.KeyU,
-	"v": fyne.KeyV,
-	"w": fyne.KeyW,
-	"x": fyne.KeyX,
-	"y": fyne.KeyY,
-	"z": fyne.KeyZ,
-
-	"[":  fyne.KeyLeftBracket,
-	"\\": fyne.KeyBackslash,
-	"]":  fyne.KeyRightBracket,
-}
-
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	if runtime.GOOS == "darwin" && scancode == 0x69 { // TODO remove once fixed upstream glfw/glfw#1786
 		code = glfw.KeyPrintScreen
@@ -514,8 +399,7 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	}
 
 	keyName := glfw.GetKeyName(code, scancode)
-	ret, ok = keyNameMap[keyName]
-	if !ok {
+	if unknownKey(keyName) {
 		return fyne.KeyUnknown
 	}
 
@@ -532,15 +416,6 @@ func convertAction(action glfw.Action) action {
 		return repeat
 	}
 	panic("Could not convert glfw.Action.")
-}
-
-func convertASCII(key glfw.Key) fyne.KeyName {
-	keyRune := rune('A' + key - glfw.KeyA)
-	if keyRune < 'A' || keyRune > 'Z' {
-		return fyne.KeyUnknown
-	}
-
-	return fyne.KeyName(keyRune)
 }
 
 func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -486,6 +486,15 @@ func convertAction(action glfw.Action) action {
 	panic("Could not convert glfw.Action.")
 }
 
+func convertASCII(key glfw.Key) fyne.KeyName {
+	keyRune := rune('A' + key - glfw.KeyA)
+	if keyRune < 'A' || keyRune > 'Z' {
+		return fyne.KeyUnknown
+	}
+
+	return fyne.KeyName(keyRune)
+}
+
 func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 	keyName := keyToName(key, scancode)
 	keyDesktopModifier := desktopModifier(mods)

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -386,7 +386,7 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-//gocyclo:ignore We need to map glfw keys to fyne keys.
+//gocyclo:ignore
 func glfwToFyneKey(key glfw.Key) fyne.KeyName {
 	switch key {
 	case glfw.KeyEscape:

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -38,10 +38,9 @@ const (
 	CursorDisabled int = glfw.CursorDisabled
 )
 
-var (
-	cursorMap    map[desktop.StandardCursor]*glfw.Cursor
-	defaultTitle = "Fyne Application"
-)
+const defaultTitle = "Fyne Application"
+
+var cursorMap map[desktop.StandardCursor]*glfw.Cursor
 
 func initCursors() {
 	cursorMap = map[desktop.StandardCursor]*glfw.Cursor{
@@ -158,8 +157,8 @@ func (w *window) doCenterOnScreen() {
 	monX, monY := monitor.GetPos()
 
 	// math them to the middle
-	newX := (monMode.Width / 2) - (viewWidth / 2) + monX
-	newY := (monMode.Height / 2) - (viewHeight / 2) + monY
+	newX := (monMode.Width-viewWidth)/2 + monX
+	newY := (monMode.Height-viewHeight)/2 + monY
 
 	// set new window coordinates
 	w.viewport.SetPos(newX, newY)

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -386,74 +386,116 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-var keyCodeMap = map[glfw.Key]fyne.KeyName{
-	// non-printable
-	glfw.KeyEscape:    fyne.KeyEscape,
-	glfw.KeyEnter:     fyne.KeyReturn,
-	glfw.KeyTab:       fyne.KeyTab,
-	glfw.KeyBackspace: fyne.KeyBackspace,
-	glfw.KeyInsert:    fyne.KeyInsert,
-	glfw.KeyDelete:    fyne.KeyDelete,
-	glfw.KeyRight:     fyne.KeyRight,
-	glfw.KeyLeft:      fyne.KeyLeft,
-	glfw.KeyDown:      fyne.KeyDown,
-	glfw.KeyUp:        fyne.KeyUp,
-	glfw.KeyPageUp:    fyne.KeyPageUp,
-	glfw.KeyPageDown:  fyne.KeyPageDown,
-	glfw.KeyHome:      fyne.KeyHome,
-	glfw.KeyEnd:       fyne.KeyEnd,
-
-	glfw.KeySpace:   fyne.KeySpace,
-	glfw.KeyKPEnter: fyne.KeyEnter,
+func glfwToFyneKey(key glfw.Key) fyne.KeyName {
+	switch key {
+	case glfw.KeyEscape:
+		return fyne.KeyEscape
+	case glfw.KeyEnter:
+		return fyne.KeyReturn
+	case glfw.KeyTab:
+		return fyne.KeyTab
+	case glfw.KeyBackspace:
+		return fyne.KeyBackspace
+	case glfw.KeyInsert:
+		return fyne.KeyInsert
+	case glfw.KeyDelete:
+		return fyne.KeyDelete
+	case glfw.KeyRight:
+		return fyne.KeyRight
+	case glfw.KeyLeft:
+		return fyne.KeyLeft
+	case glfw.KeyDown:
+		return fyne.KeyDown
+	case glfw.KeyUp:
+		return fyne.KeyUp
+	case glfw.KeyPageUp:
+		return fyne.KeyPageUp
+	case glfw.KeyPageDown:
+		return fyne.KeyPageDown
+	case glfw.KeyHome:
+		return fyne.KeyHome
+	case glfw.KeyEnd:
+		return fyne.KeyEnd
+	case glfw.KeySpace:
+		return fyne.KeySpace
+	case glfw.KeyKPEnter:
+		return fyne.KeyEnter
 
 	// functions
-	glfw.KeyF1:  fyne.KeyF1,
-	glfw.KeyF2:  fyne.KeyF2,
-	glfw.KeyF3:  fyne.KeyF3,
-	glfw.KeyF4:  fyne.KeyF4,
-	glfw.KeyF5:  fyne.KeyF5,
-	glfw.KeyF6:  fyne.KeyF6,
-	glfw.KeyF7:  fyne.KeyF7,
-	glfw.KeyF8:  fyne.KeyF8,
-	glfw.KeyF9:  fyne.KeyF9,
-	glfw.KeyF10: fyne.KeyF10,
-	glfw.KeyF11: fyne.KeyF11,
-	glfw.KeyF12: fyne.KeyF12,
+	case glfw.KeyF1:
+		return fyne.KeyF1
+	case glfw.KeyF2:
+		return fyne.KeyF2
+	case glfw.KeyF3:
+		return fyne.KeyF3
+	case glfw.KeyF4:
+		return fyne.KeyF4
+	case glfw.KeyF5:
+		return fyne.KeyF5
+	case glfw.KeyF6:
+		return fyne.KeyF6
+	case glfw.KeyF7:
+		return fyne.KeyF7
+	case glfw.KeyF8:
+		return fyne.KeyF8
+	case glfw.KeyF9:
+		return fyne.KeyF9
+	case glfw.KeyF10:
+		return fyne.KeyF10
+	case glfw.KeyF11:
+		return fyne.KeyF11
+	case glfw.KeyF12:
+		return fyne.KeyF12
 
 	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	glfw.Key0:   fyne.Key0,
-	glfw.KeyKP0: fyne.Key0,
-	glfw.Key1:   fyne.Key1,
-	glfw.KeyKP1: fyne.Key1,
-	glfw.Key2:   fyne.Key2,
-	glfw.KeyKP2: fyne.Key2,
-	glfw.Key3:   fyne.Key3,
-	glfw.KeyKP3: fyne.Key3,
-	glfw.Key4:   fyne.Key4,
-	glfw.KeyKP4: fyne.Key4,
-	glfw.Key5:   fyne.Key5,
-	glfw.KeyKP5: fyne.Key5,
-	glfw.Key6:   fyne.Key6,
-	glfw.KeyKP6: fyne.Key6,
-	glfw.Key7:   fyne.Key7,
-	glfw.KeyKP7: fyne.Key7,
-	glfw.Key8:   fyne.Key8,
-	glfw.KeyKP8: fyne.Key8,
-	glfw.Key9:   fyne.Key9,
-	glfw.KeyKP9: fyne.Key9,
+	case glfw.Key0, glfw.KeyKP0:
+		return fyne.Key0
+	case glfw.Key1, glfw.KeyKP1:
+		return fyne.Key1
+	case glfw.Key2, glfw.KeyKP2:
+		return fyne.Key2
+	case glfw.Key3, glfw.KeyKP3:
+		return fyne.Key4
+	case glfw.Key4, glfw.KeyKP4:
+		return fyne.Key4
+	case glfw.Key5, glfw.KeyKP5:
+		return fyne.Key5
+		return fyne.Key5
+	case glfw.Key6, glfw.KeyKP6:
+		return fyne.Key6
+	case glfw.Key7, glfw.KeyKP7:
+		return fyne.Key7
+	case glfw.Key8, glfw.KeyKP8:
+		return fyne.Key8
+	case glfw.Key9, glfw.KeyKP9:
+		return fyne.Key9
 
-	// desktop
-	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
-	glfw.KeyRightShift:   desktop.KeyShiftRight,
-	glfw.KeyLeftControl:  desktop.KeyControlLeft,
-	glfw.KeyRightControl: desktop.KeyControlRight,
-	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
-	glfw.KeyRightAlt:     desktop.KeyAltRight,
-	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
-	glfw.KeyRightSuper:   desktop.KeySuperRight,
-	glfw.KeyMenu:         desktop.KeyMenu,
-	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
-	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+	// return desktop keys
+	case glfw.KeyLeftShift:
+		return desktop.KeyShiftLeft
+	case glfw.KeyRightShift:
+		return desktop.KeyShiftRight
+	case glfw.KeyLeftControl:
+		return desktop.KeyControlLeft
+	case glfw.KeyRightControl:
+		return desktop.KeyControlRight
+	case glfw.KeyLeftAlt:
+		return desktop.KeyAltLeft
+	case glfw.KeyRightAlt:
+		return desktop.KeyAltRight
+	case glfw.KeyLeftSuper:
+		return desktop.KeySuperLeft
+	case glfw.KeyRightSuper:
+		return desktop.KeySuperRight
+	case glfw.KeyMenu:
+		return desktop.KeyMenu
+	case glfw.KeyPrintScreen:
+		return desktop.KeyPrintScreen
+	case glfw.KeyCapsLock:
+		return desktop.KeyCapsLock
+	default:
+		return fyne.KeyUnknown
+	}
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
@@ -461,9 +503,9 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 		code = glfw.KeyPrintScreen
 	}
 
-	ret, ok := keyCodeMap[code]
-	if ok {
-		return ret
+	key := glfwToFyneKey(code)
+	if key != fyne.KeyUnknown {
+		return key
 	}
 
 	keyName := glfw.GetKeyName(code, scancode)
@@ -471,7 +513,8 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 		return fyne.KeyUnknown
 	}
 
-	return ret
+	// The key is known and we can safely convert to fyne.KeyName (same string values).
+	return fyne.KeyName(keyName)
 }
 
 func convertAction(action glfw.Action) action {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -386,6 +386,76 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
+var keyCodeMap = map[glfw.Key]fyne.KeyName{
+	// non-printable
+	glfw.KeyEscape:    fyne.KeyEscape,
+	glfw.KeyEnter:     fyne.KeyReturn,
+	glfw.KeyTab:       fyne.KeyTab,
+	glfw.KeyBackspace: fyne.KeyBackspace,
+	glfw.KeyInsert:    fyne.KeyInsert,
+	glfw.KeyDelete:    fyne.KeyDelete,
+	glfw.KeyRight:     fyne.KeyRight,
+	glfw.KeyLeft:      fyne.KeyLeft,
+	glfw.KeyDown:      fyne.KeyDown,
+	glfw.KeyUp:        fyne.KeyUp,
+	glfw.KeyPageUp:    fyne.KeyPageUp,
+	glfw.KeyPageDown:  fyne.KeyPageDown,
+	glfw.KeyHome:      fyne.KeyHome,
+	glfw.KeyEnd:       fyne.KeyEnd,
+
+	glfw.KeySpace:   fyne.KeySpace,
+	glfw.KeyKPEnter: fyne.KeyEnter,
+
+	// functions
+	glfw.KeyF1:  fyne.KeyF1,
+	glfw.KeyF2:  fyne.KeyF2,
+	glfw.KeyF3:  fyne.KeyF3,
+	glfw.KeyF4:  fyne.KeyF4,
+	glfw.KeyF5:  fyne.KeyF5,
+	glfw.KeyF6:  fyne.KeyF6,
+	glfw.KeyF7:  fyne.KeyF7,
+	glfw.KeyF8:  fyne.KeyF8,
+	glfw.KeyF9:  fyne.KeyF9,
+	glfw.KeyF10: fyne.KeyF10,
+	glfw.KeyF11: fyne.KeyF11,
+	glfw.KeyF12: fyne.KeyF12,
+
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	glfw.Key0:   fyne.Key0,
+	glfw.KeyKP0: fyne.Key0,
+	glfw.Key1:   fyne.Key1,
+	glfw.KeyKP1: fyne.Key1,
+	glfw.Key2:   fyne.Key2,
+	glfw.KeyKP2: fyne.Key2,
+	glfw.Key3:   fyne.Key3,
+	glfw.KeyKP3: fyne.Key3,
+	glfw.Key4:   fyne.Key4,
+	glfw.KeyKP4: fyne.Key4,
+	glfw.Key5:   fyne.Key5,
+	glfw.KeyKP5: fyne.Key5,
+	glfw.Key6:   fyne.Key6,
+	glfw.KeyKP6: fyne.Key6,
+	glfw.Key7:   fyne.Key7,
+	glfw.KeyKP7: fyne.Key7,
+	glfw.Key8:   fyne.Key8,
+	glfw.KeyKP8: fyne.Key8,
+	glfw.Key9:   fyne.Key9,
+	glfw.KeyKP9: fyne.Key9,
+
+	// desktop
+	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
+	glfw.KeyRightShift:   desktop.KeyShiftRight,
+	glfw.KeyLeftControl:  desktop.KeyControlLeft,
+	glfw.KeyRightControl: desktop.KeyControlRight,
+	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
+	glfw.KeyRightAlt:     desktop.KeyAltRight,
+	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
+	glfw.KeyRightSuper:   desktop.KeySuperRight,
+	glfw.KeyMenu:         desktop.KeyMenu,
+	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
+	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+}
+
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	if runtime.GOOS == "darwin" && scancode == 0x69 { // TODO remove once fixed upstream glfw/glfw#1786
 		code = glfw.KeyPrintScreen

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -22,26 +22,6 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
-// Input modes.
-const (
-	CursorMode             glfw.InputMode = glfw.CursorMode
-	StickyKeysMode         glfw.InputMode = glfw.StickyKeysMode
-	StickyMouseButtonsMode glfw.InputMode = glfw.StickyMouseButtonsMode
-	LockKeyMods            glfw.InputMode = glfw.LockKeyMods
-	RawMouseMotion         glfw.InputMode = glfw.RawMouseMotion
-)
-
-// Cursor mode values.
-const (
-	CursorNormal   int = glfw.CursorNormal
-	CursorHidden   int = glfw.CursorHidden
-	CursorDisabled int = glfw.CursorDisabled
-)
-
-const defaultTitle = "Fyne Application"
-
-var cursorMap map[desktop.StandardCursor]*glfw.Cursor
-
 func initCursors() {
 	cursorMap = map[desktop.StandardCursor]*glfw.Cursor{
 		desktop.DefaultCursor:   glfw.CreateStandardCursor(glfw.ArrowCursor),

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -460,7 +460,6 @@ func glfwToFyneKey(key glfw.Key) fyne.KeyName {
 		return fyne.Key4
 	case glfw.Key5, glfw.KeyKP5:
 		return fyne.Key5
-		return fyne.Key5
 	case glfw.Key6, glfw.KeyKP6:
 		return fyne.Key6
 	case glfw.Key7, glfw.KeyKP7:

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -458,35 +458,6 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyCapsLock:     desktop.KeyCapsLock,
 }
 
-var keyCodeMapASCII = map[glfw.Key]fyne.KeyName{
-	glfw.KeyA: fyne.KeyA,
-	glfw.KeyB: fyne.KeyB,
-	glfw.KeyC: fyne.KeyC,
-	glfw.KeyD: fyne.KeyD,
-	glfw.KeyE: fyne.KeyE,
-	glfw.KeyF: fyne.KeyF,
-	glfw.KeyG: fyne.KeyG,
-	glfw.KeyH: fyne.KeyH,
-	glfw.KeyI: fyne.KeyI,
-	glfw.KeyJ: fyne.KeyJ,
-	glfw.KeyK: fyne.KeyK,
-	glfw.KeyL: fyne.KeyL,
-	glfw.KeyM: fyne.KeyM,
-	glfw.KeyN: fyne.KeyN,
-	glfw.KeyO: fyne.KeyO,
-	glfw.KeyP: fyne.KeyP,
-	glfw.KeyQ: fyne.KeyQ,
-	glfw.KeyR: fyne.KeyR,
-	glfw.KeyS: fyne.KeyS,
-	glfw.KeyT: fyne.KeyT,
-	glfw.KeyU: fyne.KeyU,
-	glfw.KeyV: fyne.KeyV,
-	glfw.KeyW: fyne.KeyW,
-	glfw.KeyX: fyne.KeyX,
-	glfw.KeyY: fyne.KeyY,
-	glfw.KeyZ: fyne.KeyZ,
-}
-
 var keyNameMap = map[string]fyne.KeyName{
 	"'": fyne.KeyApostrophe,
 	",": fyne.KeyComma,
@@ -564,11 +535,12 @@ func convertAction(action glfw.Action) action {
 }
 
 func convertASCII(key glfw.Key) fyne.KeyName {
-	ret, ok := keyCodeMapASCII[key]
-	if !ok {
+	keyRune := rune('A' + key - glfw.KeyA)
+	if keyRune < 'A' || keyRune > 'Z' {
 		return fyne.KeyUnknown
 	}
-	return ret
+
+	return fyne.KeyName(keyRune)
 }
 
 func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -386,6 +386,7 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
+//gocyclo:ignore We need to map glfw keys to fyne keys.
 func glfwToFyneKey(key glfw.Key) fyne.KeyName {
 	switch key {
 	case glfw.KeyEscape:

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -230,74 +230,116 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-var keyCodeMap = map[glfw.Key]fyne.KeyName{
-	// non-printable
-	glfw.KeyEscape:    fyne.KeyEscape,
-	glfw.KeyEnter:     fyne.KeyReturn,
-	glfw.KeyTab:       fyne.KeyTab,
-	glfw.KeyBackspace: fyne.KeyBackspace,
-	glfw.KeyInsert:    fyne.KeyInsert,
-	glfw.KeyDelete:    fyne.KeyDelete,
-	glfw.KeyRight:     fyne.KeyRight,
-	glfw.KeyLeft:      fyne.KeyLeft,
-	glfw.KeyDown:      fyne.KeyDown,
-	glfw.KeyUp:        fyne.KeyUp,
-	glfw.KeyPageUp:    fyne.KeyPageUp,
-	glfw.KeyPageDown:  fyne.KeyPageDown,
-	glfw.KeyHome:      fyne.KeyHome,
-	glfw.KeyEnd:       fyne.KeyEnd,
-
-	glfw.KeySpace:   fyne.KeySpace,
-	glfw.KeyKPEnter: fyne.KeyEnter,
+func glfwToFyneKey(key glfw.Key) fyne.KeyName {
+	switch key {
+	case glfw.KeyEscape:
+		return fyne.KeyEscape
+	case glfw.KeyEnter:
+		return fyne.KeyReturn
+	case glfw.KeyTab:
+		return fyne.KeyTab
+	case glfw.KeyBackspace:
+		return fyne.KeyBackspace
+	case glfw.KeyInsert:
+		return fyne.KeyInsert
+	case glfw.KeyDelete:
+		return fyne.KeyDelete
+	case glfw.KeyRight:
+		return fyne.KeyRight
+	case glfw.KeyLeft:
+		return fyne.KeyLeft
+	case glfw.KeyDown:
+		return fyne.KeyDown
+	case glfw.KeyUp:
+		return fyne.KeyUp
+	case glfw.KeyPageUp:
+		return fyne.KeyPageUp
+	case glfw.KeyPageDown:
+		return fyne.KeyPageDown
+	case glfw.KeyHome:
+		return fyne.KeyHome
+	case glfw.KeyEnd:
+		return fyne.KeyEnd
+	case glfw.KeySpace:
+		return fyne.KeySpace
+	case glfw.KeyKPEnter:
+		return fyne.KeyEnter
 
 	// functions
-	glfw.KeyF1:  fyne.KeyF1,
-	glfw.KeyF2:  fyne.KeyF2,
-	glfw.KeyF3:  fyne.KeyF3,
-	glfw.KeyF4:  fyne.KeyF4,
-	glfw.KeyF5:  fyne.KeyF5,
-	glfw.KeyF6:  fyne.KeyF6,
-	glfw.KeyF7:  fyne.KeyF7,
-	glfw.KeyF8:  fyne.KeyF8,
-	glfw.KeyF9:  fyne.KeyF9,
-	glfw.KeyF10: fyne.KeyF10,
-	glfw.KeyF11: fyne.KeyF11,
-	glfw.KeyF12: fyne.KeyF12,
+	case glfw.KeyF1:
+		return fyne.KeyF1
+	case glfw.KeyF2:
+		return fyne.KeyF2
+	case glfw.KeyF3:
+		return fyne.KeyF3
+	case glfw.KeyF4:
+		return fyne.KeyF4
+	case glfw.KeyF5:
+		return fyne.KeyF5
+	case glfw.KeyF6:
+		return fyne.KeyF6
+	case glfw.KeyF7:
+		return fyne.KeyF7
+	case glfw.KeyF8:
+		return fyne.KeyF8
+	case glfw.KeyF9:
+		return fyne.KeyF9
+	case glfw.KeyF10:
+		return fyne.KeyF10
+	case glfw.KeyF11:
+		return fyne.KeyF11
+	case glfw.KeyF12:
+		return fyne.KeyF12
 
 	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	glfw.Key0:   fyne.Key0,
-	glfw.KeyKP0: fyne.Key0,
-	glfw.Key1:   fyne.Key1,
-	glfw.KeyKP1: fyne.Key1,
-	glfw.Key2:   fyne.Key2,
-	glfw.KeyKP2: fyne.Key2,
-	glfw.Key3:   fyne.Key3,
-	glfw.KeyKP3: fyne.Key3,
-	glfw.Key4:   fyne.Key4,
-	glfw.KeyKP4: fyne.Key4,
-	glfw.Key5:   fyne.Key5,
-	glfw.KeyKP5: fyne.Key5,
-	glfw.Key6:   fyne.Key6,
-	glfw.KeyKP6: fyne.Key6,
-	glfw.Key7:   fyne.Key7,
-	glfw.KeyKP7: fyne.Key7,
-	glfw.Key8:   fyne.Key8,
-	glfw.KeyKP8: fyne.Key8,
-	glfw.Key9:   fyne.Key9,
-	glfw.KeyKP9: fyne.Key9,
+	case glfw.Key0, glfw.KeyKP0:
+		return fyne.Key0
+	case glfw.Key1, glfw.KeyKP1:
+		return fyne.Key1
+	case glfw.Key2, glfw.KeyKP2:
+		return fyne.Key2
+	case glfw.Key3, glfw.KeyKP3:
+		return fyne.Key4
+	case glfw.Key4, glfw.KeyKP4:
+		return fyne.Key4
+	case glfw.Key5, glfw.KeyKP5:
+		return fyne.Key5
+		return fyne.Key5
+	case glfw.Key6, glfw.KeyKP6:
+		return fyne.Key6
+	case glfw.Key7, glfw.KeyKP7:
+		return fyne.Key7
+	case glfw.Key8, glfw.KeyKP8:
+		return fyne.Key8
+	case glfw.Key9, glfw.KeyKP9:
+		return fyne.Key9
 
-	// desktop
-	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
-	glfw.KeyRightShift:   desktop.KeyShiftRight,
-	glfw.KeyLeftControl:  desktop.KeyControlLeft,
-	glfw.KeyRightControl: desktop.KeyControlRight,
-	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
-	glfw.KeyRightAlt:     desktop.KeyAltRight,
-	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
-	glfw.KeyRightSuper:   desktop.KeySuperRight,
-	glfw.KeyMenu:         desktop.KeyMenu,
-	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
-	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+	// return desktop keys
+	case glfw.KeyLeftShift:
+		return desktop.KeyShiftLeft
+	case glfw.KeyRightShift:
+		return desktop.KeyShiftRight
+	case glfw.KeyLeftControl:
+		return desktop.KeyControlLeft
+	case glfw.KeyRightControl:
+		return desktop.KeyControlRight
+	case glfw.KeyLeftAlt:
+		return desktop.KeyAltLeft
+	case glfw.KeyRightAlt:
+		return desktop.KeyAltRight
+	case glfw.KeyLeftSuper:
+		return desktop.KeySuperLeft
+	case glfw.KeyRightSuper:
+		return desktop.KeySuperRight
+	case glfw.KeyMenu:
+		return desktop.KeyMenu
+	case glfw.KeyPrintScreen:
+		return desktop.KeyPrintScreen
+	case glfw.KeyCapsLock:
+		return desktop.KeyCapsLock
+	default:
+		return fyne.KeyUnknown
+	}
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
@@ -305,17 +347,18 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 		code = glfw.KeyPrintScreen
 	}
 
-	ret, ok := keyCodeMap[code]
-	if ok {
-		return ret
+	key := glfwToFyneKey(code)
+	if key != fyne.KeyUnknown {
+		return key
 	}
 
-	//	keyName := glfw.GetKeyName(code, scancode)
+	// keyName := glfw.GetKeyName(code, scancode)
 	// if unknownKey(keyName) {
 	return fyne.KeyUnknown
-	//	}
+	// }
 
-	//	return ret
+	// The key is known and we can safely convert to fyne.KeyName (same string values).
+	// return fyne.KeyName(keyName)
 }
 
 func convertAction(action glfw.Action) action {

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -21,6 +21,26 @@ import (
 type Cursor struct {
 }
 
+// Input modes.
+const (
+	CursorMode             glfw.InputMode = glfw.CursorMode
+	StickyKeysMode         glfw.InputMode = glfw.StickyKeysMode
+	StickyMouseButtonsMode glfw.InputMode = glfw.StickyMouseButtonsMode
+	LockKeyMods            glfw.InputMode = glfw.LockKeyMods
+	RawMouseMotion         glfw.InputMode = glfw.RawMouseMotion
+)
+
+// Cursor mode values.
+const (
+	CursorNormal   int = glfw.CursorNormal
+	CursorHidden   int = glfw.CursorHidden
+	CursorDisabled int = glfw.CursorDisabled
+)
+
+const defaultTitle = "Fyne Application"
+
+var cursorMap map[desktop.Cursor]*Cursor
+
 // Declare conformity to Window interface
 var _ fyne.Window = (*window)(nil)
 

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -230,6 +230,76 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
+var keyCodeMap = map[glfw.Key]fyne.KeyName{
+	// non-printable
+	glfw.KeyEscape:    fyne.KeyEscape,
+	glfw.KeyEnter:     fyne.KeyReturn,
+	glfw.KeyTab:       fyne.KeyTab,
+	glfw.KeyBackspace: fyne.KeyBackspace,
+	glfw.KeyInsert:    fyne.KeyInsert,
+	glfw.KeyDelete:    fyne.KeyDelete,
+	glfw.KeyRight:     fyne.KeyRight,
+	glfw.KeyLeft:      fyne.KeyLeft,
+	glfw.KeyDown:      fyne.KeyDown,
+	glfw.KeyUp:        fyne.KeyUp,
+	glfw.KeyPageUp:    fyne.KeyPageUp,
+	glfw.KeyPageDown:  fyne.KeyPageDown,
+	glfw.KeyHome:      fyne.KeyHome,
+	glfw.KeyEnd:       fyne.KeyEnd,
+
+	glfw.KeySpace:   fyne.KeySpace,
+	glfw.KeyKPEnter: fyne.KeyEnter,
+
+	// functions
+	glfw.KeyF1:  fyne.KeyF1,
+	glfw.KeyF2:  fyne.KeyF2,
+	glfw.KeyF3:  fyne.KeyF3,
+	glfw.KeyF4:  fyne.KeyF4,
+	glfw.KeyF5:  fyne.KeyF5,
+	glfw.KeyF6:  fyne.KeyF6,
+	glfw.KeyF7:  fyne.KeyF7,
+	glfw.KeyF8:  fyne.KeyF8,
+	glfw.KeyF9:  fyne.KeyF9,
+	glfw.KeyF10: fyne.KeyF10,
+	glfw.KeyF11: fyne.KeyF11,
+	glfw.KeyF12: fyne.KeyF12,
+
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	glfw.Key0:   fyne.Key0,
+	glfw.KeyKP0: fyne.Key0,
+	glfw.Key1:   fyne.Key1,
+	glfw.KeyKP1: fyne.Key1,
+	glfw.Key2:   fyne.Key2,
+	glfw.KeyKP2: fyne.Key2,
+	glfw.Key3:   fyne.Key3,
+	glfw.KeyKP3: fyne.Key3,
+	glfw.Key4:   fyne.Key4,
+	glfw.KeyKP4: fyne.Key4,
+	glfw.Key5:   fyne.Key5,
+	glfw.KeyKP5: fyne.Key5,
+	glfw.Key6:   fyne.Key6,
+	glfw.KeyKP6: fyne.Key6,
+	glfw.Key7:   fyne.Key7,
+	glfw.KeyKP7: fyne.Key7,
+	glfw.Key8:   fyne.Key8,
+	glfw.KeyKP8: fyne.Key8,
+	glfw.Key9:   fyne.Key9,
+	glfw.KeyKP9: fyne.Key9,
+
+	// desktop
+	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
+	glfw.KeyRightShift:   desktop.KeyShiftRight,
+	glfw.KeyLeftControl:  desktop.KeyControlLeft,
+	glfw.KeyRightControl: desktop.KeyControlRight,
+	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
+	glfw.KeyRightAlt:     desktop.KeyAltRight,
+	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
+	glfw.KeyRightSuper:   desktop.KeySuperRight,
+	glfw.KeyMenu:         desktop.KeyMenu,
+	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
+	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+}
+
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	if runtime.GOOS == "darwin" && scancode == 0x69 { // TODO remove once fixed upstream glfw/glfw#1786
 		code = glfw.KeyPrintScreen

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -37,10 +37,9 @@ const (
 	CursorDisabled int = glfw.CursorDisabled
 )
 
-var (
-	cursorMap    map[desktop.Cursor]*Cursor
-	defaultTitle = "Fyne Application"
-)
+const defaultTitle = "Fyne Application"
+
+var cursorMap map[desktop.Cursor]*Cursor
 
 // Declare conformity to Window interface
 var _ fyne.Window = (*window)(nil)

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -230,6 +230,7 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
+//gocyclo:ignore We need to map glfw keys to fyne keys.
 func glfwToFyneKey(key glfw.Key) fyne.KeyName {
 	switch key {
 	case glfw.KeyEscape:

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -330,6 +330,15 @@ func convertAction(action glfw.Action) action {
 	panic("Could not convert glfw.Action.")
 }
 
+func convertASCII(key glfw.Key) fyne.KeyName {
+	keyRune := rune('A' + key - glfw.KeyA)
+	if keyRune < 'A' || keyRune > 'Z' {
+		return fyne.KeyUnknown
+	}
+
+	return fyne.KeyName(keyRune)
+}
+
 func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 	keyName := keyToName(key, scancode)
 	keyDesktopModifier := desktopModifier(mods)

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -230,7 +230,7 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-//gocyclo:ignore We need to map glfw keys to fyne keys.
+//gocyclo:ignore
 func glfwToFyneKey(key glfw.Key) fyne.KeyName {
 	switch key {
 	case glfw.KeyEscape:

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -37,8 +37,6 @@ const (
 	CursorDisabled int = glfw.CursorDisabled
 )
 
-const defaultTitle = "Fyne Application"
-
 var cursorMap map[desktop.Cursor]*Cursor
 
 // Declare conformity to Window interface

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -21,26 +21,6 @@ import (
 type Cursor struct {
 }
 
-// Input modes.
-const (
-	CursorMode             glfw.InputMode = glfw.CursorMode
-	StickyKeysMode         glfw.InputMode = glfw.StickyKeysMode
-	StickyMouseButtonsMode glfw.InputMode = glfw.StickyMouseButtonsMode
-	LockKeyMods            glfw.InputMode = glfw.LockKeyMods
-	RawMouseMotion         glfw.InputMode = glfw.RawMouseMotion
-)
-
-// Cursor mode values.
-const (
-	CursorNormal   int = glfw.CursorNormal
-	CursorHidden   int = glfw.CursorHidden
-	CursorDisabled int = glfw.CursorDisabled
-)
-
-const defaultTitle = "Fyne Application"
-
-var cursorMap map[desktop.Cursor]*Cursor
-
 // Declare conformity to Window interface
 var _ fyne.Window = (*window)(nil)
 

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -304,7 +304,6 @@ func glfwToFyneKey(key glfw.Key) fyne.KeyName {
 		return fyne.Key4
 	case glfw.Key5, glfw.KeyKP5:
 		return fyne.Key5
-		return fyne.Key5
 	case glfw.Key6, glfw.KeyKP6:
 		return fyne.Key6
 	case glfw.Key7, glfw.KeyKP7:

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -232,150 +232,6 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-var keyCodeMap = map[glfw.Key]fyne.KeyName{
-	// non-printable
-	glfw.KeyEscape:    fyne.KeyEscape,
-	glfw.KeyEnter:     fyne.KeyReturn,
-	glfw.KeyTab:       fyne.KeyTab,
-	glfw.KeyBackspace: fyne.KeyBackspace,
-	glfw.KeyInsert:    fyne.KeyInsert,
-	glfw.KeyDelete:    fyne.KeyDelete,
-	glfw.KeyRight:     fyne.KeyRight,
-	glfw.KeyLeft:      fyne.KeyLeft,
-	glfw.KeyDown:      fyne.KeyDown,
-	glfw.KeyUp:        fyne.KeyUp,
-	glfw.KeyPageUp:    fyne.KeyPageUp,
-	glfw.KeyPageDown:  fyne.KeyPageDown,
-	glfw.KeyHome:      fyne.KeyHome,
-	glfw.KeyEnd:       fyne.KeyEnd,
-
-	glfw.KeySpace:   fyne.KeySpace,
-	glfw.KeyKPEnter: fyne.KeyEnter,
-
-	// functions
-	glfw.KeyF1:  fyne.KeyF1,
-	glfw.KeyF2:  fyne.KeyF2,
-	glfw.KeyF3:  fyne.KeyF3,
-	glfw.KeyF4:  fyne.KeyF4,
-	glfw.KeyF5:  fyne.KeyF5,
-	glfw.KeyF6:  fyne.KeyF6,
-	glfw.KeyF7:  fyne.KeyF7,
-	glfw.KeyF8:  fyne.KeyF8,
-	glfw.KeyF9:  fyne.KeyF9,
-	glfw.KeyF10: fyne.KeyF10,
-	glfw.KeyF11: fyne.KeyF11,
-	glfw.KeyF12: fyne.KeyF12,
-
-	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	glfw.Key0:   fyne.Key0,
-	glfw.KeyKP0: fyne.Key0,
-	glfw.Key1:   fyne.Key1,
-	glfw.KeyKP1: fyne.Key1,
-	glfw.Key2:   fyne.Key2,
-	glfw.KeyKP2: fyne.Key2,
-	glfw.Key3:   fyne.Key3,
-	glfw.KeyKP3: fyne.Key3,
-	glfw.Key4:   fyne.Key4,
-	glfw.KeyKP4: fyne.Key4,
-	glfw.Key5:   fyne.Key5,
-	glfw.KeyKP5: fyne.Key5,
-	glfw.Key6:   fyne.Key6,
-	glfw.KeyKP6: fyne.Key6,
-	glfw.Key7:   fyne.Key7,
-	glfw.KeyKP7: fyne.Key7,
-	glfw.Key8:   fyne.Key8,
-	glfw.KeyKP8: fyne.Key8,
-	glfw.Key9:   fyne.Key9,
-	glfw.KeyKP9: fyne.Key9,
-
-	// desktop
-	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
-	glfw.KeyRightShift:   desktop.KeyShiftRight,
-	glfw.KeyLeftControl:  desktop.KeyControlLeft,
-	glfw.KeyRightControl: desktop.KeyControlRight,
-	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
-	glfw.KeyRightAlt:     desktop.KeyAltRight,
-	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
-	glfw.KeyRightSuper:   desktop.KeySuperRight,
-	glfw.KeyMenu:         desktop.KeyMenu,
-	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
-	glfw.KeyCapsLock:     desktop.KeyCapsLock,
-}
-
-var keyCodeMapASCII = map[glfw.Key]fyne.KeyName{
-	glfw.KeyA: fyne.KeyA,
-	glfw.KeyB: fyne.KeyB,
-	glfw.KeyC: fyne.KeyC,
-	glfw.KeyD: fyne.KeyD,
-	glfw.KeyE: fyne.KeyE,
-	glfw.KeyF: fyne.KeyF,
-	glfw.KeyG: fyne.KeyG,
-	glfw.KeyH: fyne.KeyH,
-	glfw.KeyI: fyne.KeyI,
-	glfw.KeyJ: fyne.KeyJ,
-	glfw.KeyK: fyne.KeyK,
-	glfw.KeyL: fyne.KeyL,
-	glfw.KeyM: fyne.KeyM,
-	glfw.KeyN: fyne.KeyN,
-	glfw.KeyO: fyne.KeyO,
-	glfw.KeyP: fyne.KeyP,
-	glfw.KeyQ: fyne.KeyQ,
-	glfw.KeyR: fyne.KeyR,
-	glfw.KeyS: fyne.KeyS,
-	glfw.KeyT: fyne.KeyT,
-	glfw.KeyU: fyne.KeyU,
-	glfw.KeyV: fyne.KeyV,
-	glfw.KeyW: fyne.KeyW,
-	glfw.KeyX: fyne.KeyX,
-	glfw.KeyY: fyne.KeyY,
-	glfw.KeyZ: fyne.KeyZ,
-}
-
-var keyNameMap = map[string]fyne.KeyName{
-	"'": fyne.KeyApostrophe,
-	",": fyne.KeyComma,
-	"-": fyne.KeyMinus,
-	".": fyne.KeyPeriod,
-	"/": fyne.KeySlash,
-	"*": fyne.KeyAsterisk,
-	"`": fyne.KeyBackTick,
-
-	";": fyne.KeySemicolon,
-	"+": fyne.KeyPlus,
-	"=": fyne.KeyEqual,
-
-	"a": fyne.KeyA,
-	"b": fyne.KeyB,
-	"c": fyne.KeyC,
-	"d": fyne.KeyD,
-	"e": fyne.KeyE,
-	"f": fyne.KeyF,
-	"g": fyne.KeyG,
-	"h": fyne.KeyH,
-	"i": fyne.KeyI,
-	"j": fyne.KeyJ,
-	"k": fyne.KeyK,
-	"l": fyne.KeyL,
-	"m": fyne.KeyM,
-	"n": fyne.KeyN,
-	"o": fyne.KeyO,
-	"p": fyne.KeyP,
-	"q": fyne.KeyQ,
-	"r": fyne.KeyR,
-	"s": fyne.KeyS,
-	"t": fyne.KeyT,
-	"u": fyne.KeyU,
-	"v": fyne.KeyV,
-	"w": fyne.KeyW,
-	"x": fyne.KeyX,
-	"y": fyne.KeyY,
-	"z": fyne.KeyZ,
-
-	"[":  fyne.KeyLeftBracket,
-	"\\": fyne.KeyBackslash,
-	"]":  fyne.KeyRightBracket,
-}
-
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	if runtime.GOOS == "darwin" && scancode == 0x69 { // TODO remove once fixed upstream glfw/glfw#1786
 		code = glfw.KeyPrintScreen
@@ -387,8 +243,7 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	}
 
 	//	keyName := glfw.GetKeyName(code, scancode)
-	//	ret, ok = keyNameMap[keyName]
-	//	if !ok {
+	// if unknownKey(keyName) {
 	return fyne.KeyUnknown
 	//	}
 
@@ -405,14 +260,6 @@ func convertAction(action glfw.Action) action {
 		return repeat
 	}
 	panic("Could not convert glfw.Action.")
-}
-
-func convertASCII(key glfw.Key) fyne.KeyName {
-	ret, ok := keyCodeMapASCII[key]
-	if !ok {
-		return fyne.KeyUnknown
-	}
-	return ret
 }
 
 func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR cleans up some of the maps that are used in the `internal/driver/glfw/window_*`.go files.
- De-duplicate a some code between desktop and goxjs.
- Remove trivial `keyCodeMapASCII` in favour of a function with simple rune value manipulation.
- Replace  `keyCodeMap` (it was basically just checking mapping "a" to "a" to check if it existed) with a switch statement instead. Benchmark shows about a 3x improvement.
- Use a function for `keyNameMap` instead. Allows for some clever ASCII value mappings in intervals.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.