### PR TITLE
Remove unecessary call to Refresh on Linux.

### DIFF
--- a/internal/driver/glfw/window_linux.go
+++ b/internal/driver/glfw/window_linux.go
@@ -4,5 +4,4 @@ import "fyne.io/fyne/v2"
 
 func (w *window) platformResize(canvasSize fyne.Size) {
 	w.canvas.Resize(canvasSize)
-	w.canvas.Refresh(w.canvas.content)
 }


### PR DESCRIPTION
### Description:
This remove excessive call to Refresh when resizing a window on Linux.

I have not noticed any issue after removing the call to Refresh and it doesn't make logical sense. It also has a direct performance impact and Refresh should not be called due to just a Layout change which is what a Resize is.

I think @Jacalz has tested it with Wayland and has also not noticed any adverse effect.

### Checklist:
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.