### PR TITLE
Don't hold lock when calling user code that could trigger a deadlock.

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -99,7 +99,9 @@ func (c *Canvas) EnsureMinSize() bool {
 				expectedSize := minSize.Max(size)
 				if expectedSize != size && size != csize {
 					objToLayout = nil
+					c.RUnlock()
 					obj.Resize(expectedSize)
+					c.RLock()
 				}
 			}
 
@@ -113,7 +115,9 @@ func (c *Canvas) EnsureMinSize() bool {
 
 	shouldResize := windowNeedsMinSizeUpdate && (csize.Width < min.Width || csize.Height < min.Height)
 	if shouldResize {
+		c.RUnlock()
 		c.impl.Resize(csize.Max(min))
+		c.RLock()
 	}
 
 	if lastParent != nil {


### PR DESCRIPTION
### Description:
While testing fyne_demo in advanced panel and resizing the window would always lead to a deadlock. This might be what @Jacalz was experiencing earlier.

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.