### PR TITLE
More cleanup and refactoring of base dialog

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -182,9 +182,6 @@ type dialogLayout struct {
 }
 
 func (l *dialogLayout) Layout(obj []fyne.CanvasObject, size fyne.Size) {
-	obj[1].Move(fyne.NewPos(0, 0))
-	obj[1].Resize(size)
-
 	btnMin := obj[3].MinSize()
 	labelMin := obj[4].MinSize()
 
@@ -193,15 +190,19 @@ func (l *dialogLayout) Layout(obj []fyne.CanvasObject, size fyne.Size) {
 	obj[0].Resize(fyne.NewSize(iconHeight, iconHeight))
 	obj[0].Move(fyne.NewPos(size.Width-iconHeight+theme.Padding(), -theme.Padding()))
 
-	// buttons
-	obj[3].Resize(btnMin)
-	obj[3].Move(fyne.NewPos(size.Width/2-(btnMin.Width/2), size.Height-padHeight-btnMin.Height))
+	// background
+	obj[1].Move(fyne.NewPos(0, 0))
+	obj[1].Resize(size)
 
 	// content
 	contentStart := obj[4].Position().Y + labelMin.Height + padHeight
 	contentEnd := obj[3].Position().Y - theme.Padding()
 	obj[2].Move(fyne.NewPos(padWidth/2, labelMin.Height+padHeight))
 	obj[2].Resize(fyne.NewSize(size.Width-padWidth, contentEnd-contentStart))
+
+	// buttons
+	obj[3].Resize(btnMin)
+	obj[3].Move(fyne.NewPos(size.Width/2-(btnMin.Width/2), size.Height-padHeight-btnMin.Height))
 }
 
 func (l *dialogLayout) MinSize(obj []fyne.CanvasObject) fyne.Size {
@@ -209,7 +210,7 @@ func (l *dialogLayout) MinSize(obj []fyne.CanvasObject) fyne.Size {
 	btnMin := obj[3].MinSize()
 	labelMin := obj[4].MinSize()
 
-	width := fyne.Max(fyne.Max(contentMin.Width, btnMin.Width), obj[4].MinSize().Width) + padWidth
+	width := fyne.Max(fyne.Max(contentMin.Width, btnMin.Width), labelMin.Width) + padWidth
 	height := contentMin.Height + btnMin.Height + labelMin.Height + theme.Padding() + padHeight*2
 
 	return fyne.NewSize(width, height)

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -40,7 +40,6 @@ type dialog struct {
 	desiredSize fyne.Size
 
 	win            *widget.PopUp
-	bg             *themedBackground
 	content, label fyne.CanvasObject
 	dismiss        *widget.Button
 	parent         fyne.Window
@@ -102,12 +101,11 @@ func (d *dialog) hideWithResponse(resp bool) {
 }
 
 func (d *dialog) create(buttons fyne.CanvasObject) {
-	d.bg = newThemedBackground()
 	d.label = widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 
 	content := container.New(&dialogLayout{d: d},
 		&canvas.Image{Resource: d.icon},
-		d.bg,
+		newThemedBackground(),
 		d.content,
 		buttons,
 		d.label,
@@ -184,8 +182,8 @@ type dialogLayout struct {
 }
 
 func (l *dialogLayout) Layout(obj []fyne.CanvasObject, size fyne.Size) {
-	l.d.bg.Move(fyne.NewPos(0, 0))
-	l.d.bg.Resize(size)
+	obj[1].Move(fyne.NewPos(0, 0))
+	obj[1].Resize(size)
 
 	btnMin := obj[3].MinSize()
 

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -39,10 +39,10 @@ type dialog struct {
 	icon        fyne.Resource
 	desiredSize fyne.Size
 
-	win            *widget.PopUp
-	content, label fyne.CanvasObject
-	dismiss        *widget.Button
-	parent         fyne.Window
+	win     *widget.PopUp
+	content fyne.CanvasObject
+	dismiss *widget.Button
+	parent  fyne.Window
 }
 
 func (d *dialog) Hide() {
@@ -101,14 +101,14 @@ func (d *dialog) hideWithResponse(resp bool) {
 }
 
 func (d *dialog) create(buttons fyne.CanvasObject) {
-	d.label = widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
+	label := widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 
 	content := container.New(&dialogLayout{d: d},
 		&canvas.Image{Resource: d.icon},
 		newThemedBackground(),
 		d.content,
 		buttons,
-		d.label,
+		label,
 	)
 
 	d.win = widget.NewModalPopUp(content, d.parent.Canvas())
@@ -186,9 +186,10 @@ func (l *dialogLayout) Layout(obj []fyne.CanvasObject, size fyne.Size) {
 	obj[1].Resize(size)
 
 	btnMin := obj[3].MinSize()
+	labelMin := obj[4].MinSize()
 
 	// icon
-	iconHeight := padHeight*2 + l.d.label.MinSize().Height*2 - theme.Padding()
+	iconHeight := padHeight*2 + labelMin.Height*2 - theme.Padding()
 	obj[0].Resize(fyne.NewSize(iconHeight, iconHeight))
 	obj[0].Move(fyne.NewPos(size.Width-iconHeight+theme.Padding(), -theme.Padding()))
 
@@ -197,18 +198,19 @@ func (l *dialogLayout) Layout(obj []fyne.CanvasObject, size fyne.Size) {
 	obj[3].Move(fyne.NewPos(size.Width/2-(btnMin.Width/2), size.Height-padHeight-btnMin.Height))
 
 	// content
-	contentStart := l.d.label.Position().Y + l.d.label.MinSize().Height + padHeight
+	contentStart := obj[4].Position().Y + labelMin.Height + padHeight
 	contentEnd := obj[3].Position().Y - theme.Padding()
-	obj[2].Move(fyne.NewPos(padWidth/2, l.d.label.MinSize().Height+padHeight))
+	obj[2].Move(fyne.NewPos(padWidth/2, labelMin.Height+padHeight))
 	obj[2].Resize(fyne.NewSize(size.Width-padWidth, contentEnd-contentStart))
 }
 
 func (l *dialogLayout) MinSize(obj []fyne.CanvasObject) fyne.Size {
 	contentMin := obj[2].MinSize()
 	btnMin := obj[3].MinSize()
+	labelMin := obj[4].MinSize()
 
 	width := fyne.Max(fyne.Max(contentMin.Width, btnMin.Width), obj[4].MinSize().Width) + padWidth
-	height := contentMin.Height + btnMin.Height + l.d.label.MinSize().Height + theme.Padding() + padHeight*2
+	height := contentMin.Height + btnMin.Height + labelMin.Height + theme.Padding() + padHeight*2
 
 	return fyne.NewSize(width, height)
 }

--- a/dialog/information_test.go
+++ b/dialog/information_test.go
@@ -17,7 +17,7 @@ func TestDialog_MinSize(t *testing.T) {
 	information := d.(*dialog)
 
 	dialogContent := information.win.Content.MinSize()
-	label := information.label.MinSize()
+	label := information.win.Content.(*fyne.Container).Objects[4].MinSize()
 
 	assert.Less(t, label.Width, dialogContent.Width)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This removes two fields that only were referenced inside the dialog layout. Instead of using pointers to elements in the parent dialog we should use the items that we get in the objects slice in the layout. On top of that, I refactored some code and avoided calling `.MinSize()` on the label multiple times.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
