### PR TITLE
Fix issue where a menu item would not appear disabled initially

### DIFF
--- a/widget/menu_item.go
+++ b/widget/menu_item.go
@@ -96,7 +96,7 @@ func (i *menuItem) CreateRenderer() fyne.WidgetRenderer {
 	}
 
 	objects = append(objects, checkIcon)
-	return &menuItemRenderer{
+	r := &menuItemRenderer{
 		BaseRenderer:  widget.NewBaseRenderer(objects),
 		i:             i,
 		expandIcon:    expandIcon,
@@ -106,6 +106,8 @@ func (i *menuItem) CreateRenderer() fyne.WidgetRenderer {
 		text:          text,
 		background:    background,
 	}
+	r.Refresh() // ensure text and icon resources match state
+	return r
 }
 
 // MouseIn activates the item which shows the submenu if the item has one.

--- a/widget/menu_item_test.go
+++ b/widget/menu_item_test.go
@@ -1,0 +1,21 @@
+package widget
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/cache"
+	"fyne.io/fyne/v2/theme"
+)
+
+func TestMenuItem_Disabled(t *testing.T) {
+	i := fyne.NewMenuItem("Disabled", func() {})
+	m := fyne.NewMenu("top", []*fyne.MenuItem{i}...)
+	i.Disabled = true
+	w := newMenuItem(i, NewMenu(m))
+	r := cache.Renderer(w)
+
+	assert.Equal(t, theme.DisabledColor(), r.(*menuItemRenderer).text.Color)
+}


### PR DESCRIPTION
Another simple fix - apply the menu item visual style at initial display

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

