### PR TITLE
Fix the dock and menu "Quit" menu item for macOS

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -182,7 +182,7 @@ func NewGLDriver() fyne.Driver {
 
 func catchTerm(d *gLDriver) {
 	terminateSignals := make(chan os.Signal, 1)
-	signal.Notify(terminateSignals, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM)
+	signal.Notify(terminateSignals, syscall.SIGINT, syscall.SIGKILL)
 
 	for range terminateSignals {
 		d.Quit()

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -6,8 +6,10 @@ import (
 	"bytes"
 	"image"
 	"os"
+	"os/signal"
 	"runtime"
 	"sync"
+	"syscall"
 
 	"github.com/fyne-io/image/ico"
 
@@ -161,6 +163,8 @@ func (d *gLDriver) Run() {
 	if goroutineID() != mainGoroutineID {
 		panic("Run() or ShowAndRun() must be called from main goroutine")
 	}
+
+	go catchTerm(d)
 	d.runGL()
 }
 
@@ -174,4 +178,14 @@ func NewGLDriver() fyne.Driver {
 	repository.Register("file", intRepo.NewFileRepository())
 
 	return d
+}
+
+func catchTerm(d *gLDriver) {
+	terminateSignals := make(chan os.Signal, 1)
+	signal.Notify(terminateSignals, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM)
+
+	for range terminateSignals {
+		d.Quit()
+		break
+	}
 }

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -182,7 +182,7 @@ func NewGLDriver() fyne.Driver {
 
 func catchTerm(d *gLDriver) {
 	terminateSignals := make(chan os.Signal, 1)
-	signal.Notify(terminateSignals, syscall.SIGINT, syscall.SIGKILL)
+	signal.Notify(terminateSignals, syscall.SIGINT, syscall.SIGTERM)
 
 	for range terminateSignals {
 		d.Quit()

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -47,6 +47,13 @@ func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 		}, func() {
 			// anything required for tear-down
 		})
+
+		// the only way we know the app was asked to quit is if this window is asked to close...
+		w := d.CreateWindow("SystrayMonitor")
+		w.(*window).create()
+		w.SetCloseIntercept(func() {
+			d.Quit()
+		})
 	})
 
 	d.refreshSystray(m)

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -181,7 +181,7 @@ func (d *gLDriver) runGL() {
 				d.windows = newWindows
 				d.windowLock.Unlock()
 
-				if d.systrayMenu == nil && len(newWindows) == 0 {
+				if len(newWindows) == 0 {
 					d.Quit()
 				}
 			}


### PR DESCRIPTION
Due to how GLFW works we don't get a unique app-quit signal.
So let's make a hidden window and wait for it to be closed....

Fixes #3395

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- I can't think how?
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
