### PR TITLE
Close manifest after writing it so it can be removed later in code

### DIFF
--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -63,10 +63,10 @@ func (p *Packager) packageWindows(tags []string) error {
 			CombinedVersion: p.combinedVersion(),
 		}
 		err := templates.ManifestWindows.Execute(manifestFile, tplData)
-		manifestFile.Close()
 		if err != nil {
 			return fmt.Errorf("failed to write manifest template: %w", err)
 		}
+		manifestFile.Close()
 	}
 
 	// launch rsrc to generate the object file

--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -63,6 +63,7 @@ func (p *Packager) packageWindows(tags []string) error {
 			CombinedVersion: p.combinedVersion(),
 		}
 		err := templates.ManifestWindows.Execute(manifestFile, tplData)
+		manifestFile.Close()
 		if err != nil {
 			return fmt.Errorf("failed to write manifest template: %w", err)
 		}


### PR DESCRIPTION
Fixes a bug where the fyne package command would fail on Windows with error:

failed to remove manifest: remove C:\Users\roffe\go\src\github.com\roffe\t7logger\t7logger.exe.manifest: The process cannot access the file because it is being used by another process.