### PR TITLE
Remove extra output to stdout

### DIFF
--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -124,8 +124,8 @@ func (p *painter) compileShader(source string, shaderType uint32) (Shader, error
 	}
 
 	// The info is probably a null terminated string.
-	// An empty info has been seen as "\x00".
-	if len(info) > 0 && info != "\x00" {
+	// An empty info has been seen as "\x00" or "\x00\x00".
+	if len(info) > 0 && info != "\x00" && info != "\x00\x00" {
 		fmt.Printf("OpenGL shader compilation output:\n%s\n>>> SHADER SOURCE\n%s\n<<< SHADER SOURCE\n", info, source)
 	}
 
@@ -161,8 +161,8 @@ func (p *painter) createProgram(shaderFilename string) Program {
 	}
 
 	// The info is probably a null terminated string.
-	// An empty info has been seen as "\x00".
-	if len(info) > 0 && info != "\x00" {
+	// An empty info has been seen as "\x00" or "\x00\x00".
+	if len(info) > 0 && info != "\x00" && info != "\x00\x00" {
 		fmt.Printf("OpenGL program linking output:\n%s\n", info)
 	}
 


### PR DESCRIPTION
### Description:
Remove empty message "OpenGL program linking output ..." from output 
Also noticed message "OpenGL shader compilation output" has the same guard clause


Fixes #(issue)

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.


