### PR TITLE
Refactor Android manifest into internal/templates

### DIFF
--- a/cmd/fyne/internal/mobile/build_androidapp.go
+++ b/cmd/fyne/internal/mobile/build_androidapp.go
@@ -20,10 +20,20 @@ import (
 	"strings"
 
 	"fyne.io/fyne/v2/cmd/fyne/internal/mobile/binres"
+	"fyne.io/fyne/v2/cmd/fyne/internal/templates"
 	"fyne.io/fyne/v2/cmd/fyne/internal/util"
 	"golang.org/x/sys/execabs"
 	"golang.org/x/tools/go/packages"
 )
+
+type manifestTmplData struct {
+	JavaPkgPath string
+	Name        string
+	Debug       bool
+	LibName     string
+	Version     string
+	Build       int
+}
 
 func goAndroidBuild(pkg *packages.Package, bundleID string, androidArchs []string,
 	iconPath, appName, version string, build, target int, release bool) (map[string]bool, error) {
@@ -46,7 +56,7 @@ func goAndroidBuild(pkg *packages.Package, bundleID string, androidArchs []strin
 
 		buf := new(bytes.Buffer)
 		buf.WriteString(`<?xml version="1.0" encoding="utf-8"?>`)
-		err := manifestTmpl.Execute(buf, manifestTmplData{
+		err := templates.ManifestAndroid.Execute(buf, manifestTmplData{
 			JavaPkgPath: bundleID,
 			Name:        strings.Title(appName),
 			Debug:       !buildRelease,

--- a/cmd/fyne/internal/mobile/manifest.go
+++ b/cmd/fyne/internal/mobile/manifest.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"html/template"
 )
 
 type manifestXML struct {
@@ -47,37 +46,3 @@ func manifestLibName(data []byte) (string, error) {
 	}
 	return libName, nil
 }
-
-type manifestTmplData struct {
-	JavaPkgPath string
-	Name        string
-	Debug       bool
-	LibName     string
-	Version     string
-	Build       int
-}
-
-var manifestTmpl = template.Must(template.New("manifest").Parse(`
-<manifest
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	package="{{.JavaPkgPath}}"
-	android:versionCode="{{.Build}}"
-	android:versionName="{{.Version}}">
-
-	<application android:label="{{.Name}}" android:debuggable="{{.Debug}}">
-	<activity android:name="org.golang.app.GoNativeActivity"
-		android:label="{{.Name}}"
-		android:configChanges="orientation|keyboardHidden|uiMode"
-		android:theme="@android:style/Theme">
-		<meta-data android:name="android.app.lib_name" android:value="{{.LibName}}" />
-		<intent-filter>
-			<action android:name="android.intent.action.MAIN" />
-			<category android:name="android.intent.category.LAUNCHER" />
-		</intent-filter>
-	</activity>
-	</application>
-
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.INTERNET" />
-</manifest>`))

--- a/cmd/fyne/internal/templates/bundled.go
+++ b/cmd/fyne/internal/templates/bundled.go
@@ -5,6 +5,11 @@ package templates
 
 import "fyne.io/fyne/v2"
 
+var resourceAndroidManifestXml = &fyne.StaticResource{
+	StaticName: "AndroidManifest.xml",
+	StaticContent: []byte(
+		"<manifest\n\txmlns:android=\"http://schemas.android.com/apk/res/android\"\n\tpackage=\"{{.JavaPkgPath}}\"\n\tandroid:versionCode=\"{{.Build}}\"\n\tandroid:versionName=\"{{.Version}}\">\n\n\t<application android:label=\"{{.Name}}\" android:debuggable=\"{{.Debug}}\">\n\t<activity android:name=\"org.golang.app.GoNativeActivity\"\n\t\tandroid:label=\"{{.Name}}\"\n\t\tandroid:configChanges=\"orientation|keyboardHidden|uiMode\"\n\t\tandroid:theme=\"@android:style/Theme\">\n\t\t<meta-data android:name=\"android.app.lib_name\" android:value=\"{{.LibName}}\" />\n\t\t<intent-filter>\n\t\t\t<action android:name=\"android.intent.action.MAIN\" />\n\t\t\t<category android:name=\"android.intent.category.LAUNCHER\" />\n\t\t</intent-filter>\n\t</activity>\n\t</application>\n\n\t<uses-permission android:name=\"android.permission.WRITE_EXTERNAL_STORAGE\" />\n\t<uses-permission android:name=\"android.permission.READ_EXTERNAL_STORAGE\" />\n\t<uses-permission android:name=\"android.permission.INTERNET\" />\n</manifest>"),
+}
 var resourceInfoPlist = &fyne.StaticResource{
 	StaticName: "Info.plist",
 	StaticContent: []byte(

--- a/cmd/fyne/internal/templates/data/AndroidManifest.xml
+++ b/cmd/fyne/internal/templates/data/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	package="{{.JavaPkgPath}}"
+	android:versionCode="{{.Build}}"
+	android:versionName="{{.Version}}">
+
+	<application android:label="{{.Name}}" android:debuggable="{{.Debug}}">
+	<activity android:name="org.golang.app.GoNativeActivity"
+		android:label="{{.Name}}"
+		android:configChanges="orientation|keyboardHidden|uiMode"
+		android:theme="@android:style/Theme">
+		<meta-data android:name="android.app.lib_name" android:value="{{.LibName}}" />
+		<intent-filter>
+			<action android:name="android.intent.action.MAIN" />
+			<category android:name="android.intent.category.LAUNCHER" />
+		</intent-filter>
+	</activity>
+	</application>
+
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/cmd/fyne/internal/templates/templates.go
+++ b/cmd/fyne/internal/templates/templates.go
@@ -20,6 +20,9 @@ var (
 	// FyneMetadataInit is the metadata injecting file for fyne metadata
 	FyneMetadataInit = template.Must(template.New("fyne_metadata_init.got").Parse(string(resourceFynemetadatainitGot.StaticContent)))
 
+	// ManifestAndroid is the default manifest for building an Android application
+	ManifestAndroid = template.Must(template.New("AndroidManifest").Parse(string(resourceAndroidManifestXml.StaticContent)))
+
 	// ManifestWindows is the manifest file for windows packaging
 	ManifestWindows = template.Must(template.New("Manifest").Parse(string(resourceAppManifest.StaticContent)))
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is just a simple cleanup that moves the template to the common templates package and also moves the data struct to where it is being used. The main benefit here is basically only that it is easier to find the manifest without having to search as we have all templates in the common place.

I don't have any Android devices to test this on, so I'd prefer that someone can verify that this regresses nothing. Normally I would think it is fine but the template seems to accidentally have used `html/template` before and I don't want to risk anything.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
