### PR TITLE
add termux available

### DIFF
--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -342,6 +342,9 @@ func archNDK() string {
 			arch = "x86_64"
 			break
 		}
+		if runtime.GOOS == "android" {
+		   return "linux-aarch64"
+		}
 		fallthrough
 	default:
 		panic("unsupported GOARCH: " + runtime.GOARCH)


### PR DESCRIPTION
well I would like to create video to fyne similar to [my video](https://youtu.be/7aUh39w_-2Q), would you agree?
On the video I show how to compile ndk apk in vlang (similar to golang) I think fyne it can done too
### Description:
add path on termux for fyne cmd (I asume that from apk cmd fyne will never call or will have similar structure like termux)
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #(issue)
none
### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
