### PR TITLE
Wrap rich text on non-inline rather than on context change

### DIFF
--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -233,16 +233,10 @@ func (l *ListSegment) Segments() []RichTextSegment {
 			txt = strconv.Itoa(i+1) + "."
 		}
 		bullet := &TextSegment{Text: txt + " ", Style: RichTextStyleStrong}
-		if para, ok := in.(*ParagraphSegment); ok {
-			seg := &ParagraphSegment{Texts: []RichTextSegment{bullet}}
-			seg.Texts = append(seg.Texts, para.Texts...)
-			out[i] = seg
-		} else {
-			out[i] = &ParagraphSegment{Texts: []RichTextSegment{
-				bullet,
-				in,
-			}}
-		}
+		out[i] = &ParagraphSegment{Texts: []RichTextSegment{
+			bullet,
+			in,
+		}}
 	}
 	return out
 }


### PR DESCRIPTION
This helps with hypertext, but will have wider improvement impact.
In 2.4 we will also improve it further by splitting newline gap from paragraph gap....

Fixes #2911 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
