### PR TITLE
Fix linking mobile simulator on Apple M1/2

### DIFF
--- a/internal/driver/mobile/gl/work.go
+++ b/internal/driver/mobile/gl/work.go
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || linux || openbsd || freebsd) && (go1.15 || go1.16 || go1.17 || go1.18 || go1.19 || go1.20 || go1.21)
+//go:build (darwin || linux || openbsd || freebsd) && go1.15
 // +build darwin linux openbsd freebsd
-// +build go1.15 go1.16 go1.17 go1.18 go1.19 go1.20 go1.21
+// +build go1.15
 
 package gl
 

--- a/internal/driver/mobile/gl/work.go
+++ b/internal/driver/mobile/gl/work.go
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || linux || openbsd || freebsd) && go115
+//go:build (darwin || linux || openbsd || freebsd) && (go1.15 || go1.16 || go1.17 || go1.18 || go1.19 || go1.20 || go1.21)
 // +build darwin linux openbsd freebsd
-// +build go115
+// +build go1.15 go1.16 go1.17 go1.18 go1.19 go1.20 go1.21
 
 package gl
 

--- a/internal/driver/mobile/gl/work114.go
+++ b/internal/driver/mobile/gl/work114.go
@@ -2,9 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || linux || openbsd || freebsd) && !go115
+//go:build (darwin || linux || openbsd || freebsd) && !go1.15 && !go1.16 && !go1.17 && !go1.18 && !go1.19 && !go1.20
 // +build darwin linux openbsd freebsd
-// +build !go115
+// +build !go1.15
+// +build !go1.16
+// +build !go1.17
+// +build !go1.18
+// +build !go1.19
+// +build !go1.20
 
 package gl
 

--- a/internal/driver/mobile/gl/work114.go
+++ b/internal/driver/mobile/gl/work114.go
@@ -2,14 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (darwin || linux || openbsd || freebsd) && !go1.15 && !go1.16 && !go1.17 && !go1.18 && !go1.19 && !go1.20
+//go:build (darwin || linux || openbsd || freebsd) && !go1.15
 // +build darwin linux openbsd freebsd
 // +build !go1.15
-// +build !go1.16
-// +build !go1.17
-// +build !go1.18
-// +build !go1.19
-// +build !go1.20
 
 package gl
 


### PR DESCRIPTION
Mobile simulator would not link on any Go newer than 1.15 due to broken build flags.
We can remove a lot of this complexity once 1.14 is not supported any more

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

