### PR TITLE
Add first RunNative to allow apps to use Android JVM context

### DIFF
--- a/driver/native.go
+++ b/driver/native.go
@@ -1,0 +1,7 @@
+package driver
+
+type AndroidContext struct {
+	VM, Env, Ctx uintptr
+}
+
+type UnknownContext struct {}

--- a/driver/native_android.go
+++ b/driver/native_android.go
@@ -1,0 +1,12 @@
+//+build android
+
+package driver
+
+import "fyne.io/fyne/v2/internal/driver/mobile/app"
+
+func RunNative(fn func(interface{}) error) error {
+	return app.RunOnJVM(func(vm, env, ctx uintptr) error {
+		data := &AndroidContext{VM: vm, Env: env, Ctx: ctx}
+		return fn(data)
+	})
+}

--- a/driver/native_other.go
+++ b/driver/native_other.go
@@ -1,0 +1,7 @@
+//+build !android
+
+package driver
+
+func RunNative(fn func(interface{}) error) error {
+	return fn(&UnknownContext{})
+}

--- a/driver/native_test.go
+++ b/driver/native_test.go
@@ -1,0 +1,20 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunNative(t *testing.T) {
+	err := RunNative(func(i interface{}) error {
+		native, ok := i.(*UnknownContext)
+
+		assert.True(t, ok)
+		assert.NotNil(t, native)
+
+		return nil
+	})
+
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Implements https://github.com/fyne-io/proposals/pull/7

I have not added the "JString" helper yet - complications with passing around C.jstring made it less favourable...

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
