### PR TITLE
Don't create a windows gui application for `fyne build`

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -28,6 +28,8 @@ type Builder struct {
 	tags               []string
 	tagsToParse        string
 
+	noWindowsGui bool
+
 	customMetadata keyValueFlag
 
 	runner runner
@@ -118,6 +120,7 @@ func (b *Builder) Build() error {
 	b.appData.Release = b.release
 	b.appData.CustomMetadata = b.customMetadata.m
 
+	b.noWindowsGui = true
 	return b.build()
 }
 
@@ -243,7 +246,7 @@ func (b *Builder) build() error {
 			args = append(args, "-trimpath")
 		}
 
-		if goos == "windows" {
+		if goos == "windows" && !b.noWindowsGui {
 			ldFlags += " -H=windowsgui"
 		}
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Currently `fyne build` and all other commands sets `-H=windowsgui` on windows and this makes debugging nearly impossible.
Because `fyne build` is lower level than others and tries to mimic `go build` it is better to just generate a console app to make debugging easier. After this patch `fyne build` will generate console apps on windows by default but doesn't change others, all `package`, `release` and `install` commands will continue to generate gui apps.

Fixes #3604 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.