### PR TITLE
Remove unecessary and excessive lock.

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -38,8 +38,6 @@ type Canvas struct {
 
 	painter gl.Painter
 
-	serializeRefresh sync.Mutex
-
 	// Any object that requestes to enter to the refresh queue should
 	// not be omitted as it is always a rendering task's decision
 	// for skipping frames or drawing calls.
@@ -320,14 +318,12 @@ func (c *Canvas) Refresh(obj fyne.CanvasObject) {
 	}
 
 	if walkNeeded {
-		c.serializeRefresh.Lock()
 		driver.WalkCompleteObjectTree(obj, func(co fyne.CanvasObject, p1, p2 fyne.Position, s fyne.Size) bool {
 			if i, ok := co.(*canvas.Image); ok {
 				i.Refresh()
 			}
 			return false
 		}, nil)
-		c.serializeRefresh.Unlock()
 	}
 
 	c.refreshQueue.In(obj)


### PR DESCRIPTION
### Description:
I added this lock previously with the assumption that walking the tree was lock less. This was an incorrect assumption as lock are being taken accordingly when walking the trees. This lock can also be taken by the user thread, which can lead to a Refresh of a subobject while the parent is being refreshed. This can lead to dead lock.

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
