### PR TITLE
Remove old fredbi/uri workaround

### DIFF
--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -28,9 +28,8 @@ func NewFileURI(path string) fyne.URI {
 	}
 
 	return &uri{
-		scheme:        "file",
-		haveAuthority: true,
-		path:          path,
+		scheme: "file",
+		path:   path,
 	}
 }
 
@@ -98,10 +97,8 @@ func ParseURI(s string) (fyne.URI, error) {
 	return &uri{
 		scheme:    scheme,
 		authority: authority,
-		// workaround for net/url, see type uri struct comments
-		haveAuthority: true,
-		path:          l.Authority().Path(),
-		query:         l.Query().Encode(),
-		fragment:      l.Fragment(),
+		path:      l.Authority().Path(),
+		query:     l.Query().Encode(),
+		fragment:  l.Fragment(),
 	}, nil
 }

--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -30,10 +30,7 @@ func NewFileURI(path string) fyne.URI {
 	return &uri{
 		scheme:        "file",
 		haveAuthority: true,
-		authority:     "",
 		path:          path,
-		query:         "",
-		fragment:      "",
 	}
 }
 
@@ -81,44 +78,25 @@ func ParseURI(s string) (fyne.URI, error) {
 
 	// There was no repository registered, or it did not provide a parser
 
-	// Ugly hack to work around fredbi/uri. Technically, something like
-	// foo:/// is invalid because it implies a host, but also has an empty
-	// host. However, this is a very common occurrence, so we convert a
-	// leading ":///" to "://".
-	rest := strings.TrimPrefix(s, scheme+":")
-	dummyHost := false
-	if len(rest) >= 3 && rest[0:3] == "///" {
-		rest = "//" + "TEMP.TEMP/" + strings.TrimPrefix(rest, "///")
-		dummyHost = true
-	}
-	s = scheme + ":" + rest
-
 	l, err := uriParser.Parse(s)
 	if err != nil {
 		return nil, err
 	}
 
 	authority := ""
-	if !dummyHost {
-		// User info makes no sense without a host, see next comment.
-		if userInfo := l.Authority().UserInfo(); len(userInfo) > 0 {
-			authority += userInfo + "@"
-		}
 
-		// In this case, we had to insert a "host" to make the parser
-		// happy, but it isn't really a host, so we can just drop it.
-		// If dummyHost isn't set, then we should have a valid host and
-		// we can include it as normal.
-		authority += l.Authority().Host()
+	if userInfo := l.Authority().UserInfo(); len(userInfo) > 0 {
+		authority += userInfo + "@"
+	}
 
-		// Port obviously makes no sense without a host.
-		if port := l.Authority().Port(); len(port) > 0 {
-			authority += ":" + port
-		}
+	authority += l.Authority().Host()
+
+	if port := l.Authority().Port(); len(port) > 0 {
+		authority += ":" + port
 	}
 
 	return &uri{
-		scheme:    l.Scheme(),
+		scheme:    scheme,
 		authority: authority,
 		// workaround for net/url, see type uri struct comments
 		haveAuthority: true,

--- a/storage/repository/uri.go
+++ b/storage/repository/uri.go
@@ -16,13 +16,9 @@ var _ fyne.URI = &uri{}
 type uri struct {
 	scheme    string
 	authority string
-	// haveAuthority lets us distinguish between a present-but-empty
-	// authority, and having no authority. This is needed because net/url
-	// incorrectly handles scheme:/absolute/path URIs.
-	haveAuthority bool
-	path          string
-	query         string
-	fragment      string
+	path      string
+	query     string
+	fragment  string
 }
 
 func (u *uri) Extension() string {
@@ -65,11 +61,7 @@ func (u *uri) String() string {
 	// NOTE: this string reconstruction is mandated by IETF RFC3986,
 	// section 5.3, pp. 35.
 
-	s := u.scheme + ":"
-	if u.haveAuthority {
-		s += "//" + u.authority
-	}
-	s += u.path
+	s := u.scheme + "://" + u.authority + u.path
 	if len(u.query) > 0 {
 		s += "?" + u.query
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Now that https://github.com/fredbi/uri/issues/3 has been fixed, we can remove the old workaround.
I also removed the haveAuthority bool` field as it always seems to be set to true.

All the tests pass as the code is a lot cleaner. However, I do not have a through understanding of of the uri standards are supposed to work so it would be good to get someone with a broader understanding to have a look at it. Opening this for inclusion into v2.4.0 at the earliest.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
