### PR TITLE
dialog: Remove unnecessary refresh call from fileitem

### DIFF
--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -48,8 +48,7 @@ func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {
 }
 
 func (i *fileDialogItem) CreateRenderer() fyne.WidgetRenderer {
-	background := canvas.NewRectangle(theme.PrimaryColor())
-	background.Hide()
+	background := canvas.NewRectangle(nil)
 	text := widget.NewLabelWithStyle(i.name, fyne.TextAlignCenter, fyne.TextStyle{})
 	text.Wrapping = fyne.TextTruncate
 	icon := widget.NewFileIcon(i.location)
@@ -129,13 +128,13 @@ func (s fileItemRenderer) MinSize() fyne.Size {
 func (s fileItemRenderer) Refresh() {
 	if s.item.isCurrent {
 		s.background.FillColor = theme.SelectionColor()
-		s.background.Show()
 	} else if s.item.hovered {
 		s.background.FillColor = theme.HoverColor()
-		s.background.Show()
 	} else {
-		s.background.Hide()
+		s.background.FillColor = nil
 	}
+
+	s.background.Refresh()
 	canvas.Refresh(s.item)
 }
 

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -44,7 +44,6 @@ func (i *fileDialogItem) MouseOut() {
 
 func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {
 	i.picker.setSelected(i)
-	i.Refresh()
 }
 
 func (i *fileDialogItem) CreateRenderer() fyne.WidgetRenderer {
@@ -136,7 +135,6 @@ func (s fileItemRenderer) Refresh() {
 	} else {
 		s.background.Hide()
 	}
-	s.background.Refresh()
 	canvas.Refresh(s.item)
 }
 

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -44,6 +44,7 @@ func (i *fileDialogItem) MouseOut() {
 
 func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {
 	i.picker.setSelected(i)
+	i.Refresh()
 }
 
 func (i *fileDialogItem) CreateRenderer() fyne.WidgetRenderer {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR  removes an unnecessary refresh call that the fileitem was doing each time it was refreshed. The background will be refreshed automatically by the `Show()/Hide()` calls and need not be refreshed once more.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

