### PR TITLE
Implement kayboard navigation in widget.Tree

### DIFF
--- a/widget/tree.go
+++ b/widget/tree.go
@@ -712,6 +712,12 @@ func (n *treeNode) TypedRune(_ rune) {
 func (n *treeNode) TypedKey(key *fyne.KeyEvent) {
 	if key.Name == fyne.KeySpace {
 		n.tree.Select(n.uid)
+	} else if n.isBranch {
+		if key.Name == fyne.KeyRight {
+			n.tree.OpenBranch(n.uid)
+		} else if key.Name == fyne.KeyLeft {
+			n.tree.CloseBranch(n.uid)
+		}
 	}
 }
 

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -662,6 +662,7 @@ func (r *treeContentRenderer) getLeaf() (l *leaf) {
 	return
 }
 
+var _ fyne.Focusable = (*treeNode)(nil)
 var _ desktop.Hoverable = (*treeNode)(nil)
 var _ fyne.CanvasObject = (*treeNode)(nil)
 var _ fyne.Tappable = (*treeNode)(nil)
@@ -695,23 +696,40 @@ func (n *treeNode) Indent() float32 {
 	return float32(n.depth) * (theme.IconInlineSize() + theme.Padding())
 }
 
-// MouseIn is called when a desktop pointer enters the widget
-func (n *treeNode) MouseIn(*desktop.MouseEvent) {
+func (n *treeNode) FocusGained() {
 	n.hovered = true
 	n.partialRefresh()
 }
 
-// MouseMoved is called when a desktop pointer hovers over the widget
-func (n *treeNode) MouseMoved(*desktop.MouseEvent) {
-}
-
-// MouseOut is called when a desktop pointer exits the widget
-func (n *treeNode) MouseOut() {
+func (n *treeNode) FocusLost() {
 	n.hovered = false
 	n.partialRefresh()
 }
 
-func (n *treeNode) Tapped(*fyne.PointEvent) {
+func (n *treeNode) TypedRune(_ rune) {
+}
+
+func (n *treeNode) TypedKey(key *fyne.KeyEvent) {
+	if key.Name == fyne.KeySpace {
+		n.tree.Select(n.uid)
+	}
+}
+
+// MouseIn is called when a desktop pointer enters the widget
+func (n *treeNode) MouseIn(_ *desktop.MouseEvent) {
+	n.FocusGained()
+}
+
+// MouseMoved is called when a desktop pointer hovers over the widget
+func (n *treeNode) MouseMoved(_ *desktop.MouseEvent) {
+}
+
+// MouseOut is called when a desktop pointer exits the widget
+func (n *treeNode) MouseOut() {
+	n.FocusLost()
+}
+
+func (n *treeNode) Tapped(_ *fyne.PointEvent) {
 	n.tree.Select(n.uid)
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This implements the Focusable interface for Tree Nodes. Added keyboard navigation:
- Navigate between tree nodes using `tab` and `shift + tab`.
- Select a tree node by pressing space.
- Open a branch by pressing `right` and close using `left`. 

For https://github.com/fyne-io/fyne/issues/1515

Opening as draft for now until I have implemented tests.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
