### PR TITLE
Fix widgets using theme.BackgroundColor() in dialogs

### DIFF
--- a/widget/check.go
+++ b/widget/check.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"fmt"
+	"image/color"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -53,7 +54,7 @@ func (c *checkRenderer) Layout(size fyne.Size) {
 
 // applyTheme updates this Check to the current theme
 func (c *checkRenderer) applyTheme() {
-	c.bg.FillColor = theme.BackgroundColor()
+	c.bg.FillColor = color.Transparent
 	c.label.Color = theme.ForegroundColor()
 	c.label.TextSize = theme.TextSize()
 	if c.check.disabled {
@@ -90,20 +91,20 @@ func (c *checkRenderer) updateResource() {
 			res = theme.NewThemedResource(theme.CheckButtonCheckedIcon())
 		}
 		res.ColorName = theme.ColorNameDisabled
-		c.bg.FillColor = theme.BackgroundColor()
+		c.bg.FillColor = color.Transparent
 	}
 	c.icon.Resource = res
 }
 
 func (c *checkRenderer) updateFocusIndicator() {
 	if c.check.Disabled() {
-		c.focusIndicator.FillColor = theme.BackgroundColor()
+		c.focusIndicator.FillColor = color.Transparent
 	} else if c.check.focused {
 		c.focusIndicator.FillColor = theme.FocusColor()
 	} else if c.check.hovered {
 		c.focusIndicator.FillColor = theme.HoverColor()
 	} else {
-		c.focusIndicator.FillColor = theme.BackgroundColor()
+		c.focusIndicator.FillColor = color.Transparent
 	}
 }
 

--- a/widget/check_internal_test.go
+++ b/widget/check_internal_test.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"fmt"
+	"image/color"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -131,11 +132,11 @@ func TestCheck_Focused(t *testing.T) {
 	render := test.WidgetRenderer(check).(*checkRenderer)
 
 	assert.False(t, check.focused)
-	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 
 	check.SetChecked(true)
 	assert.False(t, check.focused)
-	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 
 	test.Tap(check)
 	if fyne.CurrentDevice().IsMobile() {
@@ -147,7 +148,7 @@ func TestCheck_Focused(t *testing.T) {
 
 	check.Disable()
 	assert.True(t, check.disabled)
-	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 
 	check.Enable()
 	if fyne.CurrentDevice().IsMobile() {
@@ -171,7 +172,7 @@ func TestCheck_Hovered(t *testing.T) {
 
 	check.SetChecked(true)
 	assert.False(t, check.hovered)
-	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 
 	check.MouseIn(&desktop.MouseEvent{})
 	assert.True(t, check.hovered)
@@ -186,7 +187,7 @@ func TestCheck_Hovered(t *testing.T) {
 	check.Disable()
 	assert.True(t, check.disabled)
 	assert.True(t, check.hovered)
-	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 
 	check.Enable()
 	assert.True(t, check.hovered)
@@ -199,14 +200,14 @@ func TestCheck_Hovered(t *testing.T) {
 	check.MouseOut()
 	assert.False(t, check.hovered)
 	if fyne.CurrentDevice().IsMobile() {
-		assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
+		assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 	} else {
 		assert.Equal(t, theme.FocusColor(), render.focusIndicator.FillColor)
 	}
 
 	check.FocusLost()
 	assert.False(t, check.hovered)
-	assert.Equal(t, theme.BackgroundColor(), render.focusIndicator.FillColor)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 }
 
 func TestCheck_TypedRune(t *testing.T) {

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -1,6 +1,7 @@
 package widget
 
 import (
+	"image/color"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -135,16 +136,16 @@ func TestRadioGroup_Extended_Hovered(t *testing.T) {
 			render2 := cache.Renderer(radio.items[1]).(*radioItemRenderer)
 
 			assert.False(t, item1.hovered)
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			radio.SetSelected("Hi")
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			radio.SetSelected("Another")
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			item1.MouseIn(&desktop.MouseEvent{
 				PointEvent: fyne.PointEvent{
@@ -153,12 +154,12 @@ func TestRadioGroup_Extended_Hovered(t *testing.T) {
 			})
 			assert.True(t, item1.hovered)
 			assert.Equal(t, theme.HoverColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			item1.MouseOut()
 			assert.False(t, item1.hovered)
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 		})
 	}
 }

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"fmt"
+	"image/color"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -232,16 +233,16 @@ func TestRadioGroup_Hovered(t *testing.T) {
 			render2 := cache.Renderer(radio.items[1]).(*radioItemRenderer)
 
 			assert.False(t, item1.hovered)
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			radio.SetSelected("Hi")
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			radio.SetSelected("Another")
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			item1.MouseIn(&desktop.MouseEvent{
 				PointEvent: fyne.PointEvent{
@@ -250,12 +251,12 @@ func TestRadioGroup_Hovered(t *testing.T) {
 			})
 			assert.True(t, item1.hovered)
 			assert.Equal(t, theme.HoverColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 
 			item1.MouseOut()
 			assert.False(t, item1.hovered)
-			assert.Equal(t, theme.BackgroundColor(), render1.focusIndicator.FillColor)
-			assert.Equal(t, theme.BackgroundColor(), render2.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
+			assert.Equal(t, color.Transparent, render2.focusIndicator.FillColor)
 		})
 	}
 }

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -1,6 +1,8 @@
 package widget
 
 import (
+	"image/color"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
@@ -35,7 +37,7 @@ type radioItem struct {
 //
 // Implements: fyne.Widget
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
-	focusIndicator := canvas.NewCircle(theme.BackgroundColor())
+	focusIndicator := canvas.NewCircle(color.Transparent)
 	bg := canvas.NewCircle(theme.InputBackgroundColor())
 	icon := canvas.NewImageFromResource(theme.NewPrimaryThemedResource(theme.RadioButtonCheckedIcon()))
 	over := canvas.NewImageFromResource(theme.NewThemedResource(theme.RadioButtonIcon()))
@@ -215,12 +217,12 @@ func (r *radioItemRenderer) update() {
 	r.over.Resource = out
 
 	if r.item.Disabled() {
-		r.focusIndicator.FillColor = theme.BackgroundColor()
+		r.focusIndicator.FillColor = color.Transparent
 	} else if r.item.focused {
 		r.focusIndicator.FillColor = theme.FocusColor()
 	} else if r.item.hovered {
 		r.focusIndicator.FillColor = theme.HoverColor()
 	} else {
-		r.focusIndicator.FillColor = theme.BackgroundColor()
+		r.focusIndicator.FillColor = color.Transparent
 	}
 }

--- a/widget/testdata/check/layout_checked.xml
+++ b/widget/testdata/check/layout_checked.xml
@@ -2,7 +2,7 @@
 	<content>
 		<container pos="4,4" size="142x192">
 			<widget pos="39,78" size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="30x35">Test</text>

--- a/widget/testdata/check/layout_checked_disabled.xml
+++ b/widget/testdata/check/layout_checked_disabled.xml
@@ -2,8 +2,8 @@
 	<content>
 		<container pos="4,4" size="142x192">
 			<widget pos="39,78" size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="30x35">Test</text>
 			</widget>

--- a/widget/testdata/check/layout_unchecked.xml
+++ b/widget/testdata/check/layout_unchecked.xml
@@ -2,7 +2,7 @@
 	<content>
 		<container pos="4,4" size="142x192">
 			<widget pos="39,78" size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="30x35">Test</text>

--- a/widget/testdata/check/layout_unchecked_disabled.xml
+++ b/widget/testdata/check/layout_unchecked_disabled.xml
@@ -2,8 +2,8 @@
 	<content>
 		<container pos="4,4" size="142x192">
 			<widget pos="39,78" size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="30x35">Test</text>
 			</widget>

--- a/widget/testdata/check_group/disabled_append_none_selected.xml
+++ b/widget/testdata/check_group/disabled_append_none_selected.xml
@@ -2,20 +2,20 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option A</text>
 			</widget>
 			<widget pos="0,35" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option C</text>
 			</widget>

--- a/widget/testdata/check_group/disabled_none_selected.xml
+++ b/widget/testdata/check_group/disabled_none_selected.xml
@@ -2,14 +2,14 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option A</text>
 			</widget>
 			<widget pos="0,35" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option B</text>
 			</widget>

--- a/widget/testdata/check_group/focus_a_focused_b_selected.xml
+++ b/widget/testdata/check_group/focus_a_focused_b_selected.xml
@@ -8,13 +8,13 @@
 				<text pos="32,0" size="62x35">Option A</text>
 			</widget>
 			<widget pos="0,35" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="62x35">Option C</text>

--- a/widget/testdata/check_group/focus_a_focused_none_selected.xml
+++ b/widget/testdata/check_group/focus_a_focused_none_selected.xml
@@ -8,13 +8,13 @@
 				<text pos="32,0" size="62x35">Option A</text>
 			</widget>
 			<widget pos="0,35" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option C</text>

--- a/widget/testdata/check_group/focus_b_focused_b_selected.xml
+++ b/widget/testdata/check_group/focus_b_focused_b_selected.xml
@@ -2,7 +2,7 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option A</text>
@@ -14,7 +14,7 @@
 				<text pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="62x35">Option C</text>

--- a/widget/testdata/check_group/focus_b_focused_none_selected.xml
+++ b/widget/testdata/check_group/focus_b_focused_none_selected.xml
@@ -2,7 +2,7 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option A</text>
@@ -14,7 +14,7 @@
 				<text pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option C</text>

--- a/widget/testdata/check_group/focus_disabled_none_selected.xml
+++ b/widget/testdata/check_group/focus_disabled_none_selected.xml
@@ -2,20 +2,20 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option A</text>
 			</widget>
 			<widget pos="0,35" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="62x35">Option C</text>
 			</widget>

--- a/widget/testdata/check_group/focus_none_focused_b_selected.xml
+++ b/widget/testdata/check_group/focus_none_focused_b_selected.xml
@@ -2,19 +2,19 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option A</text>
 			</widget>
 			<widget pos="0,35" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="62x35">Option C</text>

--- a/widget/testdata/check_group/focus_none_focused_none_selected.xml
+++ b/widget/testdata/check_group/focus_none_focused_none_selected.xml
@@ -2,19 +2,19 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option A</text>
 			</widget>
 			<widget pos="0,35" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option B</text>
 			</widget>
 			<widget pos="0,70" size="94x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="62x35">Option C</text>

--- a/widget/testdata/check_group/layout_multiple.xml
+++ b/widget/testdata/check_group/layout_multiple.xml
@@ -2,13 +2,13 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="28x35">Foo</text>
 			</widget>
 			<widget pos="0,35" size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="28x35">Bar</text>

--- a/widget/testdata/check_group/layout_multiple_disabled.xml
+++ b/widget/testdata/check_group/layout_multiple_disabled.xml
@@ -2,14 +2,14 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="28x35">Foo</text>
 			</widget>
 			<widget pos="0,35" size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="28x35">Bar</text>
 			</widget>

--- a/widget/testdata/check_group/layout_multiple_horizontal.xml
+++ b/widget/testdata/check_group/layout_multiple_horizontal.xml
@@ -2,13 +2,13 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="27x35">Foo</text>
 			</widget>
 			<widget pos="59,0" size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="27x35">Bar</text>

--- a/widget/testdata/check_group/layout_multiple_horizontal_disabled.xml
+++ b/widget/testdata/check_group/layout_multiple_horizontal_disabled.xml
@@ -2,14 +2,14 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="27x35">Foo</text>
 			</widget>
 			<widget pos="59,0" size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="27x35">Bar</text>
 			</widget>

--- a/widget/testdata/check_group/layout_multiple_selected.xml
+++ b/widget/testdata/check_group/layout_multiple_selected.xml
@@ -2,13 +2,13 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="28x35">Foo</text>
 			</widget>
 			<widget pos="0,35" size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="28x35">Bar</text>

--- a/widget/testdata/check_group/layout_multiple_selected_disabled.xml
+++ b/widget/testdata/check_group/layout_multiple_selected_disabled.xml
@@ -2,14 +2,14 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="28x35">Foo</text>
 			</widget>
 			<widget pos="0,35" size="60x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="28x35">Bar</text>
 			</widget>

--- a/widget/testdata/check_group/layout_multiple_selected_horizontal.xml
+++ b/widget/testdata/check_group/layout_multiple_selected_horizontal.xml
@@ -2,13 +2,13 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="27x35">Foo</text>
 			</widget>
 			<widget pos="59,0" size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="27x35">Bar</text>

--- a/widget/testdata/check_group/layout_multiple_selected_horizontal_disabled.xml
+++ b/widget/testdata/check_group/layout_multiple_selected_horizontal_disabled.xml
@@ -2,14 +2,14 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="27x35">Foo</text>
 			</widget>
 			<widget pos="59,0" size="59x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="27x35">Bar</text>
 			</widget>

--- a/widget/testdata/check_group/layout_single.xml
+++ b/widget/testdata/check_group/layout_single.xml
@@ -2,7 +2,7 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="30x35">Test</text>

--- a/widget/testdata/check_group/layout_single_disabled.xml
+++ b/widget/testdata/check_group/layout_single_disabled.xml
@@ -2,8 +2,8 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="30x35">Test</text>
 			</widget>

--- a/widget/testdata/check_group/layout_single_horizontal.xml
+++ b/widget/testdata/check_group/layout_single_horizontal.xml
@@ -2,7 +2,7 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="inputBackground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 				<text pos="32,0" size="30x35">Test</text>

--- a/widget/testdata/check_group/layout_single_horizontal_disabled.xml
+++ b/widget/testdata/check_group/layout_single_horizontal_disabled.xml
@@ -2,8 +2,8 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="30x35">Test</text>
 			</widget>

--- a/widget/testdata/check_group/layout_single_selected.xml
+++ b/widget/testdata/check_group/layout_single_selected.xml
@@ -2,7 +2,7 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="30x35">Test</text>

--- a/widget/testdata/check_group/layout_single_selected_disabled.xml
+++ b/widget/testdata/check_group/layout_single_selected_disabled.xml
@@ -2,8 +2,8 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="30x35">Test</text>
 			</widget>

--- a/widget/testdata/check_group/layout_single_selected_horizontal.xml
+++ b/widget/testdata/check_group/layout_single_selected_horizontal.xml
@@ -2,7 +2,7 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
+				<circle pos="2,3" size="28x28"/>
 				<rectangle fillColor="foreground" pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 				<text pos="32,0" size="30x35">Test</text>

--- a/widget/testdata/check_group/layout_single_selected_horizontal_disabled.xml
+++ b/widget/testdata/check_group/layout_single_selected_horizontal_disabled.xml
@@ -2,8 +2,8 @@
 	<content>
 		<widget pos="4,4" size="142x192" type="*widget.CheckGroup">
 			<widget size="62x35" type="*widget.Check">
-				<circle fillColor="background" pos="2,3" size="28x28"/>
-				<rectangle fillColor="background" pos="10,11" size="12x12"/>
+				<circle pos="2,3" size="28x28"/>
+				<rectangle pos="10,11" size="12x12"/>
 				<image pos="6,7" rsc="checkButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 				<text color="disabled" pos="32,0" size="30x35">Test</text>
 			</widget>

--- a/widget/testdata/radio_group/disabled_append_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_append_none_selected.xml
@@ -3,19 +3,19 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="21,60" size="98x70" type="*widget.RadioGroup">
 				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option A</text>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/disabled_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_none_selected.xml
@@ -3,13 +3,13 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="21,60" size="98x70" type="*widget.RadioGroup">
 				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option A</text>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option B</text>

--- a/widget/testdata/radio_group/focus_a_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_b_selected.xml
@@ -9,14 +9,14 @@
 					<text pos="32,0" size="98x35">Option A</text>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
 					<text pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/focus_a_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_none_selected.xml
@@ -9,13 +9,13 @@
 					<text pos="32,0" size="98x35">Option A</text>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/focus_b_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_b_selected.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
 				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option A</text>
@@ -16,7 +16,7 @@
 					<text pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/focus_b_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_none_selected.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
 				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option A</text>
@@ -15,7 +15,7 @@
 					<text pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/focus_disabled_none_selected.xml
+++ b/widget/testdata/radio_group/focus_disabled_none_selected.xml
@@ -3,19 +3,19 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
 				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option A</text>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/focus_none_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_b_selected.xml
@@ -3,20 +3,20 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
 				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option A</text>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
 					<text pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/focus_none_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_none_selected.xml
@@ -3,19 +3,19 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
 				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option A</text>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option B</text>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="98x35">Option C</text>

--- a/widget/testdata/radio_group/layout_multiple.xml
+++ b/widget/testdata/radio_group/layout_multiple.xml
@@ -3,13 +3,13 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
 				<widget size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="64x35">Foo</text>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="64x35">Bar</text>

--- a/widget/testdata/radio_group/layout_multiple_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_disabled.xml
@@ -3,13 +3,13 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
 				<widget size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="64x35">Foo</text>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="64x35">Bar</text>

--- a/widget/testdata/radio_group/layout_multiple_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal.xml
@@ -3,13 +3,13 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="7,78" size="126x35" type="*widget.RadioGroup">
 				<widget size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="63x35">Foo</text>
 				</widget>
 				<widget pos="63,0" size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="63x35">Bar</text>

--- a/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
@@ -3,13 +3,13 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="7,78" size="126x35" type="*widget.RadioGroup">
 				<widget size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="63x35">Foo</text>
 				</widget>
 				<widget pos="63,0" size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="63x35">Bar</text>

--- a/widget/testdata/radio_group/layout_multiple_selected.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected.xml
@@ -3,14 +3,14 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
 				<widget size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
 					<text pos="32,0" size="64x35">Foo</text>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="64x35">Bar</text>

--- a/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
@@ -3,14 +3,14 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
 				<widget size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="64x35">Foo</text>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="64x35">Bar</text>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
@@ -3,14 +3,14 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="7,78" size="126x35" type="*widget.RadioGroup">
 				<widget size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
 					<text pos="32,0" size="63x35">Foo</text>
 				</widget>
 				<widget pos="63,0" size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="63x35">Bar</text>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
@@ -3,14 +3,14 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="7,78" size="126x35" type="*widget.RadioGroup">
 				<widget size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="63x35">Foo</text>
 				</widget>
 				<widget pos="63,0" size="63x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="63x35">Bar</text>

--- a/widget/testdata/radio_group/layout_single.xml
+++ b/widget/testdata/radio_group/layout_single.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="66x35">Test</text>

--- a/widget/testdata/radio_group/layout_single_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="66x35">Test</text>

--- a/widget/testdata/radio_group/layout_single_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
 					<text pos="32,0" size="66x35">Test</text>

--- a/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<text color="disabled" pos="32,0" size="66x35">Test</text>

--- a/widget/testdata/radio_group/layout_single_selected.xml
+++ b/widget/testdata/radio_group/layout_single_selected.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>

--- a/widget/testdata/radio_group/layout_single_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="inputBackground" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
@@ -3,7 +3,7 @@
 		<container pos="4,4" size="142x192">
 			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
 				<widget size="66x35" type="*widget.radioItem">
-					<circle fillColor="background" pos="2,3" size="28x28"/>
+					<circle pos="2,3" size="28x28"/>
 					<circle fillColor="background" pos="6,7" size="20x20"/>
 					<image pos="6,7" rsc="radioButtonCheckedIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The dialogs use a different color for the background now. It looks better to have transparency rather than the wrong background.
![image](https://user-images.githubusercontent.com/25466657/201494799-efe5b259-c50b-4e6a-bf18-280e3c653975.png)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.