### PR TITLE
improve LogError

### DIFF
--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -200,7 +200,7 @@ func TestGlCanvas_Focus(t *testing.T) {
 
 	foreign := &focusable{id: "o2e1"}
 	c.Focus(foreign)
-	assert.False(t, foreign.focused, "does not focus foreign object")
+	assert.False(t, foreign.focused, "does not focus foreign object but logs a Fyne error")
 	assert.True(t, o2e.focused)
 }
 
@@ -209,7 +209,7 @@ func TestGlCanvas_Focus_BeforeVisible(t *testing.T) {
 	w.SetPadded(false)
 	e := widget.NewEntry()
 	c := w.Canvas().(*glCanvas)
-	c.Focus(e) // this crashed in the past
+	c.Focus(e) // don’t crash but log a Fyne error
 }
 
 func TestGlCanvas_Focus_SetContent(t *testing.T) {

--- a/internal/driver/glfw/menu_test.go
+++ b/internal/driver/glfw/menu_test.go
@@ -14,8 +14,8 @@ import (
 
 func Test_Menu_Empty(t *testing.T) {
 	w := createWindow("Menu Test").(*window)
-	bar := buildMenuOverlay(fyne.NewMainMenu(), w)
-	assert.Nil(t, bar) // no bar but does not crash
+	bar := buildMenuOverlay(fyne.NewMainMenu(), w) // does not crash but logs a Fyne error
+	assert.Nil(t, bar, "no bar for an empty menu: a main menu must have at least one entry => see error log")
 }
 
 func Test_Menu_AddsQuit(t *testing.T) {

--- a/log.go
+++ b/log.go
@@ -14,8 +14,10 @@ func LogError(reason string, err error) {
 		log.Println("  Cause:", err)
 	}
 
-	_, file, line, ok := runtime.Caller(1)
-	if ok {
-		log.Printf("  At: %s:%d", file, line)
+	for i := 1; i < 3; i++ {
+		_, file, line, ok := runtime.Caller(i)
+		if ok {
+			log.Printf("  At: %s:%d", file, line)
+		}
 	}
 }


### PR DESCRIPTION
### Description:

This PR adds another line of context to `LogError` output. This is at least useful for _all_ messages generated by Fyne itself because it does not help to know the location of the logging in Fyne but one needs to know the location of the caller of the logging Fyne method (maybe even further but that has to be proven).

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
