### PR TITLE
Add lock protection for map read/write operations

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -61,18 +61,17 @@ func CachedFontFace(style fyne.TextStyle, opts *truetype.Options) font.Face {
 	}
 
 	comp := val.(*fontCacheItem)
-	lock := sync.RWMutex{}
-	lock.RLock()
+	comp.RLock()
 	face := comp.faces[*opts]
-	lock.RUnlock()
+	comp.RUnlock()
 	if face == nil {
 		f1 := truetype.NewFace(comp.font, opts)
 		f2 := truetype.NewFace(comp.fallback, opts)
 		face = newFontWithFallback(f1, f2, comp.font, comp.fallback)
 
-		lock.Lock()
+		comp.Lock()
 		comp.faces[*opts] = face
-		lock.Unlock()
+		comp.Unlock()
 	}
 
 	return face
@@ -297,6 +296,7 @@ type ttfFont interface {
 }
 
 type fontCacheItem struct {
+	sync.RWMutex
 	font, fallback *truetype.Font
 	faces          map[truetype.Options]font.Face
 }

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -61,13 +61,18 @@ func CachedFontFace(style fyne.TextStyle, opts *truetype.Options) font.Face {
 	}
 
 	comp := val.(*fontCacheItem)
+	lock := sync.RWMutex{}
+	lock.RLock()
 	face := comp.faces[*opts]
+	lock.RUnlock()
 	if face == nil {
 		f1 := truetype.NewFace(comp.font, opts)
 		f2 := truetype.NewFace(comp.fallback, opts)
 		face = newFontWithFallback(f1, f2, comp.font, comp.fallback)
 
+		lock.Lock()
 		comp.faces[*opts] = face
+		lock.Unlock()
 	}
 
 	return face


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Add lock protection for map read/write operations. I made it backward compatible with older go release. Starting with Go 1.19 these changes may be replaced with `sync.Map` (concurrent map).

Fixes #3269

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. **I'm not aware of reliable test procedure for concurrent map read/write operations.**
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.


#### Where applicable:

