### PR TITLE
We have to make sure all graphics routines are called on main if we will be drawing on main...

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -37,6 +37,8 @@ var (
 // Declare conformity with Driver
 var _ fyne.Driver = (*gLDriver)(nil)
 
+var drawOnMainThread bool // A workaround on Apple M1, just use 1 thread until fixed upstream
+
 type gLDriver struct {
 	windowLock sync.RWMutex
 	windows    []fyne.Window
@@ -46,7 +48,6 @@ type gLDriver struct {
 
 	animation *animation.Runner
 
-	drawOnMainThread    bool       // A workaround on Apple M1, just use 1 thread until fixed upstream
 	trayStart, trayStop func()     // shut down the system tray, if used
 	systrayMenu         *fyne.Menu // cache the menu set so we know when to refresh
 }

--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -15,7 +15,7 @@ import (
 func (d *gLDriver) initGLFW() {
 	initOnce.Do(func() {
 		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-			d.drawOnMainThread = true
+			drawOnMainThread = true
 		}
 
 		err := glfw.Init()

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -274,7 +274,7 @@ func (w *window) processClosed() {
 		return
 	}
 
-	w.Close()
+	go w.Close() // unsure which thread this comes from, so don't block
 }
 
 // destroy this window and, if it's the last window quit the app

--- a/internal/driver/glfw/window_notlinux.go
+++ b/internal/driver/glfw/window_notlinux.go
@@ -12,8 +12,13 @@ func (w *window) platformResize(canvasSize fyne.Size) {
 		return
 	}
 
-	runOnDraw(w, func() {
+	if drawOnMainThread {
 		w.canvas.Resize(canvasSize)
 		d.repaintWindow(w)
-	})
+	} else {
+		runOnDraw(w, func() {
+			w.canvas.Resize(canvasSize)
+			d.repaintWindow(w)
+		})
+	}
 }


### PR DESCRIPTION
This is more special case for M1/M2, but logical when you look into it - we want to eliminate the use of a draw thread.
More work could be done in this area, but I don't want to if this is only temporary unless the upstream GLFW bug won't be fixed.

If we can get animations to play whilst the resize blocks event thread this may be the way forward and can have more time - but for now it should unblock usage on M2.

Fixes #3336 and #3397

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- generally using the app on M2 will confirm, but also testing required on intel Mac to check that's still good...
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
