### PR TITLE
Fix issue where Windows iconifying could crash with stroked rectangle

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -281,6 +281,9 @@ func (c *glCanvas) paint(size fyne.Size) {
 			inner := clips.Push(pos, obj.Size())
 			c.Painter().StartClipping(inner.Rect())
 		}
+		if size.Width <= 0 || size.Height <= 0 { // iconifying on Windows can do bad things
+			return
+		}
 		c.Painter().Paint(obj, pos, size)
 	}
 	afterPaint := func(node *common.RenderCacheNode) {


### PR DESCRIPTION
Fixes #3552

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- this GLFW behaviour cannot be forced on some OS, so we can't unit test :(
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
