### PR TITLE
Avoid expensive GetError() calls on non-debug builds

### DIFF
--- a/internal/painter/gl/gl.go
+++ b/internal/painter/gl/gl.go
@@ -12,11 +12,16 @@ import (
 const floatSize = 4
 const max16bit = float32(255 * 255)
 
-func logGLError(err uint32) {
+// logGLError logs error in the GL renderer.
+//
+// Receives a function as parameter, to lazily get the error code only when
+// needed, avoiding unneeded overhead.
+func logGLError(getError func() uint32) {
 	if fyne.CurrentApp().Settings().BuildType() != fyne.BuildDebug {
 		return
 	}
 
+	err := getError()
 	if err == 0 {
 		return
 	}

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -188,5 +188,5 @@ func (p *painter) createProgram(shaderFilename string) Program {
 }
 
 func (p *painter) logError() {
-	logGLError(p.ctx.GetError())
+	logGLError(p.ctx.GetError)
 }


### PR DESCRIPTION
### Description:
Calling `p.ctx.GetError()` is relatively expensive, and can be entirely avoided when running non-debug builds, as the `logGLError` function only evaluates the received error code on debug builds.

This has been profiled using the demo app, just by opening the "Folder Open" dialog and scrolling to force rerenders.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.