### PR TITLE
Use content scale not DPI for Wayland scaling

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -277,6 +277,9 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 }
 
 func (w *window) detectScale() float32 {
+	if isWayland { // Wayland controls scale through content scaling
+		return 1.0
+	}
 	monitor := w.getMonitorForWindow()
 	widthMm, _ := monitor.GetPhysicalSize()
 	widthPx := monitor.GetVideoMode().Width
@@ -290,6 +293,15 @@ func (w *window) moved(_ *glfw.Window, x, y int) {
 
 func (w *window) resized(_ *glfw.Window, width, height int) {
 	w.processResized(width, height)
+}
+
+func (w *window) scaled(_ *glfw.Window, x float32, y float32) {
+	if !isWayland { // other platforms handle this using older APIs
+		return
+	}
+
+	w.canvas.texScale = x
+	w.canvas.Refresh(w.canvas.content)
 }
 
 func (w *window) frameSized(_ *glfw.Window, width, height int) {
@@ -691,6 +703,7 @@ func (w *window) create() {
 		win.SetSizeCallback(w.resized)
 		win.SetFramebufferSizeCallback(w.frameSized)
 		win.SetRefreshCallback(w.refresh)
+		win.SetContentScaleCallback(w.scaled)
 		win.SetCursorPosCallback(w.mouseMoved)
 		win.SetMouseButtonCallback(w.mouseClicked)
 		win.SetScrollCallback(w.mouseScrolled)


### PR DESCRIPTION
Fixes #2850

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- run "weston --scale 2"
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
