### PR TITLE
Improvements to application startup time and memory usage

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,8 +14,6 @@ import (
 	"fyne.io/fyne/v2/internal/app"
 	intRepo "fyne.io/fyne/v2/internal/repository"
 	"fyne.io/fyne/v2/storage/repository"
-
-	"golang.org/x/sys/execabs"
 )
 
 // Declare conformity with App interface
@@ -33,7 +31,6 @@ type fyneApp struct {
 	prefs     fyne.Preferences
 
 	running uint32 // atomic, 1 == running, 0 == stopped
-	exec    func(name string, arg ...string) *execabs.Cmd
 }
 
 func (a *fyneApp) CloudProvider() fyne.CloudProvider {
@@ -144,7 +141,7 @@ func makeStoreDocs(id string, p fyne.Preferences, s *store) *internal.Docs {
 }
 
 func newAppWithDriver(d fyne.Driver, id string) fyne.App {
-	newApp := &fyneApp{uniqueID: id, driver: d, exec: execabs.Command, lifecycle: &app.Lifecycle{}}
+	newApp := &fyneApp{uniqueID: id, driver: d, lifecycle: &app.Lifecycle{}}
 	fyne.SetCurrentApp(newApp)
 
 	newApp.prefs = newApp.newDefaultPreferences()

--- a/app/app_desktop_darwin.go
+++ b/app/app_desktop_darwin.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/sys/execabs"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
 )
@@ -52,7 +54,7 @@ func rootConfigDir() string {
 }
 
 func (a *fyneApp) OpenURL(url *url.URL) error {
-	cmd := a.exec("open", url.String())
+	cmd := execabs.Command("open", url.String())
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd.Run()
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -32,3 +32,19 @@ func TestFyneApp_UniqueID(t *testing.T) {
 
 	assert.Equal(t, meta.ID, app.UniqueID())
 }
+
+func TestFyneApp_SetIcon(t *testing.T) {
+	app := NewWithID("io.fyne.test")
+
+	metaIcon := &fyne.StaticResource{StaticName: "Metadata"}
+	SetMetadata(fyne.AppMetadata{
+		Icon: metaIcon,
+	})
+
+	assert.Equal(t, metaIcon, app.Icon())
+
+	setIcon := &fyne.StaticResource{StaticName: "Test"}
+	app.SetIcon(setIcon)
+
+	assert.Equal(t, setIcon, app.Icon())
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,16 +1,12 @@
 package app
 
 import (
-	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"fyne.io/fyne/v2"
 	_ "fyne.io/fyne/v2/test"
-
-	"golang.org/x/sys/execabs"
 )
 
 func TestDummyApp(t *testing.T) {
@@ -35,23 +31,4 @@ func TestFyneApp_UniqueID(t *testing.T) {
 	app = New()
 
 	assert.Equal(t, meta.ID, app.UniqueID())
-}
-
-func TestFyneApp_OpenURL(t *testing.T) {
-	opened := ""
-	app := NewWithID("io.fyne.test")
-	app.(*fyneApp).exec = func(cmd string, arg ...string) *execabs.Cmd {
-		opened = arg[len(arg)-1]
-		return execabs.Command("")
-	}
-
-	urlStr := "https://fyne.io"
-	u, _ := url.Parse(urlStr)
-	err := app.OpenURL(u)
-
-	if err != nil && strings.Contains(err.Error(), "unknown operating system") {
-		return // when running in CI mode we don't actually open URLs...
-	}
-
-	assert.Equal(t, urlStr, opened)
 }

--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/sys/execabs"
 	"golang.org/x/sys/windows/registry"
 
 	"fyne.io/fyne/v2"
@@ -63,7 +64,7 @@ func rootConfigDir() string {
 }
 
 func (a *fyneApp) OpenURL(url *url.URL) error {
-	cmd := a.exec("rundll32", "url.dll,FileProtocolHandler", url.String())
+	cmd := execabs.Command("rundll32", "url.dll,FileProtocolHandler", url.String())
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd.Run()
 }

--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -16,8 +16,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
-
-	"golang.org/x/sys/execabs"
 )
 
 const notificationTemplate = `$title = "%s"

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/godbus/dbus/v5"
+	"golang.org/x/sys/execabs"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
@@ -27,7 +28,7 @@ func defaultVariant() fyne.ThemeVariant {
 }
 
 func (a *fyneApp) OpenURL(url *url.URL) error {
-	cmd := a.exec("xdg-open", url.String())
+	cmd := execabs.Command("xdg-open", url.String())
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd.Start()
 }

--- a/app/cloud.go
+++ b/app/cloud.go
@@ -33,7 +33,7 @@ func (a *fyneApp) transitionCloud(p fyne.CloudProvider) {
 		a.storage = cloud.CloudStorage(a)
 	} else {
 		store := &store{a: a}
-		store.Docs = makeStoreDocs(a.uniqueID, a.prefs, store)
+		store.Docs = makeStoreDocs(a.uniqueID, store)
 		a.storage = store
 	}
 

--- a/app/storage_test.go
+++ b/app/storage_test.go
@@ -4,14 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"fyne.io/fyne/v2/internal"
 )
 
 func TestStore_RootURI(t *testing.T) {
 	id := "io.fyne.test"
 	a := &fyneApp{uniqueID: id}
-	d := makeStoreDocs(id, &internal.InMemoryPreferences{}, &store{a: a})
+	d := makeStoreDocs(id, &store{a: a})
 
 	w, err := d.Create("test")
 	assert.Nil(t, err)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR cleans up some of the app startup code to avoid an issue where preferences were loaded multiple times on startup. There are some other cleanups included as well for more performance and memory use improvements.

#### Multiple loads

We were storing a known struct as an interface and then directly doing an interface check to verify that it contained the method `load()`. However, we don't need to do an interface when we already know the type so we can remove it and know that we will have loaded the preferences. Now that we know the preferences are loaded already, we can remove the exact same interface check that was done before setting up document storage.

This improves the startup speed by only loading and parsing the preferences file once instead of twice during startup. The lack of interface casting improves things a bit further.

#### Test-only field

The app struct contained a field that was basically only used in order to intercept the command execution. This was only ever used for a single test and that test also wasn't very good due to not running in ci and so on. Removing the field uses slightly less memory but it also made the test not work. Another test was added to keep the percentage stable while the old, and bad test, was removed.  

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.