### PR TITLE
Fix #3459 by changing srcdir to it's absolute path

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -90,6 +90,13 @@ func Build() *cli.Command {
 // Build parse the tags and start building
 func (b *Builder) Build() error {
 	if b.srcdir != "" {
+		// Use absolute srcdir
+		if !filepath.IsAbs(b.srcdir) {
+			absSrcDir, err := filepath.Abs(b.srcdir)
+			if err == nil {
+				b.srcdir = absSrcDir
+			}
+		}
 		dirStat, err := os.Stat(b.srcdir)
 		if err != nil {
 			return err
@@ -297,6 +304,10 @@ func createMetadataInitFile(srcdir string, app *appData) (func(), error) {
 
 	app.ResGoString = "nil"
 	if app.icon != "" {
+		// Icon path should relative to FyneApp.toml and it is in the srcdir
+		if !filepath.IsAbs(app.icon) {
+			app.icon = filepath.Join(srcdir, app.icon)
+		}
 		res, err := fyne.LoadResourceFromPath(app.icon)
 		if err != nil {
 			fyne.LogError("Unable to load medadata icon file "+app.icon, err)

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -287,7 +287,7 @@ func createMetadataInitFile(srcdir string, app *appData) (func(), error) {
 	data, err := metadata.LoadStandard(srcdir)
 	if err == nil {
 		// When icon path specified in metadata file, we should make it relative to metadata file
-		data.Details.Icon = util.MakePathRelative(srcdir, data.Details.Icon)
+		data.Details.Icon = util.MakePathRelativeTo(srcdir, data.Details.Icon)
 
 		app.mergeMetadata(data)
 	}

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -90,13 +90,7 @@ func Build() *cli.Command {
 // Build parse the tags and start building
 func (b *Builder) Build() error {
 	if b.srcdir != "" {
-		// Use absolute srcdir
-		if !filepath.IsAbs(b.srcdir) {
-			absSrcDir, err := filepath.Abs(b.srcdir)
-			if err == nil {
-				b.srcdir = absSrcDir
-			}
-		}
+		b.srcdir = util.EnsureAbsPath(b.srcdir)
 		dirStat, err := os.Stat(b.srcdir)
 		if err != nil {
 			return err
@@ -292,6 +286,9 @@ func (b *Builder) build() error {
 func createMetadataInitFile(srcdir string, app *appData) (func(), error) {
 	data, err := metadata.LoadStandard(srcdir)
 	if err == nil {
+		// When icon path specified in metadata file, we should make it relative to metadata file
+		data.Details.Icon = util.MakePathRelative(srcdir, data.Details.Icon)
+
 		app.mergeMetadata(data)
 	}
 
@@ -304,10 +301,6 @@ func createMetadataInitFile(srcdir string, app *appData) (func(), error) {
 
 	app.ResGoString = "nil"
 	if app.icon != "" {
-		// Icon path should relative to FyneApp.toml and it is in the srcdir
-		if !filepath.IsAbs(app.icon) {
-			app.icon = filepath.Join(srcdir, app.icon)
-		}
 		res, err := fyne.LoadResourceFromPath(app.icon)
 		if err != nil {
 			fyne.LogError("Unable to load medadata icon file "+app.icon, err)

--- a/cmd/fyne/internal/commands/package-util-mock_test.go
+++ b/cmd/fyne/internal/commands/package-util-mock_test.go
@@ -13,7 +13,7 @@ var utilCopyExeFileMock func(src, tgt string) error
 var utilWriteFileMock func(target string, data []byte) error
 var utilEnsureSubDirMock func(parent, name string) string
 var utilEnsureAbsPathMock func(path string) string
-var utilMakePathRelativeMock func(root, path string) string
+var utilMakePathRelativeToMock func(root, path string) string
 
 var utilRequireAndroidSDKMock func() error
 var utilAndroidBuildToolsPathMock func() string
@@ -145,8 +145,8 @@ func (m mockUtil) EnsureAbsPath(path string) string {
 	return utilEnsureAbsPathMock(path)
 }
 
-func (m mockUtil) MakePathRelative(root, path string) string {
-	return utilMakePathRelativeMock(root, path)
+func (m mockUtil) MakePathRelativeTo(root, path string) string {
+	return utilMakePathRelativeToMock(root, path)
 }
 
 func (m mockUtil) RequireAndroidSDK() error {

--- a/cmd/fyne/internal/commands/package-util-mock_test.go
+++ b/cmd/fyne/internal/commands/package-util-mock_test.go
@@ -12,6 +12,8 @@ var utilCopyFileMock func(source string, target string) error
 var utilCopyExeFileMock func(src, tgt string) error
 var utilWriteFileMock func(target string, data []byte) error
 var utilEnsureSubDirMock func(parent, name string) string
+var utilEnsureAbsPathMock func(path string) string
+var utilMakePathRelativeMock func(root, path string) string
 
 var utilRequireAndroidSDKMock func() error
 var utilAndroidBuildToolsPathMock func() string
@@ -137,6 +139,14 @@ func (m *mockEnsureSubDirRuns) verifyExpectation(t *testing.T, parent, name stri
 
 func (m mockUtil) EnsureSubDir(parent, name string) string {
 	return utilEnsureSubDirMock(parent, name)
+}
+
+func (m mockUtil) EnsureAbsPath(path string) string {
+	return utilEnsureAbsPathMock(path)
+}
+
+func (m mockUtil) MakePathRelative(root, path string) string {
+	return utilMakePathRelativeMock(root, path)
 }
 
 func (m mockUtil) RequireAndroidSDK() error {

--- a/cmd/fyne/internal/commands/package-util.go
+++ b/cmd/fyne/internal/commands/package-util.go
@@ -13,7 +13,7 @@ type packagerUtil interface {
 	WriteFile(target string, data []byte) error
 	EnsureSubDir(parent, name string) string
 	EnsureAbsPath(path string) string
-	MakePathRelative(root, path string) string
+	MakePathRelativeTo(root, path string) string
 
 	RequireAndroidSDK() error
 	AndroidBuildToolsPath() string
@@ -49,8 +49,8 @@ func (d defaultUtil) EnsureAbsPath(path string) string {
 	return realUtil.EnsureAbsPath(path)
 }
 
-func (d defaultUtil) MakePathRelative(root, path string) string {
-	return realUtil.MakePathRelative(root, path)
+func (d defaultUtil) MakePathRelativeTo(root, path string) string {
+	return realUtil.MakePathRelativeTo(root, path)
 }
 
 func (d defaultUtil) RequireAndroidSDK() error {

--- a/cmd/fyne/internal/commands/package-util.go
+++ b/cmd/fyne/internal/commands/package-util.go
@@ -12,6 +12,8 @@ type packagerUtil interface {
 	CopyExeFile(src, tgt string) error
 	WriteFile(target string, data []byte) error
 	EnsureSubDir(parent, name string) string
+	EnsureAbsPath(path string) string
+	MakePathRelative(root, path string) string
 
 	RequireAndroidSDK() error
 	AndroidBuildToolsPath() string
@@ -41,6 +43,14 @@ func (d defaultUtil) WriteFile(target string, data []byte) error {
 
 func (d defaultUtil) EnsureSubDir(parent, name string) string {
 	return realUtil.EnsureSubDir(parent, name)
+}
+
+func (d defaultUtil) EnsureAbsPath(path string) string {
+	return realUtil.EnsureAbsPath(path)
+}
+
+func (d defaultUtil) MakePathRelative(root, path string) string {
+	return realUtil.MakePathRelative(root, path)
 }
 
 func (d defaultUtil) RequireAndroidSDK() error {

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -351,13 +351,7 @@ func (p *Packager) validate() (err error) {
 			return errors.New("parameter -sourceDir is currently not supported for mobile builds. " +
 				"Change directory to the main package and try again")
 		}
-		// Use absolute srcdir
-		if !filepath.IsAbs(p.srcDir) {
-			absSrcDir, err := filepath.Abs(p.srcDir)
-			if err == nil {
-				p.srcDir = absSrcDir
-			}
-		}
+		p.srcDir = util.EnsureAbsPath(p.srcDir)
 	}
 	os.Chdir(p.srcDir)
 
@@ -365,6 +359,9 @@ func (p *Packager) validate() (err error) {
 
 	data, err := metadata.LoadStandard(p.srcDir)
 	if err == nil {
+		// When icon path specified in metadata file, we should make it relative to metadata file
+		data.Details.Icon = util.MakePathRelative(p.srcDir, data.Details.Icon)
+		
 		p.appData.Release = p.release
 		p.appData.mergeMetadata(data)
 	}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -346,9 +346,18 @@ func (p *Packager) validate() (err error) {
 	}
 	if p.srcDir == "" {
 		p.srcDir = baseDir
-	} else if p.os == "ios" || p.os == "android" {
-		return errors.New("parameter -sourceDir is currently not supported for mobile builds. " +
-			"Change directory to the main package and try again")
+	} else {
+		if p.os == "ios" || p.os == "android" {
+			return errors.New("parameter -sourceDir is currently not supported for mobile builds. " +
+				"Change directory to the main package and try again")
+		}
+		// Use absolute srcdir
+		if !filepath.IsAbs(p.srcDir) {
+			absSrcDir, err := filepath.Abs(p.srcDir)
+			if err == nil {
+				p.srcDir = absSrcDir
+			}
+		}
 	}
 	os.Chdir(p.srcDir)
 

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -360,8 +360,8 @@ func (p *Packager) validate() (err error) {
 	data, err := metadata.LoadStandard(p.srcDir)
 	if err == nil {
 		// When icon path specified in metadata file, we should make it relative to metadata file
-		data.Details.Icon = util.MakePathRelative(p.srcDir, data.Details.Icon)
-		
+		data.Details.Icon = util.MakePathRelativeTo(p.srcDir, data.Details.Icon)
+
 		p.appData.Release = p.release
 		p.appData.mergeMetadata(data)
 	}

--- a/cmd/fyne/internal/util/file.go
+++ b/cmd/fyne/internal/util/file.go
@@ -39,6 +39,31 @@ func EnsureSubDir(parent, name string) string {
 	return path
 }
 
+// EnsureAbsPath returns the absolute path of the given file if it is not already absolute
+func EnsureAbsPath(path string) string {
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			fyne.LogError("Failed to find absolute path", err)
+		} else {
+			return abs
+		}
+	}
+	return path
+}
+
+// MakePathRelative joins root with path if path is not absolute and exists in root
+// both root and path must non-empty, otherwise path will be returned
+func MakePathRelative(root, path string) string {
+	if root != "" && path != "" && !filepath.IsAbs(path) {
+		joined := filepath.Join(root, path)
+		if Exists(joined) {
+			return joined
+		}
+	}
+	return path
+}
+
 func copyFileMode(src, tgt string, perm os.FileMode) (err error) {
 	if _, err := os.Stat(src); err != nil {
 		return err

--- a/cmd/fyne/internal/util/file.go
+++ b/cmd/fyne/internal/util/file.go
@@ -41,27 +41,27 @@ func EnsureSubDir(parent, name string) string {
 
 // EnsureAbsPath returns the absolute path of the given file if it is not already absolute
 func EnsureAbsPath(path string) string {
-	if !filepath.IsAbs(path) {
-		abs, err := filepath.Abs(path)
-		if err != nil {
-			fyne.LogError("Failed to find absolute path", err)
-		} else {
-			return abs
-		}
+	if filepath.IsAbs(path) {
+		return path
 	}
-	return path
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		fyne.LogError("Failed to find absolute path", err)
+		return path
+	}
+	return abs
 }
 
-// MakePathRelative joins root with path if path is not absolute and exists in root
-// both root and path must non-empty, otherwise path will be returned
-func MakePathRelative(root, path string) string {
-	if root != "" && path != "" && !filepath.IsAbs(path) {
-		joined := filepath.Join(root, path)
-		if Exists(joined) {
-			return joined
-		}
+// MakePathRelativeTo joins root with path if path is not absolute and exists in root
+func MakePathRelativeTo(root, path string) string {
+	if filepath.IsAbs(path) {
+		return path
 	}
-	return path
+	joined := filepath.Join(root, path)
+	if !Exists(joined) {
+		return path
+	}
+	return joined
 }
 
 func copyFileMode(src, tgt string, perm os.FileMode) (err error) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Using relative paths with os.Chdir brokes joined file paths, to prevent this we can just use absolute filepaths without changing anything other

Fixes #3459 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
