### PR TITLE
Ensure run loop is re-activated when hidden window is shown from Mac dock

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -801,6 +801,10 @@ func (w *window) processCharInput(char rune) {
 
 func (w *window) processFocused(focus bool) {
 	if focus {
+		// On Mac OS, hidden windows can be re-shown from the dock icon, which issues
+		// a GLFW window focus callback. We need to make sure the run loop is re-activated.
+		go w.doShow()
+
 		if curWindow == nil {
 			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerEnteredForeground()
 		}


### PR DESCRIPTION

### Description:

When a hidden window is re-shown from the Mac dock, GLFW issues a window focus callback. We just need to ensure the run loop is re-started in `processFocused` so the reactivated window processes events.

Fixes #3197 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
