### PR TITLE
Make sure that Resize call with a canvas Scale() == 1 express its pre…

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -105,6 +105,9 @@ func (c *glCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
 }
 
 func (c *glCanvas) Resize(size fyne.Size) {
+	// This might not be the ideal solution, but it effectively avoid the first frame to be blurry due to the
+	// rounding of the size to the loower integer when scale == 1. It does not affect the other cases as far as we tested.
+	// This can easily be seen with fyne/cmd/hello and a scale == 1 as the text will happear blurry without the following line.
 	nearestSize := fyne.NewSize(float32(math.Ceil(float64(size.Width))), float32(math.Ceil(float64(size.Height))))
 
 	c.Lock()

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -105,8 +105,9 @@ func (c *glCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
 }
 
 func (c *glCanvas) Resize(size fyne.Size) {
+	pixelsSize := fyne.NewSize(float32(math.Ceil(float64(size.Width))), float32(math.Ceil(float64(size.Height))))
 	c.Lock()
-	c.size = size
+	c.size = pixelsSize
 	c.Unlock()
 
 	for _, overlay := range c.Overlays().List() {
@@ -115,17 +116,17 @@ func (c *glCanvas) Resize(size fyne.Size) {
 			// “Notifies” the PopUp of the canvas size change.
 			p.Refresh()
 		} else {
-			overlay.Resize(size)
+			overlay.Resize(pixelsSize)
 		}
 	}
 
 	c.RLock()
-	c.content.Resize(c.contentSize(size))
+	c.content.Resize(c.contentSize(pixelsSize))
 	c.content.Move(c.contentPos())
 
 	if c.menu != nil {
 		c.menu.Refresh()
-		c.menu.Resize(fyne.NewSize(size.Width, c.menu.MinSize().Height))
+		c.menu.Resize(fyne.NewSize(pixelsSize.Width, c.menu.MinSize().Height))
 	}
 	c.RUnlock()
 }

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -105,9 +105,10 @@ func (c *glCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
 }
 
 func (c *glCanvas) Resize(size fyne.Size) {
-	pixelsSize := fyne.NewSize(float32(math.Ceil(float64(size.Width))), float32(math.Ceil(float64(size.Height))))
+	nearestSize := fyne.NewSize(float32(math.Ceil(float64(size.Width))), float32(math.Ceil(float64(size.Height))))
+
 	c.Lock()
-	c.size = pixelsSize
+	c.size = nearestSize
 	c.Unlock()
 
 	for _, overlay := range c.Overlays().List() {
@@ -116,17 +117,17 @@ func (c *glCanvas) Resize(size fyne.Size) {
 			// “Notifies” the PopUp of the canvas size change.
 			p.Refresh()
 		} else {
-			overlay.Resize(pixelsSize)
+			overlay.Resize(nearestSize)
 		}
 	}
 
 	c.RLock()
-	c.content.Resize(c.contentSize(pixelsSize))
+	c.content.Resize(c.contentSize(nearestSize))
 	c.content.Move(c.contentPos())
 
 	if c.menu != nil {
 		c.menu.Refresh()
-		c.menu.Resize(fyne.NewSize(pixelsSize.Width, c.menu.MinSize().Height))
+		c.menu.Resize(fyne.NewSize(nearestSize.Width, c.menu.MinSize().Height))
 	}
 	c.RUnlock()
 }


### PR DESCRIPTION
### Description:
The issue for the blurry first frame is actually not related to text, but to an imprecision in the canvas size that lead to a blurry output more visible by text.

Fixes #3402 

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
