### PR TITLE
Remove prompt so that the copy button copies a valid command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ If you're not sure if that's all installed or you don't know how then check out 
 
 Using the standard go tools you can install Fyne's core library using:
 
-    $ go get fyne.io/fyne/v2
+    go get fyne.io/fyne/v2
 
 # Widget demo
 
 To run a showcase of the features of Fyne execute the following:
 
-    $ go get fyne.io/fyne/v2/cmd/fyne_demo/
-    $ fyne_demo
+    go get fyne.io/fyne/v2/cmd/fyne_demo/
+    fyne_demo
 
 And you should see something like this (after you click a few buttons):
 
@@ -90,7 +90,7 @@ func main() {
 
 And you can run that simply as:
 
-    $ go run main.go
+    go run main.go
 
 It should look like this:
 
@@ -111,7 +111,7 @@ It should look like this:
 
 There is a helpful mobile simulation mode that gives a hint of how your app would work on a mobile device:
 
-    $ go run -tags mobile main.go
+    go run -tags mobile main.go
 
 Another option is to use `fyne` command, see [Packaging for mobile](#packaging-for-mobile).
 
@@ -121,8 +121,8 @@ Using `go install` will copy the executable into your go `bin` dir.
 To install the application with icons etc into your operating system's standard
 application location you can use the fyne utility and the "install" subcommand.
 
-    $ go get fyne.io/fyne/v2/cmd/fyne
-    $ fyne install
+    go get fyne.io/fyne/v2/cmd/fyne
+    fyne install
 
 # Packaging for mobile
 
@@ -131,16 +131,16 @@ To do this we can use the fyne utility "package" subcommand.
 You will need to add appropriate parameters as prompted, but the basic command is shown below.
 Once packaged you can install using the platform development tools or the fyne "install" subcommand.
 
-    $ fyne package -os android -appID my.domain.appname
-    $ fyne install -os android
+    fyne package -os android -appID my.domain.appname
+    fyne install -os android
 
 The built Android application can run either in a real device or an Android emulator.
 However, building for iOS is slightly different.
 If the "-os" argument is "ios", it is build only for a real iOS device.
 Specify "-os" to "iossimulator" allows the application be able to run in an iOS simulator:
 
-    $ fyne package -os ios -appID my.domain.appname
-    $ fyne package -os iossimulator -appID my.domain.appname
+    fyne package -os ios -appID my.domain.appname
+    fyne package -os iossimulator -appID my.domain.appname
 
 # Preparing a release
 


### PR DESCRIPTION

### Description:

I would like to the copy buttons to copy a valid command. This would mean removing the prompt from what is copied.



