### PR TITLE
Add documentation comment to button Icon property

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -66,6 +66,9 @@ var _ fyne.Focusable = (*Button)(nil)
 type Button struct {
 	DisableableWidget
 	Text string
+	// Icon specifies an icon resource to display in the button. SVG resources will automatically
+	// update their appearance according to the theme and disabled state of the button.
+	// Raster icons are supported but do not change appearance.
 	Icon fyne.Resource
 	// Specify how prominent the button should be, High will highlight the button and Low will remove some decoration.
 	//


### PR DESCRIPTION
### Description:
Add a documentation comment to the button's Icon property to specify that SVG resources will update their appearance with the theme and disabled state, while raster resources will not.

Related to #3896 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

