### PR TITLE
Add OnTapped callback to RichText HyperlinkSegment

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -195,7 +195,7 @@ func makeImage(n *ast.Image) *ImageSegment {
 
 func makeLink(n *ast.Link) *HyperlinkSegment {
 	link, _ := url.Parse(string(n.Destination))
-	return &HyperlinkSegment{fyne.TextAlignLeading, "", link}
+	return &HyperlinkSegment{fyne.TextAlignLeading, "", link, nil}
 }
 
 func parseMarkdown(content string) []RichTextSegment {

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -109,6 +109,11 @@ type HyperlinkSegment struct {
 	Alignment fyne.TextAlign
 	Text      string
 	URL       *url.URL
+
+	// OnTapped overrides the default `fyne.OpenURL` call when the link is tapped
+	//
+	// Since: 2.4
+	OnTapped func()
 }
 
 // Inline returns true as hyperlinks are inside other elements.
@@ -125,6 +130,7 @@ func (h *HyperlinkSegment) Textual() string {
 func (h *HyperlinkSegment) Visual() fyne.CanvasObject {
 	link := NewHyperlink(h.Text, h.URL)
 	link.Alignment = h.Alignment
+	link.OnTapped = h.OnTapped
 	return &fyne.Container{Layout: &unpadTextWidgetLayout{}, Objects: []fyne.CanvasObject{link}}
 }
 
@@ -134,6 +140,7 @@ func (h *HyperlinkSegment) Update(o fyne.CanvasObject) {
 	link.Text = h.Text
 	link.URL = h.URL
 	link.Alignment = h.Alignment
+	link.OnTapped = h.OnTapped
 	link.Refresh()
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR adds an `OnTapped` callback to the `HyperlinkSegment` used in `RichText`.

This is the same as #3392, which I accidentally closed by deleting its repository.

Fixes #3335

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. (I'm not sure how to test clicking a HyperlinkSegment)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
