### PR TITLE
Call ExtendBaseWidget in form.Refresh method, fixes #3153

### DIFF
--- a/widget/form.go
+++ b/widget/form.go
@@ -89,6 +89,7 @@ func (f *Form) MinSize() fyne.Size {
 
 // Refresh updates the widget state when requested.
 func (f *Form) Refresh() {
+	f.ExtendBaseWidget(f)
 	cache.Renderer(f.super()) // we are about to make changes to renderer created content... not great!
 	f.ensureRenderItems()
 	f.updateButtons()

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -416,3 +416,15 @@ func TestForm_SetOnValidationChanged(t *testing.T) {
 	assert.False(t, validationError)
 
 }
+
+func TestForm_RefreshFromStructInit(t *testing.T) {
+	form := &Form{
+		Items: []*FormItem{
+			{Text: "Entry", Widget: NewEntry()},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		form.Refresh()
+	})
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #3153 

Calling `ExtendBaseWidget` in `form.Refresh` is needed to ensure `f.super()` returns a non-nil widget (when initializing Form through struct fields without calling any method that actually call `ExtendBaseWidget`), otherwise `cache.Renderer` will not be able to create any renderer.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.


