### PR TITLE
RichText image

### DIFF
--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -178,7 +178,7 @@ func makeTextTab(_ fyne.Window) fyne.CanvasObject {
 
 ## A Sub Heading
 
-![title](/home/andy/Code/Fyne/fyne/theme/icons/fyne.png)
+![title](../../theme/icons/fyne.png)
 
 ---
 

--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -178,6 +178,8 @@ func makeTextTab(_ fyne.Window) fyne.CanvasObject {
 
 ## A Sub Heading
 
+![title](/home/andy/Code/Fyne/fyne/theme/icons/fyne.png)
+
 ---
 
 * Item1 in _three_ segments

--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -66,7 +66,7 @@ func PaintImage(img *canvas.Image, c fyne.Canvas, width, height int) image.Image
 }
 
 func paintImage(img *canvas.Image, width, height int, wantOrigSize bool, wantOrigW, wantOrigH int) (dst image.Image, origW, origH int, err error) {
-	if width <= 0 || height <= 0 {
+	if (width <= 0 || height <= 0) && !wantOrigSize {
 		return
 	}
 

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -77,8 +77,7 @@ func (m *markdownRenderer) Render(_ io.Writer, source []byte, n ast.Node) error 
 		case "HorizontalRule", "ThematicBreak":
 			m.segs = append(m.segs, &SeparatorSegment{})
 		case "Link":
-			link, _ := url.Parse(string(n.(*ast.Link).Destination))
-			m.nextSeg = &HyperlinkSegment{fyne.TextAlignLeading, "", link}
+			m.nextSeg = makeLink(n.(*ast.Link))
 		case "Paragraph":
 			m.nextSeg = &TextSegment{
 				Style: RichTextStyleInline, // we make it a paragraph at the end if there are no more elements
@@ -150,12 +149,7 @@ func (m *markdownRenderer) Render(_ io.Writer, source []byte, n ast.Node) error 
 		case "Blockquote":
 			m.blockquote = true
 		case "Image":
-			dest := string(n.(*ast.Image).Destination)
-			u, err := storage.ParseURI(dest)
-			if err != nil {
-				u = storage.NewFileURI(dest)
-			}
-			m.nextSeg = &ImageSegment{Source: u, Title: string(n.(*ast.Image).Title)}
+			m.nextSeg = makeImage(n.(*ast.Image))
 		}
 
 		return ast.WalkContinue, nil
@@ -188,6 +182,20 @@ func (m *markdownRenderer) handleExitNode(n ast.Node) error {
 		}
 	}
 	return nil
+}
+
+func makeImage(n *ast.Image) *ImageSegment {
+	dest := string(n.Destination)
+	u, err := storage.ParseURI(dest)
+	if err != nil {
+		u = storage.NewFileURI(dest)
+	}
+	return &ImageSegment{Source: u, Title: string(n.Title)}
+}
+
+func makeLink(n *ast.Link) *HyperlinkSegment {
+	link, _ := url.Parse(string(n.Destination))
+	return &HyperlinkSegment{fyne.TextAlignLeading, "", link}
 }
 
 func parseMarkdown(content string) []RichTextSegment {

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuin/goldmark/renderer"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/storage"
 )
 
 // NewRichTextFromMarkdown configures a RichText widget by parsing the provided markdown content.
@@ -148,6 +149,13 @@ func (m *markdownRenderer) Render(_ io.Writer, source []byte, n ast.Node) error 
 			}
 		case "Blockquote":
 			m.blockquote = true
+		case "Image":
+			dest := string(n.(*ast.Image).Destination)
+			u, err := storage.ParseURI(dest)
+			if err != nil {
+				u = storage.NewFileURI(dest)
+			}
+			m.nextSeg = &ImageSegment{Source: u, Title: string(n.(*ast.Image).Title)}
 		}
 
 		return ast.WalkContinue, nil

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2/storage"
 )
 
 func TestRichTextMarkdown_Blockquote(t *testing.T) {
@@ -135,6 +137,17 @@ func TestRichTextMarkdown_Hyperlink(t *testing.T) {
 		assert.Equal(t, "fyne.io", link.URL.Host)
 	} else {
 		t.Error("Segment should be a Hyperlink")
+	}
+}
+
+func TestRichTextMarkdown_Image(t *testing.T) {
+	r := NewRichTextFromMarkdown("![title](../../theme/icons/fyne.png)")
+
+	assert.Equal(t, 1, len(r.Segments))
+	if img, ok := r.Segments[0].(*ImageSegment); ok {
+		assert.Equal(t, storage.NewFileURI("../../theme/icons/fyne.png"), img.Source)
+	} else {
+		t.Error("Segment should be a Image")
 	}
 }
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -520,6 +520,12 @@ func (r *textRenderer) MinSize() fyne.Size {
 			i++
 
 			min := obj.MinSize()
+			if img, ok := obj.(*richImage); ok {
+				if !img.MinSize().Subtract(img.oldMin).IsZero() {
+					img.oldMin = img.MinSize()
+					r.Refresh() // TODO resolve this in a similar way to #2991
+				}
+			}
 			rowHeight = fyne.Max(rowHeight, min.Height)
 			rowWidth += min.Width
 		}


### PR DESCRIPTION
Insert an image and set the rendering to be @2x native pixels as discussed in our call.
Best compromise between consistency across platforms and a reasonable clarity on high-end devices.

Fixes #2366

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
