### PR TITLE
Move shaderSource lookup to switch statement

### DIFF
--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -10,8 +10,8 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-func shaderSourceNamed(fileName string) ([]byte, []byte) {
-	switch fileName {
+func shaderSourceNamed(name string) ([]byte, []byte) {
+	switch name {
 	case "line":
 		return shaderLineVert.StaticContent, shaderLineFrag.StaticContent
 	case "line_es":

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -10,11 +10,19 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-var shaderSources = map[string][2][]byte{
-	"line":      {shaderLineVert.StaticContent, shaderLineFrag.StaticContent},
-	"line_es":   {shaderLineesVert.StaticContent, shaderLineesFrag.StaticContent},
-	"simple":    {shaderSimpleVert.StaticContent, shaderSimpleFrag.StaticContent},
-	"simple_es": {shaderSimpleesVert.StaticContent, shaderSimpleesFrag.StaticContent},
+func shaderSourceNamed(fileName string) [2][]byte {
+	switch fileName {
+	case "line":
+		return [2][]byte{shaderLineVert.StaticContent, shaderLineFrag.StaticContent}
+	case "line_es":
+		return [2][]byte{shaderLineesVert.StaticContent, shaderLineesFrag.StaticContent}
+	case "simple":
+		return [2][]byte{shaderSimpleVert.StaticContent, shaderSimpleFrag.StaticContent}
+	case "simple_es":
+		return [2][]byte{shaderSimpleesVert.StaticContent, shaderSimpleesFrag.StaticContent}
+	}
+
+	return [2][]byte{}
 }
 
 // Painter defines the functionality of our OpenGL based renderer
@@ -128,7 +136,7 @@ func (p *painter) createProgram(shaderFilename string) Program {
 	// Why a switch over a filename?
 	// Because this allows for a minimal change, once we reach Go 1.16 and use go:embed instead of
 	// fyne bundle.
-	sources := shaderSources[shaderFilename]
+	sources := shaderSourceNamed(shaderFilename)
 	vertexSrc, fragmentSrc := sources[0], sources[1]
 	if vertexSrc == nil {
 		panic("shader not found: " + shaderFilename)

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -10,19 +10,19 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-func shaderSourceNamed(fileName string) [2][]byte {
+func shaderSourceNamed(fileName string) ([]byte, []byte) {
 	switch fileName {
 	case "line":
-		return [2][]byte{shaderLineVert.StaticContent, shaderLineFrag.StaticContent}
+		return shaderLineVert.StaticContent, shaderLineFrag.StaticContent
 	case "line_es":
-		return [2][]byte{shaderLineesVert.StaticContent, shaderLineesFrag.StaticContent}
+		return shaderLineesVert.StaticContent, shaderLineesFrag.StaticContent
 	case "simple":
-		return [2][]byte{shaderSimpleVert.StaticContent, shaderSimpleFrag.StaticContent}
+		return shaderSimpleVert.StaticContent, shaderSimpleFrag.StaticContent
 	case "simple_es":
-		return [2][]byte{shaderSimpleesVert.StaticContent, shaderSimpleesFrag.StaticContent}
+		return shaderSimpleesVert.StaticContent, shaderSimpleesFrag.StaticContent
 	}
 
-	return [2][]byte{}
+	return nil, nil
 }
 
 // Painter defines the functionality of our OpenGL based renderer
@@ -136,8 +136,7 @@ func (p *painter) createProgram(shaderFilename string) Program {
 	// Why a switch over a filename?
 	// Because this allows for a minimal change, once we reach Go 1.16 and use go:embed instead of
 	// fyne bundle.
-	sources := shaderSourceNamed(shaderFilename)
-	vertexSrc, fragmentSrc := sources[0], sources[1]
+	vertexSrc, fragmentSrc := shaderSourceNamed(shaderFilename)
 	if vertexSrc == nil {
 		panic("shader not found: " + shaderFilename)
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This replaces the map with a small function using a switch case. The cost is 33 units in this case and the compiler can thus inline it for even more improved performance.

This seems like a case where tests are hard to do. We can't quite hard-code each check. Will have to do without for now. Should get coverage if we add tests to the function that uses it.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
