### PR TITLE
Fix missing scaling option for images on arm linux devices

### DIFF
--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -67,7 +67,7 @@ type (
 	Uniform int32
 )
 
-var textureFilterToGL = []int32{gl.LINEAR, gl.NEAREST}
+var textureFilterToGL = []int32{gl.LINEAR, gl.NEAREST, gl.LINEAR}
 
 func (p *painter) Init() {
 	p.ctx = &esContext{}


### PR DESCRIPTION
Fixes #3891

I don't have a linux arm64 device to hand, so perhaps someone else can report if this fixes it for sure!

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

