### PR TITLE
Switch to filepath.WalkDir for faster directory traversal

### DIFF
--- a/cmd/fyne/internal/mobile/build_androidapp.go
+++ b/cmd/fyne/internal/mobile/build_androidapp.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -189,7 +190,7 @@ func addAssets(apkw *Writer, manifestData []byte, dir, iconPath string, target i
 		if err != nil {
 			return err
 		}
-		err = filepath.Walk(assetsDir, func(path string, info os.FileInfo, err error) error {
+		err = filepath.WalkDir(assetsDir, func(path string, info fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -221,7 +222,7 @@ func iosCopyAssets(pkg *packages.Package, xcodeProjDir string) error {
 	if err != nil {
 		return err
 	}
-	return filepath.Walk(srcAssets, func(path string, info os.FileInfo, err error) error {
+	return filepath.WalkDir(srcAssets, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Available since Go 1.16. Avoids call one extra syscall to get the FileInfo.
I don't have anything to test this on but it should not cause any issues.
If the reviewer wants to test this, then that would be great.

For #3242 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.