### PR TITLE
dialog: Make the file selector use rounded rectangles

### DIFF
--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -49,6 +49,7 @@ func (i *fileDialogItem) Tapped(_ *fyne.PointEvent) {
 
 func (i *fileDialogItem) CreateRenderer() fyne.WidgetRenderer {
 	background := canvas.NewRectangle(nil)
+	background.CornerRadius = theme.InputRadiusSize()
 	text := widget.NewLabelWithStyle(i.name, fyne.TextAlignCenter, fyne.TextStyle{})
 	text.Wrapping = fyne.TextTruncate
 	icon := widget.NewFileIcon(i.location)
@@ -133,6 +134,8 @@ func (s fileItemRenderer) Refresh() {
 	} else {
 		s.background.FillColor = nil
 	}
+
+	s.background.CornerRadius = theme.InputRadiusSize()
 
 	s.background.Refresh()
 	canvas.Refresh(s.item)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This improves the file dialog by using rounded rectangles for the hover and selection indicators. It fits in better with the new rounded look that we have.

![image](https://github.com/fyne-io/fyne/assets/25466657/e3597ac2-4763-4702-8b0a-636e58d81b66)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
