### PR TITLE
widget.List: Do not allocate temporary listItem for MinSize() calculation

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -75,11 +75,10 @@ func NewListWithData(data binding.DataList, createItem func() fyne.CanvasObject,
 func (l *List) CreateRenderer() fyne.WidgetRenderer {
 	l.ExtendBaseWidget(l)
 
-	if f := l.CreateItem; f != nil {
-		if l.itemMin.IsZero() {
-			l.itemMin = newListItem(f(), nil).MinSize()
-		}
+	if f := l.CreateItem; f != nil && l.itemMin.IsZero() {
+		l.itemMin = f().MinSize()
 	}
+
 	layout := &fyne.Container{Layout: newListLayout(l)}
 	l.scroller = widget.NewVScroll(layout)
 	layout.Resize(layout.MinSize())
@@ -339,7 +338,7 @@ func (l *listRenderer) MinSize() fyne.Size {
 
 func (l *listRenderer) Refresh() {
 	if f := l.list.CreateItem; f != nil {
-		l.list.itemMin = newListItem(f(), nil).MinSize()
+		l.list.itemMin = f().MinSize()
 	}
 	l.Layout(l.list.Size())
 	l.scroller.Refresh()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The list item just returns the child MinSize nowadays. There is no need to allocate a temporary &listItem just to get the right MinSize().

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
  - Already covered by tests. Everything passes and `fyne_demo` looks fine.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.