### PR TITLE
Render initial glitch when table content is smaller than space

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -124,6 +124,10 @@ func (l *List) scrollTo(id ListItemID) {
 // Resize is called when this list should change size. We refresh to ensure invisible items are drawn.
 func (l *List) Resize(s fyne.Size) {
 	l.BaseWidget.Resize(s)
+	if l.scroller == nil {
+		return
+	}
+
 	l.offsetUpdated(l.scroller.Offset)
 	l.scroller.Content.(*fyne.Container).Layout.(*listLayout).updateList(true)
 }

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -65,6 +65,18 @@ func TestList_Resize(t *testing.T) {
 
 	assert.Equal(t, float32(0), list.offsetY)
 	test.AssertRendersToMarkup(t, "list/resized.xml", w.Canvas())
+
+	// and check empty too
+	list = NewList(
+		func() int {
+			return 0
+		},
+		func() fyne.CanvasObject {
+			return NewButton("", func() {})
+		},
+		func(ListItemID, fyne.CanvasObject) {
+		})
+	list.Resize(list.Size())
 }
 
 func TestList_SetItemHeight(t *testing.T) {

--- a/widget/table.go
+++ b/widget/table.go
@@ -575,7 +575,7 @@ func (c *tableCells) MouseOut() {
 }
 
 func (c *tableCells) Resize(s fyne.Size) {
-	if s == c.t.size {
+	if s == c.BaseWidget.size {
 		return
 	}
 	c.BaseWidget.Resize(s)


### PR DESCRIPTION

Fixes #3443

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
