### PR TITLE
Remove unnecessary refreshes from check- and radiogroup

### DIFF
--- a/widget/check_group.go
+++ b/widget/check_group.go
@@ -142,7 +142,6 @@ func (r *CheckGroup) itemTapped(item *Check) {
 	if r.OnChanged != nil {
 		r.OnChanged(r.Selected)
 	}
-	r.Refresh()
 }
 
 func (r *CheckGroup) update() {

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -109,7 +109,6 @@ func (r *RadioGroup) itemTapped(item *radioItem) {
 	if r.OnChanged != nil {
 		r.OnChanged(r.Selected)
 	}
-	r.Refresh()
 }
 
 func (r *RadioGroup) update() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The individual item will be refreshed by itself when tapped but the parent was then forcing a refresh of the entire item slice directly after. This does not need to happen as the necessary state already is updated without updating all other options as well.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
