### PR TITLE
Add ability to use data binding to drive disable state of a widget.

### DIFF
--- a/widget/widget.go
+++ b/widget/widget.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/internal/cache"
 	internalWidget "fyne.io/fyne/v2/internal/widget"
 )
@@ -166,6 +167,9 @@ func (w *BaseWidget) super() fyne.Widget {
 type DisableableWidget struct {
 	BaseWidget
 
+	disableListener binding.DataListener
+	disableBinding  binding.Bool
+
 	disabled bool
 }
 
@@ -197,6 +201,67 @@ func (w *DisableableWidget) Disabled() bool {
 	defer w.propertyLock.RUnlock()
 
 	return w.disabled
+}
+
+// UnbindDisable remove the previously bound binding.Bool that manage the disable state of the widget
+//
+// Since 2.4
+func (w *DisableableWidget) UnbindDisable() {
+	w.propertyLock.RLock()
+	defer w.propertyLock.RUnlock()
+
+	if w.disableListener == nil {
+		return
+	}
+	w.disableBinding.RemoveListener(w.disableListener)
+	w.disableListener = nil
+	w.disableBinding = nil
+}
+
+// BindDisable will use the passed binding.Bool to manage the disable state of the widget
+//
+// Since 2.4
+func (w *DisableableWidget) BindDisable(data binding.Bool) {
+	w.propertyLock.RLock()
+	defer w.propertyLock.RUnlock()
+
+	getBool := func(data binding.Bool) bool {
+		v, err := data.Get()
+		if err != nil {
+			return false
+		}
+		return v
+	}
+
+	applyDisable := func(disable bool) {
+		if disable {
+			w.Disable()
+		} else {
+			w.Enable()
+		}
+	}
+
+	if w.disableBinding == data {
+		goto refreshDisable
+	}
+	if w.disableListener != nil {
+		w.UnbindDisable()
+	}
+
+	w.disableListener = binding.NewDataListener(func() {
+		isDisable := w.Disabled()
+		disable := getBool(data)
+		if isDisable == disable {
+			return
+		}
+		applyDisable(disable)
+	})
+	w.disableBinding = data
+	w.disableBinding.AddListener(w.disableListener)
+
+refreshDisable:
+	disable := getBool(data)
+	applyDisable(disable)
 }
 
 // NewSimpleRenderer creates a new SimpleRenderer to render a widget using a


### PR DESCRIPTION
### Description:
This add the ability to link the Disable state of a widget to a data binding.Bool.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Public APIs match existing style and have Since: line.
