### PR TITLE
Remove uses of multiple deprecated functions/methods

### DIFF
--- a/app/cloud_test.go
+++ b/app/cloud_test.go
@@ -98,7 +98,7 @@ func (c *mockCloud) ProviderDescription() string {
 }
 
 func (c *mockCloud) ProviderIcon() fyne.Resource {
-	return theme.FyneLogo()
+	return theme.ComputerIcon()
 }
 
 func (c *mockCloud) ProviderName() string {

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -32,7 +32,7 @@ func main() {
 	w.SetMainMenu(makeMenu(a, w))
 	w.SetMaster()
 
-	content := container.NewMax()
+	content := container.NewStack()
 	title := widget.NewLabel("Component name")
 	intro := widget.NewLabel("An introduction would probably go\nhere, as well as a")
 	intro.Wrapping = fyne.TextWrapWord

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -290,7 +290,7 @@ func showOverlay(c fyne.Canvas) {
 	content.Resize(content.MinSize())
 	content.Move(fyne.NewPos(theme.Padding(), theme.Padding()))
 
-	over := container.NewMax(
+	over := container.NewStack(
 		canvas.NewRectangle(theme.ShadowColor()), container.NewCenter(wrap),
 	)
 

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -435,7 +435,7 @@ func (r *appTabsRenderer) updateTabs(max int) {
 	// Set overflow action
 	if tabCount <= max {
 		r.action.Hide()
-		r.bar.Layout = layout.NewMaxLayout()
+		r.bar.Layout = layout.NewStackLayout()
 	} else {
 		tabCount = max
 		r.action.Show()

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -641,7 +641,7 @@ func (r *tabButtonRenderer) Refresh() {
 			r.label.Color = theme.ForegroundColor()
 		}
 	} else {
-		r.label.Color = theme.DisabledTextColor()
+		r.label.Color = theme.DisabledColor()
 	}
 	r.label.TextSize = theme.TextSize()
 	if r.button.text == "" {

--- a/driver/software/render_test.go
+++ b/driver/software/render_test.go
@@ -59,7 +59,7 @@ func TestRender_ImageSize(t *testing.T) {
 	bg.StrokeColor = color.White
 	bg.StrokeWidth = 5
 
-	c := container.NewMax(image, bg)
+	c := container.NewStack(image, bg)
 
 	test.AssertImageMatches(t, "image_size.png", Render(c, theme.LightTheme()))
 }

--- a/internal/driver/mobile/canvas_test.go
+++ b/internal/driver/mobile/canvas_test.go
@@ -254,7 +254,7 @@ func TestWindow_TappedAndDoubleTapped(t *testing.T) {
 	}
 
 	c := NewCanvas().(*mobileCanvas)
-	c.SetContent(container.NewMax(but))
+	c.SetContent(container.NewStack(but))
 	c.Resize(fyne.NewSize(36, 24))
 
 	simulateTap(c)

--- a/widget/accordion_test.go
+++ b/widget/accordion_test.go
@@ -207,7 +207,7 @@ func TestAccordion_Layout(t *testing.T) {
 				accordion.Open(o)
 			}
 
-			window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), accordion))
+			window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{accordion}})
 			window.Resize(accordion.MinSize().Max(fyne.NewSize(150, 200)))
 
 			test.AssertRendersToMarkup(t, "accordion/layout_"+name+".xml", window.Canvas())

--- a/widget/check_test.go
+++ b/widget/check_test.go
@@ -72,7 +72,7 @@ func TestCheck_Layout(t *testing.T) {
 				check.Disable()
 			}
 
-			window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), check))
+			window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{check}})
 			window.Resize(check.MinSize().Max(fyne.NewSize(150, 200)))
 
 			test.AssertRendersToMarkup(t, "check/layout_"+name+".xml", window.Canvas())

--- a/widget/form.go
+++ b/widget/form.go
@@ -160,7 +160,8 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 	text.Move(fyne.NewPos(theme.InnerPadding(), theme.InputBorderSize()))
 	item.helperOutput = text
 	f.updateHelperText(item)
-	return fyne.NewContainerWithLayout(layout.NewVBoxLayout(), item.Widget, fyne.NewContainerWithoutLayout(text))
+	textContainer := &fyne.Container{Objects: []fyne.CanvasObject{text}}
+	return &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: []fyne.CanvasObject{item.Widget, textContainer}}
 }
 
 func (f *Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
@@ -353,7 +354,8 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 	f.validationError = errFormItemInitialState // set initial state error to guarantee next error (if triggers) is always different
 
 	f.itemGrid = &fyne.Container{Layout: layout.NewFormLayout()}
-	renderer := NewSimpleRenderer(fyne.NewContainerWithLayout(layout.NewVBoxLayout(), f.itemGrid, f.buttonBox))
+	content := &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: []fyne.CanvasObject{f.itemGrid, f.buttonBox}}
+	renderer := NewSimpleRenderer(content)
 	f.ensureRenderItems()
 	f.updateButtons()
 	f.updateLabels()

--- a/widget/icon_test.go
+++ b/widget/icon_test.go
@@ -27,7 +27,7 @@ func TestIcon_Layout(t *testing.T) {
 				Resource: tt.resource,
 			}
 
-			window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), icon))
+			window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{icon}})
 			window.Resize(icon.MinSize().Max(fyne.NewSize(150, 200)))
 
 			test.AssertRendersToMarkup(t, "icon/layout_"+name+".xml", window.Canvas())

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -19,7 +19,11 @@ import (
 func TestNewList(t *testing.T) {
 	list := createList(1000)
 
-	template := newListItem(fyne.NewContainerWithLayout(layout.NewHBoxLayout(), NewIcon(theme.DocumentIcon()), NewLabel("Template Object")), nil)
+	content := &fyne.Container{Layout: layout.NewHBoxLayout(), Objects: []fyne.CanvasObject{
+		NewIcon(theme.DocumentIcon()),
+		NewLabel("Template Object")},
+	}
+	template := newListItem(content, nil)
 
 	assert.Equal(t, 1000, list.Length())
 	assert.GreaterOrEqual(t, list.MinSize().Width, template.MinSize().Width)
@@ -347,7 +351,10 @@ func TestList_SmallList(t *testing.T) {
 			return len(data)
 		},
 		func() fyne.CanvasObject {
-			return fyne.NewContainerWithLayout(layout.NewHBoxLayout(), NewIcon(theme.DocumentIcon()), NewLabel("Template Object"))
+			return &fyne.Container{Layout: layout.NewHBoxLayout(), Objects: []fyne.CanvasObject{
+				NewIcon(theme.DocumentIcon()),
+				NewLabel("Template Object")},
+			}
 		},
 		func(id ListItemID, item fyne.CanvasObject) {
 			item.(*fyne.Container).Objects[1].(*Label).SetText(data[id])
@@ -395,7 +402,10 @@ func TestList_RemoveItem(t *testing.T) {
 			return len(data)
 		},
 		func() fyne.CanvasObject {
-			return fyne.NewContainerWithLayout(layout.NewHBoxLayout(), NewIcon(theme.DocumentIcon()), NewLabel("Template Object"))
+			return &fyne.Container{Layout: layout.NewHBoxLayout(), Objects: []fyne.CanvasObject{
+				NewIcon(theme.DocumentIcon()),
+				NewLabel("Template Object")},
+			}
 		},
 		func(id ListItemID, item fyne.CanvasObject) {
 			item.(*fyne.Container).Objects[1].(*Label).SetText(data[id])
@@ -553,7 +563,7 @@ func createList(items int) *List {
 		},
 		func() fyne.CanvasObject {
 			icon := NewIcon(theme.DocumentIcon())
-			return fyne.NewContainerWithLayout(layout.NewBorderLayout(nil, nil, icon, nil), icon, NewLabel("Template Object"))
+			return &fyne.Container{Layout: layout.NewBorderLayout(nil, nil, icon, nil), Objects: []fyne.CanvasObject{icon, NewLabel("Template Object")}}
 		},
 		func(id ListItemID, item fyne.CanvasObject) {
 			item.(*fyne.Container).Objects[1].(*Label).SetText(data[id])

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -323,7 +323,7 @@ func newMenuBox(items []fyne.CanvasObject) *menuBox {
 
 func (b *menuBox) CreateRenderer() fyne.WidgetRenderer {
 	background := canvas.NewRectangle(theme.MenuBackgroundColor())
-	cont := fyne.NewContainerWithLayout(layout.NewVBoxLayout(), b.items...)
+	cont := &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: b.items}
 	return &menuBoxRenderer{
 		BaseRenderer: widget.NewBaseRenderer([]fyne.CanvasObject{background, cont}),
 		b:            b,

--- a/widget/radio_group_test.go
+++ b/widget/radio_group_test.go
@@ -14,7 +14,7 @@ import (
 func TestRadioGroup_FocusRendering(t *testing.T) {
 	t.Run("gain/lose focus", func(t *testing.T) {
 		radio := widget.NewRadioGroup([]string{"Option A", "Option B", "Option C"}, nil)
-		window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), radio))
+		window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{radio}})
 		defer window.Close()
 		window.Resize(radio.MinSize().Max(fyne.NewSize(150, 200)))
 
@@ -39,7 +39,7 @@ func TestRadioGroup_FocusRendering(t *testing.T) {
 
 	t.Run("disable/enable focused", func(t *testing.T) {
 		radio := &widget.RadioGroup{Options: []string{"Option A", "Option B", "Option C"}}
-		window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), radio))
+		window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{radio}})
 		defer window.Close()
 		window.Resize(radio.MinSize().Max(fyne.NewSize(150, 200)))
 
@@ -53,7 +53,7 @@ func TestRadioGroup_FocusRendering(t *testing.T) {
 
 	t.Run("append disabled", func(t *testing.T) {
 		radio := &widget.RadioGroup{Options: []string{"Option A", "Option B"}}
-		window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), radio))
+		window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{radio}})
 		defer window.Close()
 		window.Resize(radio.MinSize().Max(fyne.NewSize(150, 200)))
 
@@ -155,7 +155,7 @@ func TestRadioGroup_Layout(t *testing.T) {
 				radio.Disable()
 			}
 
-			window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), radio))
+			window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{radio}})
 			window.Resize(radio.MinSize().Max(fyne.NewSize(150, 200)))
 
 			test.AssertRendersToMarkup(t, "radio_group/layout_"+name+".xml", window.Canvas())

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -64,7 +64,7 @@ func NewRichTextWithText(text string) *RichText {
 func (t *RichText) CreateRenderer() fyne.WidgetRenderer {
 	if t.scr == nil && t.Scroll != widget.ScrollNone {
 		t.prop = canvas.NewRectangle(color.Transparent)
-		t.scr = widget.NewScroll(&fyne.Container{Layout: layout.NewMaxLayout(), Objects: []fyne.CanvasObject{
+		t.scr = widget.NewScroll(&fyne.Container{Layout: layout.NewStackLayout(), Objects: []fyne.CanvasObject{
 			t.prop, &fyne.Container{}}})
 	}
 
@@ -631,7 +631,7 @@ func (r *textRenderer) Refresh() {
 
 	r.obj.propertyLock.Lock()
 	if r.obj.scr != nil {
-		r.obj.scr.Content = &fyne.Container{Layout: layout.NewMaxLayout(), Objects: []fyne.CanvasObject{
+		r.obj.scr.Content = &fyne.Container{Layout: layout.NewStackLayout(), Objects: []fyne.CanvasObject{
 			r.obj.prop, &fyne.Container{Objects: objs}}}
 		r.obj.scr.Direction = scroll
 		r.SetObjects([]fyne.CanvasObject{r.obj.scr})

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -29,7 +29,7 @@ func TestSelect_Align(t *testing.T) {
 
 	sel := widget.NewSelect([]string{"Hi"}, func(string) {})
 	sel.Alignment = fyne.TextAlignCenter
-	w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), sel))
+	w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{sel}})
 	defer w.Close()
 	w.Resize(fyne.NewSize(200, 150))
 	c := fyne.CurrentApp().Driver().CanvasForObject(sel)
@@ -108,7 +108,7 @@ func TestSelect_Disable(t *testing.T) {
 	defer test.NewApp()
 
 	sel := widget.NewSelect([]string{"Hi"}, func(string) {})
-	w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), sel))
+	w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{sel}})
 	defer w.Close()
 	w.Resize(fyne.NewSize(200, 150))
 	c := fyne.CurrentApp().Driver().CanvasForObject(sel)
@@ -153,7 +153,7 @@ func TestSelect_FocusRendering(t *testing.T) {
 
 	t.Run("gain/lose focus", func(t *testing.T) {
 		sel := widget.NewSelect([]string{"Option A", "Option B", "Option C"}, nil)
-		w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), sel))
+		w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{sel}})
 		defer w.Close()
 		w.Resize(fyne.NewSize(200, 150))
 
@@ -174,7 +174,7 @@ func TestSelect_FocusRendering(t *testing.T) {
 	})
 	t.Run("disable/enable focused", func(t *testing.T) {
 		sel := widget.NewSelect([]string{"Option A", "Option B", "Option C"}, nil)
-		w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), sel))
+		w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{sel}})
 		defer w.Close()
 		w.Resize(fyne.NewSize(200, 150))
 
@@ -194,7 +194,7 @@ func TestSelect_KeyboardControl(t *testing.T) {
 
 	t.Run("activate pop-up", func(t *testing.T) {
 		sel := widget.NewSelect([]string{"Option A", "Option B"}, nil)
-		w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), sel))
+		w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{sel}})
 		defer w.Close()
 		w.Resize(fyne.NewSize(150, 200))
 		c := w.Canvas()
@@ -222,7 +222,7 @@ func TestSelect_KeyboardControl(t *testing.T) {
 
 	t.Run("traverse options without pop-up", func(t *testing.T) {
 		sel := widget.NewSelect([]string{"Option A", "Option B", "Option C"}, nil)
-		w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), sel))
+		w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{sel}})
 		defer w.Close()
 		w.Resize(fyne.NewSize(150, 200))
 		c := w.Canvas()
@@ -258,7 +258,7 @@ func TestSelect_KeyboardControl(t *testing.T) {
 
 	t.Run("trying to traverse empty options without pop-up", func(t *testing.T) {
 		sel := widget.NewSelect([]string{}, nil)
-		w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), sel))
+		w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{sel}})
 		defer w.Close()
 		w.Resize(fyne.NewSize(150, 200))
 		c := w.Canvas()
@@ -331,7 +331,7 @@ func TestSelect_SetSelected(t *testing.T) {
 		triggered = true
 		triggeredValue = s
 	})
-	w := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), combo))
+	w := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{combo}})
 	defer w.Close()
 	w.Resize(fyne.NewSize(200, 150))
 
@@ -548,7 +548,7 @@ func TestSelect_Layout(t *testing.T) {
 				Selected:    tt.selected,
 			}
 
-			window := test.NewWindow(fyne.NewContainerWithLayout(layout.NewCenterLayout(), combo))
+			window := test.NewWindow(&fyne.Container{Layout: layout.NewCenterLayout(), Objects: []fyne.CanvasObject{combo}})
 			if tt.expanded {
 				test.Tap(combo)
 			}

--- a/widget/widget_test.go
+++ b/widget/widget_test.go
@@ -67,7 +67,7 @@ func TestSimpleRenderer(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()
 
-	c := &fyne.Container{Layout: layout.NewMaxLayout(), Objects: []fyne.CanvasObject{
+	c := &fyne.Container{Layout: layout.NewStackLayout(), Objects: []fyne.CanvasObject{
 		newTestWidget(canvas.NewRectangle(color.Gray{Y: 0x79})),
 		newTestWidget(canvas.NewText("Hi", color.Black))}}
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

There are mostly just various uses of theme.LightTheme() and theme.DarkTheme() in tests remaining but I don't think we have a good path forward for those.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
