### PR TITLE
Improve performance on obtaining current theme

### DIFF
--- a/theme/theme.go
+++ b/theme/theme.go
@@ -687,11 +687,16 @@ func (t *builtinTheme) Size(s fyne.ThemeSizeName) float32 {
 }
 
 func current() fyne.Theme {
-	if fyne.CurrentApp() == nil || fyne.CurrentApp().Settings().Theme() == nil {
+	app := fyne.CurrentApp()
+	if app == nil {
+		return DarkTheme()
+	}
+	currentTheme := app.Settings().Theme()
+	if currentTheme == nil {
 		return DarkTheme()
 	}
 
-	return fyne.CurrentApp().Settings().Theme()
+	return currentTheme
 }
 
 func currentVariant() fyne.ThemeVariant {

--- a/theme/theme_benchmark_test.go
+++ b/theme/theme_benchmark_test.go
@@ -1,0 +1,15 @@
+package theme
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+)
+
+func BenchmarkTheme_current(b *testing.B) {
+	fyne.CurrentApp().Settings().SetTheme(LightTheme())
+
+	for n := 0; n < b.N; n++ {
+		current()
+	}
+}


### PR DESCRIPTION
### Description:

The `current()` util is used by many functions in the `theme` package, and can be potentially called many times during normal app navigation.

Benchmark results for this refactor:
```shell
# Before
BenchmarkTheme_current-16       123340401                9.857 ns/op
# After
BenchmarkTheme_current-16       263862091                5.018 ns/op
```

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.