### PR TITLE
Change link of repojacking vulnerable link

### DIFF
--- a/vendor/github.com/fredbi/uri/README.md
+++ b/vendor/github.com/fredbi/uri/README.md
@@ -59,7 +59,7 @@ which provides a workable but loose implementation of the RFC.
 
 This package concentrates on RFC 3986 strictness for URI validation. 
 At the moment, there is no attempt to normalize or auto-escape strings. 
-For url normalization, see github.com/PuertokitoBio/purell.
+For url normalization, see github.com/PuerkitoBio/purell.
 
 ## Disclaimer
 


### PR DESCRIPTION
Hello from Hacktoberfest :)
The link to purell is vulnerable to repojacking (due to a typo in the org name, it redirects to an unexisting project), you should change the link to the current name of the project. if you won't change the link, an attacker can open the linked repository and attacks users that trust your links
