### PR TITLE
We should only correct icon path if it is specified in metadata file

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -313,7 +313,9 @@ func createMetadataInitFile(srcdir string, app *appData) (func(), error) {
 	data, err := metadata.LoadStandard(srcdir)
 	if err == nil {
 		// When icon path specified in metadata file, we should make it relative to metadata file
-		data.Details.Icon = util.MakePathRelativeTo(srcdir, data.Details.Icon)
+		if data.Details.Icon != "" {
+			data.Details.Icon = util.MakePathRelativeTo(srcdir, data.Details.Icon)
+		}
 
 		app.mergeMetadata(data)
 	}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -360,7 +360,9 @@ func (p *Packager) validate() (err error) {
 	data, err := metadata.LoadStandard(p.srcDir)
 	if err == nil {
 		// When icon path specified in metadata file, we should make it relative to metadata file
-		data.Details.Icon = util.MakePathRelativeTo(p.srcDir, data.Details.Icon)
+		if data.Details.Icon != "" {
+			data.Details.Icon = util.MakePathRelativeTo(p.srcDir, data.Details.Icon)
+		}
 
 		p.appData.Release = p.release
 		p.appData.mergeMetadata(data)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This will fix a mistake previosly made by me in #3546 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
