### PR TITLE
add time aware RuneEvent

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -39,6 +39,7 @@ type Canvas interface {
 
 	OnTypedRune() func(rune)
 	SetOnTypedRune(func(rune))
+	SetOnTypedRuneEvent(func(*RuneEvent))
 	OnTypedKey() func(*KeyEvent)
 	SetOnTypedKey(func(*KeyEvent))
 	AddShortcut(shortcut Shortcut, handler func(shortcut Shortcut))

--- a/event.go
+++ b/event.go
@@ -1,5 +1,7 @@
 package fyne
 
+import "time"
+
 // HardwareKey contains information associated with physical key events
 // Most applications should use KeyName for cross-platform compatibility.
 type HardwareKey struct {
@@ -34,4 +36,24 @@ type ScrollEvent struct {
 type DragEvent struct {
 	PointEvent
 	Dragged Delta
+}
+
+func NewRuneEvent(char rune) *RuneEvent {
+	return &RuneEvent{
+		char:      char,
+		eventTime: time.Now(),
+	}
+}
+
+type RuneEvent struct {
+	char      rune
+	eventTime time.Time
+}
+
+func (r *RuneEvent) Rune() rune {
+	return r.char
+}
+
+func (r *RuneEvent) When() time.Time {
+	return r.eventTime
 }

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -25,10 +25,11 @@ type glCanvas struct {
 	padded  bool
 	size    fyne.Size
 
-	onTypedRune func(rune)
-	onTypedKey  func(*fyne.KeyEvent)
-	onKeyDown   func(*fyne.KeyEvent)
-	onKeyUp     func(*fyne.KeyEvent)
+	onTypedRune      func(rune)
+	onTypedRuneEvent func(*fyne.RuneEvent)
+	onTypedKey       func(*fyne.KeyEvent)
+	onKeyDown        func(*fyne.KeyEvent)
+	onKeyUp          func(*fyne.KeyEvent)
 	// shortcut    fyne.ShortcutHandler
 
 	scale, detectedScale, texScale float32
@@ -164,6 +165,10 @@ func (c *glCanvas) SetOnTypedKey(typed func(*fyne.KeyEvent)) {
 
 func (c *glCanvas) SetOnTypedRune(typed func(rune)) {
 	c.onTypedRune = typed
+}
+
+func (c *glCanvas) SetOnTypedRuneEvent(typed func(*fyne.RuneEvent)) {
+	c.onTypedRuneEvent = typed
 }
 
 func (c *glCanvas) SetPadded(padded bool) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -780,8 +780,14 @@ func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, 
 func (w *window) processCharInput(char rune) {
 	if focused := w.canvas.Focused(); focused != nil {
 		w.QueueEvent(func() { focused.TypedRune(char) })
-	} else if w.canvas.onTypedRune != nil {
-		w.QueueEvent(func() { w.canvas.onTypedRune(char) })
+	} else {
+		if w.canvas.onTypedRune != nil {
+			w.QueueEvent(func() { w.canvas.onTypedRune(char) })
+		}
+		if w.canvas.onTypedRuneEvent != nil {
+			runeEvent := fyne.NewRuneEvent(char)
+			w.QueueEvent(func() { w.canvas.onTypedRuneEvent(runeEvent) })
+		}
 	}
 }
 

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -32,8 +32,9 @@ type mobileCanvas struct {
 	touched map[int]mobile.Touchable
 	padded  bool
 
-	onTypedRune func(rune)
-	onTypedKey  func(event *fyne.KeyEvent)
+	onTypedRune      func(rune)
+	onTypedRuneEvent func(*fyne.RuneEvent)
+	onTypedKey       func(event *fyne.KeyEvent)
 
 	inited                bool
 	lastTapDown           map[int]time.Time
@@ -108,6 +109,10 @@ func (c *mobileCanvas) SetOnTypedKey(typed func(*fyne.KeyEvent)) {
 
 func (c *mobileCanvas) SetOnTypedRune(typed func(rune)) {
 	c.onTypedRune = typed
+}
+
+func (c *mobileCanvas) SetOnTypedRuneEvent(typed func(*fyne.RuneEvent)) {
+	c.onTypedRuneEvent = typed
 }
 
 func (c *mobileCanvas) Size() fyne.Size {

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -507,7 +507,8 @@ func (d *mobileDriver) typeDownCanvas(canvas *mobileCanvas, r rune, code key.Cod
 				canvas.onTypedRune(r)
 			}
 			if canvas.onTypedRuneEvent != nil {
-				canvas.onTypedRuneEvent(r)
+				runeEvent := fyne.NewRuneEvent(char)
+				canvas.onTypedRuneEvent(runeEvent)
 			}
 		}
 	}

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -502,8 +502,13 @@ func (d *mobileDriver) typeDownCanvas(canvas *mobileCanvas, r rune, code key.Cod
 		if keyName != "" && canvas.onTypedKey != nil {
 			canvas.onTypedKey(keyEvent)
 		}
-		if r > 0 && canvas.onTypedRune != nil {
-			canvas.onTypedRune(r)
+		if r > 0 {
+			if canvas.onTypedRune != nil {
+				canvas.onTypedRune(r)
+			}
+			if canvas.onTypedRuneEvent != nil {
+				canvas.onTypedRuneEvent(r)
+			}
 		}
 	}
 }

--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -37,8 +37,9 @@ type testCanvas struct {
 	padded      bool
 	transparent bool
 
-	onTypedRune func(rune)
-	onTypedKey  func(*fyne.KeyEvent)
+	onTypedRune      func(rune)
+	onTypedRuneEvent func(*fyne.RuneEvent)
+	onTypedKey       func(*fyne.KeyEvent)
 
 	fyne.ShortcutHandler
 	painter      SoftwarePainter
@@ -234,6 +235,13 @@ func (c *testCanvas) SetOnTypedRune(handler func(rune)) {
 	defer c.propertyLock.Unlock()
 
 	c.onTypedRune = handler
+}
+
+func (c *testCanvas) SetOnTypedRuneEvent(handler func(*fyne.RuneEvent)) {
+	c.propertyLock.Lock()
+	defer c.propertyLock.Unlock()
+
+	c.onTypedRuneEvent = handler
 }
 
 func (c *testCanvas) SetPadded(padded bool) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Add RuneEvent type and SetOnTtpedRuneEvent func to have a time aware typed rune logic. 
this is useful when looking for a Rune that was typed after the user was prompted for a key press.
Runes typed before of after a prompt can be ignored by comparing the RuneEvent.When() time with the time of a user prompt. 

WIP. New tests need to be added and existing tests need to be fixed…

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
