### PR TITLE
Reduce updateItem calls

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -93,19 +93,23 @@ func (l *List) MinSize() fyne.Size {
 	return l.BaseWidget.MinSize()
 }
 
+// RefreshItem refreshes a single item, specified by the item ID passed in.
+//
+// Since 2.4
 func (l *List) RefreshItem(id ListItemID) {
 	if l.scroller != nil {
-		l.BaseWidget.Refresh()
-		lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
-		visible := lo.visible
-		canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
-		var focused fyne.Focusable
-		if canvas != nil {
-			focused = canvas.Focused()
-		}
-		if item, ok := visible[id]; ok {
-			lo.setupListItem(item, id, focused == item)
-		}
+		return
+	}
+	l.BaseWidget.Refresh()
+	lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
+	visible := lo.visible
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
+	var focused fyne.Focusable
+	if canvas != nil {
+		focused = canvas.Focused()
+	}
+	if item, ok := visible[id]; ok {
+		lo.setupListItem(item, id, focused == item)
 	}
 }
 
@@ -671,9 +675,9 @@ func (l *listLayout) updateList(newOnly bool) {
 	l.renderLock.Unlock() // user code should not be locked
 
 	if newOnly {
-		for nId, nItem := range visible {
-			if _, ok := wasVisible[nId]; !ok {
-				l.setupListItem(nItem, nId, focused == nItem)
+		for row, obj := range visible {
+			if _, ok := wasVisible[row]; !ok {
+				l.setupListItem(obj, row, focused == obj)
 			}
 		}
 	} else {

--- a/widget/list.go
+++ b/widget/list.go
@@ -9,7 +9,6 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
-	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 )
@@ -96,14 +95,7 @@ func (l *List) MinSize() fyne.Size {
 
 func (l *List) Refresh() {
 	if l.scroller != nil {
-		impl := l.super()
-		if impl == nil {
-			return
-		}
-
-		render := cache.Renderer(impl)
-		render.Refresh()
-
+		l.BaseWidget.Refresh()
 		lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
 		visible := lo.visible
 		canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)

--- a/widget/list.go
+++ b/widget/list.go
@@ -93,19 +93,23 @@ func (l *List) MinSize() fyne.Size {
 	return l.BaseWidget.MinSize()
 }
 
+// RefreshItem refreshes a single item, specified by the item ID passed in.
+//
+// Since 2.4
 func (l *List) RefreshItem(id ListItemID) {
-	if l.scroller != nil {
-		l.BaseWidget.Refresh()
-		lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
-		visible := lo.visible
-		canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
-		var focused fyne.Focusable
-		if canvas != nil {
-			focused = canvas.Focused()
-		}
-		if item, ok := visible[id]; ok {
-			lo.setupListItem(item, id, focused == item)
-		}
+	if l.scroller == nil {
+		return
+	}
+	l.BaseWidget.Refresh()
+	lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
+	visible := lo.visible
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
+	var focused fyne.Focusable
+	if canvas != nil {
+		focused = canvas.Focused()
+	}
+	if item, ok := visible[id]; ok {
+		lo.setupListItem(item, id, focused == item)
 	}
 }
 
@@ -671,9 +675,9 @@ func (l *listLayout) updateList(newOnly bool) {
 	l.renderLock.Unlock() // user code should not be locked
 
 	if newOnly {
-		for nId, nItem := range visible {
-			if _, ok := wasVisible[nId]; !ok {
-				l.setupListItem(nItem, nId, focused == nItem)
+		for row, obj := range visible {
+			if _, ok := wasVisible[row]; !ok {
+				l.setupListItem(obj, row, focused == obj)
 			}
 		}
 	} else {

--- a/widget/list.go
+++ b/widget/list.go
@@ -93,23 +93,19 @@ func (l *List) MinSize() fyne.Size {
 	return l.BaseWidget.MinSize()
 }
 
-// RefreshItem refreshes a single item, specified by the item ID passed in.
-//
-// Since 2.4
 func (l *List) RefreshItem(id ListItemID) {
 	if l.scroller != nil {
-		return
-	}
-	l.BaseWidget.Refresh()
-	lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
-	visible := lo.visible
-	canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
-	var focused fyne.Focusable
-	if canvas != nil {
-		focused = canvas.Focused()
-	}
-	if item, ok := visible[id]; ok {
-		lo.setupListItem(item, id, focused == item)
+		l.BaseWidget.Refresh()
+		lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
+		visible := lo.visible
+		canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
+		var focused fyne.Focusable
+		if canvas != nil {
+			focused = canvas.Focused()
+		}
+		if item, ok := visible[id]; ok {
+			lo.setupListItem(item, id, focused == item)
+		}
 	}
 }
 
@@ -675,9 +671,9 @@ func (l *listLayout) updateList(newOnly bool) {
 	l.renderLock.Unlock() // user code should not be locked
 
 	if newOnly {
-		for row, obj := range visible {
-			if _, ok := wasVisible[row]; !ok {
-				l.setupListItem(obj, row, focused == obj)
+		for nId, nItem := range visible {
+			if _, ok := wasVisible[nId]; !ok {
+				l.setupListItem(nItem, nId, focused == nItem)
 			}
 		}
 	} else {

--- a/widget/list.go
+++ b/widget/list.go
@@ -559,7 +559,7 @@ func (l *listLayout) offsetUpdated(pos fyne.Position) {
 	l.updateList(false)
 }
 
-func (l *listLayout) setupListItem(li *listItem, id ListItemID, focus bool) {
+func (l *listLayout) setupListItem(li *listItem, id ListItemID, focus bool, update bool) {
 	previousIndicator := li.selected
 	li.selected = false
 	for _, s := range l.list.selected {
@@ -575,7 +575,7 @@ func (l *listLayout) setupListItem(li *listItem, id ListItemID, focus bool) {
 		li.hovered = false
 		li.Refresh()
 	}
-	if f := l.list.UpdateItem; f != nil {
+	if f := l.list.UpdateItem; f != nil && update {
 		f(id, li.child)
 	}
 	li.onTapped = func() {
@@ -654,8 +654,9 @@ func (l *listLayout) updateList(refresh bool) {
 	l.list.scroller.Content.(*fyne.Container).Objects = objects
 	l.renderLock.Unlock() // user code should not be locked
 
-	for row, obj := range visible {
-		l.setupListItem(obj, row, focused == obj)
+	for cId, vItem := range visible {
+		_, wasVisible := wasVisible[cId]
+		l.setupListItem(vItem, cId, focused == vItem, !wasVisible)
 	}
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -93,7 +93,7 @@ func (l *List) MinSize() fyne.Size {
 	return l.BaseWidget.MinSize()
 }
 
-func (l *List) RefreshBase() (*listLayout, map[int]*listItem, fyne.Focusable) {
+func (l *List) refreshBase() (*listLayout, map[int]*listItem, fyne.Focusable) {
 	if l.scroller != nil {
 		l.BaseWidget.Refresh()
 		lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
@@ -109,7 +109,7 @@ func (l *List) RefreshBase() (*listLayout, map[int]*listItem, fyne.Focusable) {
 }
 
 func (l *List) Refresh() {
-	lo, visible, focused := l.RefreshBase()
+	lo, visible, focused := l.refreshBase()
 	for id, item := range visible {
 		item.updated = false
 		lo.setupListItem(item, id, focused == item)
@@ -117,7 +117,7 @@ func (l *List) Refresh() {
 }
 
 func (l *List) RefreshItem(id ListItemID) {
-	lo, visible, focused := l.RefreshBase()
+	lo, visible, focused := l.refreshBase()
 	if item, ok := visible[id]; ok {
 		lo.setupListItem(item, id, focused == item)
 	}

--- a/widget/list.go
+++ b/widget/list.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 )
@@ -91,6 +92,29 @@ func (l *List) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
 
 	return l.BaseWidget.MinSize()
+}
+
+func (l *List) Refresh() {
+	if l.scroller != nil {
+		impl := l.super()
+		if impl == nil {
+			return
+		}
+
+		render := cache.Renderer(impl)
+		render.Refresh()
+
+		lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
+		visible := lo.visible
+		canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
+		var focused fyne.Focusable
+		if canvas != nil {
+			focused = canvas.Focused()
+		}
+		for id, item := range visible {
+			lo.setupListItem(item, id, focused == item, true)
+		}
+	}
 }
 
 // SetItemHeight supports changing the height of the specified list item. Items normally take the height of the template

--- a/widget/list.go
+++ b/widget/list.go
@@ -118,10 +118,8 @@ func (l *List) Refresh() {
 
 func (l *List) RefreshItem(id ListItemID) {
 	lo, visible, focused := l.RefreshBase()
-	for vId, item := range visible {
-		if id == vId {
-			lo.setupListItem(item, id, focused == item)
-		}
+	if item, ok := visible[id]; ok {
+		lo.setupListItem(item, id, focused == item)
 	}
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -95,7 +95,7 @@ func (l *List) MinSize() fyne.Size {
 
 // RefreshItem refreshes a single item, specified by the item ID passed in.
 //
-// Since 2.4
+// Since: 2.4
 func (l *List) RefreshItem(id ListItemID) {
 	if l.scroller == nil {
 		return

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -588,7 +588,7 @@ func TestList_LimitUpdateItem(t *testing.T) {
 			return 5
 		},
 		func() fyne.CanvasObject {
-			return NewLabel("Test")
+			return NewLabel("")
 		},
 		func(id ListItemID, item fyne.CanvasObject) {
 			printOut += fmt.Sprintf("%d.", id)

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -302,7 +302,7 @@ func TestList_DataChange(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()
 
-	list, w := setupList(t)
+	list, _ := setupList(t)
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
 
 	assert.Equal(t, children[0].(*listItem).child.(*fyne.Container).Objects[1].(*Label).Text, "Test Item 0")
@@ -310,7 +310,7 @@ func TestList_DataChange(t *testing.T) {
 	list.Refresh()
 	children = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
 	assert.Equal(t, children[0].(*listItem).child.(*fyne.Container).Objects[1].(*Label).Text, "a")
-	test.AssertRendersToMarkup(t, "list/new_data.xml", w.Canvas())
+	// test.AssertRendersToMarkup(t, "list/new_data.xml", w.Canvas())
 }
 
 func TestList_ThemeChange(t *testing.T) {

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -596,10 +596,11 @@ func TestList_LimitUpdateItem(t *testing.T) {
 	)
 	w.SetContent(list)
 	w.ShowAndRun()
+	assert.Equal(t, "0.0.", printOut)
 	list.scrollTo(1)
+	assert.Equal(t, "0.0.1.", printOut)
 	list.scrollTo(2)
-	time.Sleep(2 * time.Second)
-	assert.Equal(t, "0.1.2.", printOut)
+	assert.Equal(t, "0.0.1.2.", printOut)
 }
 
 func TestList_RefreshUpdatesAllItems(t *testing.T) {

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -580,11 +580,25 @@ func setupList(t *testing.T) (*List, fyne.Window) {
 }
 
 func TestList_LimitUpdateItem(t *testing.T) {
+	app := test.NewApp()
+	w := app.NewWindow("")
+	w.Resize(fyne.NewSize(500, 500))
 	updateItemCalls := 0
-	list := createList(20)
-	list.UpdateItem = func(id ListItemID, item fyne.CanvasObject) {
-		updateItemCalls++
-	}
-	assert.Equal(t, 1, updateItemCalls)
-
+	list := NewList(
+		func() int {
+			return 20
+		},
+		func() fyne.CanvasObject {
+			return NewLabel("")
+		},
+		func(id ListItemID, item fyne.CanvasObject) {
+			updateItemCalls++
+		},
+	)
+	w.SetContent(list)
+	w.ShowAndRun()
+	list.scrollTo(10)
+	list.scrollTo(20)
+	time.Sleep(2 * time.Second)
+	assert.Equal(t, 3, updateItemCalls)
 }

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -302,7 +302,7 @@ func TestList_DataChange(t *testing.T) {
 	test.NewApp()
 	defer test.NewApp()
 
-	list, _ := setupList(t)
+	list, w := setupList(t)
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
 
 	assert.Equal(t, children[0].(*listItem).child.(*fyne.Container).Objects[1].(*Label).Text, "Test Item 0")
@@ -310,7 +310,7 @@ func TestList_DataChange(t *testing.T) {
 	list.Refresh()
 	children = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
 	assert.Equal(t, children[0].(*listItem).child.(*fyne.Container).Objects[1].(*Label).Text, "a")
-	// test.AssertRendersToMarkup(t, "list/new_data.xml", w.Canvas())
+	test.AssertRendersToMarkup(t, "list/new_data.xml", w.Canvas())
 }
 
 func TestList_ThemeChange(t *testing.T) {

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -578,3 +578,13 @@ func setupList(t *testing.T) (*List, fyne.Window) {
 	test.AssertRendersToMarkup(t, "list/initial.xml", w.Canvas())
 	return list, w
 }
+
+func TestList_LimitUpdateItem(t *testing.T) {
+	updateItemCalls := 0
+	list := createList(20)
+	list.UpdateItem = func(id ListItemID, item fyne.CanvasObject) {
+		updateItemCalls++
+	}
+	assert.Equal(t, 1, updateItemCalls)
+
+}

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -582,23 +582,45 @@ func setupList(t *testing.T) (*List, fyne.Window) {
 func TestList_LimitUpdateItem(t *testing.T) {
 	app := test.NewApp()
 	w := app.NewWindow("")
-	w.Resize(fyne.NewSize(500, 500))
-	updateItemCalls := 0
+	printOut := ""
 	list := NewList(
 		func() int {
-			return 20
+			return 5
 		},
 		func() fyne.CanvasObject {
-			return NewLabel("")
+			return NewLabel("Test")
 		},
 		func(id ListItemID, item fyne.CanvasObject) {
-			updateItemCalls++
+			printOut += fmt.Sprintf("%d.", id)
 		},
 	)
 	w.SetContent(list)
 	w.ShowAndRun()
-	list.scrollTo(10)
-	list.scrollTo(20)
+	list.scrollTo(1)
+	list.scrollTo(2)
 	time.Sleep(2 * time.Second)
-	assert.Equal(t, 3, updateItemCalls)
+	assert.Equal(t, "0.1.2.", printOut)
+}
+
+func TestList_RefreshUpdatesAllItems(t *testing.T) {
+	app := test.NewApp()
+	w := app.NewWindow("")
+	printOut := ""
+	list := NewList(
+		func() int {
+			return 1
+		},
+		func() fyne.CanvasObject {
+			return NewLabel("Test")
+		},
+		func(id ListItemID, item fyne.CanvasObject) {
+			printOut += fmt.Sprintf("%d.", id)
+		},
+	)
+	w.SetContent(list)
+	w.ShowAndRun()
+	assert.Equal(t, "0.", printOut)
+
+	list.Refresh()
+	assert.Equal(t, "0.0.", printOut)
 }

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -313,6 +313,19 @@ func TestList_DataChange(t *testing.T) {
 	test.AssertRendersToMarkup(t, "list/new_data.xml", w.Canvas())
 }
 
+func TestList_ItemDataChange(t *testing.T) {
+	test.NewApp()
+	defer test.NewApp()
+
+	list, _ := setupList(t)
+	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
+	assert.Equal(t, children[0].(*listItem).child.(*fyne.Container).Objects[1].(*Label).Text, "Test Item 0")
+	changeData(list)
+	list.RefreshItem(0)
+	children = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
+	assert.Equal(t, children[0].(*listItem).child.(*fyne.Container).Objects[1].(*Label).Text, "a")
+}
+
 func TestList_ThemeChange(t *testing.T) {
 	defer test.NewApp()
 	list, w := setupList(t)


### PR DESCRIPTION
### Description:
Currently, placing a print in the `updateItem` callback for a list shows that the function is being called for all items that are visible for every change made. This makes expensive tasks repeat whenever there is any sort of change to the list, and locks up the screen for a long time. This change aims to only call the function for a given item only once, when the item becomes visible. 

The unit test shows a slight difference, however placing a print statement in the updateItem function seems to show a drastically more apparent change, as show below. 

### also, Fixes
#3826  (partially - for lists only)

#### Print out of list IDs - on loading of a list
currently
```
7.9.0.6.3.4.5.8.10.1.2.5.8.9.3.4.6.7.10.0.1.2.1.3.5.8.7.9.10.0.2.4.6.0.1.2.4.10.3.5.6.7.8.9.3.4.7.8.10.0.2.6.9.1.5.0.3.5.7.10.1.2.4.6.8.9.7.8.9.0.3.4.5.6.10.1.2.6.7.8.2.3.4.9.10.0.1.5.6.7.8.9.0.2.5.10.1.3.4.8.9.10.1.2.4.5.7.0.3.6.1.2.3.4.5.6.7.9.10.0.8.0.5.8.10.1.2.3.4.6.7.9.10.0.1.2.4.5.6.7.3.8.9.1.3.5.10.9.0.2.4.6.7.8.3.5.7.8.9.0.2.4.6.10.1.3.4.8.10.0.2.5.6.7.9.1.8.10.2.7.3.4.5.6.9.0.1.1.2.3.10.9.0.4.5.6.7.8.1.2.5.8.0.3.4.6.7.9.10.8.9.4.5.7.3.6.10.0.1.2.0.1.2.4.8.3.5.6.7.9.10.3.7.0.2.5.6.8.9.10.1.4.1.3.7.9.10.0.2.4.5.6.8.5.6.8.10.0.2.4.9.1.3.7.10.0.2.8.9.6.7.1.3.4.5.1.3.5.8.10.0.2.4.6.7.9.
```

with the change
```
7.8.10.9.0.1.2.3.4.5.6.2.3.4.10.0.1.5.6.7.8.9.
```


####  Print out of list IDs - scrolling down 2 items
current
```
1.4.6.7.8.9.0.2.3.5.10.10.0.1.5.7.8.2.3.4.6.9.3.5.6.7.8.10.0.1.2.4.9.8.9.10.0.4.5.6.7.1.2.3.4.5.7.8.9.11.3.2.6.10.1.2.3.6.8.9.11.1.5.7.10.4.11.2.6.7.8.9.1.3.4.5.10.8.4.6.7.5.9.10.11.1.2.3.5.7.9.1.2.6.8.10.11.3.4.10.11.1.3.5.7.8.2.4.6.9.6.10.1.2.3.4.5.7.8.9.11.7.11.3.4.5.6.8.9.1.2.10.6.7.8.9.1.2.3.4.10.5.11.7.9.10.11.4.5.6.8.1.2.3.10.11.3.5.4.6.7.8.9.1.2.2.4.6.8.9.10.1.3.5.7.11.3.5.7.11.1.2.8.9.10.4.6.2.3.5.6.7.9.11.1.4.8.10.8.11.3.4.6.7.10.1.2.5.9.1.2.6.7.8.10.11.3.4.5.9.11.1.3.4.7.8.9.10.2.5.6.11.4.6.8.10.7.9.1.2.3.5.5.6.7.8.9.10.1.3.11.2.4.6.7.9.11.3.5.4.8.10.1.2.2.5.8.10.1.3.4.6.7.9.11.3.5.6.8.11.1.4.7.9.10.2.9.10.11.1.2.3.5.8.4.6.7.6.8.10.1.2.3.9.11.4.5.7.3.4.6.9.10.11.1.2.5.7.8.9.11.1.3.6.7.8.2.4.5.10.4.5.11.1.3.6.7.8.9.10.2.3.4.5.10.12.2.7.8.9.11.6.2.5.7.10.11.12.3.4.6.8.9.2.7.8.9.10.3.4.5.6.11.12.7.8.9.10.11.2.3.4.5.6.12.7.9.11.10.12.2.3.4.5.6.8.4.5.8.11.12.10.2.3.6.7.9.8.11.2.3.4.5.12.6.7.9.10.2.3.4.9.10.5.6.7.8.11.12.3.4.7.10.11.12.2.6.8.9.5.6.10.9.11.2.3.4.5.7.8.12.12.5.8.10.11.7.9.2.3.4.6.7.9.4.5.6.8.10.11.2.3.12.3.5.6.8.10.11.12.2.4.7.9.5.6.8.9.11.12.3.4.7.10.2.4.5.6.8.2.3.7.9.10.11.12.2.4.5.12.11.3.6.7.8.9.10.10.11.5.7.8.6.9.12.2.3.4.2.3.4.5.10.12.6.7.8.9.11.5.6.7.8.9.2.3.4.10.11.12.7.8.9.12.2.4.5.6.3.10.11.4.8.10.11.12.3.5.6.7.9.2.3.5.6.7.8.9.10.2.11.12.4.5.6.9.10.2.3.8.11.12.4.7.
``` 

with changes
```
11.12.
```


### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
