### PR TITLE
Add ability to specify the go binary.

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -308,7 +307,6 @@ func (b *Builder) updateAndGetGoExecutable(goos string) runner {
 		fyneGoModRunner = newCommand("go")
 		goBin := os.Getenv("GO")
 		if goBin != "" {
-			log.Println("Picking", goBin, "from GOEXEC environment variable to use as go command.")
 			fyneGoModRunner = newCommand(goBin)
 			b.runner = fyneGoModRunner
 		} else {

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -189,22 +189,7 @@ func (b *Builder) build() error {
 		return errors.New("gopherjs doesn't support Windows. Only wasm target is supported for the web output. You can also use fyne-cross to solve this")
 	}
 
-	fyneGoModRunner := b.runner
-	if b.runner == nil {
-		fyneGoModRunner = newCommand("go")
-		goBin := os.Getenv("GOEXEC")
-		if goBin != "" {
-			log.Println("Picking", goBin, "from GOEXEC environment variable to use as go command.")
-			fyneGoModRunner = newCommand(goBin)
-			b.runner = fyneGoModRunner
-		} else {
-			if goos != "gopherjs" {
-				b.runner = newCommand("go")
-			} else {
-				b.runner = newCommand("gopherjs")
-			}
-		}
-	}
+	fyneGoModRunner := b.updateAndGetGoExecutable(goos)
 
 	srcdir, err := b.computeSrcDir(fyneGoModRunner)
 	if err != nil {
@@ -315,6 +300,26 @@ func (b *Builder) computeSrcDir(fyneGoModRunner runner) (string, error) {
 		return "", fmt.Errorf("unrecognized go package: %s", b.goPackage)
 	}
 	return srcdir, nil
+}
+
+func (b *Builder) updateAndGetGoExecutable(goos string) runner {
+	fyneGoModRunner := b.runner
+	if b.runner == nil {
+		fyneGoModRunner = newCommand("go")
+		goBin := os.Getenv("GO")
+		if goBin != "" {
+			log.Println("Picking", goBin, "from GOEXEC environment variable to use as go command.")
+			fyneGoModRunner = newCommand(goBin)
+			b.runner = fyneGoModRunner
+		} else {
+			if goos != "gopherjs" {
+				b.runner = newCommand("go")
+			} else {
+				b.runner = newCommand("gopherjs")
+			}
+		}
+	}
+	return fyneGoModRunner
 }
 
 func createMetadataInitFile(srcdir string, app *appData) (func(), error) {

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -191,10 +192,17 @@ func (b *Builder) build() error {
 	fyneGoModRunner := b.runner
 	if b.runner == nil {
 		fyneGoModRunner = newCommand("go")
-		if goos != "gopherjs" {
-			b.runner = newCommand("go")
+		goBin := os.Getenv("GOBIN")
+		if goBin != "" {
+			log.Println("Using GOBIN environment variable for go command:", goBin)
+			fyneGoModRunner = newCommand(goBin)
+			b.runner = fyneGoModRunner
 		} else {
-			b.runner = newCommand("gopherjs")
+			if goos != "gopherjs" {
+				b.runner = newCommand("go")
+			} else {
+				b.runner = newCommand("gopherjs")
+			}
 		}
 	}
 

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -192,9 +192,9 @@ func (b *Builder) build() error {
 	fyneGoModRunner := b.runner
 	if b.runner == nil {
 		fyneGoModRunner = newCommand("go")
-		goBin := os.Getenv("GOBIN")
+		goBin := os.Getenv("GOEXEC")
 		if goBin != "" {
-			log.Println("Using GOBIN environment variable for go command:", goBin)
+			log.Println("Picking", goBin, "from GOEXEC environment variable to use as go command.")
 			fyneGoModRunner = newCommand(goBin)
 			b.runner = fyneGoModRunner
 		} else {


### PR DESCRIPTION
### Description:
Some go module only compile with specific version of go compiler. Being able to specify it is quite useful in this situation.

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Public APIs match existing style and have Since: line.
