### PR TITLE
Make sure the enum index match between Go and C.

### DIFF
--- a/internal/driver/mobile/gl/consts.go
+++ b/internal/driver/mobile/gl/consts.go
@@ -49,6 +49,7 @@ const (
 
 	UnsignedByte = 0x1401
 	Float        = 0x1406
+	RED          = 0x1903
 	RGBA         = 0x1908
 	LUMINANCE    = 0x1909
 

--- a/internal/driver/mobile/gl/fn.go
+++ b/internal/driver/mobile/gl/fn.go
@@ -63,8 +63,8 @@ const (
 	glfnGetShaderiv
 	glfnGetTexParameteriv
 	glfnGetUniformLocation
-	glfnLinkProgram
 	glfnPixelStorei
+	glfnLinkProgram
 	glfnReadPixels
 	glfnScissor
 	glfnShaderSource

--- a/internal/driver/mobile/gl/gl.go
+++ b/internal/driver/mobile/gl/gl.go
@@ -387,7 +387,7 @@ func (ctx *context) PixelStorei(pname Enum, param int32) {
 		args: fnargs{
 			fn: glfnPixelStorei,
 			a0: pname.c(),
-			a2: uintptr(param),
+			a1: uintptr(param),
 		},
 	})
 }

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -237,6 +237,10 @@ var glfnMap = map[glfn]func(c call) (ret uintptr){
 		ret, _, _ = syscall.Syscall(glGetUniformLocation.Addr(), 2, c.args.a0, c.args.a1, 0)
 		return ret
 	},
+	glfnPixelStorei: func(c call) (ret uintptr) {
+		syscall.Syscall(glPixelStorei.Addr(), 2, c.args.a0, c.args.a1, 0)
+		return
+	},
 	glfnLinkProgram: func(c call) (ret uintptr) {
 		syscall.Syscall(glLinkProgram.Addr(), 1, c.args.a0, 0, 0)
 		return
@@ -344,6 +348,7 @@ var (
 	glGetShaderiv             = libGLESv2.NewProc("glGetShaderiv")
 	glGetTexParameteriv       = libGLESv2.NewProc("glGetTexParameteriv")
 	glGetUniformLocation      = libGLESv2.NewProc("glGetUniformLocation")
+	glPixelStorei             = libGLESv2.NewProc("glPixelStorei")
 	glLinkProgram             = libGLESv2.NewProc("glLinkProgram")
 	glReadPixels              = libGLESv2.NewProc("glReadPixels")
 	glScissor                 = libGLESv2.NewProc("glScissor")

--- a/internal/painter/gl/gl_const_darwin.go
+++ b/internal/painter/gl/gl_const_darwin.go
@@ -1,0 +1,9 @@
+package gl
+
+import (
+	"fyne.io/fyne/v2/internal/driver/mobile/gl"
+)
+
+const (
+	singleChannelColorFormat = gl.RED
+)

--- a/internal/painter/gl/gl_const_other.go
+++ b/internal/painter/gl/gl_const_other.go
@@ -10,3 +10,5 @@ import (
 const (
 	singleChannelColorFormat = gl.LUMINANCE
 )
+
+var _ = singleChannelColorFormat

--- a/internal/painter/gl/gl_const_other.go
+++ b/internal/painter/gl/gl_const_other.go
@@ -1,5 +1,5 @@
-//go:build !darwin
-// +build !darwin
+//go:build !darwin && !js && !wasm
+// +build !darwin,!js,!wasm
 
 package gl
 

--- a/internal/painter/gl/gl_const_other.go
+++ b/internal/painter/gl/gl_const_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+// +build !darwin
+
+package gl
+
+import (
+	"fyne.io/fyne/v2/internal/driver/mobile/gl"
+)
+
+const (
+	singleChannelColorFormat = gl.LUMINANCE
+)

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -18,7 +18,7 @@ const (
 	bitDepthBuffer        = gl.DepthBufferBit
 	clampToEdge           = gl.ClampToEdge
 	colorFormatRGBA       = gl.RGBA
-	colorFormatR          = gl.LUMINANCE
+	colorFormatR          = singleChannelColorFormat
 	compileStatus         = gl.CompileStatus
 	constantAlpha         = gl.ConstantAlpha
 	float                 = gl.Float


### PR DESCRIPTION
### Description:
This fixes the glLinkProgram issue when running the mobile simulator. It also fix the GL_UNPACK_ALIGNMENT returning an error as it wasn't getting the right value accross. This only affect the mobile simulator code path.

Fixes #3731 

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
