### PR TITLE
Make difference between package -release and release on mobile.

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -227,12 +227,12 @@ func (b *Builder) build() error {
 
 		if goos == "windows" {
 			if b.release {
-				args = append(args, "-ldflags", "-s -w -H=windowsgui ")
+				args = append(args, "-ldflags", "-s -w -H=windowsgui", "-trimpath")
 			} else {
 				args = append(args, "-ldflags", "-H=windowsgui ")
 			}
 		} else if b.release {
-			args = append(args, "-ldflags", "-s -w ")
+			args = append(args, "-ldflags", "-s -w", "-trimpath")
 		}
 	}
 

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -16,11 +16,11 @@ import (
 )
 
 func (p *Packager) packageAndroid(arch string) error {
-	return mobile.RunNewBuild(arch, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, "", "")
+	return mobile.RunNewBuild(arch, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, "", "")
 }
 
 func (p *Packager) packageIOS(target string) error {
-	err := mobile.RunNewBuild(target, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.certificate, p.profile)
+	err := mobile.RunNewBuild(target, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, p.certificate, p.profile)
 	if err != nil {
 		return err
 	}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -133,11 +133,11 @@ func Package() *cli.Command {
 // Packager wraps executables into full GUI app packages.
 type Packager struct {
 	*appData
-	srcDir, dir, exe, os string
-	install, release     bool
-	certificate, profile string // optional flags for releasing
-	tags, category       string
-	tempDir              string
+	srcDir, dir, exe, os           string
+	install, release, distribution bool
+	certificate, profile           string // optional flags for releasing
+	tags, category                 string
+	tempDir                        string
 
 	customMetadata keyValueFlag
 }

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -175,6 +175,8 @@ func (r *Releaser) Run(params []string) {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		return
 	}
+
+	r.Packager.distribution = true
 	r.Packager.release = true
 
 	if err := r.beforePackage(); err != nil {
@@ -192,13 +194,14 @@ func (r *Releaser) releaseAction(_ *cli.Context) error {
 		return err
 	}
 
+	r.Packager.distribution = true
 	r.Packager.release = true
+
 	if err := r.beforePackage(); err != nil {
 		return err
 	}
 
-	err := r.Packager.packageWithoutValidate()
-	if err != nil {
+	if err := r.Packager.packageWithoutValidate(); err != nil {
 		return err
 	}
 

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -273,10 +273,14 @@ var (
 )
 
 // RunNewBuild executes a new mobile build for the specified configuration
-func RunNewBuild(target, appID, icon, name, version string, build int, release bool, cert, profile string) error {
+func RunNewBuild(target, appID, icon, name, version string, build int, release, distribution bool, cert, profile string) error {
 	buildTarget = target
 	buildBundleID = appID
-	buildRelease = release
+	buildRelease = distribution
+	if release {
+		buildLdflags = "-w"
+		buildTrimpath = true
+	}
 
 	cmd := cmdBuild
 	cmd.Flag = flag.FlagSet{}


### PR DESCRIPTION
### Description:
It is expected that package -release generate a binary stripped from as much information as possible (On mobile it means stripping debug information, but not stripping of symbol). While it is expected that release generate a signed package for consumption by stores.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.