### PR TITLE
Make the password accessory look and behave disabled when the entry is disabled

### DIFF
--- a/widget/entry_password.go
+++ b/widget/entry_password.go
@@ -40,6 +40,10 @@ func (r *passwordRevealer) Cursor() desktop.Cursor {
 }
 
 func (r *passwordRevealer) Tapped(*fyne.PointEvent) {
+	if r.entry.Disabled() {
+		return
+	}
+
 	r.entry.setFieldsAndRefresh(func() {
 		r.entry.Password = !r.entry.Password
 	})
@@ -70,6 +74,10 @@ func (r *passwordRevealerRenderer) Refresh() {
 		r.icon.Resource = theme.VisibilityIcon()
 	} else {
 		r.icon.Resource = theme.VisibilityOffIcon()
+	}
+
+	if r.entry.disabled {
+		r.icon.Resource = theme.NewDisabledResource(r.icon.Resource)
 	}
 	canvas.Refresh(r.icon)
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1736,6 +1736,19 @@ func TestPasswordEntry_ActionItemSizeAndPlacement(t *testing.T) {
 	assert.Equal(t, fyne.NewPos(e.MinSize().Width-2*theme.Padding()-b.Size().Width, 2*theme.Padding()), b.Position())
 }
 
+func TestPasswordEntry_Disabled(t *testing.T) {
+	entry, window := setupPasswordTest(t)
+	defer teardownImageTest(window)
+	entry.Disable()
+
+	test.Tap(entry.ActionItem.(fyne.Tappable))
+	assert.True(t, entry.Password)
+
+	entry.Enable()
+	test.Tap(entry.ActionItem.(fyne.Tappable))
+	assert.False(t, entry.Password)
+}
+
 func TestPasswordEntry_NewlineIgnored(t *testing.T) {
 	entry := widget.NewPasswordEntry()
 	entry.SetText("test")


### PR DESCRIPTION
Fixes #3908

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

