### PR TITLE
Implement focus and keyboard controls for slider

### DIFF
--- a/widget/slider.go
+++ b/widget/slider.go
@@ -2,7 +2,6 @@ package widget
 
 import (
 	"fmt"
-	"image/color"
 	"math"
 
 	"fyne.io/fyne/v2"
@@ -256,11 +255,10 @@ func (s *Slider) CreateRenderer() fyne.WidgetRenderer {
 	track := canvas.NewRectangle(theme.InputBackgroundColor())
 	active := canvas.NewRectangle(theme.ForegroundColor())
 	thumb := &canvas.Circle{FillColor: theme.ForegroundColor()}
-	focusIndicator := &canvas.Circle{FillColor: color.Transparent}
 
-	objects := []fyne.CanvasObject{track, active, thumb, focusIndicator}
+	objects := []fyne.CanvasObject{track, active, thumb}
 
-	slide := &sliderRenderer{widget.NewBaseRenderer(objects), track, active, thumb, focusIndicator, s}
+	slide := &sliderRenderer{widget.NewBaseRenderer(objects), track, active, thumb, s}
 	slide.Refresh() // prepare for first draw
 	return slide
 }
@@ -320,11 +318,10 @@ const minLongSide = float32(34) // added to button diameter
 
 type sliderRenderer struct {
 	widget.BaseRenderer
-	track          *canvas.Rectangle
-	active         *canvas.Rectangle
-	thumb          *canvas.Circle
-	focusIndicator *canvas.Circle
-	slider         *Slider
+	track  *canvas.Rectangle
+	active *canvas.Rectangle
+	thumb  *canvas.Circle
+	slider *Slider
 }
 
 // Refresh updates the widget state for drawing.
@@ -334,11 +331,14 @@ func (s *sliderRenderer) Refresh() {
 	s.active.FillColor = theme.ForegroundColor()
 
 	if s.slider.focused {
-		s.focusIndicator.FillColor = theme.FocusColor()
+		s.thumb.StrokeColor = theme.FocusColor()
+		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
 	} else if s.slider.hovered {
-		s.focusIndicator.FillColor = theme.HoverColor()
+		s.thumb.StrokeColor = theme.HoverColor()
+		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
 	} else {
-		s.focusIndicator.FillColor = color.Transparent
+		s.thumb.StrokeColor = nil
+		s.thumb.StrokeWidth = 0
 	}
 
 	s.slider.clampValueToRange()
@@ -389,10 +389,6 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 
 	s.thumb.Move(thumbPos)
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
-
-	focusIndicatorSize := fyne.NewSize(diameter+theme.InnerPadding()*2, diameter+theme.InnerPadding()*2)
-	s.focusIndicator.Move(thumbPos.SubtractXY(theme.InnerPadding(), theme.InnerPadding()))
-	s.focusIndicator.Resize(focusIndicatorSize)
 }
 
 // MinSize calculates the minimum size of a widget.

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -151,8 +151,7 @@ func (s *Slider) MouseOut() {
 //
 // Implements: fyne.Tappable
 func (s *Slider) Tapped(_ *fyne.PointEvent) {
-	s.focused = true
-	s.Refresh()
+	s.FocusGained()
 }
 
 func (s *Slider) TypedKey(key *fyne.KeyEvent) {

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -332,10 +332,13 @@ func (s *sliderRenderer) Refresh() {
 
 	if s.slider.focused {
 		s.thumb.StrokeColor = theme.FocusColor()
+		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
 	} else if s.slider.hovered {
 		s.thumb.StrokeColor = theme.HoverColor()
+		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
 	} else {
 		s.thumb.StrokeColor = nil
+		s.thumb.StrokeWidth = 0
 	}
 
 	s.slider.clampValueToRange()
@@ -386,15 +389,6 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 
 	s.thumb.Move(thumbPos)
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
-
-	indicatorWidth := theme.IconInlineSize() + theme.InnerPadding() - diameter
-	if s.slider.focused {
-		s.thumb.StrokeWidth = indicatorWidth
-	} else if s.slider.hovered {
-		s.thumb.StrokeWidth = indicatorWidth
-	} else {
-		s.thumb.StrokeWidth = 0
-	}
 }
 
 // MinSize calculates the minimum size of a widget.

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -22,9 +22,10 @@ const (
 	Vertical   Orientation = 1
 )
 
-var _ fyne.Focusable = (*Slider)(nil)
 var _ fyne.Draggable = (*Slider)(nil)
+var _ fyne.Focusable = (*Slider)(nil)
 var _ desktop.Hoverable = (*Slider)(nil)
+var _ fyne.Tappable = (*Slider)(nil)
 
 // Slider is a widget that can slide between two fixed values.
 type Slider struct {
@@ -143,6 +144,14 @@ func (s *Slider) MouseMoved(_ *desktop.MouseEvent) {
 // Implements: desktop.Hoverable
 func (s *Slider) MouseOut() {
 	s.hovered = false
+	s.Refresh()
+}
+
+// Tapped is called when a pointer tapped event is captured and triggers any change handler
+//
+// Implements: fyne.Tappable
+func (s *Slider) Tapped(_ *fyne.PointEvent) {
+	s.focused = true
 	s.Refresh()
 }
 
@@ -325,10 +334,10 @@ func (s *sliderRenderer) Refresh() {
 	s.thumb.FillColor = theme.ForegroundColor()
 	s.active.FillColor = theme.ForegroundColor()
 
-	if s.slider.hovered {
-		s.focusIndicator.FillColor = theme.HoverColor()
-	} else if s.slider.focused {
+	if s.slider.focused {
 		s.focusIndicator.FillColor = theme.FocusColor()
+	} else if s.slider.hovered {
+		s.focusIndicator.FillColor = theme.HoverColor()
 	} else {
 		s.focusIndicator.FillColor = color.Transparent
 	}

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -167,6 +167,9 @@ func (s *Slider) Tapped(_ *fyne.PointEvent) {
 	}
 }
 
+// TypedKey is called when this item receives a key event.
+//
+// Implements: fyne.Focusable
 func (s *Slider) TypedKey(key *fyne.KeyEvent) {
 	if s.Orientation == Vertical {
 		switch key.Name {
@@ -185,6 +188,9 @@ func (s *Slider) TypedKey(key *fyne.KeyEvent) {
 	}
 }
 
+// TypedRune is called when this item receives a char event.
+//
+// Implements: fyne.Focusable
 func (s *Slider) TypedRune(_ rune) {
 }
 

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"fmt"
+	"image/color"
 	"math"
 
 	"fyne.io/fyne/v2"
@@ -255,10 +256,11 @@ func (s *Slider) CreateRenderer() fyne.WidgetRenderer {
 	track := canvas.NewRectangle(theme.InputBackgroundColor())
 	active := canvas.NewRectangle(theme.ForegroundColor())
 	thumb := &canvas.Circle{FillColor: theme.ForegroundColor()}
+	focusIndicator := &canvas.Circle{FillColor: color.Transparent}
 
-	objects := []fyne.CanvasObject{track, active, thumb}
+	objects := []fyne.CanvasObject{track, active, thumb, focusIndicator}
 
-	slide := &sliderRenderer{widget.NewBaseRenderer(objects), track, active, thumb, s}
+	slide := &sliderRenderer{widget.NewBaseRenderer(objects), track, active, thumb, focusIndicator, s}
 	slide.Refresh() // prepare for first draw
 	return slide
 }
@@ -318,10 +320,11 @@ const minLongSide = float32(34) // added to button diameter
 
 type sliderRenderer struct {
 	widget.BaseRenderer
-	track  *canvas.Rectangle
-	active *canvas.Rectangle
-	thumb  *canvas.Circle
-	slider *Slider
+	track          *canvas.Rectangle
+	active         *canvas.Rectangle
+	thumb          *canvas.Circle
+	focusIndicator *canvas.Circle
+	slider         *Slider
 }
 
 // Refresh updates the widget state for drawing.
@@ -331,14 +334,11 @@ func (s *sliderRenderer) Refresh() {
 	s.active.FillColor = theme.ForegroundColor()
 
 	if s.slider.focused {
-		s.thumb.StrokeColor = theme.FocusColor()
-		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
+		s.focusIndicator.FillColor = theme.FocusColor()
 	} else if s.slider.hovered {
-		s.thumb.StrokeColor = theme.HoverColor()
-		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
+		s.focusIndicator.FillColor = theme.HoverColor()
 	} else {
-		s.thumb.StrokeColor = nil
-		s.thumb.StrokeWidth = 0
+		s.focusIndicator.FillColor = color.Transparent
 	}
 
 	s.slider.clampValueToRange()
@@ -389,6 +389,10 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 
 	s.thumb.Move(thumbPos)
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
+
+	focusIndicatorSize := fyne.NewSize(diameter+theme.InnerPadding()*2, diameter+theme.InnerPadding()*2)
+	s.focusIndicator.Move(thumbPos.SubtractXY(theme.InnerPadding(), theme.InnerPadding()))
+	s.focusIndicator.Resize(focusIndicatorSize)
 }
 
 // MinSize calculates the minimum size of a widget.

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -82,14 +82,10 @@ func (s *Slider) Bind(data binding.Float) {
 }
 
 // DragEnd is called when the drag ends.
-//
-// Implements: fyne.Draggable
 func (s *Slider) DragEnd() {
 }
 
 // DragEnd is called when a drag event occurs.
-//
-// Implements: fyne.Draggable
 func (s *Slider) Dragged(e *fyne.DragEvent) {
 	ratio := s.getRatio(&e.PointEvent)
 	lastValue := s.Value
@@ -100,7 +96,7 @@ func (s *Slider) Dragged(e *fyne.DragEvent) {
 
 // Tapped is called when a pointer tapped event is captured.
 //
-// Implements: fyne.Tappable
+// Since: 2.4
 func (s *Slider) Tapped(e *fyne.PointEvent) {
 	driver := fyne.CurrentApp().Driver()
 	if !s.focused && !driver.Device().IsMobile() {
@@ -132,7 +128,7 @@ func (s *Slider) positionChanged(lastValue, currentValue float64) {
 
 // FocusGained is called when this item gained the focus.
 //
-// Implements: fyne.Focusable
+// Since: 2.4
 func (s *Slider) FocusGained() {
 	s.focused = true
 	s.Refresh()
@@ -140,7 +136,7 @@ func (s *Slider) FocusGained() {
 
 // FocusLost is called when this item lost the focus.
 //
-// Implements: fyne.Focusable
+// Since: 2.4
 func (s *Slider) FocusLost() {
 	s.focused = false
 	s.Refresh()
@@ -148,7 +144,7 @@ func (s *Slider) FocusLost() {
 
 // MouseIn is called when a desktop pointer enters the widget.
 //
-// Implements: desktop.Hoverable
+// Since: 2.4
 func (s *Slider) MouseIn(_ *desktop.MouseEvent) {
 	s.hovered = true
 	s.Refresh()
@@ -156,13 +152,13 @@ func (s *Slider) MouseIn(_ *desktop.MouseEvent) {
 
 // MouseMoved is called when a desktop pointer hovers over the widget.
 //
-// Implements: desktop.Hoverable
+// Since: 2.4
 func (s *Slider) MouseMoved(_ *desktop.MouseEvent) {
 }
 
 // MouseOut is called when a desktop pointer exits the widget
 //
-// Implements: desktop.Hoverable
+// Since: 2.4
 func (s *Slider) MouseOut() {
 	s.hovered = false
 	s.Refresh()
@@ -170,7 +166,7 @@ func (s *Slider) MouseOut() {
 
 // TypedKey is called when this item receives a key event.
 //
-// Implements: fyne.Focusable
+// Since: 2.4
 func (s *Slider) TypedKey(key *fyne.KeyEvent) {
 	if s.Orientation == Vertical {
 		switch key.Name {
@@ -191,7 +187,7 @@ func (s *Slider) TypedKey(key *fyne.KeyEvent) {
 
 // TypedRune is called when this item receives a char event.
 //
-// Implements: fyne.Focusable
+// Since: 2.4
 func (s *Slider) TypedRune(_ rune) {
 }
 

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -157,17 +157,17 @@ func (s *Slider) Tapped(_ *fyne.PointEvent) {
 func (s *Slider) TypedKey(key *fyne.KeyEvent) {
 	if s.Orientation == Vertical {
 		switch key.Name {
-		case fyne.KeyLeft:
-			s.SetValue(s.Value - s.Step)
-		case fyne.KeyRight:
-			s.SetValue(s.Value + s.Step)
-		}
-	} else {
-		switch key.Name {
 		case fyne.KeyUp:
 			s.SetValue(s.Value + s.Step)
 		case fyne.KeyDown:
 			s.SetValue(s.Value - s.Step)
+		}
+	} else {
+		switch key.Name {
+		case fyne.KeyLeft:
+			s.SetValue(s.Value - s.Step)
+		case fyne.KeyRight:
+			s.SetValue(s.Value + s.Step)
 		}
 	}
 }

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -81,16 +81,6 @@ func (s *Slider) Bind(data binding.Float) {
 	}
 }
 
-func (s *Slider) FocusGained() {
-	s.focused = true
-	s.Refresh()
-}
-
-func (s *Slider) FocusLost() {
-	s.focused = false
-	s.Refresh()
-}
-
 // DragEnd function.
 func (s *Slider) DragEnd() {
 }
@@ -123,6 +113,22 @@ func (s *Slider) positionChanged(lastValue, currentValue float64) {
 	if s.OnChanged != nil {
 		s.OnChanged(s.Value)
 	}
+}
+
+// FocusGained is called when this item gained the focus.
+//
+// Implements: fyne.Focusable
+func (s *Slider) FocusGained() {
+	s.focused = true
+	s.Refresh()
+}
+
+// FocusLost is called when this item lost the focus.
+//
+// Implements: fyne.Focusable
+func (s *Slider) FocusLost() {
+	s.focused = false
+	s.Refresh()
 }
 
 // MouseIn is called when a desktop pointer enters the widget.

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -155,11 +155,20 @@ func (s *Slider) Tapped(_ *fyne.PointEvent) {
 }
 
 func (s *Slider) TypedKey(key *fyne.KeyEvent) {
-	switch key.Name {
-	case fyne.KeyLeft:
-		s.SetValue(s.Value - s.Step)
-	case fyne.KeyRight:
-		s.SetValue(s.Value + s.Step)
+	if s.Orientation == Vertical {
+		switch key.Name {
+		case fyne.KeyLeft:
+			s.SetValue(s.Value - s.Step)
+		case fyne.KeyRight:
+			s.SetValue(s.Value + s.Step)
+		}
+	} else {
+		switch key.Name {
+		case fyne.KeyUp:
+			s.SetValue(s.Value + s.Step)
+		case fyne.KeyDown:
+			s.SetValue(s.Value - s.Step)
+		}
 	}
 }
 
@@ -341,6 +350,8 @@ func (s *sliderRenderer) Refresh() {
 		s.focusIndicator.FillColor = color.Transparent
 	}
 
+	s.focusIndicator.Refresh()
+
 	s.slider.clampValueToRange()
 	s.Layout(s.slider.Size())
 	canvas.Refresh(s.slider.super())
@@ -391,7 +402,7 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
 
 	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.InnerPadding(), theme.IconInlineSize()+theme.InnerPadding())
-	delta := (focusIndicatorSize.Width - diameter) / 2
+	delta := focusIndicatorSize.Width/2 - diameter/2
 	s.focusIndicator.Resize(focusIndicatorSize)
 	s.focusIndicator.Move(thumbPos.SubtractXY(delta, delta))
 }

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -390,9 +390,10 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 	s.thumb.Move(thumbPos)
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
 
-	focusIndicatorSize := fyne.NewSize(diameter+theme.InnerPadding()*2, diameter+theme.InnerPadding()*2)
-	s.focusIndicator.Move(thumbPos.SubtractXY(theme.InnerPadding(), theme.InnerPadding()))
+	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.InnerPadding(), theme.IconInlineSize()+theme.InnerPadding())
+	delta := (focusIndicatorSize.Width - diameter) / 2
 	s.focusIndicator.Resize(focusIndicatorSize)
+	s.focusIndicator.Move(thumbPos.SubtractXY(delta, delta))
 }
 
 // MinSize calculates the minimum size of a widget.

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -332,13 +332,10 @@ func (s *sliderRenderer) Refresh() {
 
 	if s.slider.focused {
 		s.thumb.StrokeColor = theme.FocusColor()
-		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
 	} else if s.slider.hovered {
 		s.thumb.StrokeColor = theme.HoverColor()
-		s.thumb.StrokeWidth = 2 * theme.InnerPadding()
 	} else {
 		s.thumb.StrokeColor = nil
-		s.thumb.StrokeWidth = 0
 	}
 
 	s.slider.clampValueToRange()
@@ -389,6 +386,15 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 
 	s.thumb.Move(thumbPos)
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
+
+	indicatorWidth := theme.IconInlineSize() + theme.InnerPadding() - diameter
+	if s.slider.focused {
+		s.thumb.StrokeWidth = indicatorWidth
+	} else if s.slider.hovered {
+		s.thumb.StrokeWidth = indicatorWidth
+	} else {
+		s.thumb.StrokeWidth = 0
+	}
 }
 
 // MinSize calculates the minimum size of a widget.

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -151,7 +151,14 @@ func (s *Slider) MouseOut() {
 //
 // Implements: fyne.Tappable
 func (s *Slider) Tapped(_ *fyne.PointEvent) {
-	s.FocusGained()
+	driver := fyne.CurrentApp().Driver()
+	if !s.focused && !driver.Device().IsMobile() {
+		impl := s.super()
+
+		if c := driver.CanvasForObject(impl); c != nil {
+			c.Focus(impl.(fyne.Focusable))
+		}
+	}
 }
 
 func (s *Slider) TypedKey(key *fyne.KeyEvent) {
@@ -402,7 +409,7 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
 
 	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.InnerPadding(), theme.IconInlineSize()+theme.InnerPadding())
-	delta := focusIndicatorSize.Width/2 - diameter/2
+	delta := (focusIndicatorSize.Width - diameter) / 2
 	s.focusIndicator.Resize(focusIndicatorSize)
 	s.focusIndicator.Move(thumbPos.SubtractXY(delta, delta))
 }

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -81,13 +81,17 @@ func (s *Slider) Bind(data binding.Float) {
 	}
 }
 
-// DragEnd function.
+// DragEnd is called when the drag ends.
+//
+// Implements: fyne.Draggable
 func (s *Slider) DragEnd() {
 }
 
-// Dragged function.
+// DragEnd is called when a drag event occurs.
+//
+// Implements: fyne.Draggable
 func (s *Slider) Dragged(e *fyne.DragEvent) {
-	ratio := s.getRatio(&(e.PointEvent))
+	ratio := s.getRatio(&e.PointEvent)
 	lastValue := s.Value
 
 	s.updateValue(ratio)

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -94,8 +94,19 @@ func (s *Slider) Dragged(e *fyne.DragEvent) {
 	s.positionChanged(lastValue, s.Value)
 }
 
-// Tapped function.
+// Tapped is called when a pointer tapped event is captured.
+//
+// Implements: fyne.Tappable
 func (s *Slider) Tapped(e *fyne.PointEvent) {
+	driver := fyne.CurrentApp().Driver()
+	if !s.focused && !driver.Device().IsMobile() {
+		impl := s.super()
+
+		if c := driver.CanvasForObject(impl); c != nil {
+			c.Focus(impl.(fyne.Focusable))
+		}
+	}
+
 	ratio := s.getRatio(e)
 	lastValue := s.Value
 
@@ -151,20 +162,6 @@ func (s *Slider) MouseMoved(_ *desktop.MouseEvent) {
 func (s *Slider) MouseOut() {
 	s.hovered = false
 	s.Refresh()
-}
-
-// Tapped is called when a pointer tapped event is captured and triggers any change handler
-//
-// Implements: fyne.Tappable
-func (s *Slider) Tapped(_ *fyne.PointEvent) {
-	driver := fyne.CurrentApp().Driver()
-	if !s.focused && !driver.Device().IsMobile() {
-		impl := s.super()
-
-		if c := driver.CanvasForObject(impl); c != nil {
-			c.Focus(impl.(fyne.Focusable))
-		}
-	}
 }
 
 // TypedKey is called when this item receives a key event.

--- a/widget/slider_extend_test.go
+++ b/widget/slider_extend_test.go
@@ -25,7 +25,7 @@ func TestSlider_Extended_Value(t *testing.T) {
 	slider := newExtendedSlider()
 	slider.Resize(slider.MinSize().Add(fyne.NewSize(20, 0)))
 	objs := cache.Renderer(slider).Objects()
-	assert.Equal(t, 3, len(objs))
+	assert.Equal(t, 4, len(objs))
 	thumb := objs[2]
 	thumbPos := thumb.Position()
 
@@ -38,7 +38,7 @@ func TestSlider_Extended_Value(t *testing.T) {
 func TestSlider_Extended_Drag(t *testing.T) {
 	slider := newExtendedSlider()
 	objs := cache.Renderer(slider).Objects()
-	assert.Equal(t, 3, len(objs))
+	assert.Equal(t, 4, len(objs))
 	thumb := objs[2]
 	thumbPos := thumb.Position()
 

--- a/widget/slider_test.go
+++ b/widget/slider_test.go
@@ -250,4 +250,13 @@ func TestSlider_Focus(t *testing.T) {
 	slider.TypedKey(left)
 	assert.Equal(t, slider.Min, slider.Value)
 
+	slider.Orientation = Vertical
+	up := &fyne.KeyEvent{Name: fyne.KeyUp}
+	down := &fyne.KeyEvent{Name: fyne.KeyDown}
+
+	slider.TypedKey(up)
+	assert.Equal(t, slider.Min+1, slider.Value)
+
+	slider.TypedKey(down)
+	assert.Equal(t, slider.Min, slider.Value)
 }

--- a/widget/slider_test.go
+++ b/widget/slider_test.go
@@ -215,3 +215,39 @@ func TestSlider_SetValue(t *testing.T) {
 	slider.SetValue(2.0)
 	assert.Equal(t, 2.0, slider.Value)
 }
+
+func TestSlider_Focus(t *testing.T) {
+	slider := NewSlider(0, 5)
+
+	slider.FocusGained()
+	assert.True(t, slider.focused)
+
+	slider.FocusLost()
+	assert.False(t, slider.focused)
+
+	slider.MouseIn(nil)
+	assert.True(t, slider.hovered)
+
+	slider.MouseOut()
+	assert.False(t, slider.hovered)
+
+	left := &fyne.KeyEvent{Name: fyne.KeyLeft}
+	right := &fyne.KeyEvent{Name: fyne.KeyRight}
+
+	for i := 1; i <= int(slider.Max); i++ {
+		slider.TypedKey(right)
+		assert.Equal(t, float64(i), slider.Value)
+	}
+
+	slider.TypedKey(right)
+	assert.Equal(t, slider.Max, slider.Value)
+
+	for i := 4; i >= int(slider.Min); i-- {
+		slider.TypedKey(left)
+		assert.Equal(t, float64(i), slider.Value)
+	}
+
+	slider.TypedKey(left)
+	assert.Equal(t, slider.Min, slider.Value)
+
+}

--- a/widget/testdata/slider/horizontal.xml
+++ b/widget/testdata/slider/horizontal.xml
@@ -4,6 +4,7 @@
 			<rectangle fillColor="inputBackground" pos="14,18" size="179x2"/>
 			<rectangle fillColor="foreground" pos="14,18" size="0x2"/>
 			<circle fillColor="foreground" pos="6,11" size="16x16"/>
+			<circle pos="0,5" size="28x28"/>
 		</widget>
 	</content>
 </canvas>

--- a/widget/testdata/slider/vertical.xml
+++ b/widget/testdata/slider/vertical.xml
@@ -4,6 +4,7 @@
 			<rectangle fillColor="inputBackground" pos="18,14" size="2x179"/>
 			<rectangle fillColor="foreground" pos="18,193" size="2x0"/>
 			<circle fillColor="foreground" pos="11,185" size="16x16"/>
+			<circle pos="5,179" size="28x28"/>
 		</widget>
 	</content>
 </canvas>


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This implements focus and hover for the slider widget to make it follow the material design guidelines better.
I have also added support for moving the slider using the arrow keys.

For #1515 

Opening as draft for now until I have fixed some things and added tests.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
