### PR TITLE
Insane boost in TextGrid performance for intense usage of the widget

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -337,6 +337,7 @@ type textGridRenderer struct {
 
 	cellSize fyne.Size
 	objects  []fyne.CanvasObject
+	current  fyne.Canvas
 }
 
 func (t *textGridRenderer) appendTextCell(str rune) {
@@ -369,9 +370,12 @@ func (t *textGridRenderer) setCellRune(str rune, pos int, style, rowStyle TextGr
 	} else if rowStyle != nil && rowStyle.TextColor() != nil {
 		fg = rowStyle.TextColor()
 	}
-	text.Text = string(str)
-	text.Color = fg
-	canvas.Refresh(text)
+	newStr := string(str)
+	if text.Text != newStr || text.Color != fg {
+		text.Text = newStr
+		text.Color = fg
+		canvas.Refresh(text)
+	}
 
 	rect := t.objects[pos*2].(*canvas.Rectangle)
 	bg := color.Color(color.Transparent)
@@ -380,8 +384,10 @@ func (t *textGridRenderer) setCellRune(str rune, pos int, style, rowStyle TextGr
 	} else if rowStyle != nil && rowStyle.BackgroundColor() != nil {
 		bg = rowStyle.BackgroundColor()
 	}
-	rect.FillColor = bg
-	canvas.Refresh(rect)
+	if rect.FillColor != bg {
+		rect.FillColor = bg
+		canvas.Refresh(rect)
+	}
 }
 
 func (t *textGridRenderer) addCellsIfRequired() {


### PR DESCRIPTION
It was difficult to write a benchmark as you're balancing the CPU and GPU usage which was lowering the apparent frame rate.
However loading this change into FyneTerm and listing a huge directory used to take around a second, but now it is so fast as to compare with native terminals!!!

I think this does all we can for the referenced issue, to some extend the newline parse on `SetText` cannot be avoided, but FyneTerm does show how to be a little lower level for greater speed.

Fixes #3994 and #3142

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

