### PR TITLE
Form should check for Validator on any validatable widget, fixes #3076

### DIFF
--- a/widget/form.go
+++ b/widget/form.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"errors"
+	"reflect"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -148,7 +149,7 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 		if !ok {
 			return item.Widget
 		}
-		if e, ok := item.Widget.(*Entry); ok && e.Validator == nil { // we don't have validation
+		if !f.itemWidgetHasValidator(item.Widget) { // we don't have validation
 			return item.Widget
 		}
 	}
@@ -159,6 +160,19 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 	item.helperOutput = text
 	f.updateHelperText(item)
 	return fyne.NewContainerWithLayout(layout.NewVBoxLayout(), item.Widget, fyne.NewContainerWithoutLayout(text))
+}
+
+func (f *Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
+	value := reflect.ValueOf(w).Elem()
+	validatorField := value.FieldByName("Validator")
+	if validatorField == (reflect.Value{}) {
+		return false
+	}
+	validator, ok := validatorField.Interface().(fyne.StringValidator)
+	if !ok {
+		return false
+	}
+	return validator != nil
 }
 
 func (f *Form) createLabel(text string) *canvas.Text {

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -416,3 +416,20 @@ func TestForm_SetOnValidationChanged(t *testing.T) {
 	assert.False(t, validationError)
 
 }
+
+func TestForm_ExtendedEntry(t *testing.T) {
+	extendedEntry := NewSelectEntry([]string{""})
+
+	test.NewApp()
+	defer test.NewApp()
+
+	form := &Form{
+		Items: []*FormItem{
+			{Text: "Extended entry", Widget: extendedEntry},
+		},
+	}
+	w := test.NewWindow(form)
+	defer w.Close()
+
+	test.AssertRendersToMarkup(t, "form/extended_entry.xml", w.Canvas())
+}

--- a/widget/testdata/form/extended_entry.xml
+++ b/widget/testdata/form/extended_entry.xml
@@ -1,0 +1,30 @@
+<canvas padded size="205x44">
+	<content>
+		<widget pos="4,4" size="197x36" type="*widget.Form">
+			<container size="197x36">
+				<container size="197x36">
+					<text alignment="trailing" bold pos="8,8" size="115x20">Extended entry</text>
+					<widget pos="135,0" size="61x36" type="*widget.SelectEntry">
+						<rectangle fillColor="rgba(102,102,102,255)" pos="0,2" size="61x32"/>
+						<rectangle fillColor="shadow" pos="0,34" size="61x2"/>
+						<widget pos="0,2" size="33x32" type="*widget.Scroll">
+							<widget size="33x32" type="*widget.entryContent">
+								<widget size="33x32" type="*widget.RichText">
+									<text color="placeholder" pos="8,6" size="17x20"></text>
+								</widget>
+								<widget size="33x32" type="*widget.RichText">
+									<text pos="8,6" size="17x20"></text>
+								</widget>
+							</widget>
+						</widget>
+						<widget pos="33,8" size="20x20" type="*widget.Button">
+							<rectangle size="20x20"/>
+							<rectangle size="0x0"/>
+							<image fillMode="contain" rsc="menuDropDownIcon" size="iconInlineSize"/>
+						</widget>
+					</widget>
+				</container>
+			</container>
+		</widget>
+	</content>
+</canvas>


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #3076 

Originally, `Form` widget check for `Entry` widget `Validator` field to know if it is necessary to allocate space for the error text object, unfortunately that means that any widget that is not an `Entry` (that applies for extended ones too) will not be part of that check.

It would be better to edit the `fyne.Validatable` interface and add a method that allow us to retrieve the underlying Validator, so we don't have to use `reflect` package to do so, however that would break the public API. Maybe this can be done on the next major release?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.