### PR TITLE
Allow for doctabs.CreateTabs to take its time before returning a value.

### DIFF
--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -301,10 +301,12 @@ func (r *docTabsRenderer) buildAllTabsButton() (all *widget.Button) {
 func (r *docTabsRenderer) buildCreateTabsButton() *widget.Button {
 	create := widget.NewButton("", func() {
 		if f := r.docTabs.CreateTab; f != nil {
-			if tab := f(); tab != nil {
-				r.docTabs.Append(tab)
-				r.docTabs.SelectIndex(len(r.docTabs.Items) - 1)
-			}
+			go func() {
+				if tab := f(); tab != nil {
+					r.docTabs.Append(tab)
+					r.docTabs.SelectIndex(len(r.docTabs.Items) - 1)
+				}
+			}()
 		}
 	})
 	create.Importance = widget.LowImportance


### PR DESCRIPTION
### Description:
This is a likely use case of showing up a dialog.NewForm and wait for the result. The problem is that, at least on linux, the input thread is mixed with the rendering thread. So when a button is tapped and the interaction is blocked, it does block the main loop.

Another potential fix for this would be to make the Tapped callback happen in a goroutine too. I didn't go with that change as it did feel a bit bigger in scope, but it might make sense to actually spawn a goroutine for each Tapped callback as it might make this kind of bugs impossible.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
