### PR TITLE
Make sure that all the build put their result in p.dir.

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -68,7 +68,7 @@ func (p *Packager) packageUNIX() error {
 		}
 
 		var buf bytes.Buffer
-		tarCmd := execabs.Command("tar", "-Jcf", p.Name+".tar.xz", "-C", tempDir, "usr", "Makefile")
+		tarCmd := execabs.Command("tar", "-Jcf", filepath.Join(p.dir, p.Name+".tar.xz"), "-C", filepath.Join(p.dir, tempDir), "usr", "Makefile")
 		tarCmd.Stderr = &buf
 		if err = tarCmd.Run(); err != nil {
 			return fmt.Errorf("failed to create archive with tar: %s - %w", buf.String(), err)

--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -115,7 +115,7 @@ func (p *Packager) packageWindows() error {
 		if filepath.Ext(p.Name) != ".exe" {
 			appName = appName + ".exe"
 		}
-		appPath = filepath.Join(filepath.Dir(p.exe), appName)
+		appPath = filepath.Join(p.dir, appName)
 		os.Rename(filepath.Base(p.exe), appName)
 	}
 


### PR DESCRIPTION
### Description:
All build when building a subdir using -src should output there content in the current directory. Windows and Linux target where not following that requirement and are corrected with this patch.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
