### PR TITLE
Fix bugs with appTabs render

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -279,7 +279,7 @@ func (r *appTabsRenderer) Layout(size fyne.Size) {
 	// Try render as many tabs as will fit, others will appear in the overflow
 	if len(r.appTabs.Items) == 0 {
 		r.updateTabs(0)
-	}else {
+	} else {
 		for i := len(r.appTabs.Items); i > 0; i-- {
 			r.updateTabs(i)
 			barMin := r.bar.MinSize()
@@ -396,7 +396,7 @@ func (r *appTabsRenderer) updateIndicator(animate bool) {
 		r.divider.Hide()
 		r.indicator.Hide()
 		return
-	}else {
+	} else {
 		r.divider.Show()
 		r.indicator.Show()
 	}

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -277,18 +277,22 @@ type appTabsRenderer struct {
 
 func (r *appTabsRenderer) Layout(size fyne.Size) {
 	// Try render as many tabs as will fit, others will appear in the overflow
-	for i := len(r.appTabs.Items); i >= 0; i-- {
-		r.updateTabs(i)
-		barMin := r.bar.MinSize()
-		if r.appTabs.location == TabLocationLeading || r.appTabs.location == TabLocationTrailing {
-			if barMin.Height <= size.Height {
-				// Tab bar is short enough to fit
-				break
-			}
-		} else {
-			if barMin.Width <= size.Width {
-				// Tab bar is thin enough to fit
-				break
+	if len(r.appTabs.Items) == 0 {
+		r.updateTabs(0)
+	}else {
+		for i := len(r.appTabs.Items); i > 0; i-- {
+			r.updateTabs(i)
+			barMin := r.bar.MinSize()
+			if r.appTabs.location == TabLocationLeading || r.appTabs.location == TabLocationTrailing {
+				if barMin.Height <= size.Height {
+					// Tab bar is short enough to fit
+					break
+				}
+			} else {
+				if barMin.Width <= size.Width {
+					// Tab bar is thin enough to fit
+					break
+				}
 			}
 		}
 	}

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -393,12 +393,8 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 
 func (r *appTabsRenderer) updateIndicator(animate bool) {
 	if r.appTabs.current < 0 {
-		r.divider.Hide()
 		r.indicator.Hide()
 		return
-	} else {
-		r.divider.Show()
-		r.indicator.Show()
 	}
 
 	var selectedPos fyne.Position

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -277,7 +277,7 @@ type appTabsRenderer struct {
 
 func (r *appTabsRenderer) Layout(size fyne.Size) {
 	// Try render as many tabs as will fit, others will appear in the overflow
-	for i := len(r.appTabs.Items); i > 0; i-- {
+	for i := len(r.appTabs.Items); i >= 0; i-- {
 		r.updateTabs(i)
 		barMin := r.bar.MinSize()
 		if r.appTabs.location == TabLocationLeading || r.appTabs.location == TabLocationTrailing {
@@ -389,8 +389,12 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 
 func (r *appTabsRenderer) updateIndicator(animate bool) {
 	if r.appTabs.current < 0 {
+		r.divider.Hide()
 		r.indicator.Hide()
 		return
+	}else {
+		r.divider.Show()
+		r.indicator.Show()
 	}
 
 	var selectedPos fyne.Position

--- a/container/apptabs_internal_test.go
+++ b/container/apptabs_internal_test.go
@@ -13,6 +13,9 @@ import (
 func TestAppTabs_tabButtonRenderer_SetText(t *testing.T) {
 	item := &TabItem{Text: "Test", Content: widget.NewLabel("Content")}
 	tabs := NewAppTabs(item)
+	// bug report #3980 : buttons will be rendered while already empty tabs. after fixed it, there has another logic that
+	// buttons will not be rendered while there has not enough space, so we add a resize logic here to make it render the button.
+	tabs.Resize(fyne.NewSize(300,200))
 	tabRenderer := cache.Renderer(tabs).(*appTabsRenderer)
 	button := tabRenderer.bar.Objects[0].(*fyne.Container).Objects[0].(*tabButton)
 	renderer := cache.Renderer(button).(*tabButtonRenderer)

--- a/container/apptabs_internal_test.go
+++ b/container/apptabs_internal_test.go
@@ -53,7 +53,7 @@ func Test_tabButtonRenderer_EmptyDeleteAdd(t *testing.T) {
 	tabs := NewAppTabs()
 
 	//cause tab button was build with enough space, without enough space, btns will not created.
-	tabs.Resize(fyne.NewSize(300,200))
+	tabs.Resize(fyne.NewSize(300, 200))
 
 	tabRenderer := cache.Renderer(tabs).(*appTabsRenderer)
 	indicator := tabRenderer.indicator

--- a/container/apptabs_internal_test.go
+++ b/container/apptabs_internal_test.go
@@ -52,7 +52,7 @@ func Test_tabButtonRenderer_EmptyDeleteAdd(t *testing.T) {
 	item1 := &TabItem{Text: "Test", Content: widget.NewLabel("Content")}
 	tabs := NewAppTabs()
 
-	//cause tab button was build with enough space, without enough space, btns will not created.
+	// ensure enough space for buttons to be created.
 	tabs.Resize(fyne.NewSize(300, 200))
 
 	tabRenderer := cache.Renderer(tabs).(*appTabsRenderer)

--- a/container/apptabs_internal_test.go
+++ b/container/apptabs_internal_test.go
@@ -13,9 +13,6 @@ import (
 func TestAppTabs_tabButtonRenderer_SetText(t *testing.T) {
 	item := &TabItem{Text: "Test", Content: widget.NewLabel("Content")}
 	tabs := NewAppTabs(item)
-	// bug report #3980 : buttons will be rendered while already empty tabs. after fixed it, there has another logic that
-	// buttons will not be rendered while there has not enough space, so we add a resize logic here to make it render the button.
-	tabs.Resize(fyne.NewSize(300,200))
 	tabRenderer := cache.Renderer(tabs).(*appTabsRenderer)
 	button := tabRenderer.bar.Objects[0].(*fyne.Container).Objects[0].(*tabButton)
 	renderer := cache.Renderer(button).(*tabButtonRenderer)

--- a/container/apptabs_internal_test.go
+++ b/container/apptabs_internal_test.go
@@ -56,19 +56,11 @@ func Test_tabButtonRenderer_EmptyDeleteAdd(t *testing.T) {
 	tabs.Resize(fyne.NewSize(300, 200))
 
 	tabRenderer := cache.Renderer(tabs).(*appTabsRenderer)
-	indicator := tabRenderer.indicator
-	divider := tabRenderer.divider
 	assert.Equal(t, 0, len(tabRenderer.bar.Objects[0].(*fyne.Container).Objects))
-	assert.Equal(t, true, indicator.Hidden)
-	assert.Equal(t, true, divider.Hidden)
 
 	tabs.Append(item1)
 	assert.Equal(t, 1, len(tabRenderer.bar.Objects[0].(*fyne.Container).Objects))
-	assert.Equal(t, false, indicator.Hidden)
-	assert.Equal(t, false, divider.Hidden)
 
 	tabs.Remove(item1)
 	assert.Equal(t, 0, len(tabRenderer.bar.Objects[0].(*fyne.Container).Objects))
-	assert.Equal(t, true, indicator.Hidden)
-	assert.Equal(t, true, divider.Hidden)
 }

--- a/container/apptabs_internal_test.go
+++ b/container/apptabs_internal_test.go
@@ -47,3 +47,28 @@ func Test_tabButtonRenderer_DeleteAdd(t *testing.T) {
 	tabs.SelectTab(item2)
 	assert.Equal(t, pos, indicator.Position())
 }
+
+func Test_tabButtonRenderer_EmptyDeleteAdd(t *testing.T) {
+	item1 := &TabItem{Text: "Test", Content: widget.NewLabel("Content")}
+	tabs := NewAppTabs()
+
+	//cause tab button was build with enough space, without enough space, btns will not created.
+	tabs.Resize(fyne.NewSize(300,200))
+
+	tabRenderer := cache.Renderer(tabs).(*appTabsRenderer)
+	indicator := tabRenderer.indicator
+	divider := tabRenderer.divider
+	assert.Equal(t, 0, len(tabRenderer.bar.Objects[0].(*fyne.Container).Objects))
+	assert.Equal(t, true, indicator.Hidden)
+	assert.Equal(t, true, divider.Hidden)
+
+	tabs.Append(item1)
+	assert.Equal(t, 1, len(tabRenderer.bar.Objects[0].(*fyne.Container).Objects))
+	assert.Equal(t, false, indicator.Hidden)
+	assert.Equal(t, false, divider.Hidden)
+
+	tabs.Remove(item1)
+	assert.Equal(t, 0, len(tabRenderer.bar.Objects[0].(*fyne.Container).Objects))
+	assert.Equal(t, true, indicator.Hidden)
+	assert.Equal(t, true, divider.Hidden)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #3980

I also fix the appTabs indicator and seperator line does not show properly.

you can compare with this demo code : 
```go
func main() {
	a := app.New()
	w := a.NewWindow("Hello")

	closeTab1Btn := widget.NewButton("Close Tab1", nil)
	tab := container.NewAppTabs(
		container.NewTabItem("Tab 1", container.NewVBox(widget.NewLabel("Content of tab 1"),
			closeTab1Btn)),
	)
	closeTab1Btn.OnTapped = func() {
		tab.RemoveIndex(0)
	}

	left := container.NewVBox(widget.NewButton("Add", func() {
		btn := widget.NewButton("Close", nil)

		item := container.NewTabItem(fmt.Sprint(rand.Int()),btn)

		btn.OnTapped = func() {
			tab.Remove(item)
		}
		tab.Append(item)
	}))

	split := container.NewHSplit(left, tab)
	split.Offset = 0.2

	w.SetContent(split)
	w.Resize(fyne.NewSize(640,480))
	w.ShowAndRun()
}
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
