### PR TITLE
layout: Reduce allocations for VBox and HBox with spacers

### DIFF
--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -57,7 +57,7 @@ func (g *boxLayout) isSpacer(obj fyne.CanvasObject) bool {
 // is full width but the height is the minimum required.
 // Any spacers added will pad the view, sharing the space if there are two or more.
 func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	spacers := make([]fyne.CanvasObject, 0)
+	spacers := 0
 	total := float32(0)
 	for _, child := range objects {
 		if !child.Visible() {
@@ -65,7 +65,7 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		}
 
 		if g.isSpacer(child) {
-			spacers = append(spacers, child)
+			spacers++
 			continue
 		}
 		if g.horizontal {
@@ -78,13 +78,13 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	x, y := float32(0), float32(0)
 	var extra float32
 	if g.horizontal {
-		extra = size.Width - total - (theme.Padding() * float32(len(objects)-len(spacers)-1))
+		extra = size.Width - total - (theme.Padding() * float32(len(objects)-spacers-1))
 	} else {
-		extra = size.Height - total - (theme.Padding() * float32(len(objects)-len(spacers)-1))
+		extra = size.Height - total - (theme.Padding() * float32(len(objects)-spacers-1))
 	}
 	extraCell := float32(0)
-	if len(spacers) > 0 {
-		extraCell = extra / float32(len(spacers))
+	if spacers > 0 {
+		extraCell = extra / float32(spacers)
 	}
 
 	for _, child := range objects {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The boxlayout code was heap-allocating a slice of canvas objects  to keep track of sliders. However, it only had to keep track of the count. This PR replaces the slice with a simple `int` counter instead.


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
