### PR TITLE
Bugs/resize table

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -410,7 +410,7 @@ type tableRenderer struct {
 }
 
 func (t *tableRenderer) Layout(s fyne.Size) {
-	t.scroll.Resize(s)
+	t.t.scroll.Resize(s)
 	t.moveIndicators()
 }
 


### PR DESCRIPTION
### Description:
Table doesn't properly resize as their is two scroller object, one in `Table` and one in `tableRenderer` that must be kept in sync and aren't.

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.