### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -12,7 +12,7 @@ jobs:
         persist-credentials: false
     - uses: WillAbides/setup-go-faster@v1.7.0
       with:      
-        go-version: '1.18.x'
+        go-version: '1.19.x'
 
     - name: Install lian
       run: go install lucor.dev/lian@latest

--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14.x, 1.17.x]
+        go-version: [1.14.x, 1.19.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14, 1.17]
+        go-version: [1.14, 1.19]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.3.0
+        go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
     - name: Cleanup repository
       run: rm -rf vendor/

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -31,7 +31,7 @@ jobs:
       run: go vet -tags ci ./...
 
     - name: Goimports
-      run: test -z $(goimports -e -d . | tee /dev/stderr)
+      run: test -z "$(goimports -e -d . | tee /dev/stderr)"
 
     - name: Gocyclo
       run: gocyclo -over 30 .

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -15,7 +15,7 @@ jobs:
         persist-credentials: false
     - uses: WillAbides/setup-go-faster@v1.7.0
       with:
-        go-version: '1.17.x'
+        go-version: '1.19.x'
 
     - name: Get dependencies
       run: |

--- a/cmd/fyne/commands/command.go
+++ b/cmd/fyne/commands/command.go
@@ -13,7 +13,7 @@ type Command interface {
 	Run(args []string)
 }
 
-//Getter is the command that can handle downloading and installing Fyne apps to the current platform.
+// Getter is the command that can handle downloading and installing Fyne apps to the current platform.
 type Getter = commands.Getter
 
 // NewGetter returns a command that can handle the download and install of GUI apps built using Fyne.

--- a/cmd/fyne/internal/mobile/binres/binres.go
+++ b/cmd/fyne/internal/mobile/binres/binres.go
@@ -12,9 +12,9 @@
 // sent to unmarshalling. This allows tests to validate each struct representation
 // of the binary format as follows:
 //
-//  * unmarshal the output of aapt
-//  * marshal the struct representation
-//  * perform byte-to-byte comparison with aapt output per chunk header and body
+//   - unmarshal the output of aapt
+//   - marshal the struct representation
+//   - perform byte-to-byte comparison with aapt output per chunk header and body
 //
 // This process should strive to make structs idiomatic to make parsing xml text
 // into structs trivial.
@@ -22,9 +22,9 @@
 // Once the struct representation is validated, tests for parsing xml text
 // into structs can become self-referential as the following holds true:
 //
-//  * the unmarshalled input of aapt output is the only valid target
-//  * the unmarshalled input of xml text may be compared to the unmarshalled
-//    input of aapt output to identify errors, e.g. text-trims, wrong flags, etc
+//   - the unmarshalled input of aapt output is the only valid target
+//   - the unmarshalled input of xml text may be compared to the unmarshalled
+//     input of aapt output to identify errors, e.g. text-trims, wrong flags, etc
 //
 // This provides validation, byte-for-byte, for producing binary xml resources.
 //
@@ -34,11 +34,11 @@
 //
 // A simple view of binary xml document structure:
 //
-//  XML
-//    Pool
-//    Map
-//    Namespace
-//    [...node]
+//	XML
+//	  Pool
+//	  Map
+//	  Namespace
+//	  [...node]
 //
 // Additional resources:
 // https://android.googlesource.com/platform/frameworks/base/+/master/include/androidfw/ResourceTypes.h
@@ -61,7 +61,7 @@ func errWrongType(have ResType, want ...ResType) error {
 	return fmt.Errorf("wrong resource type %s, want one of %v", have, want)
 }
 
-//ResType is the type of a resource
+// ResType is the type of a resource
 type ResType uint16
 
 // IsSupported returns if a type is supported

--- a/cmd/fyne/internal/mobile/binres/pool.go
+++ b/cmd/fyne/internal/mobile/binres/pool.go
@@ -27,28 +27,31 @@ func (ref PoolRef) Resolve(pl *Pool) string {
 // Pool is a container for string and style span collections.
 //
 // Pool has the following structure marshalled:
-// 	chunkHeader
-//  uint32 number of strings in this pool
-//  uint32 number of style spans in pool
-//  uint32 SortedFlag, UTF8Flag
-//  uint32 index of string data from header
-//  uint32 index of style data from header
-//  []uint32 string indices starting at zero
-//  []uint16 or []uint8 concatenation of string entries
+//
+//		chunkHeader
+//	 uint32 number of strings in this pool
+//	 uint32 number of style spans in pool
+//	 uint32 SortedFlag, UTF8Flag
+//	 uint32 index of string data from header
+//	 uint32 index of style data from header
+//	 []uint32 string indices starting at zero
+//	 []uint16 or []uint8 concatenation of string entries
 //
 // UTF-16 entries are as follows:
-//  uint16 string length, exclusive
-//  uint16 [optional] low word if high bit of length set
-//  [n]byte data
-//  uint16 0x0000 terminator
+//
+//	uint16 string length, exclusive
+//	uint16 [optional] low word if high bit of length set
+//	[n]byte data
+//	uint16 0x0000 terminator
 //
 // UTF-8 entries are as follows:
-//  uint8 character length, exclusive
-//  uint8 [optional] low word if high bit of character length set
-//  uint8 byte length, exclusive
-//  uint8 [optional] low word if high bit of byte length set
-//  [n]byte data
-//  uint8 0x00 terminator
+//
+//	uint8 character length, exclusive
+//	uint8 [optional] low word if high bit of character length set
+//	uint8 byte length, exclusive
+//	uint8 [optional] low word if high bit of byte length set
+//	[n]byte data
+//	uint8 0x00 terminator
 type Pool struct {
 	chunkHeader
 	strings []string

--- a/cmd/fyne/internal/mobile/binres/table.go
+++ b/cmd/fyne/internal/mobile/binres/table.go
@@ -23,10 +23,11 @@ type TableRef uint32
 // Resolve returns the Entry of TableRef in the given table.
 //
 // A TableRef is structured as follows:
-//  0xpptteeee
-//  pp: package index
-//  tt: type spec index in package
-//  eeee: entry index in type spec
+//
+//	0xpptteeee
+//	pp: package index
+//	tt: type spec index in package
+//	eeee: entry index in type spec
 //
 // The package and type spec values start at 1 for the first item,
 // to help catch cases where they have not been supplied.
@@ -128,8 +129,10 @@ func OpenTable() (*Table, error) {
 // indices.
 //
 // For example:
-//  tbl.SpecByName("@android:style/Theme.NoTitleBar")
-//  tbl.SpecByName("style")
+//
+//	tbl.SpecByName("@android:style/Theme.NoTitleBar")
+//	tbl.SpecByName("style")
+//
 // Both locate the spec by name "style".
 func (tbl *Table) SpecByName(name string) (int, *Package, int, *TypeSpec, error) {
 	n := strings.TrimPrefix(name, "@android:")

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -497,12 +497,11 @@ func (f *fileDialog) setView(view viewLayout) {
 //
 // Order of precedence is:
 //
-// * file.startingDirectory if non-empty, os.Stat()-able, and uses the file://
-//   URI scheme
-// * os.UserHomeDir()
-// * os.Getwd()
-// * "/" (should be filesystem root on all supported platforms)
-//
+//   - file.startingDirectory if non-empty, os.Stat()-able, and uses the file://
+//     URI scheme
+//   - os.UserHomeDir()
+//   - os.Getwd()
+//   - "/" (should be filesystem root on all supported platforms)
 func (f *FileDialog) effectiveStartingDir() fyne.ListableURI {
 	if f.startingLocation != nil {
 		if f.startingLocation.Scheme() == "file" {

--- a/fyne.go
+++ b/fyne.go
@@ -5,24 +5,24 @@
 //
 // A simple application may look like this:
 //
-//   package main
+//	package main
 //
-//   import "fyne.io/fyne/v2/app"
-//   import "fyne.io/fyne/v2/container"
-//   import "fyne.io/fyne/v2/widget"
+//	import "fyne.io/fyne/v2/app"
+//	import "fyne.io/fyne/v2/container"
+//	import "fyne.io/fyne/v2/widget"
 //
-//   func main() {
-//   	a := app.New()
-//   	w := a.NewWindow("Hello")
+//	func main() {
+//		a := app.New()
+//		w := a.NewWindow("Hello")
 //
-//   	hello := widget.NewLabel("Hello Fyne!")
-//   	w.SetContent(container.NewVBox(
-//   		hello,
-//   		widget.NewButton("Hi!", func() {
-//   			hello.SetText("Welcome :)")
-//   		}),
-//   	))
+//		hello := widget.NewLabel("Hello Fyne!")
+//		w.SetContent(container.NewVBox(
+//			hello,
+//			widget.NewButton("Hi!", func() {
+//				hello.SetText("Welcome :)")
+//			}),
+//		))
 //
-//   	w.ShowAndRun()
-//   }
+//		w.ShowAndRun()
+//	}
 package fyne // import "fyne.io/fyne/v2"

--- a/internal/driver/mobile/app/darwin_desktop.go
+++ b/internal/driver/mobile/app/darwin_desktop.go
@@ -388,6 +388,7 @@ var virtualKeyCodeMap = map[uint16]key.Code{
 // into the standard keycodes used by the key package.
 //
 // To get a sense of the key map, see the diagram on
+//
 //	http://boredzo.org/blog/archives/2007-05-22/virtual-key-codes
 func convVirtualKeyCode(vkcode uint16) key.Code {
 	if code, ok := virtualKeyCodeMap[vkcode]; ok {

--- a/internal/driver/mobile/app/doc.go
+++ b/internal/driver/mobile/app/doc.go
@@ -18,7 +18,7 @@ OpenGL, audio, and other Android NDK-like APIs. An all-Go app should
 use this app package to initialize the app, manage its lifecycle, and
 receive events.
 
-Building apps
+# Building apps
 
 Apps written entirely in Go have a main function, and can be built
 with `gomobile build`, which directly produces runnable output for
@@ -30,7 +30,7 @@ https://golang.org/x/mobile/cmd/gomobile.
 For detailed instructions and documentation, see
 https://golang.org/wiki/Mobile.
 
-Event processing in Native Apps
+# Event processing in Native Apps
 
 The Go runtime is initialized on Android when NativeActivity onCreate is
 called, and on iOS when the process starts. In both cases, Go init functions
@@ -69,17 +69,20 @@ goroutine as other code that calls OpenGL.
 An event is represented by the empty interface type interface{}. Any value can
 be an event. Commonly used types include Event types defined by the following
 packages:
-	- golang.org/x/mobile/event/lifecycle
-	- golang.org/x/mobile/event/mouse
-	- golang.org/x/mobile/event/paint
-	- golang.org/x/mobile/event/size
-	- golang.org/x/mobile/event/touch
+  - golang.org/x/mobile/event/lifecycle
+  - golang.org/x/mobile/event/mouse
+  - golang.org/x/mobile/event/paint
+  - golang.org/x/mobile/event/size
+  - golang.org/x/mobile/event/touch
+
 For example, touch.Event is the type that represents touch events. Other
 packages may define their own events, and send them on an app's event channel.
 
 Other packages can also register event filters, e.g. to manage resources in
 response to lifecycle events. Such packages should call:
+
 	app.RegisterFilter(etc)
+
 in an init function inside that package.
 */
 package app // import "fyne.io/fyne/v2/internal/driver/mobile/app"

--- a/internal/driver/mobile/event/lifecycle/lifecycle.go
+++ b/internal/driver/mobile/event/lifecycle/lifecycle.go
@@ -60,9 +60,10 @@ func (e Event) String() string {
 }
 
 // Crosses reports whether the transition from From to To crosses the stage s:
-// 	- It returns CrossOn if it does, and the lifecycle change is positive.
-// 	- It returns CrossOff if it does, and the lifecycle change is negative.
-//	- Otherwise, it returns CrossNone.
+//   - It returns CrossOn if it does, and the lifecycle change is positive.
+//   - It returns CrossOff if it does, and the lifecycle change is negative.
+//   - Otherwise, it returns CrossNone.
+//
 // See the documentation for Stage for more discussion of positive and negative
 // crosses.
 func (e Event) Crosses(s Stage) Cross {

--- a/internal/driver/mobile/event/paint/paint.go
+++ b/internal/driver/mobile/event/paint/paint.go
@@ -9,7 +9,7 @@ package paint // import "fyne.io/fyne/v2/internal/driver/mobile/event/paint"
 
 // Event indicates that the app is ready to paint the next frame of the GUI.
 //
-//A frame is completed by calling the App's Publish method.
+// A frame is completed by calling the App's Publish method.
 type Event struct {
 	// External is true for paint events sent by the screen driver.
 	//

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -86,9 +86,9 @@ func FindObjectAtPositionMatching(mouse fyne.Position, matches func(object fyne.
 // - the obj's children are traversed by calling walkObjects on each of the visible items
 // - afterChildren is called for the obj after traversing the obj's children
 // The walk can be aborted by returning true in one of the functions:
-// - if beforeChildren returns true, further traversing is stopped immediately, the after function
-//   will not be called for the obj where the walk stopped, however, it will be called for all its
-//   parents
+//   - if beforeChildren returns true, further traversing is stopped immediately, the after function
+//     will not be called for the obj where the walk stopped, however, it will be called for all its
+//     parents
 func ReverseWalkVisibleObjectTree(
 	obj fyne.CanvasObject,
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
@@ -104,9 +104,9 @@ func ReverseWalkVisibleObjectTree(
 // - the obj's children are traversed by calling walkObjects on each of the items
 // - afterChildren is called for the obj after traversing the obj's children
 // The walk can be aborted by returning true in one of the functions:
-// - if beforeChildren returns true, further traversing is stopped immediately, the after function
-//   will not be called for the obj where the walk stopped, however, it will be called for all its
-//   parents
+//   - if beforeChildren returns true, further traversing is stopped immediately, the after function
+//     will not be called for the obj where the walk stopped, however, it will be called for all its
+//     parents
 func WalkCompleteObjectTree(
 	obj fyne.CanvasObject,
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,
@@ -122,9 +122,9 @@ func WalkCompleteObjectTree(
 // - the obj's children are traversed by calling walkObjects on each of the visible items
 // - afterChildren is called for the obj after traversing the obj's children
 // The walk can be aborted by returning true in one of the functions:
-// - if beforeChildren returns true, further traversing is stopped immediately, the after function
-//   will not be called for the obj where the walk stopped, however, it will be called for all its
-//   parents
+//   - if beforeChildren returns true, further traversing is stopped immediately, the after function
+//     will not be called for the obj where the walk stopped, however, it will be called for all its
+//     parents
 func WalkVisibleObjectTree(
 	obj fyne.CanvasObject,
 	beforeChildren func(fyne.CanvasObject, fyne.Position, fyne.Position, fyne.Size) bool,

--- a/internal/repository/http.go
+++ b/internal/repository/http.go
@@ -70,7 +70,7 @@ func constructURI(u fyne.URI) string {
 // Exists checks whether the the resource at u returns a
 // non "404 NOT FOUND" response header.
 //
-// # The method is a part of the implementation for repository.Repository.Exists
+// Implements: repository.Repository
 //
 // Since: 2.1
 func (r *HTTPRepository) Exists(u fyne.URI) (bool, error) {
@@ -89,7 +89,7 @@ func (r *HTTPRepository) Exists(u fyne.URI) (bool, error) {
 // Reader provides a interface for reading the body of the response received
 // from the request to u.
 //
-// # The method is a part of the implementation for repository.Repository.Exists
+// Implements: repository.Repository
 //
 // Since: 2.1
 func (r *HTTPRepository) Reader(u fyne.URI) (fyne.URIReadCloser, error) {
@@ -103,7 +103,7 @@ func (r *HTTPRepository) Reader(u fyne.URI) (fyne.URIReadCloser, error) {
 // from the remote server.
 // Any response status code apart from 2xx is considered to be invalid.
 //
-// # CanRead implements repository.Repository.CanRead
+// Implements: repository.Repository
 //
 // Since: 2.1
 func (r *HTTPRepository) CanRead(u fyne.URI) (bool, error) {
@@ -119,9 +119,11 @@ func (r *HTTPRepository) CanRead(u fyne.URI) (bool, error) {
 	return true, nil
 }
 
-// Destroy implements repository.Repository.Destroy
+// Destroy satisfies the repository.Repository interface.
 //
-// Sine: 2.1
+// Implements: repository.Repository
+//
+// Since: 2.1
 func (r *HTTPRepository) Destroy(string) {
 	// do nothing
 }

--- a/internal/repository/http.go
+++ b/internal/repository/http.go
@@ -70,7 +70,7 @@ func constructURI(u fyne.URI) string {
 // Exists checks whether the the resource at u returns a
 // non "404 NOT FOUND" response header.
 //
-// The method is a part of the implementation for repository.Repository.Exists
+// # The method is a part of the implementation for repository.Repository.Exists
 //
 // Since: 2.1
 func (r *HTTPRepository) Exists(u fyne.URI) (bool, error) {
@@ -89,7 +89,7 @@ func (r *HTTPRepository) Exists(u fyne.URI) (bool, error) {
 // Reader provides a interface for reading the body of the response received
 // from the request to u.
 //
-// The method is a part of the implementation for repository.Repository.Exists
+// # The method is a part of the implementation for repository.Repository.Exists
 //
 // Since: 2.1
 func (r *HTTPRepository) Reader(u fyne.URI) (fyne.URIReadCloser, error) {
@@ -103,7 +103,7 @@ func (r *HTTPRepository) Reader(u fyne.URI) (fyne.URIReadCloser, error) {
 // from the remote server.
 // Any response status code apart from 2xx is considered to be invalid.
 //
-// CanRead implements repository.Repository.CanRead
+// # CanRead implements repository.Repository.CanRead
 //
 // Since: 2.1
 func (r *HTTPRepository) CanRead(u fyne.URI) (bool, error) {

--- a/internal/repository/memory.go
+++ b/internal/repository/memory.go
@@ -43,8 +43,8 @@ type nodeReaderWriter struct {
 //
 // * The Parent() of a path that exists does not necessarily exist
 //
-// * Listing takes O(number of extant paths in the repository), rather than
-//   O(number of children of path being listed).
+//   - Listing takes O(number of extant paths in the repository), rather than
+//     O(number of children of path being listed).
 //
 // This repository is not designed to be particularly fast or robust, but
 // rather to be simple and easy to read. If you need performance, look

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -390,13 +390,13 @@ func (s *Scroll) CreateRenderer() fyne.WidgetRenderer {
 	return scr
 }
 
-//ScrollToBottom will scroll content to container bottom - to show latest info which end user just added
+// ScrollToBottom will scroll content to container bottom - to show latest info which end user just added
 func (s *Scroll) ScrollToBottom() {
 	s.scrollBy(0, -1*(s.Content.MinSize().Height-s.Size().Height-s.Offset.Y))
 	s.Refresh()
 }
 
-//ScrollToTop will scroll content to container top
+// ScrollToTop will scroll content to container top
 func (s *Scroll) ScrollToTop() {
 	s.scrollBy(0, -s.Offset.Y)
 }

--- a/storage/uri.go
+++ b/storage/uri.go
@@ -44,23 +44,23 @@ func ParseURI(s string) (fyne.URI, error) {
 //
 // This can fail in several ways:
 //
-// * If the URI refers to a filesystem root, then the Parent() implementation
-//   must return (nil, URIRootError).
+//   - If the URI refers to a filesystem root, then the Parent() implementation
+//     must return (nil, URIRootError).
 //
-// * If the URI refers to a resource which does not exist in a hierarchical
-//   context (e.g. the URI references something which does not have a
-//   semantically meaningful "parent"), the Parent() implementation may return
-//   an error.
+//   - If the URI refers to a resource which does not exist in a hierarchical
+//     context (e.g. the URI references something which does not have a
+//     semantically meaningful "parent"), the Parent() implementation may return
+//     an error.
 //
-// * If determining the parent of the referenced resource requires
-//   interfacing with some external system, failures may propagate
-//   through the Parent() implementation. For example if determining
-//   the parent of a file:// URI requires reading information from
-//   the filesystem, it could fail with a permission error.
+//   - If determining the parent of the referenced resource requires
+//     interfacing with some external system, failures may propagate
+//     through the Parent() implementation. For example if determining
+//     the parent of a file:// URI requires reading information from
+//     the filesystem, it could fail with a permission error.
 //
-// * If the scheme of the given URI does not have a registered
-//   HierarchicalRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     HierarchicalRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // NOTE: since v2.0.0, Parent() is backed by the repository system - this
 // function is a helper which calls into an appropriate repository instance for
@@ -88,19 +88,19 @@ func Parent(u fyne.URI) (fyne.URI, error) {
 //
 // This can fail in several ways:
 //
-// * If the URI refers to a resource which does not exist in a hierarchical
-//   context (e.g. the URI references something which does not have a
-//   semantically meaningful "child"), the Child() implementation may return an
-//   error.
+//   - If the URI refers to a resource which does not exist in a hierarchical
+//     context (e.g. the URI references something which does not have a
+//     semantically meaningful "child"), the Child() implementation may return an
+//     error.
 //
-// * If generating a reference to a child of the referenced resource requires
-//   interfacing with some external system, failures may propagate through the
-//   Child() implementation. It is expected that this case would occur very
-//   rarely if ever.
+//   - If generating a reference to a child of the referenced resource requires
+//     interfacing with some external system, failures may propagate through the
+//     Child() implementation. It is expected that this case would occur very
+//     rarely if ever.
 //
-// * If the scheme of the given URI does not have a registered
-//   HierarchicalRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     HierarchicalRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // NOTE: since v2.0.0, Child() is backed by the repository system - this
 // function is a helper which calls into an appropriate repository instance for
@@ -125,10 +125,10 @@ func Child(u fyne.URI, component string) (fyne.URI, error) {
 //
 // This can fail in several ways:
 //
-// * If checking the existence of a resource requires interfacing with some
-//   external system, then failures may propagate through Exists(). For
-//   example, checking the existence of a resource requires reading a directory
-//   may result in a permissions error.
+//   - If checking the existence of a resource requires interfacing with some
+//     external system, then failures may propagate through Exists(). For
+//     example, checking the existence of a resource requires reading a directory
+//     may result in a permissions error.
 //
 // It is understood that a non-nil error value signals that the existence or
 // non-existence of the resource cannot be determined and is undefined.
@@ -155,16 +155,16 @@ func Exists(u fyne.URI) (bool, error) {
 //
 // This can fail in several ways:
 //
-// * If removing the resource requires interfacing with some external system,
-//   failures may propagate through Destroy(). For example, deleting a file may
-//   fail with a permissions error.
+//   - If removing the resource requires interfacing with some external system,
+//     failures may propagate through Destroy(). For example, deleting a file may
+//     fail with a permissions error.
 //
-// * If the referenced resource does not exist, attempting to destroy it should
-//   throw an error.
+//   - If the referenced resource does not exist, attempting to destroy it should
+//     throw an error.
 //
-// * If the scheme of the given URI does not have a registered
-//   WritableRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     WritableRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // Delete is backed by the repository system - this function calls
 // into a scheme-specific implementation from a registered repository.
@@ -190,16 +190,16 @@ func Delete(u fyne.URI) error {
 //
 // This method can fail in several ways:
 //
-// * Different permissions or credentials are required to read the
-//   referenced resource.
+//   - Different permissions or credentials are required to read the
+//     referenced resource.
 //
-// * This URI scheme could represent some resources that can be read,
-//   but this particular URI references a resources that is not
-//   something that can be read.
+//   - This URI scheme could represent some resources that can be read,
+//     but this particular URI references a resources that is not
+//     something that can be read.
 //
-// * Attempting to set up the reader depended on a lower level
-//   operation such as a network or filesystem access that has failed
-//   in some way.
+//   - Attempting to set up the reader depended on a lower level
+//     operation such as a network or filesystem access that has failed
+//     in some way.
 //
 // Reader is backed by the repository system - this function calls
 // into a scheme-specific implementation from a registered repository.
@@ -251,20 +251,20 @@ func CanRead(u fyne.URI) (bool, error) {
 //
 // This method can fail in several ways:
 //
-// * Different permissions or credentials are required to write to the
-//   referenced resource.
+//   - Different permissions or credentials are required to write to the
+//     referenced resource.
 //
-// * This URI scheme could represent some resources that can be
-//   written, but this particular URI references a resources that is
-//   not something that can be written.
+//   - This URI scheme could represent some resources that can be
+//     written, but this particular URI references a resources that is
+//     not something that can be written.
 //
-// * Attempting to set up the writer depended on a lower level
-//   operation such as a network or filesystem access that has failed
-//   in some way.
+//   - Attempting to set up the writer depended on a lower level
+//     operation such as a network or filesystem access that has failed
+//     in some way.
 //
-// * If the scheme of the given URI does not have a registered
-//   WritableRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     WritableRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // Writer is backed by the repository system - this function calls into a
 // scheme-specific implementation from a registered repository.
@@ -293,7 +293,6 @@ func Writer(u fyne.URI) (fyne.URIWriteCloser, error) {
 // Writer(), as the underlying filesystem may have changed since you called
 // CanWrite.
 
-//
 // CanWrite is backed by the repository system - this function calls into a
 // scheme-specific implementation from a registered repository.
 //
@@ -324,19 +323,19 @@ func CanWrite(u fyne.URI) (bool, error) {
 //
 // This method may fail in several ways:
 //
-// * Different permissions or credentials are required to perform the
-//   copy operation.
+//   - Different permissions or credentials are required to perform the
+//     copy operation.
 //
-// * This URI scheme could represent some resources that can be copied,
-//   but either the source, destination, or both are not resources
-//   that support copying.
+//   - This URI scheme could represent some resources that can be copied,
+//     but either the source, destination, or both are not resources
+//     that support copying.
 //
-// * Performing the copy operation depended on a lower level operation
-//   such as network or filesystem access that has failed in some way.
+//   - Performing the copy operation depended on a lower level operation
+//     such as network or filesystem access that has failed in some way.
 //
-// * If the scheme of the given URI does not have a registered
-//   CopyableRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     CopyableRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // Copy is backed by the repository system - this function calls into a
 // scheme-specific implementation from a registered repository.
@@ -370,22 +369,21 @@ func Copy(source fyne.URI, destination fyne.URI) error {
 // defined by the storage repository registered to the scheme of the source
 // URI.
 //
-//
 // This method may fail in several ways:
 //
-// * Different permissions or credentials are required to perform the
-//   rename operation.
+//   - Different permissions or credentials are required to perform the
+//     rename operation.
 //
-// * This URI scheme could represent some resources that can be renamed,
-//   but either the source, destination, or both are not resources
-//   that support renaming.
+//   - This URI scheme could represent some resources that can be renamed,
+//     but either the source, destination, or both are not resources
+//     that support renaming.
 //
-// * Performing the rename operation depended on a lower level operation
-//   such as network or filesystem access that has failed in some way.
+//   - Performing the rename operation depended on a lower level operation
+//     such as network or filesystem access that has failed in some way.
 //
-// * If the scheme of the given URI does not have a registered
-//   MovableRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     MovableRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // Move is backed by the repository system - this function calls into a
 // scheme-specific implementation from a registered repository.
@@ -409,19 +407,19 @@ func Move(source fyne.URI, destination fyne.URI) error {
 //
 // This method may fail in several ways:
 //
-// * Different permissions or credentials are required to check if the
-//   URI supports listing.
+//   - Different permissions or credentials are required to check if the
+//     URI supports listing.
 //
-// * This URI scheme could represent some resources that can be listed,
-//   but this specific URI is not one of them (e.g. a file on a
-//   filesystem, as opposed to a directory).
+//   - This URI scheme could represent some resources that can be listed,
+//     but this specific URI is not one of them (e.g. a file on a
+//     filesystem, as opposed to a directory).
 //
-// * Checking for listability depended on a lower level operation
-//   such as network or filesystem access that has failed in some way.
+//   - Checking for listability depended on a lower level operation
+//     such as network or filesystem access that has failed in some way.
 //
-// * If the scheme of the given URI does not have a registered
-//   ListableRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     ListableRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // CanList is backed by the repository system - this function calls into a
 // scheme-specific implementation from a registered repository.
@@ -447,20 +445,20 @@ func CanList(u fyne.URI) (bool, error) {
 //
 // This method may fail in several ways:
 //
-// * Different permissions or credentials are required to obtain a
-//   listing for the given URI.
+//   - Different permissions or credentials are required to obtain a
+//     listing for the given URI.
 //
-// * This URI scheme could represent some resources that can be listed,
-//   but this specific URI is not one of them (e.g. a file on a
-//   filesystem, as opposed to a directory). This can be tested in advance
-//   using the Listable() function.
+//   - This URI scheme could represent some resources that can be listed,
+//     but this specific URI is not one of them (e.g. a file on a
+//     filesystem, as opposed to a directory). This can be tested in advance
+//     using the Listable() function.
 //
-// * Obtaining the listing depended on a lower level operation such as
-//   network or filesystem access that has failed in some way.
+//   - Obtaining the listing depended on a lower level operation such as
+//     network or filesystem access that has failed in some way.
 //
-// * If the scheme of the given URI does not have a registered
-//   ListableRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     ListableRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // List is backed by the repository system - this function either calls into a
 // scheme-specific implementation from a registered repository, or fails with a
@@ -503,15 +501,15 @@ func List(u fyne.URI) ([]fyne.URI, error) {
 //
 // This method may fail in several ways:
 //
-// * Different permissions or credentials are required to create the requested
-//   resource.
+//   - Different permissions or credentials are required to create the requested
+//     resource.
 //
-// * Creating the resource depended on a lower level operation such as network
-//   or filesystem access that has failed in some way.
+//   - Creating the resource depended on a lower level operation such as network
+//     or filesystem access that has failed in some way.
 //
-// * If the scheme of the given URI does not have a registered
-//   ListableRepository instance, then this method will fail with a
-//   repository.ErrOperationNotSupported.
+//   - If the scheme of the given URI does not have a registered
+//     ListableRepository instance, then this method will fail with a
+//     repository.ErrOperationNotSupported.
 //
 // CreateListable is backed by the repository system - this function either
 // calls into a scheme-specific implementation from a registered repository, or

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1012,9 +1012,10 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 // Note: this functionality depends on the relationship between the selection start row/col and
 // the current cursor row/column.
 // eg: (whitespace for clarity, '_' denotes cursor)
-//   "T  e  s [t  i]_n  g" == 3, 5
-//   "T  e  s_[t  i] n  g" == 3, 5
-//   "T  e_[s  t  i] n  g" == 2, 5
+//
+//	"T  e  s [t  i]_n  g" == 3, 5
+//	"T  e  s_[t  i] n  g" == 3, 5
+//	"T  e_[s  t  i] n  g" == 2, 5
 func (e *Entry) selection() (int, int) {
 	e.propertyLock.RLock()
 	noSelection := !e.selecting || (e.CursorRow == e.selectRow && e.CursorColumn == e.selectColumn)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This brings in the latest fixes and improvements to our workflows.
- We now use Go 1.19.x instead of 1.17.x for running all tests (except those on Go 1.14.x that test the old support). The formatting with Go 1.19 is a lot stricter due to it now supporting markdown (mostly applies to the very large comments so should generally not be an issue). I added in all the changes that `goimports` was complaining about.
- It also applies a suggestion that I got about getting rid of the "too menu arguments" error when `goimports` fails (tested it and it works well).
- I also noticed that `staticcheck was a few versions behind. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

