### PR TITLE
layout: Avoid many calls to theme.Padding() and child.MinSize()

### DIFF
--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -23,26 +23,27 @@ func NewBorderLayout(top, bottom, left, right fyne.CanvasObject) fyne.Layout {
 // For BorderLayout this arranges the top, bottom, left and right widgets at
 // the sides and any remaining widgets are maximised in the middle space.
 func (b *borderLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	padding := theme.Padding()
 	var topSize, bottomSize, leftSize, rightSize fyne.Size
 	if b.top != nil && b.top.Visible() {
 		b.top.Resize(fyne.NewSize(size.Width, b.top.MinSize().Height))
 		b.top.Move(fyne.NewPos(0, 0))
-		topSize = fyne.NewSize(size.Width, b.top.MinSize().Height+theme.Padding())
+		topSize = fyne.NewSize(size.Width, b.top.MinSize().Height+padding)
 	}
 	if b.bottom != nil && b.bottom.Visible() {
 		b.bottom.Resize(fyne.NewSize(size.Width, b.bottom.MinSize().Height))
 		b.bottom.Move(fyne.NewPos(0, size.Height-b.bottom.MinSize().Height))
-		bottomSize = fyne.NewSize(size.Width, b.bottom.MinSize().Height+theme.Padding())
+		bottomSize = fyne.NewSize(size.Width, b.bottom.MinSize().Height+padding)
 	}
 	if b.left != nil && b.left.Visible() {
 		b.left.Resize(fyne.NewSize(b.left.MinSize().Width, size.Height-topSize.Height-bottomSize.Height))
 		b.left.Move(fyne.NewPos(0, topSize.Height))
-		leftSize = fyne.NewSize(b.left.MinSize().Width+theme.Padding(), size.Height-topSize.Height-bottomSize.Height)
+		leftSize = fyne.NewSize(b.left.MinSize().Width+padding, size.Height-topSize.Height-bottomSize.Height)
 	}
 	if b.right != nil && b.right.Visible() {
 		b.right.Resize(fyne.NewSize(b.right.MinSize().Width, size.Height-topSize.Height-bottomSize.Height))
 		b.right.Move(fyne.NewPos(size.Width-b.right.MinSize().Width, topSize.Height))
-		rightSize = fyne.NewSize(b.right.MinSize().Width+theme.Padding(), size.Height-topSize.Height-bottomSize.Height)
+		rightSize = fyne.NewSize(b.right.MinSize().Width+padding, size.Height-topSize.Height-bottomSize.Height)
 	}
 
 	middleSize := fyne.NewSize(size.Width-leftSize.Width-rightSize.Width, size.Height-topSize.Height-bottomSize.Height)
@@ -75,22 +76,24 @@ func (b *borderLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 	}
 
+	padding := theme.Padding()
+
 	if b.left != nil && b.left.Visible() {
 		minHeight := fyne.Max(minSize.Height, b.left.MinSize().Height)
-		minSize = fyne.NewSize(minSize.Width+b.left.MinSize().Width+theme.Padding(), minHeight)
+		minSize = fyne.NewSize(minSize.Width+b.left.MinSize().Width+padding, minHeight)
 	}
 	if b.right != nil && b.right.Visible() {
 		minHeight := fyne.Max(minSize.Height, b.right.MinSize().Height)
-		minSize = fyne.NewSize(minSize.Width+b.right.MinSize().Width+theme.Padding(), minHeight)
+		minSize = fyne.NewSize(minSize.Width+b.right.MinSize().Width+padding, minHeight)
 	}
 
 	if b.top != nil && b.top.Visible() {
 		minWidth := fyne.Max(minSize.Width, b.top.MinSize().Width)
-		minSize = fyne.NewSize(minWidth, minSize.Height+b.top.MinSize().Height+theme.Padding())
+		minSize = fyne.NewSize(minWidth, minSize.Height+b.top.MinSize().Height+padding)
 	}
 	if b.bottom != nil && b.bottom.Visible() {
 		minWidth := fyne.Max(minSize.Width, b.bottom.MinSize().Width)
-		minSize = fyne.NewSize(minWidth, minSize.Height+b.bottom.MinSize().Height+theme.Padding())
+		minSize = fyne.NewSize(minWidth, minSize.Height+b.bottom.MinSize().Height+padding)
 	}
 
 	return minSize

--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -26,24 +26,28 @@ func (b *borderLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	padding := theme.Padding()
 	var topSize, bottomSize, leftSize, rightSize fyne.Size
 	if b.top != nil && b.top.Visible() {
-		b.top.Resize(fyne.NewSize(size.Width, b.top.MinSize().Height))
+		topHeight := b.top.MinSize().Height
+		b.top.Resize(fyne.NewSize(size.Width, topHeight))
 		b.top.Move(fyne.NewPos(0, 0))
-		topSize = fyne.NewSize(size.Width, b.top.MinSize().Height+padding)
+		topSize = fyne.NewSize(size.Width, topHeight+padding)
 	}
 	if b.bottom != nil && b.bottom.Visible() {
-		b.bottom.Resize(fyne.NewSize(size.Width, b.bottom.MinSize().Height))
-		b.bottom.Move(fyne.NewPos(0, size.Height-b.bottom.MinSize().Height))
-		bottomSize = fyne.NewSize(size.Width, b.bottom.MinSize().Height+padding)
+		bottomHeight := b.bottom.MinSize().Height
+		b.bottom.Resize(fyne.NewSize(size.Width, bottomHeight))
+		b.bottom.Move(fyne.NewPos(0, size.Height-bottomHeight))
+		bottomSize = fyne.NewSize(size.Width, bottomHeight+padding)
 	}
 	if b.left != nil && b.left.Visible() {
-		b.left.Resize(fyne.NewSize(b.left.MinSize().Width, size.Height-topSize.Height-bottomSize.Height))
+		leftWidth := b.left.MinSize().Width
+		b.left.Resize(fyne.NewSize(leftWidth, size.Height-topSize.Height-bottomSize.Height))
 		b.left.Move(fyne.NewPos(0, topSize.Height))
-		leftSize = fyne.NewSize(b.left.MinSize().Width+padding, size.Height-topSize.Height-bottomSize.Height)
+		leftSize = fyne.NewSize(leftWidth+padding, size.Height-topSize.Height-bottomSize.Height)
 	}
 	if b.right != nil && b.right.Visible() {
-		b.right.Resize(fyne.NewSize(b.right.MinSize().Width, size.Height-topSize.Height-bottomSize.Height))
-		b.right.Move(fyne.NewPos(size.Width-b.right.MinSize().Width, topSize.Height))
-		rightSize = fyne.NewSize(b.right.MinSize().Width+padding, size.Height-topSize.Height-bottomSize.Height)
+		rightWidth := b.right.MinSize().Width
+		b.right.Resize(fyne.NewSize(rightWidth, size.Height-topSize.Height-bottomSize.Height))
+		b.right.Move(fyne.NewPos(size.Width-rightWidth, topSize.Height))
+		rightSize = fyne.NewSize(rightWidth+padding, size.Height-topSize.Height-bottomSize.Height)
 	}
 
 	middleSize := fyne.NewSize(size.Width-leftSize.Width-rightSize.Width, size.Height-topSize.Height-bottomSize.Height)
@@ -79,21 +83,25 @@ func (b *borderLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	padding := theme.Padding()
 
 	if b.left != nil && b.left.Visible() {
-		minHeight := fyne.Max(minSize.Height, b.left.MinSize().Height)
-		minSize = fyne.NewSize(minSize.Width+b.left.MinSize().Width+padding, minHeight)
+		leftMin := b.left.MinSize()
+		minHeight := fyne.Max(minSize.Height, leftMin.Height)
+		minSize = fyne.NewSize(minSize.Width+leftMin.Width+padding, minHeight)
 	}
 	if b.right != nil && b.right.Visible() {
-		minHeight := fyne.Max(minSize.Height, b.right.MinSize().Height)
-		minSize = fyne.NewSize(minSize.Width+b.right.MinSize().Width+padding, minHeight)
+		rightMin := b.right.MinSize()
+		minHeight := fyne.Max(minSize.Height, rightMin.Height)
+		minSize = fyne.NewSize(minSize.Width+rightMin.Width+padding, minHeight)
 	}
 
 	if b.top != nil && b.top.Visible() {
-		minWidth := fyne.Max(minSize.Width, b.top.MinSize().Width)
-		minSize = fyne.NewSize(minWidth, minSize.Height+b.top.MinSize().Height+padding)
+		topMin := b.top.MinSize()
+		minWidth := fyne.Max(minSize.Width, topMin.Width)
+		minSize = fyne.NewSize(minWidth, minSize.Height+topMin.Height+padding)
 	}
 	if b.bottom != nil && b.bottom.Visible() {
-		minWidth := fyne.Max(minSize.Width, b.bottom.MinSize().Width)
-		minSize = fyne.NewSize(minWidth, minSize.Height+b.bottom.MinSize().Height+padding)
+		bottomMin := b.bottom.MinSize()
+		minWidth := fyne.Max(minSize.Width, bottomMin.Width)
+		minSize = fyne.NewSize(minWidth, minSize.Height+bottomMin.Height+padding)
 	}
 
 	return minSize

--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -79,12 +79,13 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		}
 	}
 
+	padding := theme.Padding()
 	x, y := float32(0), float32(0)
 	var extra float32
 	if g.horizontal {
-		extra = size.Width - total - (theme.Padding() * float32(len(objects)-spacers-1))
+		extra = size.Width - total - (padding * float32(len(objects)-spacers-1))
 	} else {
-		extra = size.Height - total - (theme.Padding() * float32(len(objects)-spacers-1))
+		extra = size.Height - total - (padding * float32(len(objects)-spacers-1))
 	}
 	extraCell := float32(0)
 	if spacers > 0 {
@@ -110,10 +111,10 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		child.Move(fyne.NewPos(x, y))
 
 		if g.horizontal {
-			x += theme.Padding() + width
+			x += padding + width
 			child.Resize(fyne.NewSize(width, size.Height))
 		} else {
-			y += theme.Padding() + height
+			y += padding + height
 			child.Resize(fyne.NewSize(size.Width, height))
 		}
 	}
@@ -125,6 +126,7 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 func (g *boxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	minSize := fyne.NewSize(0, 0)
 	addPadding := false
+	padding := theme.Padding()
 	for _, child := range objects {
 		if !child.Visible() {
 			continue
@@ -138,13 +140,13 @@ func (g *boxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			minSize.Height = fyne.Max(child.MinSize().Height, minSize.Height)
 			minSize.Width += child.MinSize().Width
 			if addPadding {
-				minSize.Width += theme.Padding()
+				minSize.Width += padding
 			}
 		} else {
 			minSize.Width = fyne.Max(child.MinSize().Width, minSize.Width)
 			minSize.Height += child.MinSize().Height
 			if addPadding {
-				minSize.Height += theme.Padding()
+				minSize.Height += padding
 			}
 		}
 		addPadding = true

--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -97,9 +97,6 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 			continue
 		}
 
-		width := child.MinSize().Width
-		height := child.MinSize().Height
-
 		if g.isSpacer(child) {
 			if g.horizontal {
 				x += extraCell
@@ -111,9 +108,11 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		child.Move(fyne.NewPos(x, y))
 
 		if g.horizontal {
+			width := child.MinSize().Width
 			x += padding + width
 			child.Resize(fyne.NewSize(width, size.Height))
 		} else {
+			height := child.MinSize().Height
 			y += padding + height
 			child.Resize(fyne.NewSize(size.Width, height))
 		}
@@ -136,15 +135,16 @@ func (g *boxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			continue
 		}
 
+		childMin := child.MinSize()
 		if g.horizontal {
-			minSize.Height = fyne.Max(child.MinSize().Height, minSize.Height)
-			minSize.Width += child.MinSize().Width
+			minSize.Height = fyne.Max(childMin.Height, minSize.Height)
+			minSize.Width += childMin.Width
 			if addPadding {
 				minSize.Width += padding
 			}
 		} else {
-			minSize.Width = fyne.Max(child.MinSize().Width, minSize.Width)
-			minSize.Height += child.MinSize().Height
+			minSize.Width = fyne.Max(childMin.Width, minSize.Width)
+			minSize.Height += childMin.Height
 			if addPadding {
 				minSize.Height += padding
 			}

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -41,6 +41,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 		return table
 	}
 
+	padding := theme.Padding()
 	lowBound := 0
 	highBound := 2
 	labelCellMaxWidth := float32(0)
@@ -55,7 +56,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 
 		labelCell := currentRow[0].MinSize()
 		if _, ok := currentRow[0].(*canvas.Text); ok {
-			labelCell.Width += theme.Padding() * 4
+			labelCell.Width += padding * 4
 		}
 		labelCellMaxWidth = fyne.Max(labelCellMaxWidth, labelCell.Width)
 
@@ -72,7 +73,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 		row++
 	}
 
-	contentWidth := fyne.Max(contentCellMaxWidth, containerWidth-labelCellMaxWidth-theme.Padding())
+	contentWidth := fyne.Max(contentCellMaxWidth, containerWidth-labelCellMaxWidth-padding)
 	for row := 0; row < rows; row++ {
 		table[row][0].Width = labelCellMaxWidth
 		table[row][1].Width = contentWidth
@@ -85,6 +86,9 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	table := f.tableCellsSize(objects, size.Width)
 
+	padding := theme.Padding()
+	innerPadding := theme.InnerPadding()
+
 	row := 0
 	y := float32(0)
 	for i := 0; i < len(objects); i += formLayoutCols {
@@ -92,20 +96,20 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 			continue
 		}
 		if row > 0 {
-			y += table[row-1][0].Height + theme.Padding()
+			y += table[row-1][0].Height + padding
 		}
 
 		tableRow := table[row]
 		if _, ok := objects[i].(*canvas.Text); ok {
-			objects[i].Move(fyne.NewPos(theme.InnerPadding(), y+theme.InnerPadding()))
-			objects[i].Resize(fyne.NewSize(tableRow[0].Width-theme.InnerPadding()*2, objects[i].MinSize().Height))
+			objects[i].Move(fyne.NewPos(innerPadding, y+innerPadding))
+			objects[i].Resize(fyne.NewSize(tableRow[0].Width-innerPadding*2, objects[i].MinSize().Height))
 		} else {
 			objects[i].Move(fyne.NewPos(0, y))
 			objects[i].Resize(fyne.NewSize(tableRow[0].Width, tableRow[0].Height))
 		}
 
 		if i+1 < len(objects) {
-			objects[i+1].Move(fyne.NewPos(theme.Padding()+tableRow[0].Width, y))
+			objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width, y))
 			objects[i+1].Resize(fyne.NewSize(tableRow[1].Width, tableRow[0].Height))
 		}
 		row++
@@ -116,9 +120,9 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 // For a FormLayout this is the width of the widest label and content items and the height is
 // the sum of all column children combined with padding between each.
 func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
-
 	table := f.tableCellsSize(objects, 0)
 
+	padding := theme.Padding()
 	minSize := fyne.NewSize(0, 0)
 
 	if len(table) == 0 {
@@ -126,11 +130,11 @@ func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	}
 
 	added := false
-	minSize.Width = table[0][0].Width + table[0][1].Width + theme.Padding()
+	minSize.Width = table[0][0].Width + table[0][1].Width + padding
 	for row := 0; row < len(table); row++ {
 		minSize.Height += table[row][0].Height
 		if added {
-			minSize.Height += theme.Padding()
+			minSize.Height += padding
 		}
 		added = true
 	}

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -78,8 +78,9 @@ func getTrailing(size float64, offset int) float32 {
 func (g *gridLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	rows := g.countRows(objects)
 
-	padWidth := float32(g.Cols-1) * theme.Padding()
-	padHeight := float32(rows-1) * theme.Padding()
+	padding := theme.Padding()
+	padWidth := float32(g.Cols-1) * padding
+	padHeight := float32(rows-1) * padding
 	cellWidth := float64(size.Width-padWidth) / float64(g.Cols)
 	cellHeight := float64(size.Height-padHeight) / float64(rows)
 

--- a/layout/gridwraplayout.go
+++ b/layout/gridwraplayout.go
@@ -25,11 +25,12 @@ func NewGridWrapLayout(size fyne.Size) fyne.Layout {
 // For a GridWrapLayout this will attempt to lay all the child objects in a row
 // and wrap to a new row if the size is not large enough.
 func (g *gridWrapLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	padding := theme.Padding()
 	g.colCount = 1
 	g.rowCount = 0
 
 	if size.Width > g.CellSize.Width {
-		g.colCount = int(math.Floor(float64(size.Width+theme.Padding()) / float64(g.CellSize.Width+theme.Padding())))
+		g.colCount = int(math.Floor(float64(size.Width+padding) / float64(g.CellSize.Width+padding)))
 	}
 
 	i, x, y := 0, float32(0), float32(0)
@@ -47,9 +48,9 @@ func (g *gridWrapLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 		if (i+1)%g.colCount == 0 {
 			x = 0
-			y += g.CellSize.Height + theme.Padding()
+			y += g.CellSize.Height + padding
 		} else {
-			x += g.CellSize.Width + theme.Padding()
+			x += g.CellSize.Width + padding
 		}
 		i++
 	}

--- a/layout/paddedlayout.go
+++ b/layout/paddedlayout.go
@@ -14,8 +14,9 @@ type paddedLayout struct {
 // Layout is called to pack all child objects into a specified size.
 // For PaddedLayout this sets all children to the full size passed minus padding all around.
 func (l *paddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	pos := fyne.NewPos(theme.Padding(), theme.Padding())
-	siz := fyne.NewSize(size.Width-2*theme.Padding(), size.Height-2*theme.Padding())
+	padding := theme.Padding()
+	pos := fyne.NewPos(padding, padding)
+	siz := fyne.NewSize(size.Width-2*padding, size.Height-2*padding)
 	for _, child := range objects {
 		child.Resize(siz)
 		child.Move(pos)
@@ -32,7 +33,8 @@ func (l *paddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
 
 		min = min.Max(child.MinSize())
 	}
-	min = min.Add(fyne.NewSize(2*theme.Padding(), 2*theme.Padding()))
+	padding := theme.Padding()
+	min = min.Add(fyne.NewSize(2*padding, 2*padding))
 	return
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Some of the optimizations that @Bluebugs did for the collection widgets removed many calls to the relatively slow theme lookups. This PR applies this to layouts as well. On top of that, it also makes sure that we do not call `MinSize()` on child objects many times because we don't necessarily know how fast they will be (and function calls are generally slow etc.).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.