### PR TITLE
Clear render cache when software rendering

### DIFF
--- a/test/testcanvas.go
+++ b/test/testcanvas.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/app"
+	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -88,6 +89,7 @@ func NewTransparentCanvasWithPainter(painter SoftwarePainter) WindowlessCanvas {
 }
 
 func (c *testCanvas) Capture() image.Image {
+	cache.Clean(true)
 	bounds := image.Rect(0, 0, internal.ScaleInt(c, c.Size().Width), internal.ScaleInt(c, c.Size().Height))
 	img := image.NewNRGBA(bounds)
 	if !c.transparent {


### PR DESCRIPTION
### Description:
Each time testcanvas.Refresh is called we tell the render cache that it can be cleaned.
This gives the render cache a chance to be cleared when using the test canvas for software rendering.
This should have no impact on most users.

There isn't an open issue for this but it is essentially the same as [2069](https://github.com/fyne-io/fyne/issues/2069)

### Checklist:

- [x] Lint and formatter run with no errors.
- [x] Tests all pass

