### PR TITLE
Add desktop support for window wide drag and drop

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -14,8 +14,6 @@ import (
 	"fyne.io/fyne/v2/internal/driver"
 	"fyne.io/fyne/v2/internal/driver/common"
 	"fyne.io/fyne/v2/internal/scale"
-	"fyne.io/fyne/v2/storage"
-	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
 const (
@@ -110,23 +108,6 @@ func (w *window) SetMainMenu(menu *fyne.MainMenu) {
 
 func (w *window) SetOnClosed(closed func()) {
 	w.onClosed = closed
-}
-
-func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI)) {
-	runOnDraw(w, func() {
-		glfw.GetCurrentContext().SetDropCallback(func(win *glfw.Window, names []string) {
-			if dropped == nil {
-				return
-			}
-
-			uris := make([]fyne.URI, len(names))
-			for i, name := range names {
-				uris[i] = storage.NewFileURI(name)
-			}
-
-			dropped(w.mousePos, uris)
-		})
-	})
 }
 
 func (w *window) SetCloseIntercept(callback func()) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -115,14 +115,16 @@ func (w *window) SetOnClosed(closed func()) {
 func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI)) {
 	runOnDraw(w, func() {
 		glfw.GetCurrentContext().SetDropCallback(func(win *glfw.Window, names []string) {
-			if dropped != nil {
-				uris := make([]fyne.URI, len(names))
-				for i, name := range names {
-					uris[i] = storage.NewFileURI(name)
-				}
-
-				dropped(w.mousePos, uris)
+			if dropped == nil {
+				return
 			}
+
+			uris := make([]fyne.URI, len(names))
+			for i, name := range names {
+				uris[i] = storage.NewFileURI(name)
+			}
+
+			dropped(w.mousePos, uris)
 		})
 	})
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -14,6 +14,8 @@ import (
 	"fyne.io/fyne/v2/internal/driver"
 	"fyne.io/fyne/v2/internal/driver/common"
 	"fyne.io/fyne/v2/internal/scale"
+	"fyne.io/fyne/v2/storage"
+	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
 const (
@@ -108,6 +110,21 @@ func (w *window) SetMainMenu(menu *fyne.MainMenu) {
 
 func (w *window) SetOnClosed(closed func()) {
 	w.onClosed = closed
+}
+
+func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI)) {
+	runOnDraw(w, func() {
+		glfw.GetCurrentContext().SetDropCallback(func(win *glfw.Window, names []string) {
+			if dropped != nil {
+				uris := make([]fyne.URI, len(names))
+				for i, name := range names {
+					uris[i] = storage.NewFileURI(name)
+				}
+
+				dropped(w.mousePos, uris)
+			}
+		})
+	})
 }
 
 func (w *window) SetCloseIntercept(callback func()) {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -100,6 +100,7 @@ type window struct {
 
 	onClosed           func()
 	onCloseIntercepted func()
+	onDropped          func(fyne.Position, []fyne.URI)
 
 	menuTogglePending       fyne.KeyName
 	menuDeactivationPending fyne.KeyName
@@ -143,17 +144,19 @@ func (w *window) CenterOnScreen() {
 }
 
 func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI)) {
-	w.viewport.SetDropCallback(func(win *glfw.Window, names []string) {
-		if dropped == nil {
-			return
-		}
+	w.runOnMainWhenCreated(func() {
+		w.viewport.SetDropCallback(func(win *glfw.Window, names []string) {
+			if dropped == nil {
+				return
+			}
 
-		uris := make([]fyne.URI, len(names))
-		for i, name := range names {
-			uris[i] = storage.NewFileURI(name)
-		}
+			uris := make([]fyne.URI, len(names))
+			for i, name := range names {
+				uris[i] = storage.NewFileURI(name)
+			}
 
-		dropped(w.mousePos, uris)
+			dropped(w.mousePos, uris)
+		})
 	})
 }
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -143,19 +143,17 @@ func (w *window) CenterOnScreen() {
 }
 
 func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI)) {
-	runOnDraw(w, func() {
-		glfw.GetCurrentContext().SetDropCallback(func(win *glfw.Window, names []string) {
-			if dropped == nil {
-				return
-			}
+	w.viewport.SetDropCallback(func(win *glfw.Window, names []string) {
+		if dropped == nil {
+			return
+		}
 
-			uris := make([]fyne.URI, len(names))
-			for i, name := range names {
-				uris[i] = storage.NewFileURI(name)
-			}
+		uris := make([]fyne.URI, len(names))
+		for i, name := range names {
+			uris[i] = storage.NewFileURI(name)
+		}
 
-			dropped(w.mousePos, uris)
-		})
+		dropped(w.mousePos, uris)
 	})
 }
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -100,7 +100,6 @@ type window struct {
 
 	onClosed           func()
 	onCloseIntercepted func()
-	onDropped          func(fyne.Position, []fyne.URI)
 
 	menuTogglePending       fyne.KeyName
 	menuDeactivationPending fyne.KeyName

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -19,6 +19,7 @@ import (
 	"fyne.io/fyne/v2/internal/painter/gl"
 	"fyne.io/fyne/v2/internal/scale"
 	"fyne.io/fyne/v2/internal/svg"
+	"fyne.io/fyne/v2/storage"
 
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
@@ -139,6 +140,23 @@ func (w *window) CenterOnScreen() {
 	if w.view() != nil {
 		runOnMain(w.doCenterOnScreen)
 	}
+}
+
+func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI)) {
+	runOnDraw(w, func() {
+		glfw.GetCurrentContext().SetDropCallback(func(win *glfw.Window, names []string) {
+			if dropped == nil {
+				return
+			}
+
+			uris := make([]fyne.URI, len(names))
+			for i, name := range names {
+				uris[i] = storage.NewFileURI(name)
+			}
+
+			dropped(w.mousePos, uris)
+		})
+	})
 }
 
 func (w *window) doCenterOnScreen() {

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -107,6 +107,10 @@ func (w *window) CenterOnScreen() {
 	w.centered = true
 }
 
+func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI)) {
+	// FIXME: not implemented yet
+}
+
 func (w *window) doCenterOnScreen() {
 	// FIXME: no meaning for defining center on screen in WebGL
 }

--- a/internal/driver/mobile/window.go
+++ b/internal/driver/mobile/window.go
@@ -101,6 +101,10 @@ func (w *window) SetCloseIntercept(callback func()) {
 	w.onCloseIntercepted = callback
 }
 
+func (w *window) SetOnDropped(dropped func(fyne.Position, []fyne.URI)) {
+	// not implemented yet
+}
+
 func (w *window) Show() {
 	menu := fyne.CurrentApp().Driver().(*mobileDriver).findMenu(w)
 	menuButton := w.newMenuButton(menu)

--- a/test/testwindow.go
+++ b/test/testwindow.go
@@ -117,6 +117,10 @@ func (w *testWindow) SetCloseIntercept(callback func()) {
 	w.onCloseIntercepted = callback
 }
 
+func (w *testWindow) SetOnDropped(dropped func(fyne.Position, []fyne.URI)) {
+
+}
+
 func (w *testWindow) SetPadded(padded bool) {
 	w.canvas.SetPadded(padded)
 }

--- a/window.go
+++ b/window.go
@@ -70,6 +70,11 @@ type Window interface {
 	// Since: 1.4
 	SetCloseIntercept(func())
 
+	// SetOnDropped allows setting a window-wide callback to intercept dropped items.
+	//
+	// Since 2.4
+	SetOnDropped(func(Position, []URI))
+
 	// Show the window on screen.
 	Show()
 	// Hide the window from the user.

--- a/window.go
+++ b/window.go
@@ -71,6 +71,8 @@ type Window interface {
 	SetCloseIntercept(func())
 
 	// SetOnDropped allows setting a window-wide callback to receive dropped items.
+	// The callback function is called with the absolute position of the drop and a
+	// slice of all of the dropped URIs.
 	//
 	// Since 2.4
 	SetOnDropped(func(Position, []URI))

--- a/window.go
+++ b/window.go
@@ -70,7 +70,7 @@ type Window interface {
 	// Since: 1.4
 	SetCloseIntercept(func())
 
-	// SetOnDropped allows setting a window-wide callback to intercept dropped items.
+	// SetOnDropped allows setting a window-wide callback to receive dropped items.
 	//
 	// Since 2.4
 	SetOnDropped(func(Position, []URI))


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This adds initial support for a kind of window-wide drag and drop support that we might be able to get into v2.4.0. We can probably expand drag and drop in the future fore use cases like having it in specific areas and within `CanvasObjects` but this is similar to how you can add shortcuts to the whole window or to individual widgets. The other parts of development will take time and I hope that this can be a good stop-gap in the meantime.

For #142

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.