### PR TITLE
Animation smoothness improvement

### DIFF
--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestGLDriver_StartAnimation(t *testing.T) {
+	// ticker simulates animations ticker goroutine
+	ticker := time.NewTicker(time.Second / 60).C
 	done := make(chan float32)
 	run := &Runner{}
 	a := &fyne.Animation{
@@ -24,6 +26,8 @@ func TestGLDriver_StartAnimation(t *testing.T) {
 
 	run.Start(a)
 	select {
+	case <-ticker:
+		run.TickAnimations()
 	case d := <-done:
 		assert.Greater(t, d, float32(0))
 	case <-time.After(100 * time.Millisecond):
@@ -32,6 +36,8 @@ func TestGLDriver_StartAnimation(t *testing.T) {
 }
 
 func TestGLDriver_StopAnimation(t *testing.T) {
+	// ticker simulates animations ticker goroutine
+	ticker := time.NewTicker(time.Second / 60).C
 	done := make(chan float32)
 	run := &Runner{}
 	a := &fyne.Animation{
@@ -42,6 +48,8 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 
 	run.Start(a)
 	select {
+	case <-ticker:
+		run.TickAnimations()
 	case d := <-done:
 		assert.Greater(t, d, float32(0))
 	case <-time.After(time.Second):
@@ -85,6 +93,13 @@ func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
 		Duration: time.Second,
 		Tick:     func(f float32) {},
 	}
+	// Animations ticker goroutine simulation
+	go func() {
+		for {
+			run.TickAnimations()
+			time.Sleep(time.Second / 60)
+		}
+	}()
 	run.Start(c)
 	run.Stop(c)
 

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -65,6 +65,7 @@ func (r *Runner) TickAnimations() {
 	now := time.Now()
 	for _, a := range currList {
 		if a.isStopped() || !r.tickAnimation(a, now) {
+			a.setStopped()
 			evictAnimations = true
 		}
 	}
@@ -72,7 +73,7 @@ func (r *Runner) TickAnimations() {
 	if evictAnimations {
 		newList := make([]*anim, 0, len(currList)+len(r.pendingAnimations))
 		for _, a := range currList {
-			if !a.isStopped() && a.repeatsLeft != 0 {
+			if !a.isStopped() {
 				newList = append(newList, a)
 			}
 		}

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -65,7 +65,6 @@ func (r *Runner) TickAnimations() {
 	now := time.Now()
 	for _, a := range currList {
 		if a.isStopped() || !r.tickAnimation(a, now) {
-			a.setStopped()
 			evictAnimations = true
 		}
 	}
@@ -92,6 +91,7 @@ func (r *Runner) tickAnimation(a *anim, now time.Time) bool {
 		if a.reverse {
 			a.a.Tick(0.0)
 			if a.repeatsLeft == 0 {
+				a.setStopped()
 				return false
 			}
 			a.reverse = false
@@ -103,6 +103,7 @@ func (r *Runner) tickAnimation(a *anim, now time.Time) bool {
 		}
 		if !a.reverse {
 			if a.repeatsLeft == 0 {
+				a.setStopped()
 				return false
 			}
 			if a.repeatsLeft > 0 {

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -12,22 +12,13 @@ type Runner struct {
 	animationMutex    sync.RWMutex
 	animations        []*anim
 	pendingAnimations []*anim
-
-	runnerStarted bool
 }
 
 // Start will register the passed application and initiate its ticking.
 func (r *Runner) Start(a *fyne.Animation) {
 	r.animationMutex.Lock()
 	defer r.animationMutex.Unlock()
-
-	if !r.runnerStarted {
-		r.runnerStarted = true
-		r.animations = append(r.animations, newAnim(a))
-		r.runAnimations()
-	} else {
-		r.pendingAnimations = append(r.pendingAnimations, newAnim(a))
-	}
+	r.pendingAnimations = append(r.pendingAnimations, newAnim(a))
 }
 
 // Stop causes an animation to stop ticking (if it was still running) and removes it from the runner.
@@ -61,37 +52,42 @@ func (r *Runner) Stop(a *fyne.Animation) {
 	r.pendingAnimations = newList
 }
 
-func (r *Runner) runAnimations() {
-	draw := time.NewTicker(time.Second / 60)
-
-	go func() {
-		for done := false; !done; {
-			<-draw.C
-			r.animationMutex.Lock()
-			oldList := r.animations
-			r.animationMutex.Unlock()
-			newList := make([]*anim, 0, len(oldList))
-			for _, a := range oldList {
-				if !a.isStopped() && r.tickAnimation(a) {
-					newList = append(newList, a)
-				}
-			}
-			r.animationMutex.Lock()
-			r.animations = append(newList, r.pendingAnimations...)
-			r.pendingAnimations = nil
-			done = len(r.animations) == 0
-			r.animationMutex.Unlock()
-		}
-		r.animationMutex.Lock()
-		r.runnerStarted = false
+func (r *Runner) TickAnimations() {
+	r.animationMutex.Lock()
+	if len(r.animations) == 0 && len(r.pendingAnimations) == 0 {
 		r.animationMutex.Unlock()
-		draw.Stop()
-	}()
+		return
+	}
+	currList := r.animations
+	r.animationMutex.Unlock()
+
+	evictAnimations := false
+	now := time.Now()
+	for _, a := range currList {
+		if a.isStopped() || !r.tickAnimation(a, now) {
+			evictAnimations = true
+		}
+	}
+
+	if evictAnimations {
+		newList := make([]*anim, 0, len(currList)+len(r.pendingAnimations))
+		for _, a := range currList {
+			if !a.isStopped() && a.repeatsLeft != 0 {
+				newList = append(newList, a)
+			}
+		}
+		currList = newList
+	}
+
+	r.animationMutex.Lock()
+	r.animations = append(currList, r.pendingAnimations...)
+	r.pendingAnimations = nil
+	r.animationMutex.Unlock()
 }
 
 // tickAnimation will process a frame of animation and return true if this should continue animating
-func (r *Runner) tickAnimation(a *anim) bool {
-	if time.Now().After(a.end) {
+func (r *Runner) tickAnimation(a *anim, now time.Time) bool {
+	if now.After(a.end) {
 		if a.reverse {
 			a.a.Tick(0.0)
 			if a.repeatsLeft == 0 {
@@ -113,7 +109,7 @@ func (r *Runner) tickAnimation(a *anim) bool {
 			}
 		}
 
-		a.start = time.Now()
+		a.start = now
 		a.end = a.start.Add(a.a.Duration)
 		return true
 	}

--- a/internal/driver/glfw/animation.go
+++ b/internal/driver/glfw/animation.go
@@ -9,7 +9,3 @@ func (d *gLDriver) StartAnimation(a *fyne.Animation) {
 func (d *gLDriver) StopAnimation(a *fyne.Animation) {
 	d.animation.Stop(a)
 }
-
-func (d *gLDriver) TickAnimations() {
-	d.animation.TickAnimations()
-}

--- a/internal/driver/glfw/animation.go
+++ b/internal/driver/glfw/animation.go
@@ -9,3 +9,7 @@ func (d *gLDriver) StartAnimation(a *fyne.Animation) {
 func (d *gLDriver) StopAnimation(a *fyne.Animation) {
 	d.animation.Stop(a)
 }
+
+func (d *gLDriver) TickAnimations() {
+	d.animation.TickAnimations()
+}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -177,6 +177,7 @@ func (d *gLDriver) runGL() {
 				newWindows = append(newWindows, win)
 
 				if drawOnMainThread {
+					d.TickAnimations()
 					d.drawSingleFrame()
 				}
 			}
@@ -251,6 +252,7 @@ func (d *gLDriver) startDrawThread() {
 					go c.reloadScale()
 				})
 			case <-drawCh:
+				d.TickAnimations()
 				d.drawSingleFrame()
 			}
 		}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -177,7 +177,7 @@ func (d *gLDriver) runGL() {
 				newWindows = append(newWindows, win)
 
 				if drawOnMainThread {
-					d.TickAnimations()
+					d.animation.TickAnimations()
 					d.drawSingleFrame()
 				}
 			}
@@ -252,7 +252,7 @@ func (d *gLDriver) startDrawThread() {
 					go c.reloadScale()
 				})
 			case <-drawCh:
-				d.TickAnimations()
+				d.animation.TickAnimations()
 				d.drawSingleFrame()
 			}
 		}

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -231,6 +231,7 @@ func (d *mobileDriver) handleLifecycle(e lifecycle.Event, w fyne.Window) {
 			}
 
 			s := fyne.NewSize(float32(d.currentSize.WidthPx)/c.scale, float32(d.currentSize.HeightPx)/c.scale)
+			d.animation.TickAnimations()
 			d.paintWindow(w, s)
 			d.app.Publish()
 		}
@@ -259,6 +260,7 @@ func (d *mobileDriver) handlePaint(e paint.Event, w fyne.Window) {
 			w.Resize(newSize)
 		}
 
+		d.animation.TickAnimations()
 		d.paintWindow(w, newSize)
 		d.app.Publish()
 	}

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -184,6 +184,7 @@ func (d *mobileDriver) Run() {
 					// make sure that we paint on the next frame
 					c.Content().Refresh()
 				case paint.Event:
+					d.animation.TickAnimations()
 					d.handlePaint(e, current)
 				case touch.Event:
 					switch e.Type {
@@ -260,7 +261,6 @@ func (d *mobileDriver) handlePaint(e paint.Event, w fyne.Window) {
 			w.Resize(newSize)
 		}
 
-		d.animation.TickAnimations()
 		d.paintWindow(w, newSize)
 		d.app.Publish()
 	}


### PR DESCRIPTION
### Description:
Moved animation calculations from the separate routine to the drawing routine, to be sync with the draw call. Eliminate the race conditions and improve the animation smoothness. (FPS wasn't changed)

### Checklist:
- [x] Tests included. `TestGLDriver_StartAnimation`, `TestGLDriver_StopAnimation`, `TestGLDriver_StopAnimationImmediatelyAndInsideTick` are **modified**!
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass. The only `4106/4114` tests are `passed`, as well as `4106/4114` tests are `passed` in the `master` branch

### Warning
Since I'm not fully familiar with the project structure, so I can't cover all the cases where this improvement can cause issues. I'm not insisting on this commit to be merged, but may be used as an solution example.  
