### PR TITLE
Change StringWithFallback return to value

### DIFF
--- a/internal/preferences.go
+++ b/internal/preferences.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"sync"
 
 	"fyne.io/fyne/v2"
@@ -183,7 +184,7 @@ func (p *InMemoryPreferences) StringWithFallback(key, fallback string) string {
 		return fallback
 	}
 
-	return value.(string)
+	return fmt.Sprint(value)
 }
 
 // SetString saves a string value for the given key


### PR DESCRIPTION
### Description:
StringWithFallback was returning the string validator rather than the string causing a type mismatch.
