### PR TITLE
Add cloud document storage

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -75,50 +75,6 @@ func (a *fyneApp) Run() {
 	}
 }
 
-func (a *fyneApp) SetCloudProvider(p fyne.CloudProvider) {
-	if p == nil {
-		a.cloud = nil
-		return
-	}
-
-	a.transitionCloud(p)
-}
-
-func (a *fyneApp) transitionCloud(p fyne.CloudProvider) {
-	if a.cloud != nil {
-		a.cloud.Cleanup(a)
-	}
-
-	err := p.Setup(a)
-	if err != nil {
-		fyne.LogError("Failed to set up cloud provider "+p.ProviderName(), err)
-		return
-	}
-	a.cloud = p
-
-	listeners := a.prefs.ChangeListeners()
-	if pp, ok := p.(fyne.CloudProviderPreferences); ok {
-		a.prefs = pp.CloudPreferences(a)
-	} else {
-		a.prefs = a.newDefaultPreferences()
-	}
-	if cloud, ok := p.(fyne.CloudProviderStorage); ok {
-		a.storage = cloud.CloudStorage(a)
-	} else {
-		store := &store{a: a}
-		store.Docs = makeStoreDocs(a.uniqueID, a.prefs, store)
-		a.storage = store
-	}
-
-	for _, l := range listeners {
-		a.prefs.AddChangeListener(l)
-		l() // assume that preferences have changed because we replaced the provider
-	}
-
-	// after transition ensure settings listener is fired
-	a.settings.apply()
-}
-
 func (a *fyneApp) Quit() {
 	for _, window := range a.driver.AllWindows() {
 		window.Close()

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -9,7 +9,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	_ "fyne.io/fyne/v2/test"
-	"fyne.io/fyne/v2/theme"
 
 	"golang.org/x/sys/execabs"
 )
@@ -55,68 +54,4 @@ func TestFyneApp_OpenURL(t *testing.T) {
 	}
 
 	assert.Equal(t, urlStr, opened)
-}
-
-func TestFyneApp_SetCloudProvider(t *testing.T) {
-	a := NewWithID("io.fyne.test")
-	p := &mockCloud{}
-	a.SetCloudProvider(p)
-
-	assert.Equal(t, p, a.CloudProvider())
-	assert.True(t, p.configured)
-}
-
-func TestFyneApp_SetCloudProvider_Cleanup(t *testing.T) {
-	a := NewWithID("io.fyne.test")
-	p1 := &mockCloud{}
-	p2 := &mockCloud{}
-	a.SetCloudProvider(p1)
-
-	assert.True(t, p1.configured)
-	assert.False(t, p1.cleaned)
-
-	a.SetCloudProvider(p2)
-
-	assert.True(t, p1.cleaned)
-	assert.True(t, p2.configured)
-}
-
-func TestFyneApp_transitionCloud(t *testing.T) {
-	a := NewWithID("io.fyne.test")
-	p := &mockCloud{}
-	preferenceChanged := false
-	settingsChan := make(chan fyne.Settings)
-	a.Preferences().AddChangeListener(func() {
-		preferenceChanged = true
-	})
-	a.Settings().AddChangeListener(settingsChan)
-	a.SetCloudProvider(p)
-
-	<-settingsChan // settings were updated
-	assert.True(t, preferenceChanged)
-}
-
-type mockCloud struct {
-	configured, cleaned bool
-}
-
-func (c *mockCloud) Cleanup(_ fyne.App) {
-	c.cleaned = true
-}
-
-func (c *mockCloud) ProviderDescription() string {
-	return "Mock cloud implementation"
-}
-
-func (c *mockCloud) ProviderIcon() fyne.Resource {
-	return theme.FyneLogo()
-}
-
-func (c *mockCloud) ProviderName() string {
-	return "mock"
-}
-
-func (c *mockCloud) Setup(_ fyne.App) error {
-	c.configured = true
-	return nil
 }

--- a/app/cloud.go
+++ b/app/cloud.go
@@ -1,0 +1,47 @@
+package app
+
+import "fyne.io/fyne/v2"
+
+func (a *fyneApp) SetCloudProvider(p fyne.CloudProvider) {
+	if p == nil {
+		a.cloud = nil
+		return
+	}
+
+	a.transitionCloud(p)
+}
+
+func (a *fyneApp) transitionCloud(p fyne.CloudProvider) {
+	if a.cloud != nil {
+		a.cloud.Cleanup(a)
+	}
+
+	err := p.Setup(a)
+	if err != nil {
+		fyne.LogError("Failed to set up cloud provider "+p.ProviderName(), err)
+		return
+	}
+	a.cloud = p
+
+	listeners := a.prefs.ChangeListeners()
+	if pp, ok := p.(fyne.CloudProviderPreferences); ok {
+		a.prefs = pp.CloudPreferences(a)
+	} else {
+		a.prefs = a.newDefaultPreferences()
+	}
+	if cloud, ok := p.(fyne.CloudProviderStorage); ok {
+		a.storage = cloud.CloudStorage(a)
+	} else {
+		store := &store{a: a}
+		store.Docs = makeStoreDocs(a.uniqueID, a.prefs, store)
+		a.storage = store
+	}
+
+	for _, l := range listeners {
+		a.prefs.AddChangeListener(l)
+		l() // assume that preferences have changed because we replaced the provider
+	}
+
+	// after transition ensure settings listener is fired
+	a.settings.apply()
+}

--- a/app/cloud_test.go
+++ b/app/cloud_test.go
@@ -1,0 +1,139 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
+	"fyne.io/fyne/v2/storage"
+	"fyne.io/fyne/v2/theme"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFyneApp_SetCloudProvider(t *testing.T) {
+	a := NewWithID("io.fyne.test")
+	p := &mockCloud{}
+	a.SetCloudProvider(p)
+
+	assert.Equal(t, p, a.CloudProvider())
+	assert.True(t, p.configured)
+}
+
+func TestFyneApp_SetCloudProvider_Cleanup(t *testing.T) {
+	a := NewWithID("io.fyne.test")
+	p1 := &mockCloud{}
+	p2 := &mockCloud{}
+	a.SetCloudProvider(p1)
+
+	assert.True(t, p1.configured)
+	assert.False(t, p1.cleaned)
+
+	a.SetCloudProvider(p2)
+
+	assert.True(t, p1.cleaned)
+	assert.True(t, p2.configured)
+}
+
+func TestFyneApp_transitionCloud(t *testing.T) {
+	a := NewWithID("io.fyne.test")
+	p := &mockCloud{}
+	preferenceChanged := false
+	settingsChan := make(chan fyne.Settings)
+	a.Preferences().AddChangeListener(func() {
+		preferenceChanged = true
+	})
+	a.Settings().AddChangeListener(settingsChan)
+	a.SetCloudProvider(p)
+
+	<-settingsChan // settings were updated
+	assert.True(t, preferenceChanged)
+}
+
+func TestFyneApp_transitionCloud_Preferences(t *testing.T) {
+	a := NewWithID("io.fyne.test")
+	a.Preferences().SetString("key", "blank")
+
+	assert.Equal(t, "blank", a.Preferences().String("key"))
+
+	p := &mockCloud{}
+	a.SetCloudProvider(p)
+
+	assert.Equal(t, "", a.Preferences().String("key"))
+}
+
+func TestFyneApp_transitionCloud_Storage(t *testing.T) {
+	a := NewWithID("io.fyne.test")
+	a.Storage().Create("nothere")
+
+	l := a.Storage().List()
+	assert.Equal(t, 1, len(l))
+
+	p := &mockCloud{}
+	a.SetCloudProvider(p)
+
+	l = a.Storage().List()
+	assert.Equal(t, 0, len(l))
+}
+
+type mockCloud struct {
+	configured, cleaned bool
+}
+
+func (c *mockCloud) Cleanup(_ fyne.App) {
+	c.cleaned = true
+}
+
+func (c *mockCloud) CloudPreferences(fyne.App) fyne.Preferences {
+	return &internal.InMemoryPreferences{}
+}
+
+func (c *mockCloud) CloudStorage(fyne.App) fyne.Storage {
+	return &mockCloudStorage{}
+}
+
+func (c *mockCloud) ProviderDescription() string {
+	return "Mock cloud implementation"
+}
+
+func (c *mockCloud) ProviderIcon() fyne.Resource {
+	return theme.FyneLogo()
+}
+
+func (c *mockCloud) ProviderName() string {
+	return "mock"
+}
+
+func (c *mockCloud) Setup(_ fyne.App) error {
+	c.configured = true
+	return nil
+}
+
+type mockCloudStorage struct {
+}
+
+func (s *mockCloudStorage) Create(name string) (fyne.URIWriteCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *mockCloudStorage) List() []string {
+	return []string{}
+}
+
+func (s *mockCloudStorage) Open(name string) (fyne.URIReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *mockCloudStorage) Remove(name string) error {
+	return errors.New("not implemented")
+}
+
+func (s *mockCloudStorage) RootURI() fyne.URI {
+	u, _ := storage.ParseURI("mock://")
+	return u
+}
+
+func (s *mockCloudStorage) Save(name string) (fyne.URIWriteCloser, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cloud.go
+++ b/cloud.go
@@ -28,3 +28,12 @@ type CloudProviderPreferences interface {
 	// CloudPreferences returns a preference provider that will sync values to the cloud this provider uses.
 	CloudPreferences(App) Preferences
 }
+
+// CloudProviderStorage interface defines the functionality that a cloud provider will include if it is capable
+// of synchronizing user documents.
+//
+// Since: 2.3
+type CloudProviderStorage interface {
+	// CloudStorage returns a storage provider that will sync documents to the cloud this provider uses.
+	CloudStorage(App) Storage
+}

--- a/test/testapp.go
+++ b/test/testapp.go
@@ -129,6 +129,11 @@ func (a *testApp) transitionCloud(p fyne.CloudProvider) {
 	} else {
 		a.prefs = internal.NewInMemoryPreferences()
 	}
+	if store, ok := p.(fyne.CloudProviderStorage); ok {
+		a.storage = store.CloudStorage(a)
+	} else {
+		a.storage = &testStorage{}
+	}
 
 	for _, l := range listeners {
 		a.prefs.AddChangeListener(l)


### PR DESCRIPTION
Add support for document storage by adding Storage to the things cloud providers can hook into

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
