### PR TITLE
Add support for input in the Exec= field of desktop files

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -19,6 +19,7 @@ type unixData struct {
 	Categories       string
 	Comment          string
 	Keywords         string
+	ExecInput        string
 }
 
 func (p *Packager) packageUNIX() error {
@@ -66,6 +67,7 @@ func (p *Packager) packageUNIX() error {
 		Keywords:    formatDesktopFileList(p.linuxAndBSDMetadata.Keywords),
 		Comment:     p.linuxAndBSDMetadata.Comment,
 		Categories:  formatDesktopFileList(p.linuxAndBSDMetadata.Categories),
+		ExecInput:   p.linuxAndBSDMetadata.ExecInput,
 	}
 	err = templates.DesktopFileUNIX.Execute(deskFile, tplData)
 	if err != nil {

--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -19,7 +19,7 @@ type unixData struct {
 	Categories       string
 	Comment          string
 	Keywords         string
-	ExecInput        string
+	ExecParams       string
 }
 
 func (p *Packager) packageUNIX() error {
@@ -67,7 +67,7 @@ func (p *Packager) packageUNIX() error {
 		Keywords:    formatDesktopFileList(p.linuxAndBSDMetadata.Keywords),
 		Comment:     p.linuxAndBSDMetadata.Comment,
 		Categories:  formatDesktopFileList(p.linuxAndBSDMetadata.Categories),
-		ExecInput:   p.linuxAndBSDMetadata.ExecInput,
+		ExecParams:  p.linuxAndBSDMetadata.ExecParams,
 	}
 	err = templates.DesktopFileUNIX.Execute(deskFile, tplData)
 	if err != nil {

--- a/cmd/fyne/internal/metadata/data.go
+++ b/cmd/fyne/internal/metadata/data.go
@@ -23,5 +23,5 @@ type LinuxAndBSD struct {
 	Categories  []string `toml:",omitempty"`
 	Comment     string   `toml:",omitempty"`
 	Keywords    []string `toml:",omitempty"`
-	ExecInput   string   `toml:",omitempty"`
+	ExecParams  string   `toml:",omitempty"`
 }

--- a/cmd/fyne/internal/metadata/data.go
+++ b/cmd/fyne/internal/metadata/data.go
@@ -23,4 +23,5 @@ type LinuxAndBSD struct {
 	Categories  []string `toml:",omitempty"`
 	Comment     string   `toml:",omitempty"`
 	Keywords    []string `toml:",omitempty"`
+	ExecInput   string   `toml:",omitempty"`
 }

--- a/cmd/fyne/internal/templates/bundled.go
+++ b/cmd/fyne/internal/templates/bundled.go
@@ -23,7 +23,7 @@ var resourceMakefile = &fyne.StaticResource{
 var resourceAppDesktop = &fyne.StaticResource{
 	StaticName: "app.desktop",
 	StaticContent: []byte(
-		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\n{{if ne .Keywords \"\"}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}"),
+		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}} {{.ExecInput}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\n{{if ne .Keywords \"\"}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}"),
 }
 var resourceAppManifest = &fyne.StaticResource{
 	StaticName: "app.manifest",

--- a/cmd/fyne/internal/templates/bundled.go
+++ b/cmd/fyne/internal/templates/bundled.go
@@ -23,7 +23,7 @@ var resourceMakefile = &fyne.StaticResource{
 var resourceAppDesktop = &fyne.StaticResource{
 	StaticName: "app.desktop",
 	StaticContent: []byte(
-		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}} {{.ExecInput}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\n{{if ne .Keywords \"\"}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}"),
+		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}} {{.ExecParams}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\n{{if ne .Keywords \"\"}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}"),
 }
 var resourceAppManifest = &fyne.StaticResource{
 	StaticName: "app.manifest",

--- a/cmd/fyne/internal/templates/data/app.desktop
+++ b/cmd/fyne/internal/templates/data/app.desktop
@@ -3,7 +3,7 @@ Type=Application
 Name={{.Name}}
 {{- if ne .GenericName ""}}
 GenericName={{.GenericName}}{{end}}
-Exec={{.Exec}}
+Exec={{.Exec}} {{.ExecInput}}
 Icon={{.Name}}
 {{- if ne .Comment ""}}
 Comment={{.Comment}}{{end}}

--- a/cmd/fyne/internal/templates/data/app.desktop
+++ b/cmd/fyne/internal/templates/data/app.desktop
@@ -3,7 +3,7 @@ Type=Application
 Name={{.Name}}
 {{- if ne .GenericName ""}}
 GenericName={{.GenericName}}{{end}}
-Exec={{.Exec}} {{.ExecInput}}
+Exec={{.Exec}} {{.ExecParams}}
 Icon={{.Name}}
 {{- if ne .Comment ""}}
 Comment={{.Comment}}{{end}}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This allow the developer to pass any specific flags or arguments that are necessary but also allows passing [exec codes](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html) to tell the desktop that the file supports things like opening folders.

Example of Rymdport using `%F` to support one or more files being opened:
[Screencast from 2023-06-29 20-54-29.webm](https://github.com/fyne-io/fyne/assets/25466657/2f6ae98f-7e78-4d85-a8d1-d89050896c5d)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.