### PR TITLE
Listen to submenu item taps

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -102,16 +102,24 @@ func itemForMenuItem(i *fyne.MenuItem, parent *systray.MenuItem) *systray.MenuIt
 func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 	d.systrayMenu = m
 	systray.ResetMenu()
+	d.refreshSystrayMenu(m, nil)
+
+	systray.AddSeparator()
+	quit := systray.AddMenuItem("Quit", "Quit application")
+	go func() {
+		<-quit.ClickedCh
+		d.Quit()
+	}()
+}
+
+func (d *gLDriver) refreshSystrayMenu(m *fyne.Menu, parent *systray.MenuItem) {
 	for _, i := range m.Items {
-		item := itemForMenuItem(i, nil)
+		item := itemForMenuItem(i, parent)
 		if item == nil {
 			continue // separator
 		}
 		if i.ChildMenu != nil {
-			for _, c := range i.ChildMenu.Items {
-				itemForMenuItem(c, item)
-			}
-			continue
+			d.refreshSystrayMenu(i.ChildMenu, item)
 		}
 
 		fn := i.Action
@@ -123,13 +131,6 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 			}
 		}()
 	}
-
-	systray.AddSeparator()
-	quit := systray.AddMenuItem("Quit", "Quit application")
-	go func() {
-		<-quit.ClickedCh
-		d.Quit()
-	}()
 }
 
 func (d *gLDriver) SetSystemTrayIcon(resource fyne.Resource) {


### PR DESCRIPTION
Reported in `rc3` testing, submenu items in systray did not call their functions

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- manual test tap, from code at https://go.dev/play/p/CTIpeEEkNQs
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

