### PR TITLE
widget: Single line Entry: Submit should include selected text. (#4026)

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1027,8 +1027,10 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 		e.eraseSelection()
 		return true
 	case fyne.KeyReturn, fyne.KeyEnter:
-		// clear the selection -- return unhandled to add the newline
-		e.eraseSelection()
+		if e.MultiLine {
+			// clear the selection -- return unhandled to add the newline
+			e.eraseSelection()
+		}
 		return false
 	}
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1875,6 +1875,16 @@ func TestSingleLineEntry_SelectionSubmitted(t *testing.T) {
 	assert.Equal(t, entry.Text, "abc")
 }
 
+func TestMultiLineEntry_EnterWithSelection(t *testing.T) {
+	entry := widget.NewMultiLineEntry()
+	entry.SetText("abc")
+	assert.Equal(t, "", entry.SelectedText())
+	entry.TypedShortcut(&fyne.ShortcutSelectAll{})
+	assert.Equal(t, "abc", entry.SelectedText())
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyEnter})
+	assert.Equal(t, entry.Text, "\n")
+}
+
 func TestEntry_CarriageReturn(t *testing.T) {
 	entry := widget.NewMultiLineEntry()
 	entry.Wrapping = fyne.TextWrapOff

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1865,6 +1865,16 @@ func TestSingleLineEntry_NewlineIgnored(t *testing.T) {
 	checkNewlineIgnored(t, entry)
 }
 
+func TestSingleLineEntry_SelectionSubmitted(t *testing.T) {
+	entry := widget.NewEntry()
+	entry.SetText("abc")
+	assert.Equal(t, "", entry.SelectedText())
+	entry.TypedShortcut(&fyne.ShortcutSelectAll{})
+	assert.Equal(t, "abc", entry.SelectedText())
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyEnter})
+	assert.Equal(t, entry.Text, "abc")
+}
+
 func TestEntry_CarriageReturn(t *testing.T) {
 	entry := widget.NewMultiLineEntry()
 	entry.Wrapping = fyne.TextWrapOff


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
When hitting Enter on a single line Entry widget, it should Submit that Entry and include any selected text. Previous to this commit it was discarding any selected text.

Multi line Entry widgets should not change behaviour.

Fixes #4026

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

All the tests did not pass on my machine. All the failing ones appear to be internal/driver/glfw tests so I'm assuming I just don't have something necessary installed to properly run those tests. Looked mostly to be Width not equaling what's expected, expected 69, got 176. And a few Height mismatches, expected 37, got 9. Just examples, some tests have other value mimatches but always seems like just the Width and Height stuff.

go vet ./... gave the following warning, but didn't seem like an important fix?

`internal\driver\mobile\app\shiny.go:15:12: result of fmt.Errorf call not used`

It's in a main() so there's nowhere to return the err anyway. Maybe somebody meant log.Fatalf?

#### Where applicable:
<!-- Please delete these if not required for this PR -->
