### PR TITLE
Correct path and correctly escape path when running windows install.

### DIFF
--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -152,7 +152,7 @@ func (i *Installer) install() error {
 				dirName = p.Name[:len(p.Name)-4]
 			}
 			i.installDir = filepath.Join(os.Getenv("ProgramFiles"), dirName)
-			err := runAsAdminWindows("mkdir", "\"\""+i.installDir+"\"\"")
+			err := runAsAdminWindows("mkdir", i.installDir)
 			if err != nil {
 				fyne.LogError("Failed to run as windows administrator", err)
 				return err

--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -108,19 +108,23 @@ func (p *Packager) packageWindows(tags []string) error {
 		return fmt.Errorf("failed to rebuild after adding metadata: %w", err)
 	}
 
-	appPath := p.exe
 	appName := filepath.Base(p.exe)
 	if filepath.Base(p.exe) != p.Name {
 		appName = p.Name
 		if filepath.Ext(p.Name) != ".exe" {
 			appName = appName + ".exe"
 		}
-		appPath = filepath.Join(p.dir, appName)
 		os.Rename(filepath.Base(p.exe), appName)
 	}
 
 	if p.install {
-		err := runAsAdminWindows("copy", "\"\""+appPath+"\"\"", "\"\""+filepath.Join(p.dir, appName)+"\"\"")
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to locate current working directory")
+		}
+		appPath := filepath.Join(wd, appName)
+
+		err = runAsAdminWindows("copy", appPath, filepath.Join(p.dir, appName))
 		if err != nil {
 			return fmt.Errorf("failed to run as administrator: %w", err)
 		}
@@ -131,8 +135,15 @@ func (p *Packager) packageWindows(tags []string) error {
 func runAsAdminWindows(args ...string) error {
 	cmd := "\"/c\""
 
-	for _, arg := range args {
-		cmd += ",\"" + arg + "\""
+	for idx, arg := range args {
+		if idx == 0 {
+			cmd += ",'" + arg
+		} else {
+			cmd += " \"" + arg + "\""
+		}
+	}
+	if len(args) != 0 {
+		cmd += "'"
 	}
 
 	return execabs.Command("powershell.exe", "Start-Process", "cmd.exe", "-Verb", "runAs", "-ArgumentList", cmd).Run()

--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -132,7 +132,7 @@ func (p *Packager) packageWindows(tags []string) error {
 	return nil
 }
 
-func runAsAdminWindows(args ...string) error {
+func escapePowerShellArguments(args ...string) string {
 	cmd := "\"/c\""
 
 	for idx, arg := range args {
@@ -145,6 +145,12 @@ func runAsAdminWindows(args ...string) error {
 	if len(args) != 0 {
 		cmd += "'"
 	}
+
+	return cmd
+}
+
+func runAsAdminWindows(args ...string) error {
+	cmd := escapePowerShellArguments(args...)
 
 	return execabs.Command("powershell.exe", "Start-Process", "cmd.exe", "-Verb", "runAs", "-ArgumentList", cmd).Run()
 }

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -645,3 +645,18 @@ func Test_PackageWeb(t *testing.T) {
 	expectedTotalCount(t, len(expectedWriteFileRuns.expected), expectedWriteFileRuns.current)
 	expectedTotalCount(t, len(expectedCopyFileRuns.expected), expectedCopyFileRuns.current)
 }
+
+func Test_PowerShellArguments(t *testing.T) {
+	tests := []struct {
+		expected string
+		args     []string
+	}{
+		{"\"/c\",'mkdir \"C:\\Program Files\\toto\"'", []string{"mkdir", "C:\\Program Files\\toto"}},
+		{"\"/c\",'copy \"C:\\Program Files\\toto\\titi.txt\" \"C:\\Program Files\\toto\\tata.txt\"'", []string{"copy", "C:\\Program Files\\toto\\titi.txt", "C:\\Program Files\\toto\\tata.txt"}},
+	}
+
+	for _, test := range tests {
+		result := escapePowerShellArguments(test.args...)
+		assert.Equal(t, test.expected, result)
+	}
+}


### PR DESCRIPTION
### Description:
Make sure we actually copy the newly created executable from the right location to where we want it to be installed.

Fixes #3809

### Checklist:
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
