### PR TITLE
Fix leak in image painter

### DIFF
--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -29,6 +29,11 @@ func GetAspect(img *canvas.Image) float32 {
 		aspect = aspects[img.Resource.Name()]
 	} else if img.File != "" {
 		aspect = aspects[img.File]
+	} else if img.Image != nil {
+		// HOTFIX until Fyne 2.4 proper fix:
+		// we are not storing the aspect ratio in the map for the image.Image case
+		size := img.Image.Bounds().Size()
+		return float32(size.X) / float32(size.Y)
 	}
 
 	if aspect == 0 {
@@ -132,7 +137,9 @@ func paintImage(img *canvas.Image, width, height int, wantOrigSize bool, wantOri
 	case img.Image != nil:
 		origSize := img.Image.Bounds().Size()
 		origW, origH = origSize.X, origSize.Y
-		if checkSize(origSize.X, origSize.Y) {
+		// HOTFIX until Fyne 2.4: don't store aspect ratio in map, as checkSize(x, y) does.
+		// Doing so leaks a reference to the image.Image data
+		if !wantOrigSize || (wantOrigW == origW && wantOrigH == origH) {
 			dst = scaleImage(img.Image, width, height, img.ScaleMode)
 		}
 	default:


### PR DESCRIPTION
### Description:

Fixes a leak in the image painter impacting a `canvas.Image` drawn using
an `image.Image` as the source data. (Maybe #3818)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

