### PR TITLE
Detect theme variant for Gnome and KDE

### DIFF
--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -53,14 +53,14 @@ func findThemeVariant() fyne.ThemeVariant {
 	case "gnome", "xfce", "unity", "gnome-shell", "gnome-classic", "mate", "gnome-mate":
 		return findGnomeThemeVariant()
 	case "kde", "kde-plasma", "plasma":
-		return findKdeThemeVariant()
+		return findKDEThemeVariant()
 	default:
 		return theme.VariantDark
 	}
 }
 
 // find the current KDE theme variant. At this time, no solution.
-func findKdeThemeVariant() fyne.ThemeVariant {
+func findKDEThemeVariant() fyne.ThemeVariant {
 	homedir, err := os.UserHomeDir()
 	if err != nil || homedir == "" {
 		// there is a problem, fallback to dark theme
@@ -237,6 +237,10 @@ func watchTheme() {
 	}
 }
 
+func themeChanged() {
+	fyne.CurrentApp().Settings().(*settings).setupTheme()
+}
+
 func watchGnomeTheme() {
 	// connect to dbus to detect color-schem theme changes
 	conn, err := dbus.SessionBus()
@@ -256,20 +260,10 @@ func watchGnomeTheme() {
 	defer conn.Close()
 	dbusChan := make(chan *dbus.Signal, 10)
 	conn.Signal(dbusChan)
-	currentTheme := fyne.CurrentApp().Settings().Theme()
 	for sig := range dbusChan {
 		for _, v := range sig.Body {
-			switch v {
-			case "color-scheme":
-				if currentTheme == theme.DefaultTheme() {
-					variant := findGnomeThemeVariant()
-					switch variant {
-					case theme.VariantLight:
-						fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
-					case theme.VariantDark:
-						fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
-					}
-				}
+			if v == "color-scheme" {
+				themeChanged()
 			}
 		}
 	}

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -9,9 +9,14 @@
 package app
 
 import (
+	"io/ioutil"
+	"log"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/godbus/dbus/v5"
@@ -23,13 +28,114 @@ import (
 var once sync.Once
 
 func defaultVariant() fyne.ThemeVariant {
-	return theme.VariantDark
+	return findThemeVariant()
 }
 
 func (a *fyneApp) OpenURL(url *url.URL) error {
 	cmd := a.exec("xdg-open", url.String())
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd.Start()
+}
+
+func findCurrentWM() string {
+
+	wm := os.Getenv("XDG_CURRENT_DESKTOP")
+	if wm == "" {
+		wm = os.Getenv("DESKTOP_SESSION")
+	}
+	wm = strings.ToLower(wm)
+	return wm
+}
+
+func findThemeVariant() fyne.ThemeVariant {
+	wm := findCurrentWM()
+	switch wm {
+	case "gnome", "xfce", "unity", "gnome-shell", "gnome-classic", "mate", "gnome-mate":
+		return findGnomeThemeVariant()
+	case "kde", "kde-plasma", "plasma":
+		return findKdeThemeVariant()
+	default:
+		return theme.VariantDark
+	}
+}
+
+// find the current KDE theme variant. At this time, no solution.
+func findKdeThemeVariant() fyne.ThemeVariant {
+	homedir, err := os.UserHomeDir()
+	if err != nil || homedir == "" {
+		// there is a problem, fallback to dark theme
+		return theme.VariantDark
+	}
+
+	// check if the user has a .config/kdeglobals file
+	kdeGlobals := filepath.Join(homedir, ".config/kdeglobals")
+	if _, err := os.Stat(kdeGlobals); os.IsNotExist(err) {
+		// no kdeglobals file, fallback to dark theme
+		return theme.VariantDark
+	}
+
+	// find the LookAndFeelPackage key in the kdeglobals file
+	content, err := ioutil.ReadFile(kdeGlobals)
+	if err != nil {
+		// there is a problem, fallback to dark theme
+		return theme.VariantDark
+	}
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "LookAndFeelPackage=") {
+			// there is 2 possible values for the LookAndFeelPackage key
+			// =org.kde.breeze.desktop for the light theme
+			// =org.kde.breezedark.desktop for the dark theme
+			if strings.HasSuffix(line, "org.kde.breeze.desktop") {
+				return theme.VariantLight
+			} else if strings.HasSuffix(line, "org.kde.breezedark.desktop") {
+				return theme.VariantDark
+			}
+		}
+	}
+
+	// If we reach this point, it means that the LookAndFeelPackage key is not present in the kdeglobals file
+	// we can try to calculate the theme variant from the current KDE theme using the WM activeBackground key
+	for _, line := range lines {
+		if strings.HasPrefix(line, "activeBackground=") {
+			// read the value, it's a color in the form of r,g,b
+			col := strings.Split(line, "=")[1]
+			// convert the color to a hex string
+			cols := strings.Split(col, ",")
+			// convert the string to int
+			r, _ := strconv.Atoi(cols[0])
+			g, _ := strconv.Atoi(cols[1])
+			b, _ := strconv.Atoi(cols[2])
+
+			// calculate the luminance of the color
+			brightness := (float32(r)/255*299 + float32(g)/255*587 + float32(b)/255*114) / 1000
+			if brightness > 0.5 {
+				return theme.VariantLight
+			} else {
+				return theme.VariantDark
+			}
+
+		}
+	}
+
+	return theme.VariantDark
+}
+
+// fetch org.gnome.desktop.interface color-scheme 'prefer-dark' or 'prefer-light' from gsettings
+func findGnomeThemeVariant() fyne.ThemeVariant {
+	cmd := exec.Command("gsettings", "get", "org.gnome.desktop.interface", "color-scheme")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		w := strings.TrimSpace(string(out))
+		w = strings.Trim(w, "'")
+		switch w {
+		case "prefer-light", "default":
+			return theme.VariantLight
+		case "prefer-dark":
+			return theme.VariantDark
+		}
+	}
+	return theme.VariantDark
 }
 
 func (a *fyneApp) SendNotification(n *fyne.Notification) {
@@ -122,5 +228,53 @@ func rootCacheDir() string {
 }
 
 func watchTheme() {
-	// no-op, not able to read linux theme in a standard way
+	wm := findCurrentWM()
+	switch wm {
+	case "gnome":
+		go watchGnomeTheme()
+	case "kde":
+		// no-op, not able to read linux theme in a standard way
+	}
+}
+
+func watchGnomeTheme() {
+	// connect to dbus to detect color-schem theme changes
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	if err := conn.AddMatchSignal(
+		dbus.WithMatchObjectPath("/org/freedesktop/portal/desktop"),
+		dbus.WithMatchInterface("org.freedesktop.portal.Settings"),
+		dbus.WithMatchMember("SettingChanged"),
+	); err != nil {
+		log.Println(err)
+		return
+	}
+	defer conn.Close()
+	dbusChan := make(chan *dbus.Signal, 10)
+	conn.Signal(dbusChan)
+	currentTheme := fyne.CurrentApp().Settings().Theme()
+	for {
+		select {
+		case sig := <-dbusChan:
+			for _, v := range sig.Body {
+				switch v {
+				case "color-scheme":
+					if currentTheme == theme.DefaultTheme() {
+						variant := findGnomeThemeVariant()
+						switch variant {
+						case theme.VariantLight:
+							fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
+						case theme.VariantDark:
+							fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
+						}
+					}
+				}
+			}
+		}
+	}
+
 }

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -257,24 +257,20 @@ func watchGnomeTheme() {
 	dbusChan := make(chan *dbus.Signal, 10)
 	conn.Signal(dbusChan)
 	currentTheme := fyne.CurrentApp().Settings().Theme()
-	for {
-		select {
-		case sig := <-dbusChan:
-			for _, v := range sig.Body {
-				switch v {
-				case "color-scheme":
-					if currentTheme == theme.DefaultTheme() {
-						variant := findGnomeThemeVariant()
-						switch variant {
-						case theme.VariantLight:
-							fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
-						case theme.VariantDark:
-							fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
-						}
+	for sig := range dbusChan {
+		for _, v := range sig.Body {
+			switch v {
+			case "color-scheme":
+				if currentTheme == theme.DefaultTheme() {
+					variant := findGnomeThemeVariant()
+					switch variant {
+					case theme.VariantLight:
+						fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
+					case theme.VariantDark:
+						fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
 					}
 				}
 			}
 		}
 	}
-
 }

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -181,7 +181,7 @@ func watchFreedekstopThemeChange() {
 	}
 	defer conn.Close()
 
-	dbusChan := make(chan *dbus.Signal, 0)
+	dbusChan := make(chan *dbus.Signal)
 	conn.Signal(dbusChan)
 
 	for sig := range dbusChan {

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -62,8 +62,6 @@ func findFreedestktopColorScheme() fyne.ThemeVariant {
 	switch value {
 	case 0:
 		return theme.VariantLight
-	case 1:
-		return theme.VariantDark
 	default:
 		return theme.VariantDark
 	}

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -181,7 +181,7 @@ func watchFreedekstopThemeChange() {
 	}
 	defer conn.Close()
 
-	dbusChan := make(chan *dbus.Signal, 10)
+	dbusChan := make(chan *dbus.Signal, 0)
 	conn.Signal(dbusChan)
 
 	for sig := range dbusChan {

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -112,7 +112,7 @@ func findKDEThemeVariant() fyne.ThemeVariant {
 	return theme.VariantDark
 }
 
-// fetch org.gnome.desktop.interface color-scheme 'prefer-dark' or 'prefer-light' from gsettings
+// fetch color variant from DBus stored values
 func findGnomeThemeVariant() fyne.ThemeVariant {
 	dbusConn, err := dbus.SessionBus()
 	dbusObj := dbusConn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -9,7 +9,6 @@
 package app
 
 import (
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -37,7 +36,7 @@ func (a *fyneApp) OpenURL(url *url.URL) error {
 func findFreedestktopColorScheme() fyne.ThemeVariant {
 	dbusConn, err := dbus.SessionBus()
 	if err != nil {
-		log.Println("Unable to connect to session D-Bus", err)
+		fyne.LogError("Unable to connect to session D-Bus", err)
 		return theme.VariantDark
 	}
 
@@ -49,13 +48,13 @@ func findFreedestktopColorScheme() fyne.ThemeVariant {
 		"color-scheme",
 	)
 	if call.Err != nil {
-		log.Println("failed to read theme variant from D-Bus", call.Err)
+		fyne.LogError("failed to read theme variant from D-Bus", call.Err)
 		return theme.VariantDark
 	}
 
 	var value uint8
 	if err = call.Store(&value); err != nil {
-		log.Println("failed to read theme variant from D-Bus", err)
+		fyne.LogError("failed to read theme variant from D-Bus", err)
 		return theme.VariantDark
 	}
 
@@ -168,7 +167,7 @@ func themeChanged() {
 func watchFreedekstopThemeChange() {
 	conn, err := dbus.SessionBus()
 	if err != nil {
-		log.Println("Unable to connect to session D-Bus", err)
+		fyne.LogError("Unable to connect to session D-Bus", err)
 		return
 	}
 
@@ -177,7 +176,7 @@ func watchFreedekstopThemeChange() {
 		dbus.WithMatchInterface("org.freedesktop.portal.Settings"),
 		dbus.WithMatchMember("SettingChanged"),
 	); err != nil {
-		log.Println(err)
+		fyne.LogError("D-Bus signal match failed", err)
 		return
 	}
 	defer conn.Close()

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -115,6 +115,11 @@ func findKDEThemeVariant() fyne.ThemeVariant {
 // fetch color variant from DBus stored values
 func findGnomeThemeVariant() fyne.ThemeVariant {
 	dbusConn, err := dbus.SessionBus()
+	if err != nil {
+		log.Println("Error connecting to DBus:", err)
+		return theme.VariantDark
+	}
+
 	dbusObj := dbusConn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
 	call := dbusObj.Call(
 		"org.freedesktop.portal.Settings.Read",
@@ -126,6 +131,7 @@ func findGnomeThemeVariant() fyne.ThemeVariant {
 		log.Println("failed to read dbus value:", call.Err)
 		return theme.VariantDark
 	}
+
 	var value uint8
 	if err = call.Store(&value); err != nil {
 		log.Println("failed to read dbus value:", err)
@@ -203,7 +209,6 @@ func (a *fyneApp) cachedIconPath() string {
 	})
 
 	return filePath
-
 }
 
 // SetSystemTrayMenu creates a system tray item and attaches the specified menu.

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -189,6 +189,7 @@ func watchFreedekstopThemeChange() {
 		for _, v := range sig.Body {
 			if v == "color-scheme" {
 				themeChanged()
+				break
 			}
 		}
 	}


### PR DESCRIPTION

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This detects theme variant for Gnome and KDE.

- For Gnome, read values from `gsettings` to get the color-scheme (can be prefer-dark, prefer-light or "default"
- For KDE, read the kdeglobals file and calculate the brightness if the theme is not the standard one - this method can also be applied for older Gnome version reading GTK themes, but is this useful?
- Theme change detection: - Gnome: connect to dbus and wait for theme change - KDE, no idea at this time, but switching from KDE to Gnome has changed the Gnome theme... So maybe KDE is using dbus too.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
