### PR TITLE
Add support for synchronous table scrolling to widget.Table

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -30,6 +30,7 @@ type Table struct {
 	UpdateCell   func(id TableCellID, template fyne.CanvasObject) `json:"-"`
 	OnSelected   func(id TableCellID)                             `json:"-"`
 	OnUnselected func(id TableCellID)                             `json:"-"`
+	OnScrolled   func(pos fyne.Position)                          `json:"-"`
 
 	selectedCell, hoveredCell *TableCellID
 	cells                     *tableCells
@@ -71,10 +72,29 @@ func (t *Table) CreateRenderer() fyne.WidgetRenderer {
 		t.offset = pos
 		t.cells.Refresh()
 		r.moveIndicators()
+		if t.OnScrolled != nil {
+			t.OnScrolled(pos) // Makes tables scroll synchronisation possible
+		}
 	}
 
 	r.Layout(t.Size())
 	return r
+}
+
+// SyncHPos synchronise (set) table t horizontal scroll position
+func (t *Table) SyncHPos(pos fyne.Position) {
+	t.scroll.Offset.X = pos.X
+	t.scroll.Base.Refresh()
+	t.offset.X = pos.X
+	t.cells.Refresh()
+}
+
+// SyncVPos synchronise (set) table t vertical scroll position
+func (t *Table) SyncVPos(pos fyne.Position) {
+	t.scroll.Offset.Y = pos.Y
+	t.scroll.Base.Refresh()
+	t.offset.Y = pos.Y
+	t.cells.Refresh()
 }
 
 // Select will mark the specified cell as selected.


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Adds support for synchronous table scrolling to widget.Table. 

Using this modification it's possible to create tables with fix headers, fix columns or both with sync scroll.

https://user-images.githubusercontent.com/14954512/227771282-6f8dd436-28fa-4dea-9644-e9c9b261d54b.mp4

Working demo with correspondent container and layout is [here ](https://github.com/vinser/synctables-demo)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

