### PR TITLE
Bug report template now mentions not using .zip files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
     label: Example code
     description: |
       Add a short code snippet to help explain and simplify reproduction of the problem.
-      Please refrain from adding screenshots of code, links to other projects or very long code examples.
+      Please refrain from adding screenshots of code, links to other projects, attached `.zip` files containing source files, or very long code examples.
       A good code example should be runnable and contain no more code than is necessary to reproduce the bug.
     placeholder: |
       Please write the code inside a code block with Go syntax highlighting enabled, like this:


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I have noticed that some people send in their code examples as`.zip` files. This can be a security issue for us because downloading and extracting arbitrary archives can be dangerous. This adds it as one of the things not to do. 

(This targets `master` as it changes user facing data on GitHub)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.