### PR TITLE
Call systray.Quit() when the application is closing

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -54,6 +54,9 @@ func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 		w.SetCloseIntercept(func() {
 			d.Quit()
 		})
+		w.SetOnClosed(func() {
+			systray.Quit()
+		})
 	})
 
 	d.refreshSystray(m)


### PR DESCRIPTION
### Description:
systray.Quit() is not being called consistently when the application is closing.

This results in the inability to automatically remove the systray icon for systray-only applications.

See also: https://github.com/fyne-io/systray/pull/36

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.