### PR TITLE
Don't leak file handles for image

### DIFF
--- a/canvas/image.go
+++ b/canvas/image.go
@@ -245,21 +245,22 @@ func (i *Image) name() string {
 func (i *Image) updateReader() error {
 	i.reader = nil
 
-	var fd io.Reader
 	i.isSVG = false
 	if i.Resource != nil {
-		fd = bytes.NewReader(i.Resource.Content())
+		i.reader = bytes.NewReader(i.Resource.Content())
 		i.isSVG = svg.IsResourceSVG(i.Resource)
 	} else if i.File != "" {
 		var err error
 
-		fd, err = os.Open(i.File)
+		fd, err := os.Open(i.File)
 		if err != nil {
 			return err
 		}
 		i.isSVG = svg.IsFileSVG(i.File)
+		b, _ := ioutil.ReadAll(fd)
+		fd.Close()
+		i.reader = bytes.NewReader(b)
 	}
-	i.reader = fd
 	return nil
 }
 


### PR DESCRIPTION
This also allows us not to hold files open for faster refresh. Trade off is a bit more memory used

Sadly this means we are now storing the compressed *and* decoded versions of bitmap images loaded from a file.
I think this fix is important. But maybe we need to follow up with a more memory efficient overall solution?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
