### PR TITLE
Trigger image.Refresh outside of the rendering thread.

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/app"
 	"fyne.io/fyne/v2/internal/async"
@@ -288,6 +289,22 @@ func (c *Canvas) Painter() gl.Painter {
 
 // Refresh refreshes a canvas object.
 func (c *Canvas) Refresh(obj fyne.CanvasObject) {
+	walkNeeded := false
+	switch obj.(type) {
+	case *fyne.Container:
+		walkNeeded = true
+	case fyne.Widget:
+		walkNeeded = true
+	}
+
+	if walkNeeded {
+		driver.WalkCompleteObjectTree(obj, func(co fyne.CanvasObject, p1, p2 fyne.Position, s fyne.Size) bool {
+			if i, ok := co.(*canvas.Image); ok {
+				i.Refresh()
+			}
+			return false
+		}, nil)
+	}
 	c.refreshQueue.In(obj)
 	c.SetDirty()
 }

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -38,6 +38,8 @@ type Canvas struct {
 
 	painter gl.Painter
 
+	serializeRefresh sync.Mutex
+
 	// Any object that requestes to enter to the refresh queue should
 	// not be omitted as it is always a rendering task's decision
 	// for skipping frames or drawing calls.
@@ -298,13 +300,16 @@ func (c *Canvas) Refresh(obj fyne.CanvasObject) {
 	}
 
 	if walkNeeded {
+		c.serializeRefresh.Lock()
 		driver.WalkCompleteObjectTree(obj, func(co fyne.CanvasObject, p1, p2 fyne.Position, s fyne.Size) bool {
 			if i, ok := co.(*canvas.Image); ok {
 				i.Refresh()
 			}
 			return false
 		}, nil)
+		c.serializeRefresh.Unlock()
 	}
+
 	c.refreshQueue.In(obj)
 	c.SetDirty()
 }


### PR DESCRIPTION
### Description:
Canvas.Image.Refresh() needs to be called outside of the rendering thread. This modification by walking the object tree to call Image.Refresh() before notifying the render thread make sure that all children image are properly refresh before being updated.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
