### PR TITLE
widget: Add the GridWrap collection widget from @dweymouth

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -73,8 +73,6 @@ func NewGridWrapWithData(data binding.DataList, createItem func() fyne.CanvasObj
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
-//
-// Since: 2.4
 func (l *GridWrap) CreateRenderer() fyne.WidgetRenderer {
 	l.ExtendBaseWidget(l)
 
@@ -90,8 +88,6 @@ func (l *GridWrap) CreateRenderer() fyne.WidgetRenderer {
 }
 
 // MinSize returns the size that this widget should not shrink below.
-//
-// Since: 2.4
 func (l *GridWrap) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
 
@@ -113,8 +109,6 @@ func (l *GridWrap) scrollTo(id GridWrapItemID) {
 }
 
 // Resize is called when this GridWrap should change size. We refresh to ensure invisible items are drawn.
-//
-// Since: 2.4
 func (l *GridWrap) Resize(s fyne.Size) {
 	l.BaseWidget.Resize(s)
 	l.offsetUpdated(l.scroller.Offset)
@@ -122,8 +116,6 @@ func (l *GridWrap) Resize(s fyne.Size) {
 }
 
 // Select adds the item identified by the given ID to the selection.
-//
-// Since: 2.4
 func (l *GridWrap) Select(id GridWrapItemID) {
 	if len(l.selected) > 0 && id == l.selected[0] {
 		return
@@ -150,8 +142,6 @@ func (l *GridWrap) Select(id GridWrapItemID) {
 }
 
 // ScrollTo scrolls to the item represented by id
-//
-// Since: 2.4
 func (l *GridWrap) ScrollTo(id GridWrapItemID) {
 	length := 0
 	if f := l.Length; f != nil {
@@ -165,8 +155,6 @@ func (l *GridWrap) ScrollTo(id GridWrapItemID) {
 }
 
 // ScrollToBottom scrolls to the end of the list
-//
-// Since: 2.4
 func (l *GridWrap) ScrollToBottom() {
 	length := 0
 	if f := l.Length; f != nil {
@@ -180,31 +168,23 @@ func (l *GridWrap) ScrollToBottom() {
 }
 
 // ScrollToTop scrolls to the start of the list
-//
-// Since: 2.4
 func (l *GridWrap) ScrollToTop() {
 	l.scrollTo(0)
 	l.Refresh()
 }
 
 // ScrollToOffset scrolls the list to the given offset position
-//
-// Since: 2.4
 func (l *GridWrap) ScrollToOffset(offset float32) {
 	l.scroller.Offset.Y = offset
 	l.offsetUpdated(l.scroller.Offset)
 }
 
 // GetScrollOffset returns the current scroll offset position
-//
-// Since: 2.4
 func (l *GridWrap) GetScrollOffset() float32 {
 	return l.offsetY
 }
 
 // Unselect removes the item identified by the given ID from the selection.
-//
-// Since: 2.4
 func (l *GridWrap) Unselect(id GridWrapItemID) {
 	if len(l.selected) == 0 || l.selected[0] != id {
 		return
@@ -218,8 +198,6 @@ func (l *GridWrap) Unselect(id GridWrapItemID) {
 }
 
 // UnselectAll removes all items from the selection.
-//
-// Since: 2.4
 func (l *GridWrap) UnselectAll() {
 	if len(l.selected) == 0 {
 		return

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -17,11 +17,15 @@ import (
 var _ fyne.Widget = (*GridWrap)(nil)
 
 // GridWrapItemID is the ID of an individual item in the GridWrap widget.
+//
+// Since: 2.4
 type GridWrapItemID = int
 
 // GridWrap is a widget with an API very similar to widget.List,
 // that lays out items in a scrollable wrapping grid similar to container.NewGridWrap.
 // It caches and reuses widgets for performance.
+//
+// Since: 2.4
 type GridWrap struct {
 	BaseWidget
 
@@ -40,6 +44,8 @@ type GridWrap struct {
 
 // NewGridWrap creates and returns a GridWrap widget for displaying items in
 // a wrapping grid layout with scrolling and caching for performance.
+//
+// Since: 2.4
 func NewGridWrap(length func() int, createItem func() fyne.CanvasObject, updateItem func(GridWrapItemID, fyne.CanvasObject)) *GridWrap {
 	gwList := &GridWrap{Length: length, CreateItem: createItem, UpdateItem: updateItem}
 	gwList.ExtendBaseWidget(gwList)
@@ -47,6 +53,8 @@ func NewGridWrap(length func() int, createItem func() fyne.CanvasObject, updateI
 }
 
 // NewGridWrapWithData creates a new GridWrap widget that will display the contents of the provided data.
+//
+// Since: 2.4
 func NewGridWrapWithData(data binding.DataList, createItem func() fyne.CanvasObject, updateItem func(binding.DataItem, fyne.CanvasObject)) *GridWrap {
 	gwList := NewGridWrap(
 		data.Length,
@@ -65,6 +73,8 @@ func NewGridWrapWithData(data binding.DataList, createItem func() fyne.CanvasObj
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
+//
+// Since: 2.4
 func (l *GridWrap) CreateRenderer() fyne.WidgetRenderer {
 	l.ExtendBaseWidget(l)
 
@@ -80,6 +90,8 @@ func (l *GridWrap) CreateRenderer() fyne.WidgetRenderer {
 }
 
 // MinSize returns the size that this widget should not shrink below.
+//
+// Since: 2.4
 func (l *GridWrap) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
 
@@ -101,6 +113,8 @@ func (l *GridWrap) scrollTo(id GridWrapItemID) {
 }
 
 // Resize is called when this GridWrap should change size. We refresh to ensure invisible items are drawn.
+//
+// Since: 2.4
 func (l *GridWrap) Resize(s fyne.Size) {
 	l.BaseWidget.Resize(s)
 	l.offsetUpdated(l.scroller.Offset)
@@ -108,6 +122,8 @@ func (l *GridWrap) Resize(s fyne.Size) {
 }
 
 // Select adds the item identified by the given ID to the selection.
+//
+// Since: 2.4
 func (l *GridWrap) Select(id GridWrapItemID) {
 	if len(l.selected) > 0 && id == l.selected[0] {
 		return
@@ -134,6 +150,8 @@ func (l *GridWrap) Select(id GridWrapItemID) {
 }
 
 // ScrollTo scrolls to the item represented by id
+//
+// Since: 2.4
 func (l *GridWrap) ScrollTo(id GridWrapItemID) {
 	length := 0
 	if f := l.Length; f != nil {
@@ -147,6 +165,8 @@ func (l *GridWrap) ScrollTo(id GridWrapItemID) {
 }
 
 // ScrollToBottom scrolls to the end of the list
+//
+// Since: 2.4
 func (l *GridWrap) ScrollToBottom() {
 	length := 0
 	if f := l.Length; f != nil {
@@ -160,23 +180,31 @@ func (l *GridWrap) ScrollToBottom() {
 }
 
 // ScrollToTop scrolls to the start of the list
+//
+// Since: 2.4
 func (l *GridWrap) ScrollToTop() {
 	l.scrollTo(0)
 	l.Refresh()
 }
 
 // ScrollToOffset scrolls the list to the given offset position
+//
+// Since: 2.4
 func (l *GridWrap) ScrollToOffset(offset float32) {
 	l.scroller.Offset.Y = offset
 	l.offsetUpdated(l.scroller.Offset)
 }
 
 // GetScrollOffset returns the current scroll offset position
+//
+// Since: 2.4
 func (l *GridWrap) GetScrollOffset() float32 {
 	return l.offsetY
 }
 
 // Unselect removes the item identified by the given ID from the selection.
+//
+// Since: 2.4
 func (l *GridWrap) Unselect(id GridWrapItemID) {
 	if len(l.selected) == 0 || l.selected[0] != id {
 		return
@@ -190,6 +218,8 @@ func (l *GridWrap) Unselect(id GridWrapItemID) {
 }
 
 // UnselectAll removes all items from the selection.
+//
+// Since: 2.4
 func (l *GridWrap) UnselectAll() {
 	if len(l.selected) == 0 {
 		return

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -1,0 +1,542 @@
+package widget
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/data/binding"
+	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal/widget"
+	"fyne.io/fyne/v2/theme"
+)
+
+// Declare conformity with Widget interface.
+var _ fyne.Widget = (*GridWrap)(nil)
+
+// GridWrapItemID is the ID of an individual item in the GridWrap widget.
+type GridWrapItemID = int
+
+// GridWrap is a widget with an API very similar to widget.List,
+// that lays out items in a scrollable wrapping grid similar to container.NewGridWrap.
+// It caches and reuses widgets for performance.
+type GridWrap struct {
+	BaseWidget
+
+	Length       func() int                                      `json:"-"`
+	CreateItem   func() fyne.CanvasObject                        `json:"-"`
+	UpdateItem   func(id GridWrapItemID, item fyne.CanvasObject) `json:"-"`
+	OnSelected   func(id GridWrapItemID)                         `json:"-"`
+	OnUnselected func(id GridWrapItemID)                         `json:"-"`
+
+	scroller      *widget.Scroll
+	selected      []GridWrapItemID
+	itemMin       fyne.Size
+	offsetY       float32
+	offsetUpdated func(fyne.Position)
+}
+
+// NewGridWrap creates and returns a GridWrap widget for displaying items in
+// a wrapping grid layout with scrolling and caching for performance.
+func NewGridWrap(length func() int, createItem func() fyne.CanvasObject, updateItem func(GridWrapItemID, fyne.CanvasObject)) *GridWrap {
+	gwList := &GridWrap{Length: length, CreateItem: createItem, UpdateItem: updateItem}
+	gwList.ExtendBaseWidget(gwList)
+	return gwList
+}
+
+// NewGridWrapWithData creates a new GridWrap widget that will display the contents of the provided data.
+func NewGridWrapWithData(data binding.DataList, createItem func() fyne.CanvasObject, updateItem func(binding.DataItem, fyne.CanvasObject)) *GridWrap {
+	gwList := NewGridWrap(
+		data.Length,
+		createItem,
+		func(i GridWrapItemID, o fyne.CanvasObject) {
+			item, err := data.GetItem(int(i))
+			if err != nil {
+				fyne.LogError(fmt.Sprintf("Error getting data item %d", i), err)
+				return
+			}
+			updateItem(item, o)
+		})
+
+	data.AddListener(binding.NewDataListener(gwList.Refresh))
+	return gwList
+}
+
+// CreateRenderer is a private method to Fyne which links this widget to its renderer.
+func (l *GridWrap) CreateRenderer() fyne.WidgetRenderer {
+	l.ExtendBaseWidget(l)
+
+	if f := l.CreateItem; f != nil && l.itemMin.IsZero() {
+		l.itemMin = f().MinSize()
+	}
+
+	layout := &fyne.Container{Layout: newGridWrapLayout(l)}
+	l.scroller = widget.NewVScroll(layout)
+	layout.Resize(layout.MinSize())
+
+	return newGridWrapRenderer([]fyne.CanvasObject{l.scroller}, l, l.scroller, layout)
+}
+
+// MinSize returns the size that this widget should not shrink below.
+func (l *GridWrap) MinSize() fyne.Size {
+	l.ExtendBaseWidget(l)
+
+	return l.BaseWidget.MinSize()
+}
+
+func (l *GridWrap) scrollTo(id GridWrapItemID) {
+	if l.scroller == nil {
+		return
+	}
+	row := math.Floor(float64(id) / float64(l.getColCount()))
+	y := float32(row)*l.itemMin.Height + float32(row)*theme.Padding()
+	if y < l.scroller.Offset.Y {
+		l.scroller.Offset.Y = y
+	} else if y+l.itemMin.Height > l.scroller.Offset.Y+l.scroller.Size().Height {
+		l.scroller.Offset.Y = y + l.itemMin.Height - l.scroller.Size().Height
+	}
+	l.offsetUpdated(l.scroller.Offset)
+}
+
+// Resize is called when this GridWrap should change size. We refresh to ensure invisible items are drawn.
+func (l *GridWrap) Resize(s fyne.Size) {
+	l.BaseWidget.Resize(s)
+	l.offsetUpdated(l.scroller.Offset)
+	l.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).updateGrid(true)
+}
+
+// Select adds the item identified by the given ID to the selection.
+func (l *GridWrap) Select(id GridWrapItemID) {
+	if len(l.selected) > 0 && id == l.selected[0] {
+		return
+	}
+	length := 0
+	if f := l.Length; f != nil {
+		length = f()
+	}
+	if id < 0 || id >= length {
+		return
+	}
+	old := l.selected
+	l.selected = []GridWrapItemID{id}
+	defer func() {
+		if f := l.OnUnselected; f != nil && len(old) > 0 {
+			f(old[0])
+		}
+		if f := l.OnSelected; f != nil {
+			f(id)
+		}
+	}()
+	l.scrollTo(id)
+	l.Refresh()
+}
+
+// ScrollTo scrolls to the item represented by id
+func (l *GridWrap) ScrollTo(id GridWrapItemID) {
+	length := 0
+	if f := l.Length; f != nil {
+		length = f()
+	}
+	if id < 0 || int(id) >= length {
+		return
+	}
+	l.scrollTo(id)
+	l.Refresh()
+}
+
+// ScrollToBottom scrolls to the end of the list
+func (l *GridWrap) ScrollToBottom() {
+	length := 0
+	if f := l.Length; f != nil {
+		length = f()
+	}
+	if length > 0 {
+		length--
+	}
+	l.scrollTo(GridWrapItemID(length))
+	l.Refresh()
+}
+
+// ScrollToTop scrolls to the start of the list
+func (l *GridWrap) ScrollToTop() {
+	l.scrollTo(0)
+	l.Refresh()
+}
+
+// ScrollToOffset scrolls the list to the given offset position
+func (l *GridWrap) ScrollToOffset(offset float32) {
+	l.scroller.Offset.Y = offset
+	l.offsetUpdated(l.scroller.Offset)
+}
+
+// GetScrollOffset returns the current scroll offset position
+func (l *GridWrap) GetScrollOffset() float32 {
+	return l.offsetY
+}
+
+// Unselect removes the item identified by the given ID from the selection.
+func (l *GridWrap) Unselect(id GridWrapItemID) {
+	if len(l.selected) == 0 || l.selected[0] != id {
+		return
+	}
+
+	l.selected = nil
+	l.Refresh()
+	if f := l.OnUnselected; f != nil {
+		f(id)
+	}
+}
+
+// UnselectAll removes all items from the selection.
+func (l *GridWrap) UnselectAll() {
+	if len(l.selected) == 0 {
+		return
+	}
+
+	selected := l.selected
+	l.selected = nil
+	l.Refresh()
+	if f := l.OnUnselected; f != nil {
+		for _, id := range selected {
+			f(id)
+		}
+	}
+}
+
+// Declare conformity with WidgetRenderer interface.
+var _ fyne.WidgetRenderer = (*gridWrapRenderer)(nil)
+
+type gridWrapRenderer struct {
+	objects []fyne.CanvasObject
+
+	list     *GridWrap
+	scroller *widget.Scroll
+	layout   *fyne.Container
+}
+
+func newGridWrapRenderer(objects []fyne.CanvasObject, l *GridWrap, scroller *widget.Scroll, layout *fyne.Container) *gridWrapRenderer {
+	lr := &gridWrapRenderer{objects: objects, list: l, scroller: scroller, layout: layout}
+	lr.scroller.OnScrolled = l.offsetUpdated
+	return lr
+}
+
+func (l *gridWrapRenderer) Layout(size fyne.Size) {
+	l.scroller.Resize(size)
+}
+
+func (l *gridWrapRenderer) MinSize() fyne.Size {
+	return l.scroller.MinSize().Max(l.list.itemMin)
+}
+
+func (l *gridWrapRenderer) Refresh() {
+	if f := l.list.CreateItem; f != nil {
+		l.list.itemMin = f().MinSize()
+	}
+	l.Layout(l.list.Size())
+	l.scroller.Refresh()
+	l.layout.Layout.(*gridWrapLayout).updateGrid(true)
+	canvas.Refresh(l.list)
+}
+
+func (l *gridWrapRenderer) Destroy() {
+}
+
+func (l *gridWrapRenderer) Objects() []fyne.CanvasObject {
+	return l.objects
+}
+
+// Declare conformity with interfaces.
+var _ fyne.Focusable = (*gridWrapItem)(nil)
+var _ fyne.Widget = (*gridWrapItem)(nil)
+var _ fyne.Tappable = (*gridWrapItem)(nil)
+var _ desktop.Hoverable = (*gridWrapItem)(nil)
+
+type gridWrapItem struct {
+	BaseWidget
+
+	onTapped          func()
+	background        *canvas.Rectangle
+	child             fyne.CanvasObject
+	hovered, selected bool
+}
+
+func newGridWrapItem(child fyne.CanvasObject, tapped func()) *gridWrapItem {
+	gw := &gridWrapItem{
+		child:    child,
+		onTapped: tapped,
+	}
+
+	gw.ExtendBaseWidget(gw)
+	return gw
+}
+
+// CreateRenderer is a private method to Fyne which links this widget to its renderer.
+func (gw *gridWrapItem) CreateRenderer() fyne.WidgetRenderer {
+	gw.ExtendBaseWidget(gw)
+
+	gw.background = canvas.NewRectangle(theme.HoverColor())
+	gw.background.Hide()
+
+	objects := []fyne.CanvasObject{gw.background, gw.child}
+
+	return &gridWrapItemRenderer{widget.NewBaseRenderer(objects), gw}
+}
+
+// FocusGained is called after this listItem has gained focus.
+//
+// Implements: fyne.Focusable
+func (gw *gridWrapItem) FocusGained() {
+	gw.hovered = true
+	gw.Refresh()
+}
+
+// FocusLost is called after this listItem has lost focus.
+func (gw *gridWrapItem) FocusLost() {
+	gw.hovered = false
+	gw.Refresh()
+}
+
+// MinSize returns the size that this widget should not shrink below.
+func (gw *gridWrapItem) MinSize() fyne.Size {
+	gw.ExtendBaseWidget(gw)
+	return gw.BaseWidget.MinSize()
+}
+
+// MouseIn is called when a desktop pointer enters the widget.
+func (gw *gridWrapItem) MouseIn(*desktop.MouseEvent) {
+	gw.hovered = true
+	gw.Refresh()
+}
+
+// MouseMoved is called when a desktop pointer hovers over the widget.
+func (gw *gridWrapItem) MouseMoved(*desktop.MouseEvent) {
+}
+
+// MouseOut is called when a desktop pointer exits the widget.
+func (gw *gridWrapItem) MouseOut() {
+	gw.hovered = false
+	gw.Refresh()
+}
+
+// Tapped is called when a pointer tapped event is captured and triggers any tap handler.
+func (gw *gridWrapItem) Tapped(*fyne.PointEvent) {
+	if gw.onTapped != nil {
+		gw.selected = true
+		gw.Refresh()
+		gw.onTapped()
+	}
+}
+
+// TypedKey is called if a key event happens while this listItem is focused.
+func (gw *gridWrapItem) TypedKey(event *fyne.KeyEvent) {
+	switch event.Name {
+	case fyne.KeySpace:
+		gw.selected = true
+		gw.Refresh()
+		if gw.onTapped != nil {
+			gw.onTapped()
+		}
+	}
+}
+
+// TypedRune is called if a text event happens while this listItem is focused.
+func (gw *gridWrapItem) TypedRune(_ rune) {
+	// intentionally left blank
+}
+
+// Declare conformity with the WidgetRenderer interface.
+var _ fyne.WidgetRenderer = (*gridWrapItemRenderer)(nil)
+
+type gridWrapItemRenderer struct {
+	widget.BaseRenderer
+
+	item *gridWrapItem
+}
+
+// MinSize calculates the minimum size of a listItem.
+// This is based on the size of the status indicator and the size of the child object.
+func (gw *gridWrapItemRenderer) MinSize() fyne.Size {
+	return gw.item.child.MinSize()
+}
+
+// Layout the components of the listItem widget.
+func (gw *gridWrapItemRenderer) Layout(size fyne.Size) {
+	gw.item.background.Resize(size)
+	gw.item.child.Resize(size)
+}
+
+func (gw *gridWrapItemRenderer) Refresh() {
+	if gw.item.selected {
+		gw.item.background.FillColor = theme.SelectionColor()
+		gw.item.background.Show()
+	} else if gw.item.hovered {
+		gw.item.background.FillColor = theme.HoverColor()
+		gw.item.background.Show()
+	} else {
+		gw.item.background.Hide()
+	}
+	gw.item.background.Refresh()
+	canvas.Refresh(gw.item.super())
+}
+
+// Declare conformity with Layout interface.
+var _ fyne.Layout = (*gridWrapLayout)(nil)
+
+type gridWrapLayout struct {
+	list     *GridWrap
+	children []fyne.CanvasObject
+
+	itemPool   *syncPool
+	visible    map[GridWrapItemID]*gridWrapItem
+	renderLock sync.Mutex
+}
+
+func newGridWrapLayout(list *GridWrap) fyne.Layout {
+	l := &gridWrapLayout{list: list, itemPool: &syncPool{}, visible: make(map[GridWrapItemID]*gridWrapItem)}
+	list.offsetUpdated = l.offsetUpdated
+	return l
+}
+
+func (l *gridWrapLayout) Layout(_ []fyne.CanvasObject, _ fyne.Size) {
+	l.updateGrid(true)
+}
+
+func (l *gridWrapLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
+	if lenF := l.list.Length; lenF != nil {
+		cols := l.list.getColCount()
+		rows := float32(math.Ceil(float64(lenF()) / float64(cols)))
+		return fyne.NewSize(l.list.itemMin.Width,
+			(l.list.itemMin.Height+theme.Padding())*rows-theme.Padding())
+	}
+	return fyne.NewSize(0, 0)
+}
+
+func (l *gridWrapLayout) getItem() *gridWrapItem {
+	item := l.itemPool.Obtain()
+	if item == nil {
+		if f := l.list.CreateItem; f != nil {
+			item = newGridWrapItem(f(), nil)
+		}
+	}
+	return item.(*gridWrapItem)
+}
+
+func (l *gridWrapLayout) offsetUpdated(pos fyne.Position) {
+	if l.list.offsetY == pos.Y {
+		return
+	}
+	l.list.offsetY = pos.Y
+	l.updateGrid(false)
+}
+
+func (l *gridWrapLayout) setupGridItem(li *gridWrapItem, id GridWrapItemID, focus bool) {
+	previousIndicator := li.selected
+	li.selected = false
+	for _, s := range l.list.selected {
+		if id == s {
+			li.selected = true
+			break
+		}
+	}
+	if focus {
+		li.hovered = true
+		li.Refresh()
+	} else if previousIndicator != li.selected || li.hovered {
+		li.hovered = false
+		li.Refresh()
+	}
+	if f := l.list.UpdateItem; f != nil {
+		f(id, li.child)
+	}
+	li.onTapped = func() {
+		l.list.Select(id)
+	}
+}
+
+func (l *GridWrap) getColCount() int {
+	colCount := 1
+	width := l.Size().Width
+	if width > l.itemMin.Width {
+		colCount = int(math.Floor(float64(width+theme.Padding()) / float64(l.itemMin.Width+theme.Padding())))
+	}
+	return colCount
+}
+
+func (l *gridWrapLayout) updateGrid(refresh bool) {
+	// code here is a mashup of listLayout.updateList and gridWrapLayout.Layout
+
+	l.renderLock.Lock()
+	length := 0
+	if f := l.list.Length; f != nil {
+		length = f()
+	}
+
+	colCount := l.list.getColCount()
+	visibleRowsCount := int(math.Ceil(float64(l.list.scroller.Size().Height)/float64(l.list.itemMin.Height+theme.Padding()))) + 1
+
+	offY := l.list.offsetY - float32(math.Mod(float64(l.list.offsetY), float64(l.list.itemMin.Height+theme.Padding())))
+	minRow := int(offY / (l.list.itemMin.Height + theme.Padding()))
+	minItem := GridWrapItemID(minRow * colCount)
+	maxRow := int(math.Min(float64(minRow+visibleRowsCount), math.Ceil(float64(length)/float64(colCount))))
+	maxItem := GridWrapItemID(math.Min(float64(maxRow*colCount), float64(length-1)))
+
+	if l.list.UpdateItem == nil {
+		fyne.LogError("Missing UpdateCell callback required for GridWrap", nil)
+	}
+
+	wasVisible := l.visible
+	l.visible = make(map[GridWrapItemID]*gridWrapItem)
+	var cells []fyne.CanvasObject
+	y := offY
+	curItem := minItem
+	for row := minRow; row <= maxRow && curItem <= maxItem; row++ {
+		x := float32(0)
+		for col := 0; col < colCount && curItem <= maxItem; col++ {
+			c, ok := wasVisible[curItem]
+			if !ok {
+				c = l.getItem()
+				if c == nil {
+					continue
+				}
+				c.Resize(l.list.itemMin)
+			}
+
+			c.Move(fyne.NewPos(x, y))
+			if refresh {
+				c.Resize(l.list.itemMin)
+			}
+
+			x += l.list.itemMin.Width + theme.Padding()
+			l.visible[curItem] = c
+			cells = append(cells, c)
+			curItem++
+		}
+		y += l.list.itemMin.Height + theme.Padding()
+	}
+
+	var focused fyne.Focusable
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(l.list)
+	if canvas != nil {
+		focused = canvas.Focused()
+	}
+
+	for id, old := range wasVisible {
+		if _, ok := l.visible[id]; !ok {
+			if focused == old {
+				canvas.Focus(nil)
+			}
+			l.itemPool.Release(old)
+		}
+	}
+	l.children = cells
+
+	objects := l.children
+	l.list.scroller.Content.(*fyne.Container).Objects = objects
+	l.renderLock.Unlock() // user code should not be locked
+
+	for row, obj := range l.visible {
+		l.setupGridItem(obj, row, focused == obj)
+	}
+}

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -1,0 +1,148 @@
+package widget
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGridWrap_New(t *testing.T) {
+	g := createGridWrap(1000)
+	template := NewIcon(theme.AccountIcon())
+
+	assert.Equal(t, 1000, g.Length())
+	assert.GreaterOrEqual(t, g.MinSize().Width, template.MinSize().Width)
+	assert.Equal(t, float32(0), g.offsetY)
+}
+
+func TestGridWrap_OffsetChange(t *testing.T) {
+	g := createGridWrap(1000)
+
+	assert.Equal(t, float32(0), g.offsetY)
+
+	g.scroller.Scrolled(&fyne.ScrollEvent{Scrolled: fyne.NewDelta(0, -280)})
+
+	assert.NotEqual(t, 0, g.offsetY)
+}
+
+func TestGridWrap_ScrollTo(t *testing.T) {
+	g := createGridWrap(1000)
+
+	// override update item to keep track of greatest item rendered
+	oldUpdateFunc := g.UpdateItem
+	var greatest GridWrapItemID = -1
+	g.UpdateItem = func(id GridWrapItemID, item fyne.CanvasObject) {
+		if id > greatest {
+			greatest = id
+		}
+		oldUpdateFunc(id, item)
+	}
+
+	g.ScrollTo(650)
+	assert.GreaterOrEqual(t, greatest, 650)
+
+	g.ScrollTo(800)
+	assert.GreaterOrEqual(t, greatest, 800)
+
+	g.ScrollToBottom()
+	assert.Equal(t, greatest, GridWrapItemID(999))
+}
+
+func TestGridWrap_ScrollToTop(t *testing.T) {
+	g := createGridWrap(1000)
+	g.ScrollTo(750)
+	assert.NotEqual(t, g.offsetY, float32(0))
+	g.ScrollToTop()
+	assert.Equal(t, g.offsetY, float32(0))
+}
+
+func createGridWrap(items int) *GridWrap {
+	data := make([]fyne.Resource, items)
+	for i := 0; i < items; i++ {
+		switch i % 10 {
+		case 0:
+			data[i] = theme.AccountIcon()
+		case 1:
+			data[i] = theme.CancelIcon()
+		case 2:
+			data[i] = theme.CheckButtonIcon()
+		case 3:
+			data[i] = theme.FileApplicationIcon()
+		case 4:
+			data[i] = theme.FileVideoIcon()
+		case 5:
+			data[i] = theme.DocumentIcon()
+		case 6:
+			data[i] = theme.MediaPlayIcon()
+		case 7:
+			data[i] = theme.MediaRecordIcon()
+		case 8:
+			data[i] = theme.FolderIcon()
+		case 9:
+			data[i] = theme.FolderOpenIcon()
+		}
+	}
+
+	list := NewGridWrap(
+		func() int {
+			return len(data)
+		},
+		func() fyne.CanvasObject {
+			icon := NewIcon(theme.DocumentIcon())
+			return icon
+		},
+		func(id GridWrapItemID, item fyne.CanvasObject) {
+			item.(*Icon).SetResource(data[id])
+		},
+	)
+	list.Resize(fyne.NewSize(200, 400))
+	return list
+}
+
+func TestGridWrap_IndexIsInt(t *testing.T) {
+	gw := &GridWrap{}
+
+	// Both of these should be allowed to match List behaviour.
+	// It allows the same update item function to be shared between both widgets if necessary.
+	gw.UpdateItem = func(id GridWrapItemID, item fyne.CanvasObject) {}
+	gw.UpdateItem = func(id int, item fyne.CanvasObject) {}
+}
+
+func TestGridWrap_Selection(t *testing.T) {
+	g := createGridWrap(10)
+	assert.Zero(t, len(g.selected))
+
+	selected := -1
+	unselected := -1
+	g.OnSelected = func(id GridWrapItemID) {
+		selected = id
+		unselected = -1
+	}
+
+	g.OnUnselected = func(id GridWrapItemID) {
+		selected = -1
+		unselected = id
+	}
+
+	g.Select(0)
+	assert.Equal(t, 1, len(g.selected))
+	assert.Zero(t, selected)
+	assert.Equal(t, -1, unselected)
+
+	g.UnselectAll()
+	assert.Zero(t, len(g.selected))
+	assert.Equal(t, -1, selected)
+	assert.Zero(t, unselected)
+
+	g.Select(9)
+	assert.Equal(t, 1, len(g.selected))
+	assert.Equal(t, 9, selected)
+	assert.Equal(t, -1, unselected)
+
+	g.Unselect(9)
+	assert.Zero(t, len(g.selected))
+	assert.Equal(t, -1, selected)
+	assert.Equal(t, 9, unselected)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Initial implementation was by @dweymouth over at https://github.com/fyne-io/fyne-x/pull/56. This PR includes that work plus selection support and some of the improvements that I have done (see https://github.com/fyne-io/fyne-x/pull/61 and https://github.com/fyne-io/fyne-x/compare/master...Jacalz:gridwrap-selection?expand=1).

This was done as a PR directly to Fyne and not fyne-x as the `.super()` call from `widget.BaseWidget` wasn't public and not using it made the selection work bad. All of the changes in this PR compared to the widget in fyne-x can be found here: https://github.com/fyne-io/fyne-x/compare/master...Jacalz:gridwrap-selection?expand=1

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
