### PR TITLE
Guard for nil when closing windows

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -318,7 +318,9 @@ func (w *window) refresh(_ *glfw.Window) {
 }
 
 func (w *window) closed(viewport *glfw.Window) {
-	viewport.SetShouldClose(false) // reset the closed flag until we check the veto in processClosed
+	if viewport != nil {
+		viewport.SetShouldClose(false) // reset the closed flag until we check the veto in processClosed
+	}
 
 	w.processClosed()
 }

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1720,6 +1720,12 @@ func TestWindow_CloseInterception(t *testing.T) {
 	})
 }
 
+func TestWindow_ClosedBeforeShow(t *testing.T) {
+	w := createWindow("Test").(*window)
+	// viewport will be nil if window is closed before show
+	assert.NotPanics(t, func() { w.closed(nil) })
+}
+
 func TestWindow_SetContent_Twice(t *testing.T) {
 	w := createWindow("Test").(*window)
 


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

As described in: https://github.com/fyne-io/fyne/issues/3870#issuecomment-1536719761
When the autogenerated quit is called from the main menu, if any windows were created but not shown, the program with panic. This is because the viewport would be nil.

This can be fixed with a nil check in `closed`

Fixes  https://github.com/fyne-io/fyne/issues/3870

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

The test that I added fails without my added changes, verified with `go test fyne.io/fyne/v2/internal/driver/glfw -run ClosedBeforeShow` however on my local machine I have some tests that fail irregardless of my changes (padding/resizing/hoverable) so I am not checking the last box