### PR TITLE
Add new truncation mode, ellipsis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b
 	github.com/go-ole/go-ole v1.2.6
 	github.com/go-text/render v0.0.0-20230327192424-adef04305ec0
-	github.com/go-text/typesetting v0.0.0-20230405155246-bf9c697c6e16
+	github.com/go-text/typesetting v0.0.0-20230618175549-b5753034b590
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gopherjs/gopherjs v1.17.2
 	github.com/jackmordaunt/icns/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -103,10 +103,11 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/go-text/render v0.0.0-20230327192424-adef04305ec0 h1:1F5PnpZdOJnVRxfy378mjm2j6HYBA5suRLlqA+RndhA=
 github.com/go-text/render v0.0.0-20230327192424-adef04305ec0/go.mod h1:+qxdVKijbZKOO8XX9gt6gnHnu3qNU3APpPLiSQSgvXM=
 github.com/go-text/typesetting v0.0.0-20230326213217-3355bdaa7d70/go.mod h1:zvWM81wAVW6QfVDI6yxfbCuoLnobSYTuMsrXU/u11y8=
-github.com/go-text/typesetting v0.0.0-20230405155246-bf9c697c6e16 h1:DvHeDNqK8cxdZ7C6y88pt3uE7euZH7/LluzyfnUfH/Q=
-github.com/go-text/typesetting v0.0.0-20230405155246-bf9c697c6e16/go.mod h1:zvWM81wAVW6QfVDI6yxfbCuoLnobSYTuMsrXU/u11y8=
-github.com/go-text/typesetting-utils v0.0.0-20230326210548-458646692de6 h1:zAAA1U4ykFwqPbcj6YDxvq3F2g0wc/ngPfLJjkR/8zs=
+github.com/go-text/typesetting v0.0.0-20230618175549-b5753034b590 h1:n6u3xKVUsKptNLSgG4IbJIuha5tS++YpMHVBCNk4ssE=
+github.com/go-text/typesetting v0.0.0-20230618175549-b5753034b590/go.mod h1:evDBbvNR/KaVFZ2ZlDSOWWXIUKq0wCOEtzLxRM8SG3k=
 github.com/go-text/typesetting-utils v0.0.0-20230326210548-458646692de6/go.mod h1:RaqFwjcYyM5BjbYGwON0H5K0UqwO3sJlo9ukKha80ZE=
+github.com/go-text/typesetting-utils v0.0.0-20230616150549-2a7df14b6a22 h1:LBQTFxP2MfsyEDqSKmUBZaDuDHN1vpqDyOZjcqS7MYI=
+github.com/go-text/typesetting-utils v0.0.0-20230616150549-2a7df14b6a22/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 	"image/draw"
 	"math"
+	"strings"
 	"sync"
 
 	"github.com/go-text/render"
@@ -155,6 +156,9 @@ func tabStop(spacew, x float32, tabWidth int) float32 {
 
 func walkString(faces []font.Face, s string, textSize fixed.Int26_6, tabWidth int, advance *float32, scale float32,
 	cb func(run shaping.Output, x float32)) (size fyne.Size, base float32) {
+	if strings.Contains(s, "\r") {
+		s = strings.ReplaceAll(s, "\r", "")
+	}
 
 	runes := []rune(s)
 	in := shaping.Input{
@@ -180,23 +184,13 @@ func walkString(faces []font.Face, s string, textSize fixed.Int26_6, tabWidth in
 
 		pending := false
 		for i, r := range in.Text[in.RunStart:in.RunEnd] {
-			if r == '\t' { // move forward to next tabstop
+			if r == '\t' {
 				if pending {
 					in.RunEnd = i
 					out = shaper.Shape(in)
 					x = shapeCallback(shaper, in, out, x, cb)
 				}
 				x = tabStop(spacew, x, tabWidth)
-
-				in.RunStart = i + 1
-				in.RunEnd = inEnd
-				pending = false
-			} else if r == '\r' { // ignore carriage return
-				if pending {
-					in.RunEnd = i
-					out = shaper.Shape(in)
-					x = shapeCallback(shaper, in, out, x, cb)
-				}
 
 				in.RunStart = i + 1
 				in.RunEnd = inEnd

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -156,9 +156,7 @@ func tabStop(spacew, x float32, tabWidth int) float32 {
 
 func walkString(faces []font.Face, s string, textSize fixed.Int26_6, tabWidth int, advance *float32, scale float32,
 	cb func(run shaping.Output, x float32)) (size fyne.Size, base float32) {
-	if strings.Contains(s, "\r") {
-		s = strings.ReplaceAll(s, "\r", "")
-	}
+	s = strings.ReplaceAll(s, "\r", "")
 
 	runes := []rune(s)
 	in := shaping.Input{

--- a/text.go
+++ b/text.go
@@ -22,6 +22,11 @@ const (
 	// TextTruncate trims the text to the widget's width, no wrapping is applied.
 	// If an entry is asked to truncate it will provide scrolling capabilities.
 	TextTruncate
+	// TextTruncateEllipsis is like regular truncation except that an ellipses (…) will be inserted
+	// wherever text has been shortened to fit.
+	//
+	// Since: 2.4
+	TextTruncateEllipsis
 	// TextWrapBreak trims the line of characters to the widget's width adding the excess as new line.
 	// An Entry with text wrapping will scroll vertically if there is not enough space for all the text.
 	TextWrapBreak

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -10,9 +10,13 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/cache"
+	paint "fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
+	"github.com/go-text/typesetting/di"
+	"github.com/go-text/typesetting/shaping"
+	"golang.org/x/image/math/fixed"
 )
 
 const (
@@ -634,6 +638,10 @@ func (r *textRenderer) Refresh() {
 			} else if i == len(bound.segments)-1 && len(bound.segments) > 1 {
 				txt.Text = string(runes[:bound.end])
 			}
+			if bound.ellipsis && i == len(bound.segments)-1 {
+				txt.Text = txt.Text + "…"
+			}
+
 			if concealed(seg) {
 				txt.Text = strings.Repeat(passwordChar, len(runes))
 			}
@@ -812,6 +820,10 @@ func findSpaceIndex(text []rune, fallback int) int {
 	return curIndex
 }
 
+func float32ToFixed266(f float32) fixed.Int26_6 {
+	return fixed.Int26_6(float64(f) * (1 << 6))
+}
+
 // lineBounds accepts a slice of Segments, a wrapping mode, a maximum line width and a function to measure line width.
 // lineBounds returns a slice containing the boundary metadata of each line with the given wrapping applied.
 func lineBounds(seg *TextSegment, wrap fyne.TextWrap, firstWidth, maxWidth float32, measurer func([]rune) float32) []rowBoundary {
@@ -840,12 +852,17 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, firstWidth, maxWidth float
 		switch wrap {
 		case fyne.TextTruncate:
 			high = binarySearch(checker, low, high)
-			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high})
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+			reuse++
+		case fyne.TextTruncateEllipsis:
+			end, full := truncateLimit(seg.Text, seg.Visual().(*canvas.Text), int(firstWidth), []rune{'…'})
+			high = end
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 			reuse++
 		case fyne.TextWrapBreak:
 			for low < high {
 				if measurer(text[low:high]) <= measureWidth {
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high})
+					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 					reuse++
 					low = high
 					high = l.end
@@ -853,7 +870,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, firstWidth, maxWidth float
 				} else {
 					newHigh := binarySearch(checker, low, high)
 					if newHigh <= low {
-						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1})
+						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
 						reuse++
 						low++
 					} else {
@@ -866,7 +883,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, firstWidth, maxWidth float
 				sub := text[low:high]
 				subWidth := measurer(sub)
 				if subWidth <= measureWidth {
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high})
+					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 					reuse++
 					low = high
 					high = l.end
@@ -880,7 +897,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, firstWidth, maxWidth float
 					fallback := binarySearch(checker, low, last) - low
 
 					if fallback < 1 { // even a character won't fit
-						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1})
+						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
 						low++
 						high = low + 1
 						reuse++
@@ -897,7 +914,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, firstWidth, maxWidth float
 						high = low + spaceIndex
 					}
 					if high == fallback && subWidth <= maxWidth { // add a newline as there is more space on next
-						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low})
+						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
 						reuse++
 						high = oldHigh
 						measureWidth = maxWidth
@@ -934,15 +951,52 @@ func splitLines(seg *TextSegment) []rowBoundary {
 	for i := 0; i < length; i++ {
 		if text[i] == '\n' {
 			high = i
-			lines = append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, high})
+			lines = append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, high, false})
 			low = i + 1
 		}
 	}
-	return append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, length})
+	return append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, length, false})
+}
+
+func truncateLimit(s string, text *canvas.Text, limit int, ellipsis []rune) (int, bool) {
+	s = strings.ReplaceAll(s, "\r", "")
+	face := paint.CachedFontFace(text.TextStyle, text.TextSize, 1.0)
+
+	runes := []rune(s)
+	in := shaping.Input{
+		Text:      ellipsis,
+		RunStart:  0,
+		RunEnd:    len(ellipsis),
+		Direction: di.DirectionLTR,
+		Face:      face.Fonts[0],
+		Size:      float32ToFixed266(text.TextSize),
+	}
+	shaper := &shaping.HarfbuzzShaper{}
+
+	conf := shaping.WrapConfig{}
+	conf = conf.WithTruncator(shaper, in)
+	conf.BreakPolicy = shaping.WhenNecessary
+	conf.TruncateAfterLines = 1
+	l := shaping.LineWrapper{}
+
+	in.Text = runes
+	in.RunEnd = len(runes)
+	out := shaper.Shape(in)
+
+	l.Prepare(conf, runes, shaping.NewSliceIterator([]shaping.Output{out}))
+	finalLine, _, done := l.WrapNextLine(limit)
+
+	count := finalLine[0].Runes.Count
+	full := done && count == len(runes)
+	if !full && len(ellipsis) > 0 {
+		count--
+	}
+	return count, full
 }
 
 type rowBoundary struct {
 	segments          []RichTextSegment
 	firstSegmentReuse int
 	begin, end        int
+	ellipsis          bool
 }

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -959,7 +959,6 @@ func splitLines(seg *TextSegment) []rowBoundary {
 }
 
 func truncateLimit(s string, text *canvas.Text, limit int, ellipsis []rune) (int, bool) {
-	s = strings.ReplaceAll(s, "\r", "")
 	face := paint.CachedFontFace(text.TextStyle, text.TextSize, 1.0)
 
 	runes := []rune(s)

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -425,8 +425,8 @@ func TestText_splitLines(t *testing.T) {
 }
 
 func TestText_lineBounds(t *testing.T) {
-	mockMeasurer := func(text []rune) float32 {
-		return float32(len(text))
+	measurer := func(text []rune) float32 {
+		return fyne.MeasureText(string(text), 14, fyne.TextStyle{}).Width
 	}
 	tests := []struct {
 		name string
@@ -483,6 +483,14 @@ func TestText_lineBounds(t *testing.T) {
 			},
 		},
 		{
+			name: "Single_Short_TruncateEllipsis",
+			text: "foobar",
+			wrap: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 6},
+			},
+		},
+		{
 			name: "Single_Short_WrapBreak",
 			text: "foobar",
 			wrap: fyne.TextWrapBreak,
@@ -510,6 +518,14 @@ func TestText_lineBounds(t *testing.T) {
 			name: "Single_Long_Truncate",
 			text: "foobar foobar",
 			wrap: fyne.TextTruncate,
+			want: [][2]int{
+				{0, 10},
+			},
+		},
+		{
+			name: "Single_Long_TruncateEllipsis",
+			text: "foobar fo…",
+			wrap: fyne.TextTruncateEllipsis,
 			want: [][2]int{
 				{0, 10},
 			},
@@ -753,7 +769,7 @@ func TestText_lineBounds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, 10, 10, mockMeasurer)
+			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, 76, 76, measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)


### PR DESCRIPTION
And adjust text tests to be real measuring now as we can't fake it!

This is the beginning of a migration to go-text for line wrap and truncation, but this new mode was easier than migrating the existing ones...

It does not support multi-line truncation (adding ... on 2nd or 3rd line)
In fact a point of discussion is that the current truncation tests /do/ support multi-line but they do it by truncating every line which seems peculiar. Revisiting in a follow-on item

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
