### PR TITLE
Add ability to specify custom metadata when doing a release as forgotten

### DIFF
--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -121,6 +121,11 @@ func Release() *cli.Command {
 				Value:       "",
 				Destination: &r.icon,
 			},
+			&cli.GenericFlag{
+				Name:  "metadata",
+				Usage: "Specify custom metadata key value pair that you do not want to store in your FyneApp.toml (key=value)",
+				Value: &r.customMetadata,
+			},
 		},
 		Action: r.releaseAction,
 	}


### PR DESCRIPTION
### Description:
It seems while we added custom metadata, we forgot to add the flags to the `fyne release` command. This solve this lack.

### Checklist:
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
