### PR TITLE
Fix custom shortcuts with fyne.KeyTab

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -760,7 +760,11 @@ func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, 
 		// key repeat will fall through to TypedKey and TypedShortcut
 	}
 
-	if (keyName == fyne.KeyTab && !w.capturesTab(keyDesktopModifier)) || w.triggersShortcut(keyName, keyASCII, keyDesktopModifier) {
+	modifierOtherThanShift := (keyDesktopModifier & fyne.KeyModifierControl) |
+		(keyDesktopModifier & fyne.KeyModifierAlt) |
+		(keyDesktopModifier & fyne.KeyModifierSuper)
+	if (keyName == fyne.KeyTab && modifierOtherThanShift == 0 && !w.capturesTab(keyDesktopModifier)) ||
+		w.triggersShortcut(keyName, keyASCII, keyDesktopModifier) {
 		return
 	}
 


### PR DESCRIPTION
### Description:
Earlier all keypresses that had Tab in them were excluded from the normal shortcut handling process.
With this PR, only Tab & Shift+Tab are afforded that exclusion, all others will be routed through the `triggersShortcut` flow

Fixes #3087

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.