### PR TITLE
Don't block main thread with our lifecycle callbacks

### DIFF
--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -40,34 +40,38 @@ func (l *Lifecycle) SetOnStopped(f func()) {
 	l.onStopped.Store(f)
 }
 
-// TriggerEnteredForeground will call the focus gained hook, if one is registered.
-func (l *Lifecycle) TriggerEnteredForeground() {
+// OnEnteredForeground returns the focus gained hook, if one is registered.
+func (l *Lifecycle) OnEnteredForeground() func() {
 	f := l.onForeground.Load()
-	if ff, ok := f.(func()); ok && ff != nil {
-		ff()
+	if ff, ok := f.(func()); ok {
+		return ff
 	}
+	return nil
 }
 
-// TriggerExitedForeground will call the focus lost hook, if one is registered.
-func (l *Lifecycle) TriggerExitedForeground() {
+// OnExitedForeground returns the focus lost hook, if one is registered.
+func (l *Lifecycle) OnExitedForeground() func() {
 	f := l.onBackground.Load()
-	if ff, ok := f.(func()); ok && ff != nil {
-		ff()
+	if ff, ok := f.(func()); ok {
+		return ff
 	}
+	return nil
 }
 
-// TriggerStarted will call the started hook, if one is registered.
-func (l *Lifecycle) TriggerStarted() {
+// OnStarted returns the started hook, if one is registered.
+func (l *Lifecycle) OnStarted() func() {
 	f := l.onStarted.Load()
-	if ff, ok := f.(func()); ok && ff != nil {
-		ff()
+	if ff, ok := f.(func()); ok {
+		return ff
 	}
+	return nil
 }
 
-// TriggerStopped will call the stopped hook, if one is registered.
-func (l *Lifecycle) TriggerStopped() {
+// OnStopped returns the stopped hook, if one is registered.
+func (l *Lifecycle) OnStopped() func() {
 	f := l.onStopped.Load()
 	if ff, ok := f.(func()); ok && ff != nil {
-		ff()
+		return ff
 	}
+	return nil
 }

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -102,7 +102,9 @@ func (d *gLDriver) Quit() {
 		if d.trayStop != nil {
 			d.trayStop()
 		}
-		fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).TriggerExitedForeground()
+		if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
+			curWindow.QueueEvent(f)
+		}
 	}
 	defer func() {
 		recover() // we could be called twice - no safe way to check if d.done is closed

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -120,14 +120,18 @@ func (d *gLDriver) runGL() {
 	if d.trayStart != nil {
 		d.trayStart()
 	}
-	fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerStarted()
+	if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnStarted(); f != nil {
+		go f() // don't block main, we don't have window event queue
+	}
 	for {
 		select {
 		case <-d.done:
 			eventTick.Stop()
 			d.drawDone <- nil // wait for draw thread to stop
 			d.Terminate()
-			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerStopped()
+			if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnStopped(); f != nil {
+				go f() // don't block main, we don't have window event queue
+			}
 			return
 		case f := <-funcQueue:
 			f.f()

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -792,7 +792,9 @@ func (w *window) processCharInput(char rune) {
 func (w *window) processFocused(focus bool) {
 	if focus {
 		if curWindow == nil {
-			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerEnteredForeground()
+			if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnEnteredForeground(); f != nil {
+				w.QueueEvent(f)
+			}
 		}
 		curWindow = w
 		w.canvas.FocusGained()
@@ -809,7 +811,9 @@ func (w *window) processFocused(focus bool) {
 			}
 
 			curWindow = nil
-			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerExitedForeground()
+			if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnExitedForeground(); f != nil {
+				w.QueueEvent(f)
+			}
 		}()
 	}
 }

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -207,7 +207,7 @@ func (d *mobileDriver) Run() {
 	})
 }
 
-func (d *mobileDriver) handleLifecycle(e lifecycle.Event, w fyne.Window) {
+func (d *mobileDriver) handleLifecycle(e lifecycle.Event, w *window) {
 	c := w.Canvas().(*mobileCanvas)
 	switch e.Crosses(lifecycle.StageVisible) {
 	case lifecycle.CrossOn:
@@ -224,7 +224,9 @@ func (d *mobileDriver) handleLifecycle(e lifecycle.Event, w fyne.Window) {
 	}
 	switch e.Crosses(lifecycle.StageFocused) {
 	case lifecycle.CrossOn: // foregrounding
-		fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).TriggerEnteredForeground()
+		if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnEnteredForeground(); f != nil {
+			w.QueueEvent(f)
+		}
 	case lifecycle.CrossOff: // will enter background
 		if runtime.GOOS == "darwin" {
 			if d.glctx == nil {
@@ -235,7 +237,9 @@ func (d *mobileDriver) handleLifecycle(e lifecycle.Event, w fyne.Window) {
 			d.paintWindow(w, s)
 			d.app.Publish()
 		}
-		fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).TriggerExitedForeground()
+		if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
+			w.QueueEvent(f)
+		}
 	}
 }
 
@@ -267,11 +271,15 @@ func (d *mobileDriver) handlePaint(e paint.Event, w fyne.Window) {
 }
 
 func (d *mobileDriver) onStart() {
-	fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).TriggerStarted()
+	if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnStarted(); f != nil {
+		go f() // don't block main, we don't have window event queue
+	}
 }
 
 func (d *mobileDriver) onStop() {
-	fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).TriggerStopped()
+	if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnStopped(); f != nil {
+		go f() // don't block main, we don't have window event queue
+	}
 }
 
 func (d *mobileDriver) paintWindow(window fyne.Window, size fyne.Size) {


### PR DESCRIPTION
How they are called depends on the context, ideally an event queue.

Fixes #3724

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- not sure how, race is in runtime driver callbacks
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
