### PR TITLE
Don't crash when no monitor found

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -281,6 +281,10 @@ func (w *window) detectScale() float32 {
 		return 1.0
 	}
 	monitor := w.getMonitorForWindow()
+	if monitor == nil {
+		return 1.0
+	}
+
 	widthMm, _ := monitor.GetPhysicalSize()
 	widthPx := monitor.GetVideoMode().Width
 


### PR DESCRIPTION

Fixes #3609, #2972

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- we haven't got GLFW mocks
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

