### PR TITLE
Crash parsing invalid file uri

### DIFF
--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -44,20 +44,12 @@ func NewFileURI(path string) fyne.URI {
 // Since: 2.0
 func ParseURI(s string) (fyne.URI, error) {
 	// Extract the scheme.
-	scheme := ""
-	validScheme := false
-	for i := 0; i < len(s); i++ {
-		if s[i] == ':' {
-			validScheme = true
-			break
-		}
-		scheme += string(s[i])
-	}
-	scheme = strings.ToLower(scheme)
-
-	if !validScheme {
+	colonIndex := strings.Index(s, ":")
+	if colonIndex == -1 {
 		return nil, errors.New("invalid URI, scheme must be present")
 	}
+
+	scheme := strings.ToLower(s[:colonIndex])
 
 	if scheme == "file" {
 		// Does this really deserve to be special? In principle, the

--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -44,8 +44,8 @@ func NewFileURI(path string) fyne.URI {
 // Since: 2.0
 func ParseURI(s string) (fyne.URI, error) {
 	// Extract the scheme.
-	colonIndex := strings.Index(s, ":")
-	if colonIndex == -1 {
+	colonIndex := strings.IndexByte(s, ':')
+	if colonIndex <= 0 {
 		return nil, errors.New("invalid URI, scheme must be present")
 	}
 

--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -44,13 +45,19 @@ func NewFileURI(path string) fyne.URI {
 func ParseURI(s string) (fyne.URI, error) {
 	// Extract the scheme.
 	scheme := ""
+	validScheme := false
 	for i := 0; i < len(s); i++ {
 		if s[i] == ':' {
+			validScheme = true
 			break
 		}
 		scheme += string(s[i])
 	}
 	scheme = strings.ToLower(scheme)
+
+	if !validScheme {
+		return nil, errors.New("invalid URI, scheme must be present")
+	}
 
 	if scheme == "file" {
 		// Does this really deserve to be special? In principle, the

--- a/storage/repository/parse_test.go
+++ b/storage/repository/parse_test.go
@@ -24,3 +24,17 @@ func TestParseURI(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "file://C:/tmp/foo.txt", uri.String())
 }
+
+func TestParseInvalidURI(t *testing.T) {
+	uri, err := ParseURI("/tmp/foo.txt")
+	assert.NotNil(t, err)
+	assert.Nil(t, uri)
+
+	uri, err = ParseURI("file")
+	assert.NotNil(t, err)
+	assert.Nil(t, uri)
+
+	uri, err = ParseURI(":foo")
+	assert.NotNil(t, err)
+	assert.Nil(t, uri)
+}


### PR DESCRIPTION
### Description:
storage/repository/parse.go assumed that there would always be a colon terminating the scheme. As seen in #3275 this led to an unexpected panic.

Note that I'm not as familiar with the usage of URI's in fyne, and this does make the code less lenient and throw errors more often (in theory). For example, "path/to/file" now expected to throw an error. After some research I think this is acceptable behavior as I don't see any way for those 'URI's to work. Let me know if this isn't a valid assumption and I can resubmit with a different fix in place (targeting just the reported issue)

Fixes #3275

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Public APIs match existing style and have Since: line.
- [x] Any breaking changes have a deprecation path or have been discussed.