### PR TITLE
Fix crazy peak in memory when moving selection

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1158,17 +1158,23 @@ func (e *Entry) truncatePosition(row, col int) (int, int) {
 
 func (e *Entry) updateMousePointer(p fyne.Position, rightClick bool) {
 	row, col := e.getRowCol(p)
-	e.setFieldsAndRefresh(func() {
-		if !rightClick || rightClick && !e.selecting {
-			e.CursorRow = row
-			e.CursorColumn = col
-		}
+	e.propertyLock.Lock()
 
-		if !e.selecting {
-			e.selectRow = row
-			e.selectColumn = col
-		}
-	})
+	if !rightClick || rightClick && !e.selecting {
+		e.CursorRow = row
+		e.CursorColumn = col
+	}
+
+	if !e.selecting {
+		e.selectRow = row
+		e.selectColumn = col
+	}
+	e.propertyLock.Unlock()
+
+	r := cache.Renderer(e.content)
+	if r != nil {
+		r.(*entryContentRenderer).moveCursor()
+	}
 }
 
 // updateText updates the internal text to the given value

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1160,7 +1160,7 @@ func (e *Entry) updateMousePointer(p fyne.Position, rightClick bool) {
 	row, col := e.getRowCol(p)
 	e.propertyLock.Lock()
 
-	if !rightClick || rightClick && !e.selecting {
+	if !rightClick || !e.selecting {
 		e.CursorRow = row
 		e.CursorColumn = col
 	}


### PR DESCRIPTION
There is an underlying issue where text refresh memory is not freed

but here we are able to avoid refresh which is always good.
Fixes #3426

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- an optimisation
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

