### PR TITLE
Correct all version used while building application to ensure Windows…

### DIFF
--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -259,7 +259,13 @@ func (p *Packager) buildPackage(runner runner) ([]string, error) {
 }
 
 func (p *Packager) combinedVersion() string {
-	return fmt.Sprintf("%s.%d", p.AppVersion, p.AppBuild)
+	versions := strings.Split(p.AppVersion, ".")
+	for len(versions) < 3 {
+		versions = append(versions, "0")
+	}
+	appVersion := strings.Join(versions, ".")
+
+	return fmt.Sprintf("%s.%d", appVersion, p.AppBuild)
 }
 
 func (p *Packager) doPackage(runner runner) error {

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -51,6 +51,24 @@ func Test_isValidVersion(t *testing.T) {
 	assert.False(t, isValidVersion("1..2"))
 }
 
+func Test_combinedVersion(t *testing.T) {
+	tests := []struct {
+		ver   string
+		build int
+		comb  string
+	}{
+		{"1.2.3", 4, "1.2.3.4"},
+		{"1.2", 4, "1.2.0.4"},
+		{"1", 4, "1.0.0.4"},
+	}
+
+	for _, tt := range tests {
+		p := &Packager{appData: &appData{AppVersion: tt.ver, AppBuild: tt.build}}
+		comb := p.combinedVersion()
+		assert.Equal(t, tt.comb, comb)
+	}
+}
+
 func Test_MergeMetata(t *testing.T) {
 	p := &Packager{appData: &appData{}}
 	p.AppVersion = "v0.1"


### PR DESCRIPTION
### Description:
Compiling for Windows with a short AppVersion, like 1.0, lead to the version not being consistent from Windows perspective and prevent the starting of the application on up to date Windows.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.