### PR TITLE
Allow removal of the Quit entry in the Taskbar Menu.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -162,4 +162,5 @@ func newAppWithDriver(d fyne.Driver, id string) fyne.App {
 type systrayDriver interface {
 	SetSystemTrayMenu(*fyne.Menu)
 	SetSystemTrayIcon(resource fyne.Resource)
+	SetSystemTrayQuitText(title string, tooltip string)
 }

--- a/app/app_desktop_darwin.go
+++ b/app/app_desktop_darwin.go
@@ -37,6 +37,13 @@ func (a *fyneApp) SetSystemTrayIcon(icon fyne.Resource) {
 	a.Driver().(systrayDriver).SetSystemTrayIcon(icon)
 }
 
+// SetSystemTrayQuitText sets the title and tooltip strings for the Quit option that's available by default on a SystemTray Menu.
+func (a *fyneApp) SetSystemTrayQuitText(title string, tooltip string) {
+	if desk, ok := a.Driver().(systrayDriver); ok {
+		desk.SetSystemTrayQuitText(title, tooltip)
+	}
+}
+
 func defaultVariant() fyne.ThemeVariant {
 	if C.isDarkMode() {
 		return theme.VariantDark

--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -95,6 +95,11 @@ func (a *fyneApp) SetSystemTrayIcon(icon fyne.Resource) {
 	a.Driver().(systrayDriver).SetSystemTrayIcon(icon)
 }
 
+// SetSystemTrayQuitText sets the title and tooltip strings for the Quit option that's available by default on a SystemTray Menu.
+func (a *fyneApp) SetSystemTrayQuitText(title string, tooltip string) {
+	a.Driver().(systrayDriver).SetSystemTrayQuitText(title, tooltip)
+}
+
 func escapeNotificationString(in string) string {
 	noSlash := strings.ReplaceAll(in, "`", "``")
 	return strings.ReplaceAll(noSlash, "\"", "`\"")

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -151,6 +151,13 @@ func (a *fyneApp) SetSystemTrayIcon(icon fyne.Resource) {
 	}
 }
 
+// SetSystemTrayQuitText sets the title and tooltip strings for the Quit option that's available by default on a SystemTray Menu.
+func (a *fyneApp) SetSystemTrayQuitText(title string, tooltip string) {
+	if desk, ok := a.Driver().(systrayDriver); ok { // don't use this on mobile tag
+		desk.SetSystemTrayQuitText(title, tooltip)
+	}
+}
+
 func rootConfigDir() string {
 	desktopConfig, _ := os.UserConfigDir()
 	return filepath.Join(desktopConfig, "fyne")

--- a/driver/desktop/app.go
+++ b/driver/desktop/app.go
@@ -8,4 +8,5 @@ import "fyne.io/fyne/v2"
 type App interface {
 	SetSystemTrayMenu(menu *fyne.Menu)
 	SetSystemTrayIcon(icon fyne.Resource)
+	SetSystemTrayQuitText(title string, tooltip string)
 }

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -18,8 +18,11 @@ import (
 )
 
 var (
-	systrayIcon fyne.Resource
-	setup       sync.Once
+	systrayIcon    fyne.Resource
+	setup          sync.Once
+	systrayTitle   string
+	systrayTooltip string
+	quitMenuItem   *systray.MenuItem
 )
 
 func goroutineID() (id uint64) {
@@ -105,9 +108,16 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 	d.refreshSystrayMenu(m, nil)
 
 	systray.AddSeparator()
-	quit := systray.AddMenuItem("Quit", "Quit application")
+
+	if systrayTitle == "" {
+		quitMenuItem = systray.AddMenuItem("Quit", "Quit application")
+	} else {
+		quitMenuItem = systray.AddMenuItem(systrayTitle, systrayTooltip)
+	}
+
 	go func() {
-		<-quit.ClickedCh
+		<-quitMenuItem.ClickedCh
+		quitMenuItem = nil
 		d.Quit()
 	}()
 }
@@ -143,6 +153,18 @@ func (d *gLDriver) SetSystemTrayIcon(resource fyne.Resource) {
 	}
 
 	systray.SetIcon(img)
+}
+
+func (d *gLDriver) SetSystemTrayQuitText(title string, tooltip string) {
+	// in case we need it later
+	systrayTitle = title
+	systrayTooltip = tooltip
+
+	// in case we can apply it right now
+	if quitMenuItem != nil {
+		quitMenuItem.SetTitle(systrayTitle)
+		quitMenuItem.SetTooltip(systrayTooltip)
+	}
 }
 
 func (d *gLDriver) SystemTrayMenu() *fyne.Menu {

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -104,12 +104,14 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 	systray.ResetMenu()
 	d.refreshSystrayMenu(m, nil)
 
-	systray.AddSeparator()
-	quit := systray.AddMenuItem("Quit", "Quit application")
-	go func() {
-		<-quit.ClickedCh
-		d.Quit()
-	}()
+	if !m.NoDefaultEntries {
+		systray.AddSeparator()
+		quit := systray.AddMenuItem("Quit", "Quit application")
+		go func() {
+			<-quit.ClickedCh
+			d.Quit()
+		}()
+	}
 }
 
 func (d *gLDriver) refreshSystrayMenu(m *fyne.Menu, parent *systray.MenuItem) {

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -104,14 +104,12 @@ func (d *gLDriver) refreshSystray(m *fyne.Menu) {
 	systray.ResetMenu()
 	d.refreshSystrayMenu(m, nil)
 
-	if !m.NoDefaultEntries {
-		systray.AddSeparator()
-		quit := systray.AddMenuItem("Quit", "Quit application")
-		go func() {
-			<-quit.ClickedCh
-			d.Quit()
-		}()
-	}
+	systray.AddSeparator()
+	quit := systray.AddMenuItem("Quit", "Quit application")
+	go func() {
+		<-quit.ClickedCh
+		d.Quit()
+	}()
 }
 
 func (d *gLDriver) refreshSystrayMenu(m *fyne.Menu, parent *systray.MenuItem) {

--- a/menu.go
+++ b/menu.go
@@ -9,13 +9,14 @@ type systemTrayDriver interface {
 // Menu stores the information required for a standard menu.
 // A menu can pop down from a MainMenu or could be a pop out menu.
 type Menu struct {
-	Label string
-	Items []*MenuItem
+	Label            string
+	Items            []*MenuItem
+	NoDefaultEntries bool
 }
 
 // NewMenu creates a new menu given the specified label (to show in a MainMenu) and list of items to display.
 func NewMenu(label string, items ...*MenuItem) *Menu {
-	return &Menu{Label: label, Items: items}
+	return &Menu{Label: label, Items: items, NoDefaultEntries: false}
 }
 
 // Refresh will instruct this menu to update its display.

--- a/menu.go
+++ b/menu.go
@@ -9,14 +9,13 @@ type systemTrayDriver interface {
 // Menu stores the information required for a standard menu.
 // A menu can pop down from a MainMenu or could be a pop out menu.
 type Menu struct {
-	Label            string
-	Items            []*MenuItem
-	NoDefaultEntries bool
+	Label string
+	Items []*MenuItem
 }
 
 // NewMenu creates a new menu given the specified label (to show in a MainMenu) and list of items to display.
 func NewMenu(label string, items ...*MenuItem) *Menu {
-	return &Menu{Label: label, Items: items, NoDefaultEntries: false}
+	return &Menu{Label: label, Items: items}
 }
 
 // Refresh will instruct this menu to update its display.


### PR DESCRIPTION
### Description:
If developers wish to use the Taskbar Menu, as it stands today, the code forces you to have a "Quit" entry in said menu.

The string is also hardcoded.
This simple limitation makes it extremely frustrating (or downright impossible!) to localize a software.

While the correct approach would be to fully remove the "Quit" entry without looking back, such a thing would break the tutorial code and its YouTube video.

This is why I opted to add a public member to the Menu struct - which lets developers control whether the "Quit" entry should exist or not.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
