### PR TITLE
Replace theme maps with switch statements

### DIFF
--- a/theme/theme.go
+++ b/theme/theme.go
@@ -639,7 +639,7 @@ func currentVariant() fyne.ThemeVariant {
 	return fyne.CurrentApp().Settings().ThemeVariant()
 }
 
-func primaryColorNamed(name string) color.Color {
+func primaryColorNamed(name string) color.NRGBA {
 	switch name {
 	case ColorRed:
 		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
@@ -662,7 +662,7 @@ func primaryColorNamed(name string) color.Color {
 	return color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
 }
 
-func focusColorNamed(name string) color.Color {
+func focusColorNamed(name string) color.NRGBA {
 	switch name {
 	case ColorRed:
 		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f}
@@ -685,7 +685,7 @@ func focusColorNamed(name string) color.Color {
 	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
 }
 
-func selectionColorNamed(name string) color.Color {
+func selectionColorNamed(name string) color.NRGBA {
 	switch name {
 	case ColorRed:
 		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f}

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -558,12 +558,13 @@ func (t *builtinTheme) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.C
 		v = t.variant
 	}
 
+	primary := fyne.CurrentApp().Settings().PrimaryColor()
 	if n == ColorNamePrimary {
-		return primaryColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
+		return primaryColorNamed(primary)
 	} else if n == ColorNameFocus {
-		return focusColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
+		return focusColorNamed(primary)
 	} else if n == ColorNameSelection {
-		return selectionColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
+		return selectionColorNamed(primary)
 	}
 
 	if v == VariantLight {

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -639,75 +639,6 @@ func currentVariant() fyne.ThemeVariant {
 	return fyne.CurrentApp().Settings().ThemeVariant()
 }
 
-func primaryColorNamed(name string) color.NRGBA {
-	switch name {
-	case ColorRed:
-		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
-	case ColorOrange:
-		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
-	case ColorYellow:
-		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
-	case ColorGreen:
-		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
-	case ColorPurple:
-		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
-	case ColorBrown:
-		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
-	case ColorGray:
-		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
-	}
-
-	// We return the value for ColorBlue for every other value.
-	// There is no need to have it in the switch above.
-	return color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
-}
-
-func focusColorNamed(name string) color.NRGBA {
-	switch name {
-	case ColorRed:
-		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f}
-	case ColorOrange:
-		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f}
-	case ColorYellow:
-		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x7f}
-	case ColorGreen:
-		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x7f}
-	case ColorPurple:
-		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x7f}
-	case ColorBrown:
-		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x7f}
-	case ColorGray:
-		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x7f}
-	}
-
-	// We return the value for ColorBlue for every other value.
-	// There is no need to have it in the switch above.
-	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
-}
-
-func selectionColorNamed(name string) color.NRGBA {
-	switch name {
-	case ColorRed:
-		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f}
-	case ColorOrange:
-		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x3f}
-	case ColorYellow:
-		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x3f}
-	case ColorGreen:
-		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x3f}
-	case ColorPurple:
-		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x3f}
-	case ColorBrown:
-		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f}
-	case ColorGray:
-		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x3f}
-	}
-
-	// We return the value for ColorBlue for every other value.
-	// There is no need to have it in the switch above.
-	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
-}
-
 func darkPaletColorNamed(name fyne.ThemeColorName) color.Color {
 	switch name {
 	case ColorNameBackground:
@@ -745,6 +676,29 @@ func darkPaletColorNamed(name fyne.ThemeColorName) color.Color {
 	}
 
 	return color.Transparent
+}
+
+func focusColorNamed(name string) color.NRGBA {
+	switch name {
+	case ColorRed:
+		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f}
+	case ColorOrange:
+		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f}
+	case ColorYellow:
+		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x7f}
+	case ColorGreen:
+		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x7f}
+	case ColorPurple:
+		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x7f}
+	case ColorBrown:
+		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x7f}
+	case ColorGray:
+		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x7f}
+	}
+
+	// We return the value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
 }
 
 func lightPaletColorNamed(name fyne.ThemeColorName) color.Color {
@@ -798,6 +752,29 @@ func loadCustomFont(env, variant string, fallback fyne.Resource) fyne.Resource {
 	return res
 }
 
+func primaryColorNamed(name string) color.NRGBA {
+	switch name {
+	case ColorRed:
+		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+	case ColorOrange:
+		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
+	case ColorYellow:
+		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
+	case ColorGreen:
+		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
+	case ColorPurple:
+		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
+	case ColorBrown:
+		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
+	case ColorGray:
+		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
+	}
+
+	// We return the value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
+}
+
 func safeColorLookup(n fyne.ThemeColorName, v fyne.ThemeVariant) color.Color {
 	col := current().Color(n, v)
 	if col == nil {
@@ -828,6 +805,29 @@ func safeFontLookup(s fyne.TextStyle) fyne.Resource {
 	}
 
 	return DefaultTextFont()
+}
+
+func selectionColorNamed(name string) color.NRGBA {
+	switch name {
+	case ColorRed:
+		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f}
+	case ColorOrange:
+		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x3f}
+	case ColorYellow:
+		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x3f}
+	case ColorGreen:
+		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x3f}
+	case ColorPurple:
+		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x3f}
+	case ColorBrown:
+		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f}
+	case ColorGray:
+		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x3f}
+	}
+
+	// We return the value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
 }
 
 func setupDefaultTheme() fyne.Theme {

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -397,11 +397,7 @@ func PrimaryColor() color.Color {
 //
 // Since: 1.4
 func PrimaryColorNamed(name string) color.Color {
-	col, ok := primaryColors[name]
-	if !ok {
-		return primaryColors[ColorBlue]
-	}
-	return col
+	return primaryColorNamed(name)
 }
 
 // PrimaryColorNames returns a list of the standard primary color options.
@@ -523,74 +519,6 @@ var (
 	errorColor   = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
 	successColor = color.NRGBA{R: 0x43, G: 0xf4, B: 0x36, A: 0xff}
 	warningColor = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
-	focusColors  = map[string]color.Color{
-		ColorRed:    color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f},
-		ColorOrange: color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f},
-		ColorYellow: color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x7f},
-		ColorGreen:  color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x7f},
-		ColorBlue:   color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a},
-		ColorPurple: color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x7f},
-		ColorBrown:  color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x7f},
-		ColorGray:   color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x7f},
-	}
-	primaryColors = map[string]color.Color{
-		ColorRed:    color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff},
-		ColorOrange: color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff},
-		ColorYellow: color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff},
-		ColorGreen:  color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff},
-		ColorBlue:   color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff},
-		ColorPurple: color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff},
-		ColorBrown:  color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff},
-		ColorGray:   color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff},
-	}
-	selectionColors = map[string]color.Color{
-		ColorRed:    color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f},
-		ColorOrange: color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x3f},
-		ColorYellow: color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x3f},
-		ColorGreen:  color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x3f},
-		ColorBlue:   color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a},
-		ColorPurple: color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x3f},
-		ColorBrown:  color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f},
-		ColorGray:   color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x3f},
-	}
-
-	darkPalette = map[fyne.ThemeColorName]color.Color{
-		ColorNameBackground:      color.NRGBA{R: 0x14, G: 0x14, B: 0x15, A: 0xff},
-		ColorNameButton:          color.NRGBA{R: 0x28, G: 0x29, B: 0x2e, A: 0xff},
-		ColorNameDisabled:        color.NRGBA{R: 0x39, G: 0x39, B: 0x3a, A: 0xff},
-		ColorNameDisabledButton:  color.NRGBA{R: 0x26, G: 0x26, B: 0x26, A: 0xff},
-		ColorNameError:           errorColor,
-		ColorNameForeground:      color.NRGBA{R: 0xf3, G: 0xf3, B: 0xf3, A: 0xff},
-		ColorNameHover:           color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0x0f},
-		ColorNameInputBackground: color.NRGBA{R: 0x24, G: 0x25, B: 0x29, A: 0xff},
-		ColorNameInputBorder:     color.NRGBA{R: 0x39, G: 0x39, B: 0x3a, A: 0xff},
-		ColorNamePlaceHolder:     color.NRGBA{R: 0xb2, G: 0xb2, B: 0xb2, A: 0xff},
-		ColorNamePressed:         color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0x66},
-		ColorNameScrollBar:       color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0x99},
-		ColorNameSeparator:       color.NRGBA{R: 0x0, G: 0x0, B: 0x0, A: 0xff},
-		ColorNameShadow:          color.NRGBA{A: 0x66},
-		ColorNameSuccess:         successColor,
-		ColorNameWarning:         warningColor,
-	}
-
-	lightPalette = map[fyne.ThemeColorName]color.Color{
-		ColorNameBackground:      color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff},
-		ColorNameButton:          color.NRGBA{R: 0xf5, G: 0xf5, B: 0xf5, A: 0xff},
-		ColorNameDisabled:        color.NRGBA{R: 0xe3, G: 0xe3, B: 0xe3, A: 0xff},
-		ColorNameDisabledButton:  color.NRGBA{R: 0xe5, G: 0xe5, B: 0xe5, A: 0xff},
-		ColorNameError:           errorColor,
-		ColorNameForeground:      color.NRGBA{R: 0x56, G: 0x56, B: 0x56, A: 0xff},
-		ColorNameHover:           color.NRGBA{A: 0x0f},
-		ColorNameInputBackground: color.NRGBA{R: 0xf3, G: 0xf3, B: 0xf3, A: 0xff},
-		ColorNameInputBorder:     color.NRGBA{R: 0xe3, G: 0xe3, B: 0xe3, A: 0xff},
-		ColorNamePlaceHolder:     color.NRGBA{R: 0x88, G: 0x88, B: 0x88, A: 0xff},
-		ColorNamePressed:         color.NRGBA{A: 0x19},
-		ColorNameScrollBar:       color.NRGBA{A: 0x99},
-		ColorNameSeparator:       color.NRGBA{R: 0xf5, G: 0xf5, B: 0xf5, A: 0xff},
-		ColorNameShadow:          color.NRGBA{A: 0x33},
-		ColorNameSuccess:         successColor,
-		ColorNameWarning:         warningColor,
-	}
 )
 
 type builtinTheme struct {
@@ -629,23 +557,20 @@ func (t *builtinTheme) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.C
 	if t.variant != variantNameUserPreference {
 		v = t.variant
 	}
-	colors := darkPalette
-	if v == VariantLight {
-		colors = lightPalette
-	}
 
 	if n == ColorNamePrimary {
-		return PrimaryColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
+		return primaryColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
 	} else if n == ColorNameFocus {
 		return focusColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
 	} else if n == ColorNameSelection {
 		return selectionColorNamed(fyne.CurrentApp().Settings().PrimaryColor())
 	}
 
-	if c, ok := colors[n]; ok {
-		return c
+	if v == VariantLight {
+		return lightPaletColorNamed(n)
 	}
-	return color.Transparent
+
+	return darkPaletColorNamed(n)
 }
 
 func (t *builtinTheme) Font(style fyne.TextStyle) fyne.Resource {
@@ -713,12 +638,151 @@ func currentVariant() fyne.ThemeVariant {
 	return fyne.CurrentApp().Settings().ThemeVariant()
 }
 
-func focusColorNamed(name string) color.Color {
-	col, ok := focusColors[name]
-	if !ok {
-		return focusColors[ColorBlue]
+func primaryColorNamed(name string) color.Color {
+	switch name {
+	case ColorRed:
+		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+	case ColorOrange:
+		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
+	case ColorYellow:
+		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
+	case ColorGreen:
+		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
+	case ColorPurple:
+		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
+	case ColorBrown:
+		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
+	case ColorGray:
+		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
 	}
-	return col
+
+	// We return the value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
+}
+
+func focusColorNamed(name string) color.Color {
+	switch name {
+	case ColorRed:
+		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f}
+	case ColorOrange:
+		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f}
+	case ColorYellow:
+		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x7f}
+	case ColorGreen:
+		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x7f}
+	case ColorPurple:
+		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x7f}
+	case ColorBrown:
+		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x7f}
+	case ColorGray:
+		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x7f}
+	}
+
+	// We return the value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
+}
+
+func selectionColorNamed(name string) color.Color {
+	switch name {
+	case ColorRed:
+		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f}
+	case ColorOrange:
+		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x3f}
+	case ColorYellow:
+		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x3f}
+	case ColorGreen:
+		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x3f}
+	case ColorPurple:
+		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x3f}
+	case ColorBrown:
+		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f}
+	case ColorGray:
+		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x3f}
+	}
+
+	// We return the value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
+}
+
+func darkPaletColorNamed(name fyne.ThemeColorName) color.Color {
+	switch name {
+	case ColorNameBackground:
+		return color.NRGBA{R: 0x14, G: 0x14, B: 0x15, A: 0xff}
+	case ColorNameButton:
+		return color.NRGBA{R: 0x28, G: 0x29, B: 0x2e, A: 0xff}
+	case ColorNameDisabled:
+		return color.NRGBA{R: 0x39, G: 0x39, B: 0x3a, A: 0xff}
+	case ColorNameDisabledButton:
+		return color.NRGBA{R: 0x26, G: 0x26, B: 0x26, A: 0xff}
+	case ColorNameError:
+		return errorColor
+	case ColorNameForeground:
+		return color.NRGBA{R: 0xf3, G: 0xf3, B: 0xf3, A: 0xff}
+	case ColorNameHover:
+		return color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0x0f}
+	case ColorNameInputBackground:
+		return color.NRGBA{R: 0x24, G: 0x25, B: 0x29, A: 0xff}
+	case ColorNameInputBorder:
+		return color.NRGBA{R: 0x39, G: 0x39, B: 0x3a, A: 0xff}
+	case ColorNamePlaceHolder:
+		return color.NRGBA{R: 0xb2, G: 0xb2, B: 0xb2, A: 0xff}
+	case ColorNamePressed:
+		return color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0x66}
+	case ColorNameScrollBar:
+		return color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0x99}
+	case ColorNameSeparator:
+		return color.NRGBA{R: 0x0, G: 0x0, B: 0x0, A: 0xff}
+	case ColorNameShadow:
+		return color.NRGBA{A: 0x66}
+	case ColorNameSuccess:
+		return successColor
+	case ColorNameWarning:
+		return warningColor
+	}
+
+	return color.Transparent
+}
+
+func lightPaletColorNamed(name fyne.ThemeColorName) color.Color {
+	switch name {
+	case ColorNameBackground:
+		return color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+	case ColorNameButton:
+		return color.NRGBA{R: 0xf5, G: 0xf5, B: 0xf5, A: 0xff}
+	case ColorNameDisabled:
+		return color.NRGBA{R: 0xe3, G: 0xe3, B: 0xe3, A: 0xff}
+	case ColorNameDisabledButton:
+		return color.NRGBA{R: 0xe5, G: 0xe5, B: 0xe5, A: 0xff}
+	case ColorNameError:
+		return errorColor
+	case ColorNameForeground:
+		return color.NRGBA{R: 0x56, G: 0x56, B: 0x56, A: 0xff}
+	case ColorNameHover:
+		return color.NRGBA{A: 0x0f}
+	case ColorNameInputBackground:
+		return color.NRGBA{R: 0xf3, G: 0xf3, B: 0xf3, A: 0xff}
+	case ColorNameInputBorder:
+		return color.NRGBA{R: 0xe3, G: 0xe3, B: 0xe3, A: 0xff}
+	case ColorNamePlaceHolder:
+		return color.NRGBA{R: 0x88, G: 0x88, B: 0x88, A: 0xff}
+	case ColorNamePressed:
+		return color.NRGBA{A: 0x19}
+	case ColorNameScrollBar:
+		return color.NRGBA{A: 0x99}
+	case ColorNameSeparator:
+		return color.NRGBA{R: 0xf5, G: 0xf5, B: 0xf5, A: 0xff}
+	case ColorNameShadow:
+		return color.NRGBA{A: 0x33}
+	case ColorNameSuccess:
+		return successColor
+	case ColorNameWarning:
+		return warningColor
+	}
+
+	return color.Transparent
 }
 
 func loadCustomFont(env, variant string, fallback fyne.Resource) fyne.Resource {
@@ -763,14 +827,6 @@ func safeFontLookup(s fyne.TextStyle) fyne.Resource {
 	}
 
 	return DefaultTextFont()
-}
-
-func selectionColorNamed(name string) color.Color {
-	col, ok := selectionColors[name]
-	if !ok {
-		return selectionColors[ColorBlue]
-	}
-	return col
 }
 
 func setupDefaultTheme() fyne.Theme {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This refactors and cleans up some of the theme code to use use functions with switch statements instead of static maps.
It has been said before but static maps can not be optimised by the compiler because it can not prove that they never change.
This decreases binary size by about 0,06% and is much more efficient.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- Should already be covered. It is also hard to write useful tests for functions that only switch on inputs.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
