### PR TITLE
Fix the basic size of non-scrolling entry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1393,6 +1393,9 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 // This is based on the contained text with a standard amount of padding added.
 // If MultiLine is true then we will reserve space for at leasts 3 lines
 func (r *entryRenderer) MinSize() fyne.Size {
+	if rend := cache.Renderer(r.entry.content); rend != nil {
+		rend.(*entryContentRenderer).updateScrollDirections()
+	}
 	if r.scroll.Direction == widget.ScrollNone {
 		return r.entry.content.MinSize().Add(fyne.NewSize(0, theme.InputBorderSize()*2))
 	}

--- a/widget/testdata/entry/placeholder_with_text.xml
+++ b/widget/testdata/entry/placeholder_with_text.xml
@@ -1,10 +1,10 @@
-<canvas padded size="44x43">
+<canvas padded size="50x43">
 	<content>
-		<widget pos="4,4" size="36x35" type="*widget.Entry">
-			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="32x31"/>
-			<rectangle pos="1,1" radius="4" size="34x32" strokeColor="inputBorder" strokeWidth="2"/>
-			<widget pos="0,2" size="36x31" type="*widget.entryContent">
-				<widget size="36x31" type="*widget.RichText">
+		<widget pos="4,4" size="42x35" type="*widget.Entry">
+			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="38x31"/>
+			<rectangle pos="1,1" radius="4" size="40x32" strokeColor="inputBorder" strokeWidth="2"/>
+			<widget pos="0,2" size="42x31" type="*widget.entryContent">
+				<widget size="42x31" type="*widget.RichText">
 					<text pos="8,6" size="26x19">Text</text>
 				</widget>
 			</widget>

--- a/widget/testdata/entry/placeholder_without_text.xml
+++ b/widget/testdata/entry/placeholder_without_text.xml
@@ -1,13 +1,13 @@
-<canvas padded size="44x43">
+<canvas padded size="50x43">
 	<content>
-		<widget pos="4,4" size="36x35" type="*widget.Entry">
-			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="32x31"/>
-			<rectangle pos="1,1" radius="4" size="34x32" strokeColor="inputBorder" strokeWidth="2"/>
-			<widget pos="0,2" size="36x31" type="*widget.entryContent">
-				<widget size="36x31" type="*widget.RichText">
+		<widget pos="4,4" size="42x35" type="*widget.Entry">
+			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="38x31"/>
+			<rectangle pos="1,1" radius="4" size="40x32" strokeColor="inputBorder" strokeWidth="2"/>
+			<widget pos="0,2" size="42x31" type="*widget.entryContent">
+				<widget size="42x31" type="*widget.RichText">
 					<text color="placeholder" pos="8,6" size="63x19">Placehold</text>
 				</widget>
-				<widget size="36x31" type="*widget.RichText">
+				<widget size="42x31" type="*widget.RichText">
 					<text pos="8,6" size="0x19"></text>
 				</widget>
 			</widget>


### PR DESCRIPTION
This was an issue I found when updating the widget screenshot code


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

