### PR TITLE
Add helpers for square size and offset position

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -42,8 +42,8 @@ func NewPos(x float32, y float32) Position {
 	return Position{x, y}
 }
 
-// NewSquarePos returns a newly allocated Position with the same x and y position.
-func NewSquarePos(length float32) Position {
+// NewSquareOffsetPos returns a newly allocated Position with the same x and y position.
+func NewSquareOffsetPos(length float32) Position {
 	return Position{length, length}
 }
 

--- a/geometry.go
+++ b/geometry.go
@@ -42,6 +42,11 @@ func NewPos(x float32, y float32) Position {
 	return Position{x, y}
 }
 
+// NewSquarePos returns a newly allocated Position with the same x and y position.
+func NewSquarePos(length float32) Position {
+	return Position{length, length}
+}
+
 // Add returns a new Position that is the result of offsetting the current
 // position by p2 X and Y.
 func (p Position) Add(v Vector2) Position {
@@ -85,6 +90,11 @@ type Size struct {
 // NewSize returns a newly allocated Size of the specified dimensions.
 func NewSize(w float32, h float32) Size {
 	return Size{w, h}
+}
+
+// NewSquareSize returns a newly allocated Size with the same width and height.
+func NewSquareSize(side float32) Size {
+	return Size{side, side}
 }
 
 // Add returns a new Size that is the result of increasing the current size by

--- a/geometry.go
+++ b/geometry.go
@@ -43,6 +43,8 @@ func NewPos(x float32, y float32) Position {
 }
 
 // NewSquareOffsetPos returns a newly allocated Position with the same x and y position.
+//
+// Since: 2.4
 func NewSquareOffsetPos(length float32) Position {
 	return Position{length, length}
 }
@@ -93,6 +95,8 @@ func NewSize(w float32, h float32) Size {
 }
 
 // NewSquareSize returns a newly allocated Size with the same width and height.
+//
+// Since: 2.4
 func NewSquareSize(side float32) Size {
 	return Size{side, side}
 }

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewSquarePosition(t *testing.T) {
-	pos := fyne.NewSquarePos(10)
+func TestNewSquareOffsetPosition(t *testing.T) {
+	pos := fyne.NewSquareOffsetPos(10)
 	assert.Equal(t, pos.X, pos.Y)
 }
 

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -7,6 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewSquarePosition(t *testing.T) {
+	pos := fyne.NewSquarePos(10)
+	assert.Equal(t, pos.X, pos.Y)
+}
+
 func TestPosition_Add(t *testing.T) {
 	pos1 := fyne.NewPos(10, 10)
 	pos2 := fyne.NewPos(25, 25)
@@ -175,6 +180,11 @@ func TestSize_SubtractWidthHeight(t *testing.T) {
 
 	assert.Equal(t, float32(15), size2.Width)
 	assert.Equal(t, float32(15), size2.Height)
+}
+
+func TestSquareSize(t *testing.T) {
+	size := fyne.NewSquareSize(10)
+	assert.Equal(t, size.Height, size.Width)
 }
 
 func TestVector_IsZero(t *testing.T) {

--- a/layout/paddedlayout.go
+++ b/layout/paddedlayout.go
@@ -33,8 +33,7 @@ func (l *paddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
 
 		min = min.Max(child.MinSize())
 	}
-	padding := theme.Padding()
-	min = min.Add(fyne.NewSize(2*padding, 2*padding))
+	min = min.Add(fyne.NewSquareSize(2 * theme.Padding()))
 	return
 }
 

--- a/widget/button.go
+++ b/widget/button.go
@@ -110,7 +110,7 @@ func (b *Button) CreateRenderer() fyne.WidgetRenderer {
 	seg := &TextSegment{Text: b.Text, Style: RichTextStyleStrong}
 	seg.Style.Alignment = fyne.TextAlignCenter
 	text := NewRichText(seg)
-	text.inset = fyne.NewSize(theme.InnerPadding(), theme.InnerPadding())
+	text.inset = fyne.NewSquareSize(theme.InnerPadding())
 
 	b.background = canvas.NewRectangle(theme.ButtonColor())
 	b.background.CornerRadius = theme.InputRadiusSize()
@@ -299,7 +299,7 @@ func (r *buttonRenderer) Layout(size fyne.Size) {
 		// Nothing to layout
 		return
 	}
-	iconSize := fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
+	iconSize := fyne.NewSquareSize(theme.IconInlineSize())
 	labelSize := r.label.MinSize()
 	padding := r.padding()
 	if hasLabel {
@@ -336,7 +336,7 @@ func (r *buttonRenderer) Layout(size fyne.Size) {
 func (r *buttonRenderer) MinSize() (size fyne.Size) {
 	hasIcon := r.icon != nil
 	hasLabel := r.label.Segments[0].(*TextSegment).Text != ""
-	iconSize := fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
+	iconSize := fyne.NewSquareSize(theme.IconInlineSize())
 	labelSize := r.label.MinSize()
 	if hasLabel {
 		size.Width = labelSize.Width
@@ -394,7 +394,7 @@ func (r *buttonRenderer) applyTheme() {
 }
 
 func (r *buttonRenderer) padding() fyne.Size {
-	return fyne.NewSize(theme.InnerPadding()*2, theme.InnerPadding()*2)
+	return fyne.NewSquareSize(theme.InnerPadding() * 2)
 }
 
 func (r *buttonRenderer) updateIconAndText() {

--- a/widget/card.go
+++ b/widget/card.go
@@ -101,7 +101,7 @@ const (
 // Layout the components of the card container.
 func (c *cardRenderer) Layout(size fyne.Size) {
 	padding := theme.Padding()
-	pos := fyne.NewSquarePos(padding / 2)
+	pos := fyne.NewSquareOffsetPos(padding / 2)
 	size = size.Subtract(fyne.NewSquareSize(padding))
 	c.LayoutShadow(size, pos)
 

--- a/widget/card.go
+++ b/widget/card.go
@@ -37,7 +37,7 @@ func (c *Card) CreateRenderer() fyne.WidgetRenderer {
 
 	header := canvas.NewText(c.Title, theme.ForegroundColor())
 	header.TextStyle.Bold = true
-	subHeader := canvas.NewText(c.Subtitle, theme.ForegroundColor())
+	subHeader := canvas.NewText(c.Subtitle, header.Color)
 
 	objects := []fyne.CanvasObject{header, subHeader}
 	if c.Image != nil {
@@ -100,8 +100,9 @@ const (
 
 // Layout the components of the card container.
 func (c *cardRenderer) Layout(size fyne.Size) {
-	pos := fyne.NewPos(theme.Padding()/2, theme.Padding()/2)
-	size = size.Subtract(fyne.NewSize(theme.Padding(), theme.Padding()))
+	padding := theme.Padding()
+	pos := fyne.NewSquarePos(padding / 2)
+	size = size.Subtract(fyne.NewSquareSize(padding))
 	c.LayoutShadow(size, pos)
 
 	if c.card.Image != nil {
@@ -110,9 +111,8 @@ func (c *cardRenderer) Layout(size fyne.Size) {
 		pos.Y += cardMediaHeight
 	}
 
-	contentPad := theme.Padding()
 	if c.card.Title != "" || c.card.Subtitle != "" {
-		titlePad := theme.Padding() * 2
+		titlePad := padding * 2
 		size.Width -= titlePad * 2
 		pos.X += titlePad
 		pos.Y += titlePad
@@ -121,14 +121,14 @@ func (c *cardRenderer) Layout(size fyne.Size) {
 			height := c.header.MinSize().Height
 			c.header.Move(pos)
 			c.header.Resize(fyne.NewSize(size.Width, height))
-			pos.Y += height + theme.Padding()
+			pos.Y += height + padding
 		}
 
 		if c.card.Subtitle != "" {
 			height := c.subHeader.MinSize().Height
 			c.subHeader.Move(pos)
 			c.subHeader.Resize(fyne.NewSize(size.Width, height))
-			pos.Y += height + theme.Padding()
+			pos.Y += height + padding
 		}
 
 		size.Width = size.Width + titlePad*2
@@ -136,15 +136,15 @@ func (c *cardRenderer) Layout(size fyne.Size) {
 		pos.Y += titlePad
 	}
 
-	size.Width -= contentPad * 2
-	pos.X += contentPad
+	size.Width -= padding * 2
+	pos.X += padding
 	if c.card.Content != nil {
-		height := size.Height - contentPad*2 - (pos.Y - theme.Padding()/2) // adjust for content and initial offset
+		height := size.Height - padding*2 - (pos.Y - padding/2) // adjust for content and initial offset
 		if c.card.Title != "" || c.card.Subtitle != "" {
-			height += contentPad
-			pos.Y -= contentPad
+			height += padding
+			pos.Y -= padding
 		}
-		c.card.Content.Move(pos.Add(fyne.NewPos(0, contentPad)))
+		c.card.Content.Move(pos.Add(fyne.NewPos(0, padding)))
 		c.card.Content.Resize(fyne.NewSize(size.Width, height))
 	}
 }
@@ -157,41 +157,41 @@ func (c *cardRenderer) MinSize() fyne.Size {
 	hasImage := c.card.Image != nil
 	hasContent := c.card.Content != nil
 
+	padding := theme.Padding()
 	if !hasHeader && !hasSubHeader && !hasContent { // just image, or nothing
 		if c.card.Image == nil {
-			return fyne.NewSize(theme.Padding(), theme.Padding()) // empty, just space for border
+			return fyne.NewSize(padding, padding) // empty, just space for border
 		}
-		return fyne.NewSize(c.card.Image.MinSize().Width+theme.Padding(), cardMediaHeight+theme.Padding())
+		return fyne.NewSize(c.card.Image.MinSize().Width+padding, cardMediaHeight+padding)
 	}
 
-	contentPad := theme.Padding()
-	min := fyne.NewSize(theme.Padding(), theme.Padding())
+	min := fyne.NewSize(padding, padding)
 	if hasImage {
 		min = fyne.NewSize(min.Width, min.Height+cardMediaHeight)
 	}
 
 	if hasHeader || hasSubHeader {
-		titlePad := theme.Padding() * 2
+		titlePad := padding * 2
 		min = min.Add(fyne.NewSize(0, titlePad*2))
 		if hasHeader {
 			headerMin := c.header.MinSize()
-			min = fyne.NewSize(fyne.Max(min.Width, headerMin.Width+titlePad*2+theme.Padding()),
+			min = fyne.NewSize(fyne.Max(min.Width, headerMin.Width+titlePad*2+padding),
 				min.Height+headerMin.Height)
 			if hasSubHeader {
-				min.Height += theme.Padding()
+				min.Height += padding
 			}
 		}
 		if hasSubHeader {
 			subHeaderMin := c.subHeader.MinSize()
-			min = fyne.NewSize(fyne.Max(min.Width, subHeaderMin.Width+titlePad*2+theme.Padding()),
+			min = fyne.NewSize(fyne.Max(min.Width, subHeaderMin.Width+titlePad*2+padding),
 				min.Height+subHeaderMin.Height)
 		}
 	}
 
 	if hasContent {
 		contentMin := c.card.Content.MinSize()
-		min = fyne.NewSize(fyne.Max(min.Width, contentMin.Width+contentPad*2+theme.Padding()),
-			min.Height+contentMin.Height+contentPad*2)
+		min = fyne.NewSize(fyne.Max(min.Width, contentMin.Width+padding*3),
+			min.Height+contentMin.Height+padding*2)
 	}
 
 	return min

--- a/widget/check.go
+++ b/widget/check.go
@@ -34,7 +34,7 @@ func (c *checkRenderer) MinSize() fyne.Size {
 
 // Layout the components of the check widget
 func (c *checkRenderer) Layout(size fyne.Size) {
-	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.InnerPadding(), theme.IconInlineSize()+theme.InnerPadding())
+	focusIndicatorSize := fyne.NewSquareSize(theme.IconInlineSize() + theme.InnerPadding())
 	c.focusIndicator.Resize(focusIndicatorSize)
 	c.focusIndicator.Move(fyne.NewPos(theme.InputBorderSize(), (size.Height-focusIndicatorSize.Height)/2))
 
@@ -44,7 +44,7 @@ func (c *checkRenderer) Layout(size fyne.Size) {
 	c.label.Move(fyne.NewPos(xOff, 0))
 
 	iconPos := fyne.NewPos(theme.InnerPadding()/2+theme.InputBorderSize(), (size.Height-theme.IconInlineSize())/2)
-	iconSize := fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
+	iconSize := fyne.NewSquareSize(theme.IconInlineSize())
 	c.bg.Move(iconPos)
 	c.bg.Resize(iconSize)
 	c.icon.Resize(iconSize)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1332,9 +1332,9 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 	// 0.5 is removed so on low DPI it rounds down on the trailing edge
 	r.border.Resize(fyne.NewSize(size.Width-theme.InputBorderSize()-.5, size.Height-theme.InputBorderSize()-.5))
 	r.border.StrokeWidth = theme.InputBorderSize()
-	r.border.Move(fyne.NewSquarePos(theme.InputBorderSize() / 2))
+	r.border.Move(fyne.NewSquareOffsetPos(theme.InputBorderSize() / 2))
 	r.box.Resize(size.Subtract(fyne.NewSquareSize(theme.InputBorderSize() * 2)))
-	r.box.Move(fyne.NewSquarePos(theme.InputBorderSize()))
+	r.box.Move(fyne.NewSquareOffsetPos(theme.InputBorderSize()))
 
 	actionIconSize := fyne.NewSize(0, 0)
 	if r.entry.ActionItem != nil {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1332,13 +1332,13 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 	// 0.5 is removed so on low DPI it rounds down on the trailing edge
 	r.border.Resize(fyne.NewSize(size.Width-theme.InputBorderSize()-.5, size.Height-theme.InputBorderSize()-.5))
 	r.border.StrokeWidth = theme.InputBorderSize()
-	r.border.Move(fyne.NewPos(theme.InputBorderSize()/2, theme.InputBorderSize()/2))
-	r.box.Resize(size.Subtract(fyne.NewSize(theme.InputBorderSize()*2, theme.InputBorderSize()*2)))
-	r.box.Move(fyne.NewPos(theme.InputBorderSize(), theme.InputBorderSize()))
+	r.border.Move(fyne.NewSquarePos(theme.InputBorderSize() / 2))
+	r.box.Resize(size.Subtract(fyne.NewSquareSize(theme.InputBorderSize() * 2)))
+	r.box.Move(fyne.NewSquarePos(theme.InputBorderSize()))
 
 	actionIconSize := fyne.NewSize(0, 0)
 	if r.entry.ActionItem != nil {
-		actionIconSize = fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
+		actionIconSize = fyne.NewSquareSize(theme.IconInlineSize())
 
 		r.entry.ActionItem.Resize(actionIconSize)
 		r.entry.ActionItem.Move(fyne.NewPos(size.Width-actionIconSize.Width-theme.InnerPadding(), theme.InnerPadding()))
@@ -1346,7 +1346,7 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 
 	validatorIconSize := fyne.NewSize(0, 0)
 	if r.entry.Validator != nil {
-		validatorIconSize = fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
+		validatorIconSize = fyne.NewSquareSize(theme.IconInlineSize())
 
 		r.ensureValidationSetup()
 		r.entry.validationStatus.Resize(validatorIconSize)
@@ -1401,7 +1401,7 @@ func (r *entryRenderer) MinSize() fyne.Size {
 	}
 
 	charMin := r.entry.placeholderProvider().charMinSize(r.entry.Password, r.entry.TextStyle)
-	minSize := charMin.Add(fyne.NewSize(theme.InnerPadding(), theme.InnerPadding()))
+	minSize := charMin.Add(fyne.NewSquareSize(theme.InnerPadding()))
 
 	if r.entry.MultiLine {
 		count := r.entry.multiLineRows

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -140,8 +140,7 @@ type fileIconRenderer struct {
 }
 
 func (s *fileIconRenderer) MinSize() fyne.Size {
-	size := theme.IconInlineSize()
-	return fyne.NewSize(size, size)
+	return fyne.NewSquareSize(theme.IconInlineSize())
 }
 
 func (s *fileIconRenderer) Layout(size fyne.Size) {

--- a/widget/icon.go
+++ b/widget/icon.go
@@ -15,8 +15,7 @@ type iconRenderer struct {
 }
 
 func (i *iconRenderer) MinSize() fyne.Size {
-	size := theme.IconInlineSize()
-	return fyne.NewSize(size, size)
+	return fyne.NewSquareSize(theme.IconInlineSize())
 }
 
 func (i *iconRenderer) Layout(size fyne.Size) {

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -158,7 +158,7 @@ type radioItemRenderer struct {
 }
 
 func (r *radioItemRenderer) Layout(size fyne.Size) {
-	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.InnerPadding(), theme.IconInlineSize()+theme.InnerPadding())
+	focusIndicatorSize := fyne.NewSquareSize(theme.IconInlineSize() + theme.InnerPadding())
 	r.focusIndicator.Resize(focusIndicatorSize)
 	r.focusIndicator.Move(fyne.NewPos(theme.InputBorderSize(), (size.Height-focusIndicatorSize.Height)/2))
 
@@ -167,7 +167,7 @@ func (r *radioItemRenderer) Layout(size fyne.Size) {
 	r.label.Move(fyne.NewPos(focusIndicatorSize.Width+theme.Padding(), 0))
 
 	iconPos := fyne.NewPos(theme.InnerPadding()/2+theme.InputBorderSize(), (size.Height-theme.IconInlineSize())/2)
-	iconSize := fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize())
+	iconSize := fyne.NewSquareSize(theme.IconInlineSize())
 	r.icon.Resize(iconSize)
 	r.icon.Move(iconPos)
 	r.over.Resize(iconSize)

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -435,7 +435,7 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 	s.thumb.Move(thumbPos)
 	s.thumb.Resize(fyne.NewSize(diameter, diameter))
 
-	focusIndicatorSize := fyne.NewSize(theme.IconInlineSize()+theme.InnerPadding(), theme.IconInlineSize()+theme.InnerPadding())
+	focusIndicatorSize := fyne.NewSquareSize(theme.IconInlineSize() + theme.InnerPadding())
 	delta := (focusIndicatorSize.Width - diameter) / 2
 	s.focusIndicator.Resize(focusIndicatorSize)
 	s.focusIndicator.Move(thumbPos.SubtractXY(delta, delta))


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I have noticed that it is quite common to create sizes and positions that are "squared", with the same values in both places. This PR introduces helpers for simplifying code to make it less to write and easier to read as there is less information to parse on one line. Another benefit is that it allows there to be less theme lookups without having to cache the value in a variable first (less to write, simpler).

On top of introducing that API, this PR also adapts some existing code to use the new API.   

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
