### PR TITLE
fyne_settings: Apply roundness to color selector

### DIFF
--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -210,6 +210,7 @@ func newColorButton(n string, c color.Color, s *Settings) *colorButton {
 
 func (c *colorButton) CreateRenderer() fyne.WidgetRenderer {
 	r := canvas.NewRectangle(c.color)
+	r.CornerRadius = theme.InputRadiusSize()
 	r.StrokeWidth = 5
 
 	if c.name == c.s.fyneSettings.PrimaryColor {
@@ -250,6 +251,7 @@ func (c *colorRenderer) Refresh() {
 		c.rect.StrokeColor = color.Transparent
 	}
 	c.rect.FillColor = c.c.color
+	c.rect.CornerRadius = theme.InputRadiusSize()
 
 	c.rect.Refresh()
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Apply rounded corners to the color selector in `fyne_demo`. I thought that this would apply to the actual fill and not rectangle but it looks quite good this way as well.

#### Before:
![image](https://github.com/fyne-io/fyne/assets/25466657/f445276d-3fd0-4549-b97a-815ba54d5add)

#### After:
![image](https://github.com/fyne-io/fyne/assets/25466657/1d59d855-63c1-46dd-acc9-7182d6861451)



### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
