### PR TITLE
Remove unnecessary layout field for dialogs

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -44,7 +44,6 @@ type dialog struct {
 	content, label fyne.CanvasObject
 	dismiss        *widget.Button
 	parent         fyne.Window
-	layout         *dialogLayout
 }
 
 func (d *dialog) Hide() {
@@ -106,8 +105,7 @@ func (d *dialog) create(buttons fyne.CanvasObject) {
 	d.bg = newThemedBackground()
 	d.label = widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 
-	d.layout = &dialogLayout{d: d}
-	content := container.New(d.layout,
+	content := container.New(&dialogLayout{d: d},
 		&canvas.Image{Resource: d.icon},
 		d.bg,
 		d.content,

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -106,6 +106,7 @@ func (d *dialog) create(buttons fyne.CanvasObject) {
 	d.bg = newThemedBackground()
 	d.label = widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 
+	d.layout = &dialogLayout{d: d}
 	content := container.New(d.layout,
 		&canvas.Image{Resource: d.icon},
 		d.bg,
@@ -121,7 +122,6 @@ func (d *dialog) create(buttons fyne.CanvasObject) {
 // The method .create() needs to be called before the dialog cna be shown.
 func newDialog(title, message string, icon fyne.Resource, callback func(bool), parent fyne.Window) *dialog {
 	d := &dialog{content: newCenterLabel(message), title: title, icon: icon, parent: parent}
-	d.layout = &dialogLayout{d: d}
 	d.callback = callback
 
 	return d

--- a/dialog/color.go
+++ b/dialog/color.go
@@ -41,14 +41,11 @@ type ColorPickerDialog struct {
 //
 // Since: 1.4
 func NewColorPicker(title, message string, callback func(c color.Color), parent fyne.Window) *ColorPickerDialog {
-	p := &ColorPickerDialog{
+	return &ColorPickerDialog{
 		dialog:   newDialog(title, message, theme.ColorPaletteIcon(), nil /*cancel?*/, parent),
 		color:    theme.PrimaryColor(),
 		callback: callback,
 	}
-	p.dialog.layout = &dialogLayout{d: p.dialog}
-
-	return p
 }
 
 // ShowColorPicker creates and shows a color dialog.

--- a/dialog/custom.go
+++ b/dialog/custom.go
@@ -13,7 +13,6 @@ import (
 // The MinSize() of the CanvasObject passed will be used to set the size of the window.
 func NewCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Window) Dialog {
 	d := &dialog{content: content, title: title, parent: parent}
-	d.layout = &dialogLayout{d: d}
 
 	d.dismiss = &widget.Button{Text: dismiss,
 		OnTapped: d.Hide,
@@ -36,9 +35,7 @@ func ShowCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Wi
 // The MinSize() of the CanvasObject passed will be used to set the size of the window.
 func NewCustomConfirm(title, confirm, dismiss string, content fyne.CanvasObject,
 	callback func(bool), parent fyne.Window) *ConfirmDialog {
-	d := &dialog{content: content, title: title, parent: parent}
-	d.layout = &dialogLayout{d: d}
-	d.callback = callback
+	d := &dialog{content: content, title: title, parent: parent, callback: callback}
 
 	d.dismiss = &widget.Button{Text: dismiss, Icon: theme.CancelIcon(),
 		OnTapped: d.Hide,

--- a/dialog/form.go
+++ b/dialog/form.go
@@ -49,7 +49,6 @@ func NewForm(title, confirm, dismiss string, items []*widget.FormItem, callback 
 	form := widget.NewForm(items...)
 
 	d := &dialog{content: form, callback: callback, title: title, parent: parent}
-	d.layout = &dialogLayout{d: d}
 	d.dismiss = &widget.Button{Text: dismiss, Icon: theme.CancelIcon(),
 		OnTapped: d.Hide,
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This cleans up the dialog code a bit to remove a layout field. Was always set to the same value.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
