### PR TITLE
dialog: Fix padding to the left of favorite directory icon

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -206,10 +206,10 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 			return len(f.favorites)
 		},
 		func() fyne.CanvasObject {
-			return container.NewHBox(widget.NewIcon(theme.DocumentIcon()), widget.NewLabel("Template Object"))
+			return container.NewHBox(container.New(&iconPaddingLayout{}, widget.NewIcon(theme.DocumentIcon())), widget.NewLabel("Template Object"))
 		},
 		func(id widget.ListItemID, item fyne.CanvasObject) {
-			item.(*fyne.Container).Objects[0].(*widget.Icon).SetResource(f.favorites[id].locIcon)
+			item.(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Icon).SetResource(f.favorites[id].locIcon)
 			item.(*fyne.Container).Objects[1].(*widget.Label).SetText(f.favorites[id].locName)
 		},
 	)
@@ -788,4 +788,19 @@ func hasAppFiles(a fyne.App) bool {
 func storageURI(a fyne.App) fyne.URI {
 	dir, _ := storage.Child(a.Storage().RootURI(), "Documents")
 	return dir
+}
+
+// iconPaddingLayout adds padding to the left of a widget.Icon().
+// NOTE: It assumes that the slice only contains one item.
+type iconPaddingLayout struct {
+}
+
+func (i *iconPaddingLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	padding := theme.Padding()
+	objects[0].Move(fyne.NewPos(padding, 0))
+	objects[0].Resize(size.SubtractWidthHeight(padding, 0))
+}
+
+func (i *iconPaddingLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	return objects[0].MinSize().AddWidthHeight(theme.Padding(), 0)
 }

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -796,11 +796,11 @@ type iconPaddingLayout struct {
 }
 
 func (i *iconPaddingLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	padding := theme.Padding()
+	padding := theme.Padding() * 2
 	objects[0].Move(fyne.NewPos(padding, 0))
 	objects[0].Resize(size.SubtractWidthHeight(padding, 0))
 }
 
 func (i *iconPaddingLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
-	return objects[0].MinSize().AddWidthHeight(theme.Padding(), 0)
+	return objects[0].MinSize().AddWidthHeight(theme.Padding()*2, 0)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The icon was way too close to the edge and needed some padding on the left side.
Is there a cleaner way to achieve this? Adding a custom layout for this seems annoying but it is what I did.

### Before:
![image](https://github.com/fyne-io/fyne/assets/25466657/0d4655ea-8481-471d-805c-805664fa1e17)


### After:
![image](https://github.com/fyne-io/fyne/assets/25466657/ea59a4ac-ff91-4d77-9640-cb540cabee33)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
