### PR TITLE
Propagate tags when building for iOS and Android.

### DIFF
--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -15,12 +15,12 @@ import (
 	"golang.org/x/sys/execabs"
 )
 
-func (p *Packager) packageAndroid(arch string) error {
-	return mobile.RunNewBuild(arch, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, "", "")
+func (p *Packager) packageAndroid(arch string, tags []string) error {
+	return mobile.RunNewBuild(arch, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, "", "", tags)
 }
 
-func (p *Packager) packageIOS(target string) error {
-	err := mobile.RunNewBuild(target, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, p.certificate, p.profile)
+func (p *Packager) packageIOS(target string, tags []string) error {
+	err := mobile.RunNewBuild(target, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, p.certificate, p.profile, tags)
 	if err != nil {
 		return err
 	}

--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -21,7 +21,7 @@ type windowsData struct {
 	CombinedVersion string
 }
 
-func (p *Packager) packageWindows() error {
+func (p *Packager) packageWindows(tags []string) error {
 	exePath := filepath.Dir(p.exe)
 
 	// convert icon
@@ -103,7 +103,7 @@ func (p *Packager) packageWindows() error {
 		}
 	}
 
-	_, err = p.buildPackage(nil)
+	_, err = p.buildPackage(nil, tags)
 	if err != nil {
 		return fmt.Errorf("failed to rebuild after adding metadata: %w", err)
 	}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -199,11 +199,7 @@ func (p *Packager) packageWithoutValidate() error {
 	return metadata.SaveStandard(data, p.srcDir)
 }
 
-func (p *Packager) buildPackage(runner runner) ([]string, error) {
-	var tags []string
-	if p.tags != "" {
-		tags = strings.Split(p.tags, ",")
-	}
+func (p *Packager) buildPackage(runner runner, tags []string) ([]string, error) {
 	if p.os != "web" {
 		b := &Builder{
 			os:      p.os,
@@ -278,8 +274,13 @@ func (p *Packager) doPackage(runner runner) error {
 	}
 	defer os.RemoveAll(p.tempDir)
 
+	var tags []string
+	if p.tags != "" {
+		tags = strings.Split(p.tags, ",")
+	}
+
 	if !util.Exists(p.exe) && !util.IsMobile(p.os) {
-		files, err := p.buildPackage(runner)
+		files, err := p.buildPackage(runner, tags)
 		if err != nil {
 			return fmt.Errorf("error building application: %w", err)
 		}
@@ -307,11 +308,11 @@ func (p *Packager) doPackage(runner runner) error {
 	case "linux", "openbsd", "freebsd", "netbsd":
 		return p.packageUNIX()
 	case "windows":
-		return p.packageWindows()
+		return p.packageWindows(tags)
 	case "android/arm", "android/arm64", "android/amd64", "android/386", "android":
-		return p.packageAndroid(p.os)
+		return p.packageAndroid(p.os, tags)
 	case "ios", "iossimulator":
-		return p.packageIOS(p.os)
+		return p.packageIOS(p.os, tags)
 	case "wasm":
 		return p.packageWasm()
 	case "gopherjs":

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -162,7 +162,7 @@ func Test_buildPackageWasm(t *testing.T) {
 		release: true,
 	}
 	wasmBuildTest := &testCommandRuns{runs: expected, t: t}
-	files, err := p.buildPackage(wasmBuildTest)
+	files, err := p.buildPackage(wasmBuildTest, []string{})
 	assert.Nil(t, err)
 	assert.NotNil(t, files)
 	assert.Equal(t, 1, len(files))
@@ -321,7 +321,7 @@ func Test_buildPackageGopherJS(t *testing.T) {
 		release: true,
 	}
 	wasmBuildTest := &testCommandRuns{runs: expected, t: t}
-	files, err := p.buildPackage(wasmBuildTest)
+	files, err := p.buildPackage(wasmBuildTest, []string{})
 	assert.Nil(t, err)
 	assert.NotNil(t, files)
 	assert.Equal(t, 1, len(files))
@@ -507,7 +507,7 @@ func Test_BuildPackageWeb(t *testing.T) {
 		exe:     "myTest",
 	}
 	webBuildTest := &testCommandRuns{runs: expected, t: t}
-	files, err := p.buildPackage(webBuildTest)
+	files, err := p.buildPackage(webBuildTest, []string{})
 	assert.Nil(t, err)
 	assert.NotNil(t, files)
 	expectedFiles := 2

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -273,10 +273,11 @@ var (
 )
 
 // RunNewBuild executes a new mobile build for the specified configuration
-func RunNewBuild(target, appID, icon, name, version string, build int, release, distribution bool, cert, profile string) error {
+func RunNewBuild(target, appID, icon, name, version string, build int, release, distribution bool, cert, profile string, tags []string) error {
 	buildTarget = target
 	buildBundleID = appID
 	buildRelease = distribution
+	buildTags = tags
 	if release {
 		buildLdflags = "-w"
 		buildTrimpath = true


### PR DESCRIPTION
### Description:
Properly propagate tags when building for mobile.

Fixes #3641

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
