### PR TITLE
Fix bad characters in android appID

### DIFF
--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -515,6 +515,24 @@ func validateAppID(appID, os, name string, release bool) (string, error) {
 			return "", errors.New("missing appID parameter for package")
 		} else if !strings.Contains(appID, ".") {
 			return "", errors.New("appID must be globally unique and contain at least 1 '.'")
+		} else if util.IsAndroid(os) {
+			if strings.Contains(appID, "-") {
+				return "", errors.New("appID can not contain '-'")
+			}
+
+			// appID package names can not start with '_' or a number
+			packageNames := strings.Split(appID, ".")
+			for _, name := range packageNames {
+				if len(name) == 0 {
+					continue
+				}
+
+				if name[0] == '_' {
+					return "", fmt.Errorf("appID package names can not start with '_' (%s)", name)
+				} else if name[0] >= '0' && name[0] <= '9' {
+					return "", fmt.Errorf("appID package names can not start with a number (%s)", name)
+				}
+			}
 		}
 	}
 

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -93,6 +93,21 @@ func Test_validateAppID(t *testing.T) {
 
 	_, err = validateAppID("myApp", "android", "myApp", true)
 	assert.NotNil(t, err)
+
+	_, err = validateAppID("com._server.myApp", "android", "myApp", true)
+	assert.NotNil(t, err)
+
+	_, err = validateAppID("com.5server.myApp", "android", "myApp", true)
+	assert.NotNil(t, err)
+
+	_, err = validateAppID("0com.server.myApp", "android", "myApp", true)
+	assert.NotNil(t, err)
+
+	_, err = validateAppID("......", "android", "myApp", true)
+	assert.Nil(t, err)
+
+	_, err = validateAppID(".....myApp", "android", "myApp", true)
+	assert.Nil(t, err)
 }
 
 func Test_buildPackageWasm(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #3000

This PR does not allow appIDs on android to contain a '-' character or have a package name that starts with '_' or a number.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
