### PR TITLE
.github/workflows: Make sure to run all Go 1.19 tests

### DIFF
--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14, 1.19]
+        go-version: [1.14, 1.17]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -44,7 +44,7 @@ jobs:
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: coverage.out
-      if: ${{ runner.os == 'Linux' && matrix.go-version == '1.19' }}
+      if: ${{ runner.os == 'Linux' && matrix.go-version == '1.17' }}
 
     - name: Build WebAssembly binary
       env:
@@ -52,11 +52,11 @@ jobs:
         GOARCH: wasm
       working-directory: cmd/fyne_demo
       run: go build
-      if: ${{ matrix.go-version == '1.19' }}
+      if: ${{ matrix.go-version == '1.17' }}
 
     - name: Build GopherJS and Wasm full website
       run: |
         go install github.com/gopherjs/gopherjs@latest
         go install ./cmd/fyne
         cd cmd/fyne_demo && fyne package --target=web
-      if: ${{ matrix.go-version == '1.19' && runner.os == 'Linux' }}
+      if: ${{ matrix.go-version == '1.17' && runner.os == 'Linux' }}

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -44,7 +44,7 @@ jobs:
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: coverage.out
-      if: ${{ runner.os == 'Linux' && matrix.go-version == '1.17' }}
+      if: ${{ runner.os == 'Linux' && matrix.go-version == '1.19' }}
 
     - name: Build WebAssembly binary
       env:
@@ -52,11 +52,11 @@ jobs:
         GOARCH: wasm
       working-directory: cmd/fyne_demo
       run: go build
-      if: ${{ matrix.go-version == '1.17' }}
+      if: ${{ matrix.go-version == '1.19' }}
 
     - name: Build GopherJS and Wasm full website
       run: |
         go install github.com/gopherjs/gopherjs@latest
         go install ./cmd/fyne
         cd cmd/fyne_demo && fyne package --target=web
-      if: ${{ matrix.go-version == '1.17' && runner.os == 'Linux' }}
+      if: ${{ matrix.go-version == '1.19' && runner.os == 'Linux' }}


### PR DESCRIPTION
This makes sure to enable all tests to run using Go 1.19. Apparently they are checking for only Go 1.17 which is a not so elegant solution. This is a quick-fix to make sure that everything runs as expected.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This makes sure to enable all tests to run using Go 1.19. Apparently they are checking for only Go 1.17 which is a not so elegant solution. This is a quick-fix to make sure that everything runs as expected.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
