### PR TITLE
Stop using deprecated io/ioutil functions

### DIFF
--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -106,7 +105,7 @@ func runScript(name, script string) {
 	fileName := fmt.Sprintf("fyne-%s-%s-%d.ps1", appID, name, scriptNum)
 
 	tmpFilePath := filepath.Join(os.TempDir(), fileName)
-	err := ioutil.WriteFile(tmpFilePath, []byte(script), 0600)
+	err := os.WriteFile(tmpFilePath, []byte(script), 0600)
 	if err != nil {
 		fyne.LogError("Could not write script to show notification", err)
 		return

--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,11 +50,11 @@ func TestPreferences_Save(t *testing.T) {
 	err := p.saveToFile(path)
 	assert.Nil(t, err)
 
-	expected, err := ioutil.ReadFile(filepath.Join("testdata", "preferences.json"))
+	expected, err := os.ReadFile(filepath.Join("testdata", "preferences.json"))
 	if err != nil {
 		assert.Fail(t, "Failed to load, %v", err)
 	}
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		assert.Fail(t, "Failed to load, %v", err)
 	}

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -7,7 +7,6 @@ import (
 	_ "image/jpeg" // avoid users having to import when using image widget
 	_ "image/png"  // avoid the same for PNG images
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -134,7 +133,7 @@ func (i *Image) Refresh() {
 			fyne.LogError("Failed to load image", err)
 			return
 		}
-		rc = ioutil.NopCloser(r)
+		rc = io.NopCloser(r)
 	}
 
 	if i.File != "" || i.Resource != nil {
@@ -223,7 +222,7 @@ func NewImageFromURI(uri fyne.URI) *Image {
 //
 // Since: 2.0
 func NewImageFromReader(read io.Reader, name string) *Image {
-	data, err := ioutil.ReadAll(read)
+	data, err := io.ReadAll(read)
 	if err != nil {
 		fyne.LogError("Unable to read image data", err)
 		return nil
@@ -265,7 +264,7 @@ func (i *Image) updateReader() (io.ReadCloser, error) {
 	i.isSVG = false
 	if i.Resource != nil {
 		i.isSVG = svg.IsResourceSVG(i.Resource)
-		return ioutil.NopCloser(bytes.NewReader(i.Resource.Content())), nil
+		return io.NopCloser(bytes.NewReader(i.Resource.Content())), nil
 	} else if i.File != "" {
 		var err error
 

--- a/canvas/image_test.go
+++ b/canvas/image_test.go
@@ -1,7 +1,6 @@
 package canvas_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -83,11 +82,11 @@ func TestNewImageFromURI_HTTP(t *testing.T) {
 
 	pwd, _ := os.Getwd()
 	path := filepath.Join(filepath.Dir(pwd), "theme", "icons", "fyne.png")
-	f, _ := ioutil.ReadFile(path)
+	f, _ := os.ReadFile(path)
 
 	// start a test server to test http calls
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		f, err := ioutil.ReadFile(path)
+		f, err := os.ReadFile(path)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -175,7 +174,7 @@ func (b *Bundler) bundleAction(ctx *cli.Context) (err error) {
 }
 
 func (b *Bundler) dirBundle(dirpath string, out *os.File) error {
-	files, err := ioutil.ReadDir(dirpath)
+	files, err := os.ReadDir(dirpath)
 	if err != nil {
 		fyne.LogError("Error reading specified directory", err)
 		return err

--- a/cmd/fyne/internal/commands/bundle_test.go
+++ b/cmd/fyne/internal/commands/bundle_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestSanitiseName_Special(t *testing.T) {
 }
 
 func TestWriteResource(t *testing.T) {
-	f, err := ioutil.TempFile("", "*.go")
+	f, err := os.CreateTemp("", "*.go")
 	if err != nil {
 		t.Fatal("Unable to create temp file:", err)
 	}
@@ -52,7 +51,7 @@ func TestWriteResource(t *testing.T) {
 		t.Fatal("Unable to seek temp file:", err)
 	}
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatal("Unable to read temp file:", err)
 	}
@@ -63,7 +62,7 @@ func TestWriteResource(t *testing.T) {
 func BenchmarkWriteResource(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		f, _ := ioutil.TempFile("", "*.go")
+		f, _ := os.CreateTemp("", "*.go")
 		b.StartTimer()
 
 		writeHeader("test", f)

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -27,7 +26,7 @@ func (p *Packager) packageIOS(target string, tags []string) error {
 
 	assetDir := util.EnsureSubDir(p.dir, "Images.xcassets")
 	defer os.RemoveAll(assetDir)
-	err = ioutil.WriteFile(filepath.Join(assetDir, "Contents.json"), []byte(`{
+	err = os.WriteFile(filepath.Join(assetDir, "Contents.json"), []byte(`{
   "info" : {
     "author" : "xcode",
     "version" : 1

--- a/cmd/fyne/internal/commands/package-util.go
+++ b/cmd/fyne/internal/commands/package-util.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"io/ioutil"
+	"os"
 
 	realUtil "fyne.io/fyne/v2/cmd/fyne/internal/util"
 )
@@ -38,7 +38,7 @@ func (d defaultUtil) CopyExeFile(src, tgt string) error {
 }
 
 func (d defaultUtil) WriteFile(target string, data []byte) error {
-	return ioutil.WriteFile(target, data, 0644)
+	return os.WriteFile(target, data, 0644)
 }
 
 func (d defaultUtil) EnsureSubDir(parent, name string) string {

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -7,7 +7,6 @@ import (
 	"image"
 	_ "image/jpeg" // import image encodings
 	"image/png"    // import image encodings
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -340,7 +339,7 @@ func (p *Packager) removeBuild(files []string) {
 }
 
 func (p *Packager) validate() (err error) {
-	p.tempDir, err = ioutil.TempDir("", "fyne-package-*")
+	p.tempDir, err = os.MkdirTemp("", "fyne-package-*")
 	defer func() {
 		if err != nil {
 			_ = os.RemoveAll(p.tempDir)
@@ -421,10 +420,10 @@ func (p *Packager) validate() (err error) {
 	return nil
 }
 
-func calculateExeName(sourceDir, os string) string {
+func calculateExeName(sourceDir, osys string) string {
 	exeName := filepath.Base(sourceDir)
 	/* #nosec */
-	if data, err := ioutil.ReadFile(filepath.Join(sourceDir, "go.mod")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(sourceDir, "go.mod")); err == nil {
 		modulePath := modfile.ModulePath(data)
 		moduleName, _, ok := module.SplitPathVersion(modulePath)
 		if ok {
@@ -436,7 +435,7 @@ func calculateExeName(sourceDir, os string) string {
 		}
 	}
 
-	if os == "windows" {
+	if osys == "windows" {
 		exeName = exeName + ".exe"
 	}
 
@@ -471,7 +470,7 @@ func (p *Packager) normaliseIcon(path string) (string, error) {
 		return "", fmt.Errorf("failed to decode source image: %w", err)
 	}
 
-	out, err := ioutil.TempFile(p.tempDir, "fyne-ico-*.png")
+	out, err := os.CreateTemp(p.tempDir, "fyne-ico-*.png")
 	if err != nil {
 		return "", fmt.Errorf("failed to open image output file: %w", err)
 	}

--- a/cmd/fyne/internal/mobile/bind.go
+++ b/cmd/fyne/internal/mobile/bind.go
@@ -7,7 +7,6 @@ package mobile
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +48,7 @@ func writeFile(filename string, generate func(io.Writer) error) error {
 	}
 
 	if buildN {
-		return generate(ioutil.Discard)
+		return generate(io.Discard)
 	}
 
 	f, err := os.Create(filename)

--- a/cmd/fyne/internal/mobile/binres/binres_test.go
+++ b/cmd/fyne/internal/mobile/binres/binres_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"sort"
@@ -59,7 +58,7 @@ func printrecurse(t *testing.T, pl *Pool, el *Element, ws string) {
 
 func TestBootstrap(t *testing.T) {
 	r := require.New(t)
-	bin, err := ioutil.ReadFile("testdata/bootstrap.bin")
+	bin, err := os.ReadFile("testdata/bootstrap.bin")
 	r.NoError(err)
 
 	// unmarshal binary xml and store byte indices of decoded resources.
@@ -158,7 +157,7 @@ func TestEncode(t *testing.T) {
 	bx, err := UnmarshalXML(f, false, 30)
 	r.NoError(err)
 
-	bin, err := ioutil.ReadFile("testdata/bootstrap.bin")
+	bin, err := os.ReadFile("testdata/bootstrap.bin")
 	r.NoError(err)
 
 	bxml := new(XML)

--- a/cmd/fyne/internal/mobile/binres/genarsc.go
+++ b/cmd/fyne/internal/mobile/binres/genarsc.go
@@ -14,8 +14,8 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strconv"
 
 	"fyne.io/fyne/v2/cmd/fyne/internal/mobile/binres"
@@ -36,7 +36,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := ioutil.WriteFile("arsc.go", []byte(fmt.Sprintf(tmpl, strconv.Quote(string(arsc)))), 0644); err != nil {
+	if err := os.WriteFile("arsc.go", []byte(fmt.Sprintf(tmpl, strconv.Quote(string(arsc)))), 0644); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/fyne/internal/mobile/build_androidapp.go
+++ b/cmd/fyne/internal/mobile/build_androidapp.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ func goAndroidBuild(pkg *packages.Package, bundleID string, androidArchs []strin
 	dir := filepath.Dir(pkg.GoFiles[0])
 
 	manifestPath := filepath.Join(dir, "AndroidManifest.xml")
-	manifestData, err := ioutil.ReadFile(filepath.Clean(manifestPath))
+	manifestData, err := os.ReadFile(filepath.Clean(manifestPath))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
@@ -314,7 +313,7 @@ func apkwCreate(name string, apkw *Writer) (io.Writer, error) {
 		fmt.Fprintf(os.Stderr, "apk: %s\n", name)
 	}
 	if buildN {
-		return ioutil.Discard, nil
+		return io.Discard, nil
 	}
 	return apkw.Create(name)
 }

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -76,7 +75,7 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 			printcmd("echo \"%s\" > %s", file.contents, file.name)
 		}
 		if !buildN {
-			if err := ioutil.WriteFile(file.name, file.contents, 0600); err != nil {
+			if err := os.WriteFile(file.name, file.contents, 0600); err != nil {
 				return nil, err
 			}
 		}

--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -3,7 +3,6 @@ package mobile
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -69,7 +68,7 @@ func buildEnvInit() (cleanup func(), err error) {
 		tmpdir = "$WORK"
 		cleanupFn = func() {}
 	} else {
-		tmpdir, err = ioutil.TempDir("", "fyne-work-")
+		tmpdir, err = os.MkdirTemp("", "fyne-work-")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/fyne/internal/mobile/gendex/gendex.go
+++ b/cmd/fyne/internal/mobile/gendex/gendex.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -40,7 +39,7 @@ func main() {
 	flag.Parse()
 
 	var err error
-	tmpdir, err = ioutil.TempDir("", "gendex-")
+	tmpdir, err = os.MkdirTemp("", "gendex-")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,7 +97,7 @@ func gendex() error {
 		os.Stderr.Write(out)
 		return err
 	}
-	src, err := ioutil.ReadFile(tmpdir + "/classes.dex")
+	src, err := os.ReadFile(tmpdir + "/classes.dex")
 	if err != nil {
 		return err
 	}

--- a/cmd/fyne/internal/util/mobile.go
+++ b/cmd/fyne/internal/util/mobile.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,7 @@ func AndroidBuildToolsPath() string {
 	dir := filepath.Join(env, "build-tools")
 
 	// this may contain a version subdir
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return dir
 	}

--- a/cmd/fyne_demo/tutorials/dialog.go
+++ b/cmd/fyne_demo/tutorials/dialog.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"image/color"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"fyne.io/fyne/v2"
@@ -171,7 +171,7 @@ func fileSaved(f fyne.URIWriteCloser, w fyne.Window) {
 }
 
 func loadImage(f fyne.URIReadCloser) *canvas.Image {
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		fyne.LogError("Failed to load image data", err)
 		return nil

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"image"
 	"image/color"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -191,7 +190,7 @@ func (s *Settings) saveToFile(path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0644)
 }
 
 type colorButton struct {

--- a/internal/driver/mobile/gl/dll_windows.go
+++ b/internal/driver/mobile/gl/dll_windows.go
@@ -10,7 +10,6 @@ import (
 	"debug/pe"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -18,7 +17,7 @@ import (
 	"runtime"
 )
 
-var debug = log.New(ioutil.Discard, "gl: ", log.LstdFlags)
+var debug = log.New(io.Discard, "gl: ", log.LstdFlags)
 
 func downloadDLLs() (path string, err error) {
 	url := "https://dl.google.com/go/mobile/angle-bd3f8780b-" + runtime.GOARCH + ".tgz"
@@ -54,11 +53,11 @@ func downloadDLLs() (path string, err error) {
 		}
 		switch header.Name {
 		case "angle-" + runtime.GOARCH + "/libglesv2.dll":
-			bytesGLESv2, err = ioutil.ReadAll(tr)
+			bytesGLESv2, err = io.ReadAll(tr)
 		case "angle-" + runtime.GOARCH + "/libegl.dll":
-			bytesEGL, err = ioutil.ReadAll(tr)
+			bytesEGL, err = io.ReadAll(tr)
 		case "angle-" + runtime.GOARCH + "/d3dcompiler_47.dll":
-			bytesD3DCompiler, err = ioutil.ReadAll(tr)
+			bytesD3DCompiler, err = io.ReadAll(tr)
 		default: // skip
 		}
 		if err != nil {
@@ -70,13 +69,13 @@ func downloadDLLs() (path string, err error) {
 	}
 
 	writeDLLs := func(path string) error {
-		if err := ioutil.WriteFile(filepath.Join(path, "libglesv2.dll"), bytesGLESv2, 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(path, "libglesv2.dll"), bytesGLESv2, 0755); err != nil {
 			return fmt.Errorf("gl: cannot install ANGLE: %v", err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(path, "libegl.dll"), bytesEGL, 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(path, "libegl.dll"), bytesEGL, 0755); err != nil {
 			return fmt.Errorf("gl: cannot install ANGLE: %v", err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(path, "d3dcompiler_47.dll"), bytesD3DCompiler, 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(path, "d3dcompiler_47.dll"), bytesD3DCompiler, 0755); err != nil {
 			return fmt.Errorf("gl: cannot install ANGLE: %v", err)
 		}
 		return nil
@@ -152,7 +151,7 @@ func chromePath() string {
 	}
 
 	for _, installdir := range installdirs {
-		versiondirs, err := ioutil.ReadDir(installdir)
+		versiondirs, err := os.ReadDir(installdir)
 		if err != nil {
 			continue
 		}

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -216,7 +215,7 @@ func (r *FileRepository) Child(u fyne.URI, component string) (fyne.URI, error) {
 func (r *FileRepository) List(u fyne.URI) ([]fyne.URI, error) {
 
 	path := u.Path()
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/file_test.go
+++ b/internal/repository/file_test.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -41,7 +41,7 @@ func TestFileRepositoryRegistration(t *testing.T) {
 }
 
 func TestFileRepositoryExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestFileRepositoryExists(t *testing.T) {
 	existsPath := path.Join(dir, "exists")
 	notExistsPath := path.Join(dir, "notExists")
 
-	err = ioutil.WriteFile(existsPath, []byte{1, 2, 3, 4}, 0755)
+	err = os.WriteFile(existsPath, []byte{1, 2, 3, 4}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestFileRepositoryExists(t *testing.T) {
 
 func TestFileRepositoryReader(t *testing.T) {
 	// Set up a temporary directory.
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,11 +76,11 @@ func TestFileRepositoryReader(t *testing.T) {
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
 	bazPath := path.Join(dir, "baz")
-	err = ioutil.WriteFile(fooPath, []byte{}, 0755)
+	err = os.WriteFile(fooPath, []byte{}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(barPath, []byte{1, 2, 3}, 0755)
+	err = os.WriteFile(barPath, []byte{1, 2, 3}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,14 +97,14 @@ func TestFileRepositoryReader(t *testing.T) {
 	// Make sure we can read the empty file.
 	fooReader, err := storage.Reader(foo)
 	assert.Nil(t, err)
-	fooData, err := ioutil.ReadAll(fooReader)
+	fooData, err := io.ReadAll(fooReader)
 	assert.Equal(t, []byte{}, fooData)
 	assert.Nil(t, err)
 
 	// Make sure we can read the file with data.
 	barReader, err := storage.Reader(bar)
 	assert.Nil(t, err)
-	barData, err := ioutil.ReadAll(barReader)
+	barData, err := io.ReadAll(barReader)
 	assert.Equal(t, []byte{1, 2, 3}, barData)
 	assert.Nil(t, err)
 
@@ -128,7 +128,7 @@ func TestFileRepositoryReader(t *testing.T) {
 
 func TestFileRepositoryWriter(t *testing.T) {
 	// Set up a temporary directory.
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,11 +139,11 @@ func TestFileRepositoryWriter(t *testing.T) {
 	barPath := path.Join(dir, "bar")
 	bazPath := path.Join(dir, "baz")
 	spamHamPath := path.Join(dir, "spam", "ham")
-	err = ioutil.WriteFile(fooPath, []byte{}, 0755)
+	err = os.WriteFile(fooPath, []byte{}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(barPath, []byte{1, 2, 3}, 0755)
+	err = os.WriteFile(barPath, []byte{1, 2, 3}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,19 +201,19 @@ func TestFileRepositoryWriter(t *testing.T) {
 	// now make sure we can read the data back correctly
 	fooReader, err := storage.Reader(foo)
 	assert.Nil(t, err)
-	fooData, err := ioutil.ReadAll(fooReader)
+	fooData, err := io.ReadAll(fooReader)
 	assert.Equal(t, []byte{1, 2, 3, 4, 5}, fooData)
 	assert.Nil(t, err)
 
 	barReader, err := storage.Reader(bar)
 	assert.Nil(t, err)
-	barData, err := ioutil.ReadAll(barReader)
+	barData, err := io.ReadAll(barReader)
 	assert.Equal(t, []byte{6, 7, 8, 9}, barData)
 	assert.Nil(t, err)
 
 	bazReader, err := storage.Reader(baz)
 	assert.Nil(t, err)
-	bazData, err := ioutil.ReadAll(bazReader)
+	bazData, err := io.ReadAll(bazReader)
 	assert.Equal(t, []byte{5, 4, 3, 2, 1, 0}, bazData)
 	assert.Nil(t, err)
 
@@ -248,7 +248,7 @@ func TestFileRepositoryWriter(t *testing.T) {
 
 func TestFileRepositoryCanWrite(t *testing.T) {
 	// Set up a temporary directory.
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,11 +258,11 @@ func TestFileRepositoryCanWrite(t *testing.T) {
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
 	bazPath := path.Join(dir, "baz")
-	err = ioutil.WriteFile(fooPath, []byte{}, 0755)
+	err = os.WriteFile(fooPath, []byte{}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(barPath, []byte{1, 2, 3}, 0755)
+	err = os.WriteFile(barPath, []byte{1, 2, 3}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestFileRepositoryChild(t *testing.T) {
 
 func TestFileRepositoryCopy(t *testing.T) {
 	// Set up a temporary directory.
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +375,7 @@ func TestFileRepositoryCopy(t *testing.T) {
 	// Create some files to test with.
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
-	err = ioutil.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
+	err = os.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,10 +386,10 @@ func TestFileRepositoryCopy(t *testing.T) {
 	err = storage.Copy(foo, bar)
 	assert.Nil(t, err)
 
-	fooData, err := ioutil.ReadFile(fooPath)
+	fooData, err := os.ReadFile(fooPath)
 	assert.Nil(t, err)
 
-	barData, err := ioutil.ReadFile(barPath)
+	barData, err := os.ReadFile(barPath)
 	assert.Nil(t, err)
 
 	assert.Equal(t, fooData, barData)
@@ -397,7 +397,7 @@ func TestFileRepositoryCopy(t *testing.T) {
 
 func TestFileRepositoryMove(t *testing.T) {
 	// Set up a temporary directory.
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +406,7 @@ func TestFileRepositoryMove(t *testing.T) {
 	// Create some files to test with.
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
-	err = ioutil.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
+	err = os.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +417,7 @@ func TestFileRepositoryMove(t *testing.T) {
 	err = storage.Move(foo, bar)
 	assert.Nil(t, err)
 
-	barData, err := ioutil.ReadFile(barPath)
+	barData, err := os.ReadFile(barPath)
 	assert.Nil(t, err)
 
 	assert.Equal(t, []byte{1, 2, 3, 4, 5}, barData)
@@ -430,7 +430,7 @@ func TestFileRepositoryMove(t *testing.T) {
 
 func TestFileRepositoryListing(t *testing.T) {
 	// Set up a temporary directory.
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,7 +467,7 @@ func TestFileRepositoryListing(t *testing.T) {
 
 func TestFileRepositoryCreateListable(t *testing.T) {
 	// Set up a temporary directory.
-	dir, err := ioutil.TempDir("", "FyneInternalRepositoryFileTest")
+	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repository/memory_test.go
+++ b/internal/repository/memory_test.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"fyne.io/fyne/v2/storage"
@@ -109,13 +109,13 @@ func TestInMemoryRepositoryReader(t *testing.T) {
 
 	fooReader, err := storage.Reader(foo)
 	assert.Nil(t, err)
-	fooData, err := ioutil.ReadAll(fooReader)
+	fooData, err := io.ReadAll(fooReader)
 	assert.Equal(t, []byte{}, fooData)
 	assert.Nil(t, err)
 
 	barReader, err := storage.Reader(bar)
 	assert.Nil(t, err)
-	barData, err := ioutil.ReadAll(barReader)
+	barData, err := io.ReadAll(barReader)
 	assert.Equal(t, []byte{1, 2, 3}, barData)
 	assert.Nil(t, err)
 
@@ -193,19 +193,19 @@ func TestInMemoryRepositoryWriter(t *testing.T) {
 	// now make sure we can read the data back correctly
 	fooReader, err := storage.Reader(foo)
 	assert.Nil(t, err)
-	fooData, err := ioutil.ReadAll(fooReader)
+	fooData, err := io.ReadAll(fooReader)
 	assert.Equal(t, []byte{1, 2, 3, 4, 5}, fooData)
 	assert.Nil(t, err)
 
 	barReader, err := storage.Reader(bar)
 	assert.Nil(t, err)
-	barData, err := ioutil.ReadAll(barReader)
+	barData, err := io.ReadAll(barReader)
 	assert.Equal(t, []byte{6, 7, 8, 9}, barData)
 	assert.Nil(t, err)
 
 	bazReader, err := storage.Reader(baz)
 	assert.Nil(t, err)
-	bazData, err := ioutil.ReadAll(bazReader)
+	bazData, err := io.ReadAll(bazReader)
 	assert.Equal(t, []byte{5, 4, 3, 2, 1, 0}, bazData)
 	assert.Nil(t, err)
 

--- a/internal/svg/svg.go
+++ b/internal/svg/svg.go
@@ -9,7 +9,6 @@ import (
 	"image"
 	"image/color"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -286,7 +285,7 @@ func (s *svg) replaceFillColor(color color.Color) error {
 
 func svgFromXML(reader io.Reader) (*svg, error) {
 	var s svg
-	bSlice, err := ioutil.ReadAll(reader)
+	bSlice, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/svg/svg_test.go
+++ b/internal/svg/svg_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"image"
 	"image/color"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -137,7 +137,7 @@ func TestColorize(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			bytes, err := ioutil.ReadFile(filepath.Join("testdata", tt.svgFile))
+			bytes, err := os.ReadFile(filepath.Join("testdata", tt.svgFile))
 			require.NoError(t, err)
 			got := helperDrawSVG(t, Colorize(bytes, tt.color))
 			test.AssertImageMatches(t, tt.wantImage, got)
@@ -146,7 +146,7 @@ func TestColorize(t *testing.T) {
 }
 
 func TestSVG_ReplaceFillColor(t *testing.T) {
-	src, err := ioutil.ReadFile("testdata/cancel_Paths.svg")
+	src, err := os.ReadFile("testdata/cancel_Paths.svg")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestSVG_ReplaceFillColor(t *testing.T) {
 }
 
 func TestSVG_ReplaceFillColor_Ellipse(t *testing.T) {
-	src, err := ioutil.ReadFile("testdata/ellipse.svg")
+	src, err := os.ReadFile("testdata/ellipse.svg")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/resource.go
+++ b/resource.go
@@ -1,8 +1,9 @@
 package fyne
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 )
 
@@ -47,7 +48,7 @@ func NewStaticResource(name string, content []byte) *StaticResource {
 
 // LoadResourceFromPath creates a new StaticResource in memory using the contents of the specified file.
 func LoadResourceFromPath(path string) (Resource, error) {
-	bytes, err := ioutil.ReadFile(filepath.Clean(path))
+	bytes, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +65,7 @@ func LoadResourceFromURLString(urlStr string) (Resource, error) {
 	}
 	defer res.Body.Close()
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/resource.go
+++ b/storage/resource.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"io/ioutil"
+	"io"
 
 	"fyne.io/fyne/v2"
 )
@@ -16,7 +16,7 @@ func LoadResourceFromURI(u fyne.URI) (fyne.Resource, error) {
 	}
 
 	defer read.Close()
-	bytes, err := ioutil.ReadAll(read)
+	bytes, err := io.ReadAll(read)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/uri_test.go
+++ b/storage/uri_test.go
@@ -1,7 +1,7 @@
 package storage_test
 
 import (
-	"io/ioutil"
+	"io"
 	"runtime"
 	"testing"
 
@@ -273,19 +273,19 @@ func TestWriteAndDelete(t *testing.T) {
 	// now make sure we can read the data back correctly
 	fooReader, err := storage.Reader(foo)
 	assert.Nil(t, err)
-	fooData, err := ioutil.ReadAll(fooReader)
+	fooData, err := io.ReadAll(fooReader)
 	assert.Equal(t, []byte{1, 2, 3, 4, 5}, fooData)
 	assert.Nil(t, err)
 
 	barReader, err := storage.Reader(bar)
 	assert.Nil(t, err)
-	barData, err := ioutil.ReadAll(barReader)
+	barData, err := io.ReadAll(barReader)
 	assert.Equal(t, []byte{6, 7, 8, 9}, barData)
 	assert.Nil(t, err)
 
 	bazReader, err := storage.Reader(baz)
 	assert.Nil(t, err)
-	bazData, err := ioutil.ReadAll(bazReader)
+	bazData, err := io.ReadAll(bazReader)
 	assert.Equal(t, []byte{5, 4, 3, 2, 1, 0}, bazData)
 	assert.Nil(t, err)
 

--- a/test/test.go
+++ b/test/test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"fmt"
 	"image"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -116,7 +115,7 @@ func AssertRendersToMarkup(t *testing.T, masterFilename string, c fyne.Canvas, m
 		return false
 	}
 
-	raw, err := ioutil.ReadFile(masterPath)
+	raw, err := os.ReadFile(masterPath)
 	require.NoError(t, err)
 	master := strings.ReplaceAll(string(raw), "\r", "")
 
@@ -368,5 +367,5 @@ func writeMarkup(path string, markup string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, []byte(markup), 0644)
+	return os.WriteFile(path, []byte(markup), 0644)
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -2,7 +2,6 @@ package test_test
 
 import (
 	"image/color"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -230,7 +229,7 @@ func TestScroll(t *testing.T) {
 }
 
 func readMarkup(t *testing.T, path string) string {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return string(raw)
 }

--- a/test/testfile.go
+++ b/test/testfile.go
@@ -3,7 +3,6 @@ package test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -88,7 +87,7 @@ func (d *directory) List() ([]fyne.URI, error) {
 	}
 
 	path := d.String()[len(d.Scheme())+3 : len(d.String())]
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/theme/gen.go
+++ b/theme/gen.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"go/format"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -266,5 +265,5 @@ func writeFile(filename string, contents []byte) error {
 		return err
 	}
 	_, dirname, _, _ := runtime.Caller(0)
-	return ioutil.WriteFile(filepath.Join(filepath.Dir(dirname), filename), formatted, 0644)
+	return os.WriteFile(filepath.Join(filepath.Dir(dirname), filename), formatted, 0644)
 }


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Replacements are in `io` and `os` packages from Go 1.16 and forward.

For #3242 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
