### PR TITLE
dialog: Add .Submit() to form dialog

### DIFF
--- a/dialog/entry.go
+++ b/dialog/entry.go
@@ -9,7 +9,7 @@ import (
 //
 // Deprecated: Use dialog.NewFormDialog() or dialog.ShowFormDialog() with a widget.Entry inside instead.
 type EntryDialog struct {
-	*formDialog
+	*FormDialog
 
 	entry *widget.Entry
 
@@ -49,7 +49,7 @@ func (i *EntryDialog) SetOnClosed(callback func()) {
 func NewEntryDialog(title, message string, onConfirm func(string), parent fyne.Window) *EntryDialog {
 	i := &EntryDialog{entry: widget.NewEntry()}
 	items := []*widget.FormItem{widget.NewFormItem(message, i.entry)}
-	i.formDialog = NewForm(title, "Ok", "Cancel", items, func(ok bool) {
+	i.FormDialog = NewForm(title, "Ok", "Cancel", items, func(ok bool) {
 		// User has confirmed and entered an input
 		if ok && onConfirm != nil {
 			onConfirm(i.entry.Text)
@@ -61,7 +61,7 @@ func NewEntryDialog(title, message string, onConfirm func(string), parent fyne.W
 
 		i.entry.Text = ""
 		i.win.Hide() // Close directly without executing the callback. This is the callback.
-	}, parent).(*formDialog)
+	}, parent)
 
 	return i
 }

--- a/dialog/form.go
+++ b/dialog/form.go
@@ -17,11 +17,11 @@ type FormDialog struct {
 	cancel  *widget.Button
 }
 
-// HideWithSubmit hides the dialog and tries to submit if the form validators are valid.
-// Hiding with validation not passing will behave just like when calling .Hide().
+// Submit tries to submit the form if validation passes and then hides the dialog.
+// Hiding with validation not passing is equivalent to calling .Hide().
 //
 // Since: 2.4
-func (d *FormDialog) HideWithSubmit() {
+func (d *FormDialog) Submit() {
 	d.hideWithResponse(!d.confirm.Disabled())
 }
 

--- a/dialog/form.go
+++ b/dialog/form.go
@@ -7,12 +7,22 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
-// formDialog is a simple dialog window for displaying FormItems inside a form.
-type formDialog struct {
+// FormDialog is a simple dialog window for displaying FormItems inside a form.
+//
+// Since: 2.4
+type FormDialog struct {
 	*dialog
 	items   []*widget.FormItem
 	confirm *widget.Button
 	cancel  *widget.Button
+}
+
+// HideWithSubmit hides the dialog and tries to submit if the form validators are valid.
+// Hiding with validation not passing will behave just like when calling .Hide().
+//
+// Since: 2.4
+func (d *FormDialog) HideWithSubmit() {
+	d.hideWithResponse(!d.confirm.Disabled())
 }
 
 // validateItems acts as a validation edge state handler that will respond to an individual widget's validation
@@ -20,7 +30,7 @@ type formDialog struct {
 // confirm button will be disabled. If the error parameter is nil, then all other Validatable widgets in items are
 // checked as well to determine whether the confirm button should be disabled.
 // This method is passed to each Validatable widget's SetOnValidationChanged method in items by NewFormDialog.
-func (d *formDialog) validateItems(err error) {
+func (d *FormDialog) validateItems(err error) {
 	if err != nil {
 		d.confirm.Disable()
 		return
@@ -44,7 +54,7 @@ func (d *formDialog) validateItems(err error) {
 // validation state of the items added to the form dialog.
 //
 // Since: 2.0
-func NewForm(title, confirm, dismiss string, items []*widget.FormItem, callback func(bool), parent fyne.Window) Dialog {
+func NewForm(title, confirm, dismiss string, items []*widget.FormItem, callback func(bool), parent fyne.Window) *FormDialog {
 	form := widget.NewForm(items...)
 
 	d := &dialog{content: form, callback: callback, title: title, parent: parent}
@@ -54,7 +64,7 @@ func NewForm(title, confirm, dismiss string, items []*widget.FormItem, callback 
 	confirmBtn := &widget.Button{Text: confirm, Icon: theme.ConfirmIcon(), Importance: widget.HighImportance,
 		OnTapped: func() { d.hideWithResponse(true) },
 	}
-	formDialog := &formDialog{
+	formDialog := &FormDialog{
 		dialog:  d,
 		items:   items,
 		confirm: confirmBtn,

--- a/dialog/form.go
+++ b/dialog/form.go
@@ -17,12 +17,15 @@ type FormDialog struct {
 	cancel  *widget.Button
 }
 
-// Submit tries to submit the form if validation passes and then hides the dialog.
-// Hiding with validation not passing is equivalent to calling .Hide().
+// Submit will submit the form and then hide the dialog if validation passes.
 //
 // Since: 2.4
 func (d *FormDialog) Submit() {
-	d.hideWithResponse(!d.confirm.Disabled())
+	if d.confirm.Disabled() {
+		return
+	}
+
+	d.hideWithResponse(true)
 }
 
 // validateItems acts as a validation edge state handler that will respond to an individual widget's validation

--- a/dialog/form_test.go
+++ b/dialog/form_test.go
@@ -119,7 +119,42 @@ func TestFormDialog_Hints(t *testing.T) {
 	assert.Equal(t, formDialogCancel, result, "Expected cancel result")
 }
 
-func validatingFormDialog(result *formDialogResult, parent fyne.Window) *formDialog {
+func TestFormDialog_HideWithSubmit(t *testing.T) {
+	validatingEntry := widget.NewEntry()
+	validatingEntry.Validator = func(input string) error {
+		if input != "abc" {
+			return errors.New("only accepts 'abc'")
+		}
+		return nil
+	}
+	validatingItem := &widget.FormItem{Widget: validatingEntry}
+
+	confirmed := false
+
+	items := []*widget.FormItem{validatingItem}
+	form := NewForm("Validating Form Dialog", "Submit", "Cancel", items, func(confirm bool) {
+		confirmed = confirm
+	}, test.NewWindow(nil))
+
+	form.Hide()
+	assert.Equal(t, false, confirmed)
+	form.Show()
+
+	form.HideWithSubmit()
+	assert.Equal(t, false, confirmed)
+	form.Show()
+
+	validatingEntry.SetText("abc")
+
+	form.Hide()
+	assert.Equal(t, false, confirmed)
+	form.Show()
+
+	form.HideWithSubmit()
+	assert.Equal(t, true, confirmed)
+}
+
+func validatingFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {
 	validatingEntry := widget.NewEntry()
 	validatingEntry.Validator = func(input string) error {
 		if input != "abc" {
@@ -144,10 +179,10 @@ func validatingFormDialog(result *formDialogResult, parent fyne.Window) *formDia
 		} else {
 			*result = formDialogCancel
 		}
-	}, parent).(*formDialog)
+	}, parent)
 }
 
-func controlFormDialog(result *formDialogResult, parent fyne.Window) *formDialog {
+func controlFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {
 	controlEntry := widget.NewEntry()
 	controlItem := &widget.FormItem{
 		Text:   "I accept anything",
@@ -165,10 +200,10 @@ func controlFormDialog(result *formDialogResult, parent fyne.Window) *formDialog
 		} else {
 			*result = formDialogCancel
 		}
-	}, parent).(*formDialog)
+	}, parent)
 }
 
-func hintsFormDialog(result *formDialogResult, parent fyne.Window) *formDialog {
+func hintsFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {
 	validatingEntry := widget.NewEntry()
 	validatingEntry.Validator = func(input string) error {
 		if input != "abc" {
@@ -189,5 +224,5 @@ func hintsFormDialog(result *formDialogResult, parent fyne.Window) *formDialog {
 		} else {
 			*result = formDialogCancel
 		}
-	}, parent).(*formDialog)
+	}, parent)
 }

--- a/dialog/form_test.go
+++ b/dialog/form_test.go
@@ -136,22 +136,18 @@ func TestFormDialog_Submit(t *testing.T) {
 		confirmed = confirm
 	}, test.NewWindow(nil))
 
-	form.Hide()
-	assert.Equal(t, false, confirmed)
 	form.Show()
+	validatingEntry.SetText("cba")
 
 	form.Submit()
 	assert.Equal(t, false, confirmed)
-	form.Show()
+	assert.Equal(t, false, form.win.Hidden)
 
 	validatingEntry.SetText("abc")
 
-	form.Hide()
-	assert.Equal(t, false, confirmed)
-	form.Show()
-
 	form.Submit()
 	assert.Equal(t, true, confirmed)
+	assert.Equal(t, true, form.win.Hidden)
 }
 
 func validatingFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {

--- a/dialog/form_test.go
+++ b/dialog/form_test.go
@@ -119,7 +119,7 @@ func TestFormDialog_Hints(t *testing.T) {
 	assert.Equal(t, formDialogCancel, result, "Expected cancel result")
 }
 
-func TestFormDialog_HideWithSubmit(t *testing.T) {
+func TestFormDialog_Submit(t *testing.T) {
 	validatingEntry := widget.NewEntry()
 	validatingEntry.Validator = func(input string) error {
 		if input != "abc" {
@@ -140,7 +140,7 @@ func TestFormDialog_HideWithSubmit(t *testing.T) {
 	assert.Equal(t, false, confirmed)
 	form.Show()
 
-	form.HideWithSubmit()
+	form.Submit()
 	assert.Equal(t, false, confirmed)
 	form.Show()
 
@@ -150,7 +150,7 @@ func TestFormDialog_HideWithSubmit(t *testing.T) {
 	assert.Equal(t, false, confirmed)
 	form.Show()
 
-	form.HideWithSubmit()
+	form.Submit()
 	assert.Equal(t, true, confirmed)
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This allows a form dialog to be hidden and submitted if all validators are passing. The new API cna be very useful when implementing an entry that should close the dialog when submitted. Just calling hide will run the OnClosed() with false in that case so the user will not be able to submit, even if the validation is passing.


Unblocks https://github.com/Jacalz/rymdport/issues/55

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
