### PR TITLE
Update to latest typesetting to remove go mod replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b
 	github.com/go-ole/go-ole v1.2.6
-	github.com/go-text/typesetting v0.0.0-20221012165447-0e1e8228dbc3
+	github.com/go-text/typesetting v0.0.0-20221123115637-1b69ca38a859
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff
 	github.com/gopherjs/gopherjs v1.17.2
@@ -35,5 +35,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2
 )
-
-replace github.com/benoitkugler/textlayout v0.2.0 => github.com/benoitkugler/textlayout v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b h1:GgabKamyOY
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
-github.com/go-text/typesetting v0.0.0-20221012165447-0e1e8228dbc3 h1:P8ktGq6NweQCPb/hL8CLoS5RIkVrTizxDxaImsBo6SA=
-github.com/go-text/typesetting v0.0.0-20221012165447-0e1e8228dbc3/go.mod h1:RO32JTaCKQV+XI9psTihlQhZsQJp0R4BIkJvHQGsuVo=
+github.com/go-text/typesetting v0.0.0-20221123115637-1b69ca38a859 h1:AaAwnpLoDn9nCsCpWOEV9CW8lQ44yJq1MzFciSzZp+8=
+github.com/go-text/typesetting v0.0.0-20221123115637-1b69ca38a859/go.mod h1:kssHQBiSa7hcHEW4iDHI8JnhXB87V5kDmLtnk9Ccx/A=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/vendor/github.com/go-text/typesetting/shaping/output.go
+++ b/vendor/github.com/go-text/typesetting/shaping/output.go
@@ -86,6 +86,8 @@ func (b Bounds) LineHeight() fixed.Int26_6 {
 type Output struct {
 	// Advance is the distance the Dot has advanced.
 	Advance fixed.Int26_6
+	// Size is copied from the shaping.Input.Size that produced this Output.
+	Size fixed.Int26_6
 	// Glyphs are the shaped output text.
 	Glyphs []Glyph
 	// LineBounds describes the font's suggested line bounding dimensions. The

--- a/vendor/github.com/go-text/typesetting/shaping/shaper.go
+++ b/vendor/github.com/go-text/typesetting/shaping/shaper.go
@@ -110,6 +110,7 @@ func (t *HarfbuzzShaper) Shape(input Input) Output {
 		Glyphs:    glyphs,
 		Direction: input.Direction,
 		Face:      input.Face,
+		Size:      input.Size,
 	}
 	fontExtents := font.ExtentsForDirection(t.buf.Props.Direction)
 	out.LineBounds = Bounds{

--- a/vendor/github.com/go-text/typesetting/shaping/wrapping.go
+++ b/vendor/github.com/go-text/typesetting/shaping/wrapping.go
@@ -256,10 +256,12 @@ type breakOption struct {
 // isValid returns whether a given option violates shaping rules (like breaking
 // a shaped text cluster).
 func (option breakOption) isValid(runeToGlyph []int, out Output) bool {
-	if option.breakAtRune+1 < len(runeToGlyph) {
+	breakAfter := option.breakAtRune - out.Runes.Offset
+	nextRune := breakAfter + 1
+	if nextRune < len(runeToGlyph) && breakAfter >= 0 {
 		// Check if this break is valid.
-		gIdx := runeToGlyph[option.breakAtRune]
-		g2Idx := runeToGlyph[option.breakAtRune+1]
+		gIdx := runeToGlyph[breakAfter]
+		g2Idx := runeToGlyph[nextRune]
 		cIdx := out.Glyphs[gIdx].ClusterIndex
 		c2Idx := out.Glyphs[g2Idx].ClusterIndex
 		if cIdx == c2Idx {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/BurntSushi/toml/internal
 github.com/akavel/rsrc/binutil
 github.com/akavel/rsrc/coff
 github.com/akavel/rsrc/ico
-# github.com/benoitkugler/textlayout v0.2.0 => github.com/benoitkugler/textlayout v0.2.1
+# github.com/benoitkugler/textlayout v0.2.1
 github.com/benoitkugler/textlayout/fonts
 github.com/benoitkugler/textlayout/fonts/binaryreader
 github.com/benoitkugler/textlayout/fonts/glyphsnames
@@ -63,7 +63,7 @@ github.com/go-gl/glfw/v3.3/glfw/glfw/src
 ## explicit
 github.com/go-ole/go-ole
 github.com/go-ole/go-ole/oleutil
-# github.com/go-text/typesetting v0.0.0-20221012165447-0e1e8228dbc3
+# github.com/go-text/typesetting v0.0.0-20221123115637-1b69ca38a859
 ## explicit
 github.com/go-text/typesetting/di
 github.com/go-text/typesetting/font


### PR DESCRIPTION

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Updated the vendor folder (using `go mod vendor`).
