### PR TITLE
Add OnTapped callback to RichText HyperlinkSegment

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -77,7 +77,7 @@ func (m *markdownRenderer) Render(_ io.Writer, source []byte, n ast.Node) error 
 			m.segs = append(m.segs, &SeparatorSegment{})
 		case "Link":
 			link, _ := url.Parse(string(n.(*ast.Link).Destination))
-			m.nextSeg = &HyperlinkSegment{fyne.TextAlignLeading, "", link}
+			m.nextSeg = &HyperlinkSegment{fyne.TextAlignLeading, "", link, nil}
 		case "Paragraph":
 			m.nextSeg = &TextSegment{
 				Style: RichTextStyleInline, // we make it a paragraph at the end if there are no more elements

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -110,6 +110,8 @@ type HyperlinkSegment struct {
 	URL       *url.URL
 
 	// OnTapped overrides the default `fyne.OpenURL` call when the link is tapped
+	//
+	// Since 2.4
 	OnTapped func()
 }
 

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -108,6 +108,9 @@ type HyperlinkSegment struct {
 	Alignment fyne.TextAlign
 	Text      string
 	URL       *url.URL
+
+	// OnTapped overrides the default `fyne.OpenURL` call when the link is tapped
+	OnTapped func()
 }
 
 // Inline returns true as hyperlinks are inside other elements.
@@ -124,6 +127,7 @@ func (h *HyperlinkSegment) Textual() string {
 func (h *HyperlinkSegment) Visual() fyne.CanvasObject {
 	link := NewHyperlink(h.Text, h.URL)
 	link.Alignment = h.Alignment
+	link.OnTapped = h.OnTapped
 	return &fyne.Container{Layout: &unpadTextWidgetLayout{}, Objects: []fyne.CanvasObject{link}}
 }
 
@@ -133,6 +137,7 @@ func (h *HyperlinkSegment) Update(o fyne.CanvasObject) {
 	link.Text = h.Text
 	link.URL = h.URL
 	link.Alignment = h.Alignment
+	link.OnTapped = h.OnTapped
 	link.Refresh()
 }
 

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -111,7 +111,7 @@ type HyperlinkSegment struct {
 
 	// OnTapped overrides the default `fyne.OpenURL` call when the link is tapped
 	//
-	// Since 2.4
+	// Since: 2.4
 	OnTapped func()
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR adds an `OnTapped` callback to the `HyperlinkSegment` used in `RichText`.

Fixes #3335

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. (I'm not sure how to test clicking a HyperlinkSegment)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
