### PR TITLE
Refactor GitHub workflow runners

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -7,12 +7,12 @@ jobs:
   licenses:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.7.0
+    - uses: WillAbides/setup-go-faster@v1.8.0
       with:      
-        go-version: '1.19.x'
+        go-version: '1.20.x'
 
     - name: Install lian
       run: go install lucor.dev/lian@latest

--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14.x, 1.19.x]
+        go-version: [1.14.x, 1.20.x]
 
     steps:
     - uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.7.0
+    - uses: WillAbides/setup-go-faster@v1.8.0
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -13,10 +13,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.7.0
+    - uses: WillAbides/setup-go-faster@v1.8.0
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -30,18 +30,3 @@ jobs:
     - name: Wayland Tests
       run: go test -tags ci,wayland ./...
       if: ${{ runner.os == 'Linux' }}
-
-    - name: Update coverage
-      run: |
-        GO111MODULE=off go get github.com/mattn/goveralls
-        set -e
-        go test -tags ci -covermode=atomic -coverprofile=coverage.out ./...
-        coverage=`go tool cover -func coverage.out | grep total | tr -s '\t' | cut -f 3 | grep -o '[^%]*'`
-        if (( $(echo "$coverage < 63" | bc) )); then echo "Test coverage lowered"; exit 1; fi
-      if: ${{ runner.os == 'Linux' }}
-
-    - name: Update PR Coverage
-      uses: shogo82148/actions-goveralls@v1
-      with:
-        path-to-profile: coverage.out
-      if: ${{ runner.os == 'Linux' && matrix.go-version == '1.20' }}

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14, 1.20]
+        go-version: ['1.14.x', '1.20.x']
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14, 1.17]
+        go-version: [1.14, 1.20]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -44,19 +44,4 @@ jobs:
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: coverage.out
-      if: ${{ runner.os == 'Linux' && matrix.go-version == '1.17' }}
-
-    - name: Build WebAssembly binary
-      env:
-        GOOS: js
-        GOARCH: wasm
-      working-directory: cmd/fyne_demo
-      run: go build
-      if: ${{ matrix.go-version == '1.17' }}
-
-    - name: Build GopherJS and Wasm full website
-      run: |
-        go install github.com/gopherjs/gopherjs@latest
-        go install ./cmd/fyne
-        cd cmd/fyne_demo && fyne package --target=web
-      if: ${{ matrix.go-version == '1.17' && runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && matrix.go-version == '1.20' }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,6 +23,7 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
         go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
+        go install github.com/mattn/goveralls@latest
 
     - name: Cleanup repository
       run: rm -rf vendor/
@@ -38,3 +39,15 @@ jobs:
 
     - name: Staticcheck
       run: staticcheck ./...
+
+    - name: Update coverage
+      run: |
+        set -e
+        go test -tags ci -covermode=atomic -coverprofile=coverage.out ./...
+        coverage=`go tool cover -func coverage.out | grep total | tr -s '\t' | cut -f 3 | grep -o '[^%]*'`
+        if (( $(echo "$coverage < 63" | bc) )); then echo "Test coverage lowered"; exit 1; fi
+
+    - name: Update PR Coverage
+      uses: shogo82148/actions-goveralls@v1
+      with:
+        path-to-profile: coverage.out

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -10,19 +10,19 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.7.0
+    - uses: WillAbides/setup-go-faster@v1.8.0
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
 
     - name: Get dependencies
       run: |
         sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.4.0
+        go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
 
     - name: Cleanup repository
       run: rm -rf vendor/

--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -1,0 +1,34 @@
+name: Web Tests
+on: [push, pull_request]
+permissions:
+  contents: read
+
+jobs:
+  web_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - uses: WillAbides/setup-go-faster@v1.8.0
+      with:
+        go-version: '1.17.x'
+
+    - name: Get dependencies
+      run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
+
+    - name: Build WebAssembly binary
+      env:
+        GOOS: js
+        GOARCH: wasm
+      working-directory: cmd/fyne_demo
+      run: go build
+
+    - name: Build GopherJS and Wasm full website
+      run: |
+        go install github.com/gopherjs/gopherjs@latest
+        go install ./cmd/fyne
+        cd cmd/fyne_demo && fyne package --target=web


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This brings a major rework of the workflows that we run for tests and static analysis. Below is a list of all the improvements that have been made. However, in short, the biggest improvement is moving web tests out to their own workflow so we finally can run tests on Go > 1.17 :)

List of changes:
- Update to run all tests (except for Go 1.14 tests and new Web workflow) on Go 1.20.
- Use `actions/checkout@v3` instead of `actions/checkout@v2`.
- Update `WillAbides/setup-go-faster` to `v1.8.0`.
- Moved coverage generation to the Static Analysis workflow. As these were run only on Linux, it did not make sense to check it on every iteration. It also saves us some time as the old check ran tests twice (for both Go versions) but only pushed one of them to coveralls.
- All web tests are moved out to a separate Web Tests workflow that can keep a Go version that gopherjs supports.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.