### PR TITLE
list: implements the Focusable interface

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -246,6 +246,7 @@ func (l *listRenderer) Refresh() {
 }
 
 // Declare conformity with interfaces.
+var _ fyne.Focusable = (*listItem)(nil)
 var _ fyne.Widget = (*listItem)(nil)
 var _ fyne.Tappable = (*listItem)(nil)
 var _ desktop.Hoverable = (*listItem)(nil)
@@ -281,6 +282,22 @@ func (li *listItem) CreateRenderer() fyne.WidgetRenderer {
 	return &listItemRenderer{widget.NewBaseRenderer(objects), li}
 }
 
+// FocusGained is called after this listItem has gained focus.
+//
+// Implements: fyne.Focusable
+func (li *listItem) FocusGained() {
+	li.hovered = true
+	li.Refresh()
+}
+
+// FocusLost is called after this listItem has lost focus.
+//
+// Implements: fyne.Focusable
+func (li *listItem) FocusLost() {
+	li.hovered = false
+	li.Refresh()
+}
+
 // MinSize returns the size that this widget should not shrink below.
 func (li *listItem) MinSize() fyne.Size {
 	li.ExtendBaseWidget(li)
@@ -310,6 +327,27 @@ func (li *listItem) Tapped(*fyne.PointEvent) {
 		li.Refresh()
 		li.onTapped()
 	}
+}
+
+// TypedKey is called if a key event happens while this listItem is focused.
+//
+// Implements: fyne.Focusable
+func (li *listItem) TypedKey(event *fyne.KeyEvent) {
+	switch event.Name {
+	case fyne.KeySpace:
+		li.selected = true
+		li.Refresh()
+		if li.onTapped != nil {
+			li.onTapped()
+		}
+	}
+}
+
+// TypedRune is called if a text event happens while this listItem is focused.
+//
+// Implements: fyne.Focusable
+func (li *listItem) TypedRune(_ rune) {
+	// intentionally left blank
 }
 
 // Declare conformity with the WidgetRenderer interface.

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -425,6 +425,52 @@ func TestList_NoFunctionsSet(t *testing.T) {
 	list.Refresh()
 }
 
+func TestList_Focus(t *testing.T) {
+	defer test.NewApp()
+	list := createList(10)
+	window := test.NewWindow(list)
+	defer window.Close()
+	window.Resize(list.MinSize().Max(fyne.NewSize(150, 200)))
+
+	canvas := window.Canvas().(test.WindowlessCanvas)
+	assert.Nil(t, canvas.Focused())
+
+	canvas.FocusNext()
+	assert.NotNil(t, canvas.Focused())
+	assert.True(t, canvas.Focused().(*listItem).hovered)
+	assert.False(t, canvas.Focused().(*listItem).selected)
+
+	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
+	assert.True(t, children[0].(*listItem).hovered)
+	assert.False(t, children[1].(*listItem).hovered)
+	assert.False(t, children[2].(*listItem).hovered)
+	assert.Equal(t, children[0].(*listItem), canvas.Focused().(*listItem))
+
+	canvas.FocusNext()
+	assert.NotNil(t, canvas.Focused())
+	assert.True(t, canvas.Focused().(*listItem).hovered)
+	assert.False(t, canvas.Focused().(*listItem).selected)
+	assert.False(t, children[0].(*listItem).hovered)
+	assert.True(t, children[1].(*listItem).hovered)
+	assert.False(t, children[2].(*listItem).hovered)
+	assert.NotEqual(t, children[0].(*listItem), canvas.Focused().(*listItem))
+	assert.Equal(t, children[1].(*listItem), canvas.Focused().(*listItem))
+
+	canvas.FocusPrevious()
+	assert.NotNil(t, canvas.Focused())
+	assert.True(t, canvas.Focused().(*listItem).hovered)
+	assert.False(t, canvas.Focused().(*listItem).selected)
+	assert.True(t, children[0].(*listItem).hovered)
+	assert.False(t, children[1].(*listItem).hovered)
+	assert.False(t, children[2].(*listItem).hovered)
+	assert.Equal(t, children[0].(*listItem), canvas.Focused().(*listItem))
+	assert.NotEqual(t, children[1].(*listItem), canvas.Focused().(*listItem))
+
+	canvas.Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+	assert.True(t, canvas.Focused().(*listItem).selected)
+	assert.True(t, canvas.Focused().(*listItem).hovered)
+}
+
 func createList(items int) *List {
 	var data []string
 	for i := 0; i < items; i++ {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
This PR implements the `Focusable` interface for the `listItem` widget. This allows to handle some keyboard behaviours:
- handle the focus when `tab` / `shift+tab` is pressed;
- select the focused listItem when `space` is pressed;

Related to #1515

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

