### PR TITLE
Fix the problem of calling LightTheme() or DarkTheme() font garbled after setting custom font

### DIFF
--- a/theme/theme.go
+++ b/theme/theme.go
@@ -4,6 +4,7 @@ package theme // import "fyne.io/fyne/v2/theme"
 import (
 	"image/color"
 	"os"
+	"reflect"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -610,6 +611,18 @@ func (t *builtinTheme) initFonts() {
 	font = os.Getenv("FYNE_FONT_SYMBOL")
 	if font != "" {
 		t.symbol = loadCustomFont(font, "Regular", symbol)
+	}
+
+	// after applying custom fonts, prevent them from being overwritten
+	if fyne.CurrentApp() != nil && !reflect.ValueOf(fyne.CurrentApp().Settings()).IsNil()  && fyne.CurrentApp().Settings().Theme() != nil {
+		currentFont := current().Font(fyne.TextStyle{})
+		if currentFont != nil {
+			t.regular = currentFont
+			t.bold = currentFont
+			t.italic = currentFont
+			t.boldItalic = currentFont
+			t.monospace = currentFont
+		}
 	}
 }
 


### PR DESCRIPTION
Fix the problem of calling LightTheme() or DarkTheme() font garbled after setting custom font

before:
![image](https://github.com/fyne-io/fyne/assets/50353613/87d8fd35-3206-4605-b8d8-00c30a488886)
after:
![image](https://github.com/fyne-io/fyne/assets/50353613/68c80c3f-fa0a-4bfd-95e6-1755cdb85699)




<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.


