### PR TITLE
Split container hidden sizing

### DIFF
--- a/container/split.go
+++ b/container/split.go
@@ -95,7 +95,7 @@ func (r *splitContainerRenderer) Layout(size fyne.Size) {
 	var dividerSize, leadingSize, trailingSize fyne.Size
 
 	if r.split.Horizontal {
-		lw, tw := r.computeSplitLengths(size.Width, r.split.Leading.MinSize().Width, r.split.Trailing.MinSize().Width)
+		lw, tw := r.computeSplitLengths(size.Width, r.minLeadingWidth(), r.minTrailingWidth())
 		leadingPos.X = 0
 		leadingSize.Width = lw
 		leadingSize.Height = size.Height
@@ -106,7 +106,7 @@ func (r *splitContainerRenderer) Layout(size fyne.Size) {
 		trailingSize.Width = tw
 		trailingSize.Height = size.Height
 	} else {
-		lh, th := r.computeSplitLengths(size.Height, r.split.Leading.MinSize().Height, r.split.Trailing.MinSize().Height)
+		lh, th := r.computeSplitLengths(size.Height, r.minLeadingHeight(), r.minTrailingHeight())
 		leadingPos.Y = 0
 		leadingSize.Width = size.Width
 		leadingSize.Height = lh
@@ -181,6 +181,34 @@ func (r *splitContainerRenderer) computeSplitLengths(total, lMin, tMin float32) 
 	ld = offset * available
 	tr = available - ld
 	return float32(ld), float32(tr)
+}
+
+func (r *splitContainerRenderer) minLeadingWidth() float32 {
+	if r.split.Leading.Visible() {
+		return r.split.Leading.MinSize().Width
+	}
+	return 0
+}
+
+func (r *splitContainerRenderer) minLeadingHeight() float32 {
+	if r.split.Leading.Visible() {
+		return r.split.Leading.MinSize().Height
+	}
+	return 0
+}
+
+func (r *splitContainerRenderer) minTrailingWidth() float32 {
+	if r.split.Trailing.Visible() {
+		return r.split.Trailing.MinSize().Width
+	}
+	return 0
+}
+
+func (r *splitContainerRenderer) minTrailingHeight() float32 {
+	if r.split.Trailing.Visible() {
+		return r.split.Trailing.MinSize().Height
+	}
+	return 0
 }
 
 // Declare conformity with interfaces

--- a/container/split_test.go
+++ b/container/split_test.go
@@ -413,3 +413,48 @@ func TestSplitContainer_divider_MinSize(t *testing.T) {
 		assert.Equal(t, dividerThickness(), min.Height)
 	})
 }
+
+func TestSplitContainer_Hidden(t *testing.T) {
+	dt := dividerThickness()
+	size := fyne.NewSize(10, 10)
+	objA := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	objA.SetMinSize(size)
+	objB := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+
+	t.Run("Horizontal_Leading", func(t *testing.T) {
+		sc := NewHSplit(objA, objB)
+		sc.Resize(fyne.NewSize(100, 100))
+		assert.Equal(t, 50-(dt/2), sc.Leading.Size().Width)
+
+		objA.Hide()
+		sc.SetOffset(0)
+		assert.Equal(t, float32(0), sc.Leading.Size().Width)
+	})
+	t.Run("Horizontal_Trailing", func(t *testing.T) {
+		sc := NewHSplit(objA, objB)
+		sc.Resize(fyne.NewSize(100, 100))
+		assert.Equal(t, 50-(dt/2), sc.Trailing.Size().Width)
+
+		objB.Hide()
+		sc.SetOffset(1)
+		assert.Equal(t, float32(0), sc.Trailing.Size().Width)
+	})
+	t.Run("Vertical_Leading", func(t *testing.T) {
+		sc := NewVSplit(objA, objB)
+		sc.Resize(fyne.NewSize(100, 100))
+		assert.Equal(t, 50-(dt/2), sc.Leading.Size().Height)
+
+		objA.Hide()
+		sc.SetOffset(0)
+		assert.Equal(t, float32(0), sc.Leading.Size().Height)
+	})
+	t.Run("Vertical_Trailing", func(t *testing.T) {
+		sc := NewVSplit(objA, objB)
+		sc.Resize(fyne.NewSize(100, 100))
+		assert.Equal(t, 50-(dt/2), sc.Trailing.Size().Height)
+
+		objB.Hide()
+		sc.SetOffset(1)
+		assert.Equal(t, float32(0), sc.Trailing.Size().Height)
+	})
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Addresses Split Container not respecting item's visible status if item is not in a container.  When calculating the size of each split, my fix checks if the item is visible and returns a size of 0 if not.

Fixes #3232

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.