### PR TITLE
Minor performance improvement for dialogs

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -119,6 +119,11 @@ func (d *dialog) create(buttons fyne.CanvasObject) {
 	d.win = widget.NewModalPopUp(content, d.parent.Canvas())
 }
 
+func (d *dialog) setButtons(buttons fyne.CanvasObject) {
+	d.win.Content.(*fyne.Container).Objects[3] = buttons
+	d.win.Refresh()
+}
+
 // The method .create() needs to be called before the dialog cna be shown.
 func newDialog(title, message string, icon fyne.Resource, callback func(bool), parent fyne.Window) *dialog {
 	d := &dialog{content: newCenterLabel(message), title: title, icon: icon, parent: parent}

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -117,7 +117,6 @@ func (d *dialog) create(buttons fyne.CanvasObject) {
 	)
 
 	d.win = widget.NewModalPopUp(content, d.parent.Canvas())
-	d.Refresh()
 }
 
 // The method .create() needs to be called before the dialog cna be shown.

--- a/dialog/custom.go
+++ b/dialog/custom.go
@@ -52,7 +52,7 @@ func NewCustomWithoutButtons(title string, content fyne.CanvasObject, parent fyn
 // Since: 2.4
 func (d *CustomDialog) SetButtons(buttons []fyne.CanvasObject) {
 	d.dismiss = nil // New button row invalidates possible dismiss button.
-	d.create(container.NewGridWithRows(1, buttons...))
+	d.setButtons(container.NewGridWithRows(1, buttons...))
 }
 
 // ShowCustomWithoutButtons shows a dialog, wihout buttons, over the specified application


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This implements two minor performance improvements for the dialog. Firstly, it removes an unnecessary refresh within the `create` function because the call to `d.win.Show()` already does a refresh before showing. It also makes sure that we are not creating a new modal popup when setting the button row.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
