### PR TITLE
Allow nil Action for systray menu items

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -110,7 +110,9 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 		fn := i.Action
 		go func() {
 			for range item.ClickedCh {
-				fn()
+				if fn != nil {
+					fn()
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
### Description:
Throughout fyne the MenuItem Action can be set to nil if it shouldn't execute an action. This behavior isn't supported when setting the menu using SetSystemTrayMenu. This PR fixes that.

Note that no tests are included as it doesn't appear that the systray stuff is covered by tests (and adding tests is a bit out of scope of my intended fix). If I just missed where the tests are located, let me know and I can add this into those.

For example (borrowed and adapted from fyne_demo):
```go
func makeTray(a fyne.App) {
	if desk, ok := a.(desktop.App); ok {
		h := fyne.NewMenuItem("Hello", nil)
		h.Icon = theme.HomeIcon()
		menu := fyne.NewMenu("Hello World", h)
		desk.SetSystemTrayMenu(menu)
	}
}
```

### Checklist:
- [o] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

