### PR TITLE
Take two at optimizing key translation

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -526,11 +526,9 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 	}
 
 	char := code[0]
-
-	relativeLetter := char - 'a'
-	if relativeLetter <= 'z' {
+	if char >= 'a' && char <= 'z' {
 		// Our alphabetical keys are all upper case characters.
-		return fyne.KeyName('A' + relativeLetter)
+		return fyne.KeyName('A' + char - 'a')
 	}
 
 	switch char {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -531,7 +531,36 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 		return fyne.KeyName('A' + char - 'a')
 	}
 
-	return fyne.KeyName(char)
+	switch char {
+	case '[':
+		return fyne.KeyLeftBracket
+	case '\\':
+		return fyne.KeyBackslash
+	case ']':
+		return fyne.KeyRightBracket
+	case '\'':
+		return fyne.KeyApostrophe
+	case ',':
+		return fyne.KeyComma
+	case '-':
+		return fyne.KeyMinus
+	case '.':
+		return fyne.KeyPeriod
+	case '/':
+		return fyne.KeySlash
+	case '*':
+		return fyne.KeyAsterisk
+	case '`':
+		return fyne.KeyBackTick
+	case ';':
+		return fyne.KeySemicolon
+	case '+':
+		return fyne.KeyPlus
+	case '=':
+		return fyne.KeyEqual
+	}
+
+	return fyne.KeyUnknown
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -526,9 +526,11 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 	}
 
 	char := code[0]
-	if char >= 'a' && char <= 'z' {
+
+	relativeLetter := char - 'a'
+	if relativeLetter <= 'z' {
 		// Our alphabetical keys are all upper case characters.
-		return fyne.KeyName('A' + char - 'a')
+		return fyne.KeyName('A' + relativeLetter)
 	}
 
 	switch char {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -517,7 +517,7 @@ func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
 		return fyne.Key9
 	}
 
-	return ""
+	return fyne.KeyUnknown
 }
 
 func keyCodeToKeyName(code string) fyne.KeyName {
@@ -569,7 +569,7 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	}
 
 	ret := glfwKeyToKeyName(code)
-	if ret != "" {
+	if ret != fyne.KeyUnknown {
 		return ret
 	}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -403,7 +403,7 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 //gocyclo:ignore
 func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
 	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	if key >= '0' && key <= '9' {
+	if key >= glfw.Key0 && key <= glfw.Key9 {
 		return fyne.KeyName(rune(key))
 	}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -400,74 +400,124 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-var keyCodeMap = map[glfw.Key]fyne.KeyName{
-	// non-printable
-	glfw.KeyEscape:    fyne.KeyEscape,
-	glfw.KeyEnter:     fyne.KeyReturn,
-	glfw.KeyTab:       fyne.KeyTab,
-	glfw.KeyBackspace: fyne.KeyBackspace,
-	glfw.KeyInsert:    fyne.KeyInsert,
-	glfw.KeyDelete:    fyne.KeyDelete,
-	glfw.KeyRight:     fyne.KeyRight,
-	glfw.KeyLeft:      fyne.KeyLeft,
-	glfw.KeyDown:      fyne.KeyDown,
-	glfw.KeyUp:        fyne.KeyUp,
-	glfw.KeyPageUp:    fyne.KeyPageUp,
-	glfw.KeyPageDown:  fyne.KeyPageDown,
-	glfw.KeyHome:      fyne.KeyHome,
-	glfw.KeyEnd:       fyne.KeyEnd,
-
-	glfw.KeySpace:   fyne.KeySpace,
-	glfw.KeyKPEnter: fyne.KeyEnter,
-
-	// functions
-	glfw.KeyF1:  fyne.KeyF1,
-	glfw.KeyF2:  fyne.KeyF2,
-	glfw.KeyF3:  fyne.KeyF3,
-	glfw.KeyF4:  fyne.KeyF4,
-	glfw.KeyF5:  fyne.KeyF5,
-	glfw.KeyF6:  fyne.KeyF6,
-	glfw.KeyF7:  fyne.KeyF7,
-	glfw.KeyF8:  fyne.KeyF8,
-	glfw.KeyF9:  fyne.KeyF9,
-	glfw.KeyF10: fyne.KeyF10,
-	glfw.KeyF11: fyne.KeyF11,
-	glfw.KeyF12: fyne.KeyF12,
-
+//gocyclo:ignore
+func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
 	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	glfw.Key0:   fyne.Key0,
-	glfw.KeyKP0: fyne.Key0,
-	glfw.Key1:   fyne.Key1,
-	glfw.KeyKP1: fyne.Key1,
-	glfw.Key2:   fyne.Key2,
-	glfw.KeyKP2: fyne.Key2,
-	glfw.Key3:   fyne.Key3,
-	glfw.KeyKP3: fyne.Key3,
-	glfw.Key4:   fyne.Key4,
-	glfw.KeyKP4: fyne.Key4,
-	glfw.Key5:   fyne.Key5,
-	glfw.KeyKP5: fyne.Key5,
-	glfw.Key6:   fyne.Key6,
-	glfw.KeyKP6: fyne.Key6,
-	glfw.Key7:   fyne.Key7,
-	glfw.KeyKP7: fyne.Key7,
-	glfw.Key8:   fyne.Key8,
-	glfw.KeyKP8: fyne.Key8,
-	glfw.Key9:   fyne.Key9,
-	glfw.KeyKP9: fyne.Key9,
+	if key >= '0' && key <= '9' {
+		return fyne.KeyName(rune(key))
+	}
+
+	// Keys that can not be easily translated:
+	switch key {
+	// non-printable
+	case glfw.KeyEscape:
+		return fyne.KeyEscape
+	case glfw.KeyEnter:
+		return fyne.KeyReturn
+	case glfw.KeyTab:
+		return fyne.KeyTab
+	case glfw.KeyBackspace:
+		return fyne.KeyBackspace
+	case glfw.KeyInsert:
+		return fyne.KeyInsert
+	case glfw.KeyDelete:
+		return fyne.KeyDelete
+	case glfw.KeyRight:
+		return fyne.KeyRight
+	case glfw.KeyLeft:
+		return fyne.KeyLeft
+	case glfw.KeyDown:
+		return fyne.KeyDown
+	case glfw.KeyUp:
+		return fyne.KeyUp
+	case glfw.KeyPageUp:
+		return fyne.KeyPageUp
+	case glfw.KeyPageDown:
+		return fyne.KeyPageDown
+	case glfw.KeyHome:
+		return fyne.KeyHome
+	case glfw.KeyEnd:
+		return fyne.KeyEnd
+
+	case glfw.KeySpace:
+		return fyne.KeySpace
+	case glfw.KeyKPEnter:
+		return fyne.KeyEnter
 
 	// desktop
-	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
-	glfw.KeyRightShift:   desktop.KeyShiftRight,
-	glfw.KeyLeftControl:  desktop.KeyControlLeft,
-	glfw.KeyRightControl: desktop.KeyControlRight,
-	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
-	glfw.KeyRightAlt:     desktop.KeyAltRight,
-	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
-	glfw.KeyRightSuper:   desktop.KeySuperRight,
-	glfw.KeyMenu:         desktop.KeyMenu,
-	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
-	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+	case glfw.KeyLeftShift:
+		return desktop.KeyShiftLeft
+	case glfw.KeyRightShift:
+		return desktop.KeyShiftRight
+	case glfw.KeyLeftControl:
+		return desktop.KeyControlLeft
+	case glfw.KeyRightControl:
+		return desktop.KeyControlRight
+	case glfw.KeyLeftAlt:
+		return desktop.KeyAltLeft
+	case glfw.KeyRightAlt:
+		return desktop.KeyAltRight
+	case glfw.KeyLeftSuper:
+		return desktop.KeySuperLeft
+	case glfw.KeyRightSuper:
+		return desktop.KeySuperRight
+	case glfw.KeyMenu:
+		return desktop.KeyMenu
+	case glfw.KeyPrintScreen:
+		return desktop.KeyPrintScreen
+	case glfw.KeyCapsLock:
+		return desktop.KeyCapsLock
+
+	// functions
+	case glfw.KeyF1:
+		return fyne.KeyF1
+	case glfw.KeyF2:
+		return fyne.KeyF2
+	case glfw.KeyF3:
+		return fyne.KeyF3
+	case glfw.KeyF4:
+		return fyne.KeyF4
+	case glfw.KeyF5:
+		return fyne.KeyF5
+	case glfw.KeyF6:
+		return fyne.KeyF6
+	case glfw.KeyF7:
+		return fyne.KeyF7
+	case glfw.KeyF8:
+		return fyne.KeyF8
+	case glfw.KeyF9:
+		return fyne.KeyF9
+	case glfw.KeyF10:
+		return fyne.KeyF10
+	case glfw.KeyF11:
+		return fyne.KeyF11
+	case glfw.KeyF12:
+		return fyne.KeyF12
+
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	case glfw.KeyKP0:
+		return fyne.Key0
+	case glfw.KeyKP1:
+		return fyne.Key1
+	case glfw.KeyKP2:
+		return fyne.Key2
+	case glfw.KeyKP3:
+		return fyne.Key3
+	case glfw.KeyKP4:
+		return fyne.Key4
+	case glfw.KeyKP5:
+		return fyne.Key5
+	case glfw.KeyKP6:
+		return fyne.Key6
+	case glfw.KeyKP7:
+		return fyne.Key7
+	case glfw.KeyKP8:
+		return fyne.Key8
+	case glfw.KeyKP9:
+		return fyne.Key9
+	}
+
+	return ""
 }
 
 func keyCodeToKeyName(code string) fyne.KeyName {
@@ -489,8 +539,8 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 		code = glfw.KeyPrintScreen
 	}
 
-	ret, ok := keyCodeMap[code]
-	if ok {
+	ret := glfwKeyToKeyName(code)
+	if ret != "" {
 		return ret
 	}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -470,49 +470,18 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyCapsLock:     desktop.KeyCapsLock,
 }
 
-var keyNameMap = map[string]fyne.KeyName{
-	"'": fyne.KeyApostrophe,
-	",": fyne.KeyComma,
-	"-": fyne.KeyMinus,
-	".": fyne.KeyPeriod,
-	"/": fyne.KeySlash,
-	"*": fyne.KeyAsterisk,
-	"`": fyne.KeyBackTick,
+func keyCodeToKeyName(code string) fyne.KeyName {
+	if len(code) != 1 {
+		return fyne.KeyUnknown
+	}
 
-	";": fyne.KeySemicolon,
-	"+": fyne.KeyPlus,
-	"=": fyne.KeyEqual,
+	char := code[0]
+	if char >= 'a' && char <= 'z' {
+		// The fyne keys are all upper case characters.
+		return fyne.KeyName('A' + char - 'a')
+	}
 
-	"a": fyne.KeyA,
-	"b": fyne.KeyB,
-	"c": fyne.KeyC,
-	"d": fyne.KeyD,
-	"e": fyne.KeyE,
-	"f": fyne.KeyF,
-	"g": fyne.KeyG,
-	"h": fyne.KeyH,
-	"i": fyne.KeyI,
-	"j": fyne.KeyJ,
-	"k": fyne.KeyK,
-	"l": fyne.KeyL,
-	"m": fyne.KeyM,
-	"n": fyne.KeyN,
-	"o": fyne.KeyO,
-	"p": fyne.KeyP,
-	"q": fyne.KeyQ,
-	"r": fyne.KeyR,
-	"s": fyne.KeyS,
-	"t": fyne.KeyT,
-	"u": fyne.KeyU,
-	"v": fyne.KeyV,
-	"w": fyne.KeyW,
-	"x": fyne.KeyX,
-	"y": fyne.KeyY,
-	"z": fyne.KeyZ,
-
-	"[":  fyne.KeyLeftBracket,
-	"\\": fyne.KeyBackslash,
-	"]":  fyne.KeyRightBracket,
+	return fyne.KeyName(char)
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
@@ -526,12 +495,7 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	}
 
 	keyName := glfw.GetKeyName(code, scancode)
-	ret, ok = keyNameMap[keyName]
-	if !ok {
-		return fyne.KeyUnknown
-	}
-
-	return ret
+	return keyCodeToKeyName(keyName)
 }
 
 func convertAction(action glfw.Action) action {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -470,35 +470,6 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyCapsLock:     desktop.KeyCapsLock,
 }
 
-var keyCodeMapASCII = map[glfw.Key]fyne.KeyName{
-	glfw.KeyA: fyne.KeyA,
-	glfw.KeyB: fyne.KeyB,
-	glfw.KeyC: fyne.KeyC,
-	glfw.KeyD: fyne.KeyD,
-	glfw.KeyE: fyne.KeyE,
-	glfw.KeyF: fyne.KeyF,
-	glfw.KeyG: fyne.KeyG,
-	glfw.KeyH: fyne.KeyH,
-	glfw.KeyI: fyne.KeyI,
-	glfw.KeyJ: fyne.KeyJ,
-	glfw.KeyK: fyne.KeyK,
-	glfw.KeyL: fyne.KeyL,
-	glfw.KeyM: fyne.KeyM,
-	glfw.KeyN: fyne.KeyN,
-	glfw.KeyO: fyne.KeyO,
-	glfw.KeyP: fyne.KeyP,
-	glfw.KeyQ: fyne.KeyQ,
-	glfw.KeyR: fyne.KeyR,
-	glfw.KeyS: fyne.KeyS,
-	glfw.KeyT: fyne.KeyT,
-	glfw.KeyU: fyne.KeyU,
-	glfw.KeyV: fyne.KeyV,
-	glfw.KeyW: fyne.KeyW,
-	glfw.KeyX: fyne.KeyX,
-	glfw.KeyY: fyne.KeyY,
-	glfw.KeyZ: fyne.KeyZ,
-}
-
 var keyNameMap = map[string]fyne.KeyName{
 	"'": fyne.KeyApostrophe,
 	",": fyne.KeyComma,
@@ -576,11 +547,11 @@ func convertAction(action glfw.Action) action {
 }
 
 func convertASCII(key glfw.Key) fyne.KeyName {
-	ret, ok := keyCodeMapASCII[key]
-	if !ok {
+	if key < glfw.KeyA || key > glfw.KeyZ {
 		return fyne.KeyUnknown
 	}
-	return ret
+
+	return fyne.KeyName(rune(key))
 }
 
 func (w *window) keyPressed(_ *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -527,7 +527,7 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 
 	char := code[0]
 	if char >= 'a' && char <= 'z' {
-		// The fyne keys are all upper case characters.
+		// Our alphabetical keys are all upper case characters.
 		return fyne.KeyName('A' + char - 'a')
 	}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -402,13 +402,29 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 
 //gocyclo:ignore
 func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
-	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	if key >= glfw.Key0 && key <= glfw.Key9 {
-		return fyne.KeyName(rune(key))
-	}
-
-	// Keys that can not be easily translated:
 	switch key {
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	case glfw.Key0, glfw.KeyKP0:
+		return fyne.Key0
+	case glfw.Key1, glfw.KeyKP1:
+		return fyne.Key1
+	case glfw.Key2, glfw.KeyKP2:
+		return fyne.Key2
+	case glfw.Key3, glfw.KeyKP3:
+		return fyne.Key3
+	case glfw.Key4, glfw.KeyKP4:
+		return fyne.Key4
+	case glfw.Key5, glfw.KeyKP5:
+		return fyne.Key5
+	case glfw.Key6, glfw.KeyKP6:
+		return fyne.Key6
+	case glfw.Key7, glfw.KeyKP7:
+		return fyne.Key7
+	case glfw.Key8, glfw.KeyKP8:
+		return fyne.Key8
+	case glfw.Key9, glfw.KeyKP9:
+		return fyne.Key9
+
 	// non-printable
 	case glfw.KeyEscape:
 		return fyne.KeyEscape
@@ -493,28 +509,6 @@ func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
 		return fyne.KeyF11
 	case glfw.KeyF12:
 		return fyne.KeyF12
-
-	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	case glfw.KeyKP0:
-		return fyne.Key0
-	case glfw.KeyKP1:
-		return fyne.Key1
-	case glfw.KeyKP2:
-		return fyne.Key2
-	case glfw.KeyKP3:
-		return fyne.Key3
-	case glfw.KeyKP4:
-		return fyne.Key4
-	case glfw.KeyKP5:
-		return fyne.Key5
-	case glfw.KeyKP6:
-		return fyne.Key6
-	case glfw.KeyKP7:
-		return fyne.Key7
-	case glfw.KeyKP8:
-		return fyne.Key8
-	case glfw.KeyKP9:
-		return fyne.Key9
 	}
 
 	return fyne.KeyUnknown

--- a/internal/driver/glfw/window_desktop_test.go
+++ b/internal/driver/glfw/window_desktop_test.go
@@ -1,0 +1,132 @@
+//go:build !js && !wasm && !test_web_driver
+// +build !js,!wasm,!test_web_driver
+
+package glfw
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/driver/desktop"
+	"github.com/go-gl/glfw/v3.3/glfw"
+	"github.com/stretchr/testify/assert"
+)
+
+var keyCodeMap = map[glfw.Key]fyne.KeyName{
+	// non-printable
+	glfw.KeyEscape:    fyne.KeyEscape,
+	glfw.KeyEnter:     fyne.KeyReturn,
+	glfw.KeyTab:       fyne.KeyTab,
+	glfw.KeyBackspace: fyne.KeyBackspace,
+	glfw.KeyInsert:    fyne.KeyInsert,
+	glfw.KeyDelete:    fyne.KeyDelete,
+	glfw.KeyRight:     fyne.KeyRight,
+	glfw.KeyLeft:      fyne.KeyLeft,
+	glfw.KeyDown:      fyne.KeyDown,
+	glfw.KeyUp:        fyne.KeyUp,
+	glfw.KeyPageUp:    fyne.KeyPageUp,
+	glfw.KeyPageDown:  fyne.KeyPageDown,
+	glfw.KeyHome:      fyne.KeyHome,
+	glfw.KeyEnd:       fyne.KeyEnd,
+
+	glfw.KeySpace:   fyne.KeySpace,
+	glfw.KeyKPEnter: fyne.KeyEnter,
+
+	// functions
+	glfw.KeyF1:  fyne.KeyF1,
+	glfw.KeyF2:  fyne.KeyF2,
+	glfw.KeyF3:  fyne.KeyF3,
+	glfw.KeyF4:  fyne.KeyF4,
+	glfw.KeyF5:  fyne.KeyF5,
+	glfw.KeyF6:  fyne.KeyF6,
+	glfw.KeyF7:  fyne.KeyF7,
+	glfw.KeyF8:  fyne.KeyF8,
+	glfw.KeyF9:  fyne.KeyF9,
+	glfw.KeyF10: fyne.KeyF10,
+	glfw.KeyF11: fyne.KeyF11,
+	glfw.KeyF12: fyne.KeyF12,
+
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	glfw.Key0:   fyne.Key0,
+	glfw.KeyKP0: fyne.Key0,
+	glfw.Key1:   fyne.Key1,
+	glfw.KeyKP1: fyne.Key1,
+	glfw.Key2:   fyne.Key2,
+	glfw.KeyKP2: fyne.Key2,
+	glfw.Key3:   fyne.Key3,
+	glfw.KeyKP3: fyne.Key3,
+	glfw.Key4:   fyne.Key4,
+	glfw.KeyKP4: fyne.Key4,
+	glfw.Key5:   fyne.Key5,
+	glfw.KeyKP5: fyne.Key5,
+	glfw.Key6:   fyne.Key6,
+	glfw.KeyKP6: fyne.Key6,
+	glfw.Key7:   fyne.Key7,
+	glfw.KeyKP7: fyne.Key7,
+	glfw.Key8:   fyne.Key8,
+	glfw.KeyKP8: fyne.Key8,
+	glfw.Key9:   fyne.Key9,
+	glfw.KeyKP9: fyne.Key9,
+
+	// desktop
+	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
+	glfw.KeyRightShift:   desktop.KeyShiftRight,
+	glfw.KeyLeftControl:  desktop.KeyControlLeft,
+	glfw.KeyRightControl: desktop.KeyControlRight,
+	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
+	glfw.KeyRightAlt:     desktop.KeyAltRight,
+	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
+	glfw.KeyRightSuper:   desktop.KeySuperRight,
+	glfw.KeyMenu:         desktop.KeyMenu,
+	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
+	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+}
+
+func TestGlfwKeyToKeyName(t *testing.T) {
+	for key, value := range keyCodeMap {
+		translated := glfwKeyToKeyName(key)
+		assert.Equal(t, value, translated)
+	}
+}
+
+func TestConvertASCII(t *testing.T) {
+	for i := 0; i <= 'Z'-'A'; i++ {
+		translated := convertASCII(glfw.KeyA + glfw.Key(i))
+		expected := fyne.KeyName(rune(fyne.KeyA[0] + byte(i)))
+		assert.Equal(t, expected, translated)
+	}
+}
+
+var keyNameMapSpecialCharacters = map[string]fyne.KeyName{
+	"'": fyne.KeyApostrophe,
+	",": fyne.KeyComma,
+	"-": fyne.KeyMinus,
+	".": fyne.KeyPeriod,
+	"/": fyne.KeySlash,
+	"*": fyne.KeyAsterisk,
+	"`": fyne.KeyBackTick,
+
+	";": fyne.KeySemicolon,
+	"+": fyne.KeyPlus,
+	"=": fyne.KeyEqual,
+
+	"[":  fyne.KeyLeftBracket,
+	"\\": fyne.KeyBackslash,
+	"]":  fyne.KeyRightBracket,
+}
+
+func TestKeyCodeToKeyName(t *testing.T) {
+	for key, value := range keyNameMapSpecialCharacters {
+		translated := keyCodeToKeyName(key)
+		assert.Equal(t, value, translated)
+	}
+
+	for i := rune(0); i <= 'z'-'a'; i++ {
+		translated := keyCodeToKeyName(string('a' + i))
+		expected := fyne.KeyName(rune(fyne.KeyA[0]) + i)
+		assert.Equal(t, expected, translated)
+	}
+
+	translated := keyCodeToKeyName("invalid")
+	assert.Equal(t, fyne.KeyUnknown, translated)
+}

--- a/internal/driver/glfw/window_desktop_test.go
+++ b/internal/driver/glfw/window_desktop_test.go
@@ -87,6 +87,9 @@ func TestGlfwKeyToKeyName(t *testing.T) {
 		translated := glfwKeyToKeyName(key)
 		assert.Equal(t, value, translated)
 	}
+
+	invalid := glfwKeyToKeyName(glfw.Key(-1))
+	assert.Equal(t, fyne.KeyUnknown, invalid)
 }
 
 func TestConvertASCII(t *testing.T) {
@@ -95,6 +98,9 @@ func TestConvertASCII(t *testing.T) {
 		expected := fyne.KeyName(rune(fyne.KeyA[0] + byte(i)))
 		assert.Equal(t, expected, translated)
 	}
+
+	invalid := convertASCII(glfw.Key(-1))
+	assert.Equal(t, fyne.KeyUnknown, invalid)
 }
 
 var keyNameMapSpecialCharacters = map[string]fyne.KeyName{
@@ -127,6 +133,9 @@ func TestKeyCodeToKeyName(t *testing.T) {
 		assert.Equal(t, expected, translated)
 	}
 
-	translated := keyCodeToKeyName("invalid")
-	assert.Equal(t, fyne.KeyUnknown, translated)
+	invalid := keyCodeToKeyName("@")
+	assert.Equal(t, fyne.KeyUnknown, invalid)
+
+	invalid = keyCodeToKeyName("invalid")
+	assert.Equal(t, fyne.KeyUnknown, invalid)
 }

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -232,74 +232,124 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 	return button, modifier
 }
 
-var keyCodeMap = map[glfw.Key]fyne.KeyName{
-	// non-printable
-	glfw.KeyEscape:    fyne.KeyEscape,
-	glfw.KeyEnter:     fyne.KeyReturn,
-	glfw.KeyTab:       fyne.KeyTab,
-	glfw.KeyBackspace: fyne.KeyBackspace,
-	glfw.KeyInsert:    fyne.KeyInsert,
-	glfw.KeyDelete:    fyne.KeyDelete,
-	glfw.KeyRight:     fyne.KeyRight,
-	glfw.KeyLeft:      fyne.KeyLeft,
-	glfw.KeyDown:      fyne.KeyDown,
-	glfw.KeyUp:        fyne.KeyUp,
-	glfw.KeyPageUp:    fyne.KeyPageUp,
-	glfw.KeyPageDown:  fyne.KeyPageDown,
-	glfw.KeyHome:      fyne.KeyHome,
-	glfw.KeyEnd:       fyne.KeyEnd,
-
-	glfw.KeySpace:   fyne.KeySpace,
-	glfw.KeyKPEnter: fyne.KeyEnter,
-
-	// functions
-	glfw.KeyF1:  fyne.KeyF1,
-	glfw.KeyF2:  fyne.KeyF2,
-	glfw.KeyF3:  fyne.KeyF3,
-	glfw.KeyF4:  fyne.KeyF4,
-	glfw.KeyF5:  fyne.KeyF5,
-	glfw.KeyF6:  fyne.KeyF6,
-	glfw.KeyF7:  fyne.KeyF7,
-	glfw.KeyF8:  fyne.KeyF8,
-	glfw.KeyF9:  fyne.KeyF9,
-	glfw.KeyF10: fyne.KeyF10,
-	glfw.KeyF11: fyne.KeyF11,
-	glfw.KeyF12: fyne.KeyF12,
-
+//gocyclo:ignore
+func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
 	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	glfw.Key0:   fyne.Key0,
-	glfw.KeyKP0: fyne.Key0,
-	glfw.Key1:   fyne.Key1,
-	glfw.KeyKP1: fyne.Key1,
-	glfw.Key2:   fyne.Key2,
-	glfw.KeyKP2: fyne.Key2,
-	glfw.Key3:   fyne.Key3,
-	glfw.KeyKP3: fyne.Key3,
-	glfw.Key4:   fyne.Key4,
-	glfw.KeyKP4: fyne.Key4,
-	glfw.Key5:   fyne.Key5,
-	glfw.KeyKP5: fyne.Key5,
-	glfw.Key6:   fyne.Key6,
-	glfw.KeyKP6: fyne.Key6,
-	glfw.Key7:   fyne.Key7,
-	glfw.KeyKP7: fyne.Key7,
-	glfw.Key8:   fyne.Key8,
-	glfw.KeyKP8: fyne.Key8,
-	glfw.Key9:   fyne.Key9,
-	glfw.KeyKP9: fyne.Key9,
+	if key >= '0' && key <= '9' {
+		return fyne.KeyName(rune(key))
+	}
+
+	// Keys that can not be easily translated:
+	switch key {
+	// non-printable
+	case glfw.KeyEscape:
+		return fyne.KeyEscape
+	case glfw.KeyEnter:
+		return fyne.KeyReturn
+	case glfw.KeyTab:
+		return fyne.KeyTab
+	case glfw.KeyBackspace:
+		return fyne.KeyBackspace
+	case glfw.KeyInsert:
+		return fyne.KeyInsert
+	case glfw.KeyDelete:
+		return fyne.KeyDelete
+	case glfw.KeyRight:
+		return fyne.KeyRight
+	case glfw.KeyLeft:
+		return fyne.KeyLeft
+	case glfw.KeyDown:
+		return fyne.KeyDown
+	case glfw.KeyUp:
+		return fyne.KeyUp
+	case glfw.KeyPageUp:
+		return fyne.KeyPageUp
+	case glfw.KeyPageDown:
+		return fyne.KeyPageDown
+	case glfw.KeyHome:
+		return fyne.KeyHome
+	case glfw.KeyEnd:
+		return fyne.KeyEnd
+
+	case glfw.KeySpace:
+		return fyne.KeySpace
+	case glfw.KeyKPEnter:
+		return fyne.KeyEnter
 
 	// desktop
-	glfw.KeyLeftShift:    desktop.KeyShiftLeft,
-	glfw.KeyRightShift:   desktop.KeyShiftRight,
-	glfw.KeyLeftControl:  desktop.KeyControlLeft,
-	glfw.KeyRightControl: desktop.KeyControlRight,
-	glfw.KeyLeftAlt:      desktop.KeyAltLeft,
-	glfw.KeyRightAlt:     desktop.KeyAltRight,
-	glfw.KeyLeftSuper:    desktop.KeySuperLeft,
-	glfw.KeyRightSuper:   desktop.KeySuperRight,
-	glfw.KeyMenu:         desktop.KeyMenu,
-	glfw.KeyPrintScreen:  desktop.KeyPrintScreen,
-	glfw.KeyCapsLock:     desktop.KeyCapsLock,
+	case glfw.KeyLeftShift:
+		return desktop.KeyShiftLeft
+	case glfw.KeyRightShift:
+		return desktop.KeyShiftRight
+	case glfw.KeyLeftControl:
+		return desktop.KeyControlLeft
+	case glfw.KeyRightControl:
+		return desktop.KeyControlRight
+	case glfw.KeyLeftAlt:
+		return desktop.KeyAltLeft
+	case glfw.KeyRightAlt:
+		return desktop.KeyAltRight
+	case glfw.KeyLeftSuper:
+		return desktop.KeySuperLeft
+	case glfw.KeyRightSuper:
+		return desktop.KeySuperRight
+	case glfw.KeyMenu:
+		return desktop.KeyMenu
+	case glfw.KeyPrintScreen:
+		return desktop.KeyPrintScreen
+	case glfw.KeyCapsLock:
+		return desktop.KeyCapsLock
+
+	// functions
+	case glfw.KeyF1:
+		return fyne.KeyF1
+	case glfw.KeyF2:
+		return fyne.KeyF2
+	case glfw.KeyF3:
+		return fyne.KeyF3
+	case glfw.KeyF4:
+		return fyne.KeyF4
+	case glfw.KeyF5:
+		return fyne.KeyF5
+	case glfw.KeyF6:
+		return fyne.KeyF6
+	case glfw.KeyF7:
+		return fyne.KeyF7
+	case glfw.KeyF8:
+		return fyne.KeyF8
+	case glfw.KeyF9:
+		return fyne.KeyF9
+	case glfw.KeyF10:
+		return fyne.KeyF10
+	case glfw.KeyF11:
+		return fyne.KeyF11
+	case glfw.KeyF12:
+		return fyne.KeyF12
+
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	case glfw.KeyKP0:
+		return fyne.Key0
+	case glfw.KeyKP1:
+		return fyne.Key1
+	case glfw.KeyKP2:
+		return fyne.Key2
+	case glfw.KeyKP3:
+		return fyne.Key3
+	case glfw.KeyKP4:
+		return fyne.Key4
+	case glfw.KeyKP5:
+		return fyne.Key5
+	case glfw.KeyKP6:
+		return fyne.Key6
+	case glfw.KeyKP7:
+		return fyne.Key7
+	case glfw.KeyKP8:
+		return fyne.Key8
+	case glfw.KeyKP9:
+		return fyne.Key9
+	}
+
+	return ""
 }
 
 func keyCodeToKeyName(code string) fyne.KeyName {
@@ -321,8 +371,8 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 		code = glfw.KeyPrintScreen
 	}
 
-	ret, ok := keyCodeMap[code]
-	if ok {
+	ret := glfwKeyToKeyName(code)
+	if ret != "" {
 		return ret
 	}
 

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -359,7 +359,7 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 
 	char := code[0]
 	if char >= 'a' && char <= 'z' {
-		// The fyne keys are all upper case characters.
+		// Our alphabetical keys are all upper case characters.
 		return fyne.KeyName('A' + char - 'a')
 	}
 

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -302,35 +302,6 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyCapsLock:     desktop.KeyCapsLock,
 }
 
-var keyCodeMapASCII = map[glfw.Key]fyne.KeyName{
-	glfw.KeyA: fyne.KeyA,
-	glfw.KeyB: fyne.KeyB,
-	glfw.KeyC: fyne.KeyC,
-	glfw.KeyD: fyne.KeyD,
-	glfw.KeyE: fyne.KeyE,
-	glfw.KeyF: fyne.KeyF,
-	glfw.KeyG: fyne.KeyG,
-	glfw.KeyH: fyne.KeyH,
-	glfw.KeyI: fyne.KeyI,
-	glfw.KeyJ: fyne.KeyJ,
-	glfw.KeyK: fyne.KeyK,
-	glfw.KeyL: fyne.KeyL,
-	glfw.KeyM: fyne.KeyM,
-	glfw.KeyN: fyne.KeyN,
-	glfw.KeyO: fyne.KeyO,
-	glfw.KeyP: fyne.KeyP,
-	glfw.KeyQ: fyne.KeyQ,
-	glfw.KeyR: fyne.KeyR,
-	glfw.KeyS: fyne.KeyS,
-	glfw.KeyT: fyne.KeyT,
-	glfw.KeyU: fyne.KeyU,
-	glfw.KeyV: fyne.KeyV,
-	glfw.KeyW: fyne.KeyW,
-	glfw.KeyX: fyne.KeyX,
-	glfw.KeyY: fyne.KeyY,
-	glfw.KeyZ: fyne.KeyZ,
-}
-
 var keyNameMap = map[string]fyne.KeyName{
 	"'": fyne.KeyApostrophe,
 	",": fyne.KeyComma,
@@ -408,11 +379,11 @@ func convertAction(action glfw.Action) action {
 }
 
 func convertASCII(key glfw.Key) fyne.KeyName {
-	ret, ok := keyCodeMapASCII[key]
-	if !ok {
+	if key < glfw.KeyA || key > glfw.KeyZ {
 		return fyne.KeyUnknown
 	}
-	return ret
+
+	return fyne.KeyName(rune(key))
 }
 
 func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -235,7 +235,7 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 //gocyclo:ignore
 func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
 	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	if key >= '0' && key <= '9' {
+	if key >= glfw.Key0 && key <= glfw.Key9 {
 		return fyne.KeyName(rune(key))
 	}
 

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -401,7 +401,7 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	}
 
 	ret := glfwKeyToKeyName(code)
-	if ret != "" {
+	if ret != fyne.KeyUnknown {
 		return ret
 	}
 

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -234,13 +234,29 @@ func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.Mo
 
 //gocyclo:ignore
 func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
-	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	if key >= glfw.Key0 && key <= glfw.Key9 {
-		return fyne.KeyName(rune(key))
-	}
-
-	// Keys that can not be easily translated:
 	switch key {
+	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
+	case glfw.Key0, glfw.KeyKP0:
+		return fyne.Key0
+	case glfw.Key1, glfw.KeyKP1:
+		return fyne.Key1
+	case glfw.Key2, glfw.KeyKP2:
+		return fyne.Key2
+	case glfw.Key3, glfw.KeyKP3:
+		return fyne.Key3
+	case glfw.Key4, glfw.KeyKP4:
+		return fyne.Key4
+	case glfw.Key5, glfw.KeyKP5:
+		return fyne.Key5
+	case glfw.Key6, glfw.KeyKP6:
+		return fyne.Key6
+	case glfw.Key7, glfw.KeyKP7:
+		return fyne.Key7
+	case glfw.Key8, glfw.KeyKP8:
+		return fyne.Key8
+	case glfw.Key9, glfw.KeyKP9:
+		return fyne.Key9
+
 	// non-printable
 	case glfw.KeyEscape:
 		return fyne.KeyEscape
@@ -325,31 +341,9 @@ func glfwKeyToKeyName(key glfw.Key) fyne.KeyName {
 		return fyne.KeyF11
 	case glfw.KeyF12:
 		return fyne.KeyF12
-
-	// numbers - lookup by code to avoid AZERTY using the symbol name instead of number
-	case glfw.KeyKP0:
-		return fyne.Key0
-	case glfw.KeyKP1:
-		return fyne.Key1
-	case glfw.KeyKP2:
-		return fyne.Key2
-	case glfw.KeyKP3:
-		return fyne.Key3
-	case glfw.KeyKP4:
-		return fyne.Key4
-	case glfw.KeyKP5:
-		return fyne.Key5
-	case glfw.KeyKP6:
-		return fyne.Key6
-	case glfw.KeyKP7:
-		return fyne.Key7
-	case glfw.KeyKP8:
-		return fyne.Key8
-	case glfw.KeyKP9:
-		return fyne.Key9
 	}
 
-	return ""
+	return fyne.KeyUnknown
 }
 
 func keyCodeToKeyName(code string) fyne.KeyName {

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -363,7 +363,36 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 		return fyne.KeyName('A' + char - 'a')
 	}
 
-	return fyne.KeyName(char)
+	switch char {
+	case '[':
+		return fyne.KeyLeftBracket
+	case '\\':
+		return fyne.KeyBackslash
+	case ']':
+		return fyne.KeyRightBracket
+	case '\'':
+		return fyne.KeyApostrophe
+	case ',':
+		return fyne.KeyComma
+	case '-':
+		return fyne.KeyMinus
+	case '.':
+		return fyne.KeyPeriod
+	case '/':
+		return fyne.KeySlash
+	case '*':
+		return fyne.KeyAsterisk
+	case '`':
+		return fyne.KeyBackTick
+	case ';':
+		return fyne.KeySemicolon
+	case '+':
+		return fyne.KeyPlus
+	case '=':
+		return fyne.KeyEqual
+	}
+
+	return fyne.KeyUnknown
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -358,11 +358,9 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 	}
 
 	char := code[0]
-
-	relativeLetter := char - 'a'
-	if relativeLetter <= 'z' {
+	if char >= 'a' && char <= 'z' {
 		// Our alphabetical keys are all upper case characters.
-		return fyne.KeyName('A' + relativeLetter)
+		return fyne.KeyName('A' + char - 'a')
 	}
 
 	switch char {

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -358,9 +358,11 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 	}
 
 	char := code[0]
-	if char >= 'a' && char <= 'z' {
+
+	relativeLetter := char - 'a'
+	if relativeLetter <= 'z' {
 		// Our alphabetical keys are all upper case characters.
-		return fyne.KeyName('A' + char - 'a')
+		return fyne.KeyName('A' + relativeLetter)
 	}
 
 	switch char {

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -302,49 +302,18 @@ var keyCodeMap = map[glfw.Key]fyne.KeyName{
 	glfw.KeyCapsLock:     desktop.KeyCapsLock,
 }
 
-var keyNameMap = map[string]fyne.KeyName{
-	"'": fyne.KeyApostrophe,
-	",": fyne.KeyComma,
-	"-": fyne.KeyMinus,
-	".": fyne.KeyPeriod,
-	"/": fyne.KeySlash,
-	"*": fyne.KeyAsterisk,
-	"`": fyne.KeyBackTick,
+func keyCodeToKeyName(code string) fyne.KeyName {
+	if len(code) != 1 {
+		return fyne.KeyUnknown
+	}
 
-	";": fyne.KeySemicolon,
-	"+": fyne.KeyPlus,
-	"=": fyne.KeyEqual,
+	char := code[0]
+	if char >= 'a' && char <= 'z' {
+		// The fyne keys are all upper case characters.
+		return fyne.KeyName('A' + char - 'a')
+	}
 
-	"a": fyne.KeyA,
-	"b": fyne.KeyB,
-	"c": fyne.KeyC,
-	"d": fyne.KeyD,
-	"e": fyne.KeyE,
-	"f": fyne.KeyF,
-	"g": fyne.KeyG,
-	"h": fyne.KeyH,
-	"i": fyne.KeyI,
-	"j": fyne.KeyJ,
-	"k": fyne.KeyK,
-	"l": fyne.KeyL,
-	"m": fyne.KeyM,
-	"n": fyne.KeyN,
-	"o": fyne.KeyO,
-	"p": fyne.KeyP,
-	"q": fyne.KeyQ,
-	"r": fyne.KeyR,
-	"s": fyne.KeyS,
-	"t": fyne.KeyT,
-	"u": fyne.KeyU,
-	"v": fyne.KeyV,
-	"w": fyne.KeyW,
-	"x": fyne.KeyX,
-	"y": fyne.KeyY,
-	"z": fyne.KeyZ,
-
-	"[":  fyne.KeyLeftBracket,
-	"\\": fyne.KeyBackslash,
-	"]":  fyne.KeyRightBracket,
+	return fyne.KeyName(char)
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
@@ -358,12 +327,8 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 	}
 
 	//	keyName := glfw.GetKeyName(code, scancode)
-	//	ret, ok = keyNameMap[keyName]
-	//	if !ok {
+	//	return keyCodeToKeyName(keyName)
 	return fyne.KeyUnknown
-	//	}
-
-	//	return ret
 }
 
 func convertAction(action glfw.Action) action {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is a rework of the improvements in #3179. Not only are the shortcut issues fixed but certain other aspects have
also been improved further. For example, I noted that a few glfw keys (and strings) just map directly to ascii so
we can often just reuse the values directly without even having to switch on them.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
