### PR TITLE
widget: Write initial password entry markup once

### DIFF
--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1771,6 +1771,8 @@ func TestPasswordEntry_Placeholder(t *testing.T) {
 	defer teardownImageTest(window)
 	c := window.Canvas()
 
+	test.AssertRendersToMarkup(t, "password_entry/initial.xml", window.Canvas())
+
 	entry.SetPlaceHolder("Password")
 	test.AssertRendersToMarkup(t, "password_entry/placeholder_initial.xml", c)
 
@@ -1965,8 +1967,6 @@ func setupPasswordTest(t *testing.T) (*widget.Entry, fyne.Window) {
 
 	entry.Resize(entry.MinSize().Max(fyne.NewSize(130, 0)))
 	entry.Move(fyne.NewPos(entryOffset, entryOffset))
-
-	test.AssertRendersToMarkup(t, "password_entry/initial.xml", w.Canvas())
 
 	return entry, w
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The "setupPasswordTest" wrote the markup for an initial entry each time it was called, leading to unnecessary writes and slowdown. Only run it once by moving it out to a suitable test.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
