### PR TITLE
Implement keyboard navigation in file dialog

### DIFF
--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -30,15 +30,16 @@ type fileDialogItem struct {
 	dir      bool
 
 	hovered bool
+	focused bool
 }
 
 func (i *fileDialogItem) FocusGained() {
-	i.hovered = true
+	i.focused = true
 	i.Refresh()
 }
 
 func (i *fileDialogItem) FocusLost() {
-	i.hovered = false
+	i.focused = false
 	i.Refresh()
 }
 
@@ -53,14 +54,16 @@ func (i *fileDialogItem) TypedKey(key *fyne.KeyEvent) {
 }
 
 func (i *fileDialogItem) MouseIn(_ *desktop.MouseEvent) {
-	i.FocusGained()
+	i.hovered = true
+	i.Refresh()
 }
 
 func (i *fileDialogItem) MouseMoved(_ *desktop.MouseEvent) {
 }
 
 func (i *fileDialogItem) MouseOut() {
-	i.FocusLost()
+	i.hovered = false
+	i.Refresh()
 }
 
 func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {
@@ -150,7 +153,7 @@ func (s fileItemRenderer) Refresh() {
 	if s.item.isCurrent {
 		s.background.FillColor = theme.SelectionColor()
 		s.background.Show()
-	} else if s.item.hovered {
+	} else if s.item.hovered || s.item.focused {
 		s.background.FillColor = theme.HoverColor()
 		s.background.Show()
 	} else {

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -154,7 +154,6 @@ func (s fileItemRenderer) Refresh() {
 	} else {
 		s.background.Hide()
 	}
-	s.background.Refresh()
 	canvas.Refresh(s.item)
 }
 

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -46,9 +46,9 @@ func (i *fileDialogItem) TypedRune(_ rune) {
 }
 
 func (i *fileDialogItem) TypedKey(key *fyne.KeyEvent) {
-	if key.Name == fyne.KeySpace {
+	switch key.Name {
+	case fyne.KeySpace, fyne.KeyEnter, fyne.KeyReturn:
 		i.picker.setSelected(i)
-		i.Refresh()
 	}
 }
 
@@ -65,7 +65,6 @@ func (i *fileDialogItem) MouseOut() {
 
 func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {
 	i.picker.setSelected(i)
-	i.Refresh()
 }
 
 func (i *fileDialogItem) CreateRenderer() fyne.WidgetRenderer {

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -17,6 +17,9 @@ const (
 	fileIconCellWidth  = fileIconSize * 1.25
 )
 
+var _ fyne.Focusable = (*fileDialogItem)(nil)
+var _ fyne.Tappable = (*fileDialogItem)(nil)
+
 type fileDialogItem struct {
 	widget.BaseWidget
 	picker    *fileDialog

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -29,17 +29,35 @@ type fileDialogItem struct {
 	hovered bool
 }
 
-func (i *fileDialogItem) MouseIn(*desktop.MouseEvent) {
+func (i *fileDialogItem) FocusGained() {
 	i.hovered = true
 	i.Refresh()
 }
 
-func (i *fileDialogItem) MouseMoved(*desktop.MouseEvent) {
+func (i *fileDialogItem) FocusLost() {
+	i.hovered = false
+	i.Refresh()
+}
+
+func (i *fileDialogItem) TypedRune(_ rune) {
+}
+
+func (i *fileDialogItem) TypedKey(key *fyne.KeyEvent) {
+	if key.Name == fyne.KeySpace {
+		i.picker.setSelected(i)
+		i.Refresh()
+	}
+}
+
+func (i *fileDialogItem) MouseIn(_ *desktop.MouseEvent) {
+	i.FocusGained()
+}
+
+func (i *fileDialogItem) MouseMoved(_ *desktop.MouseEvent) {
 }
 
 func (i *fileDialogItem) MouseOut() {
-	i.hovered = false
-	i.Refresh()
+	i.FocusLost()
 }
 
 func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/storage"
 
 	"fyne.io/fyne/v2/test"
@@ -118,4 +119,27 @@ func TestNewFileItem_ParentFolder(t *testing.T) {
 	assert.False(t, item.isCurrent)
 	assert.Equal(t, (*fileDialogItem)(nil), f.selected)
 	assert.Equal(t, parentDir.String(), f.dir.String())
+}
+
+func TestFileDialogItemNavigation(t *testing.T) {
+	f := &fileDialog{file: &FileDialog{}}
+	_ = f.makeUI()
+
+	uri := storage.NewFileURI("/random/file")
+	item := f.newFileItem(uri, false)
+
+	item.FocusGained()
+	assert.True(t, item.hovered)
+
+	item.FocusLost()
+	assert.False(t, item.hovered)
+
+	item.MouseIn(nil)
+	assert.True(t, item.hovered)
+
+	item.MouseOut()
+	assert.False(t, item.hovered)
+
+	item.TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+	assert.True(t, item.isCurrent)
 }

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -129,10 +129,10 @@ func TestFileDialogItemNavigation(t *testing.T) {
 	item := f.newFileItem(uri, false)
 
 	item.FocusGained()
-	assert.True(t, item.hovered)
+	assert.True(t, item.focused)
 
 	item.FocusLost()
-	assert.False(t, item.hovered)
+	assert.False(t, item.focused)
 
 	item.MouseIn(nil)
 	assert.True(t, item.hovered)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This greatly improves the usability of the file dialog
by making sure that it can be navigated with a keyboard.
- Hover previous and next items using tab and shift+tab.
- Select hovered item by pressing space.

I also noticed that the background was refreshed twice, so I removed that. Should avoid a redraw, I think :)

For #1515

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.