### PR TITLE
fix glfw window test

### DIFF
--- a/internal/driver/glfw/testdata/windows_hover_object.xml
+++ b/internal/driver/glfw/testdata/windows_hover_object.xml
@@ -20,6 +20,7 @@
 						</widget>
 					</widget>
 					<widget pos="0,39" size="188x33" type="*widget.listItem">
+						<rectangle fillColor="hover" size="188x33"/>
 						<widget size="188x33" type="*widget.Entry">
 							<rectangle fillColor="inputBackground" pos="1,1" size="186x31"/>
 							<rectangle size="186x32" strokeColor="inputBorder" strokeWidth="1"/>

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -311,7 +311,7 @@ func TestWindow_HandleOutsideHoverableObject(t *testing.T) {
 	w.Resize(fyne.NewSize(200, 300))
 	repaintWindow(w)
 
-	w.mouseMoved(w.viewport, 7, 42)
+	w.mouseMoved(w.viewport, 15, 48)
 	w.WaitForEvents()
 	repaintWindow(w)
 	w.mouseLock.RLock()
@@ -319,7 +319,7 @@ func TestWindow_HandleOutsideHoverableObject(t *testing.T) {
 	w.mouseLock.RUnlock()
 	test.AssertRendersToMarkup(t, "windows_hover_object.xml", w.Canvas())
 
-	w.mouseMoved(w.viewport, 42, 42)
+	w.mouseMoved(w.viewport, 42, 48)
 	w.WaitForEvents()
 	repaintWindow(w)
 	w.mouseLock.RLock()

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -2014,6 +2014,6 @@ type tabbable struct {
 }
 
 func (t *tabbable) AcceptsTab() bool {
-	t.acceptTabCallCount += 1
+	t.acceptTabCallCount++
 	return true
 }


### PR DESCRIPTION
### Description:

Two GLFW tests failed (locally on my Mac):
1. The window hover test did not work since some padding changed in the past and the mouse movement did not fit any more.
2. The window close interception test did not take into account the asynchronous nature of the `Close()` call.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.