### PR TITLE
Force writing preferences to file when application stops (fixes #3170)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -148,6 +148,11 @@ func newAppWithDriver(d fyne.Driver, id string) fyne.App {
 	fyne.SetCurrentApp(newApp)
 
 	newApp.prefs = newApp.newDefaultPreferences()
+	newApp.lifecycle.(*app.Lifecycle).SetAfterStopped(func() {
+		if prefs, ok := newApp.prefs.(*preferences); ok {
+			prefs.forceImmediateSave()
+		}
+	})
 	newApp.settings = loadSettings()
 	store := &store{a: newApp}
 	store.Docs = makeStoreDocs(id, newApp.prefs, store)

--- a/app/app.go
+++ b/app/app.go
@@ -148,7 +148,7 @@ func newAppWithDriver(d fyne.Driver, id string) fyne.App {
 	fyne.SetCurrentApp(newApp)
 
 	newApp.prefs = newApp.newDefaultPreferences()
-	newApp.lifecycle.(*app.Lifecycle).SetAfterStopped(func() {
+	newApp.lifecycle.(*app.Lifecycle).SetOnStoppedHookExecuted(func() {
 		if prefs, ok := newApp.prefs.(*preferences); ok {
 			prefs.forceImmediateSave()
 		}

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -62,7 +62,6 @@ func (p *preferences) saveToFile(path string) error {
 	p.savedRecently = true
 	p.prefLock.Unlock()
 	defer p.resetSavedRecently()
-
 	err := os.MkdirAll(filepath.Dir(path), 0700)
 	if err != nil { // this is not an exists error according to docs
 		return err

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -17,13 +17,13 @@ type Lifecycle struct {
 	onStarted    atomic.Value // func()
 	onStopped    atomic.Value // func()
 
-	internalAfterStoppedTrigger atomic.Value // func()
+	onStoppedHookExecuted atomic.Value // func()
 }
 
-// SetAfterStopped is an internal function that lets Fyne schedule a clean-up after
+// SetOnStoppedHookExecuted is an internal function that lets Fyne schedule a clean-up after
 // the user-provided stopped hook.
-func (l *Lifecycle) SetAfterStopped(f func()) {
-	l.internalAfterStoppedTrigger.Store(f)
+func (l *Lifecycle) SetOnStoppedHookExecuted(f func()) {
+	l.onStoppedHookExecuted.Store(f)
 }
 
 // SetOnEnteredForeground hooks into the the app becoming foreground.
@@ -79,7 +79,7 @@ func (l *Lifecycle) TriggerStopped() {
 	if ff, ok := f.(func()); ok && ff != nil {
 		ff()
 	}
-	f = l.internalAfterStoppedTrigger.Load()
+	f = l.onStoppedHookExecuted.Load()
 	if ff, ok := f.(func()); ok && ff != nil {
 		ff()
 	}

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -17,13 +17,13 @@ type Lifecycle struct {
 	onStarted    atomic.Value // func()
 	onStopped    atomic.Value // func()
 
-	onStoppedHookExecuted atomic.Value // func()
+	onStoppedHookExecuted func()
 }
 
 // SetOnStoppedHookExecuted is an internal function that lets Fyne schedule a clean-up after
-// the user-provided stopped hook.
+// the user-provided stopped hook. It should only be called once during an application start-up.
 func (l *Lifecycle) SetOnStoppedHookExecuted(f func()) {
-	l.onStoppedHookExecuted.Store(f)
+	l.onStoppedHookExecuted = f
 }
 
 // SetOnEnteredForeground hooks into the the app becoming foreground.
@@ -79,8 +79,7 @@ func (l *Lifecycle) TriggerStopped() {
 	if ff, ok := f.(func()); ok && ff != nil {
 		ff()
 	}
-	f = l.onStoppedHookExecuted.Load()
-	if ff, ok := f.(func()); ok && ff != nil {
-		ff()
+	if l.onStoppedHookExecuted != nil {
+		l.onStoppedHookExecuted()
 	}
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

Fyne's preferences mechanism implements a debouncing strategy for modifications, it saves the preferences changes to the filesystem at most every 100ms. As explained in issue #3170, the implementation has a bug: if an application modifies at least two preferences (say "A" and "B") during the `OnStopped` lifecycle trigger, we get this:

1. Preference "A" modified, the preferences change listener saves the result to file.
2. Preference "B" modified, the preferences change listener **does not write** the result to file, but instead schedules the save 100ms later.
3. Application exits.
4. After about 100ms, the updated value of the preference "B" would be written to file, but the application is not running anymore. Thus only the value of the preference "A" is updated.

This pull request forces the application to write preferences to file on exit. It does this by adding a new internal lifecycle event, `AfterStoppedTrigger`, which is evaluated after the user-provided `Stopped` lifecycle callback. This modification does not change any public-facing interfaces, only internal implementations.

Fixes #3170.

### Example code

For completeness, here's an example code that demonstrates that the issue #3170 applies to the lifecycle triggers as well. It starts working as intended after this patch.

```go
package main

import (
	"fmt"
	"math/rand"
	"time"

	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/container"
	"fyne.io/fyne/v2/layout"
	"fyne.io/fyne/v2/widget"
)

func main() {
	application := app.NewWithID("preferences-bug")
	window := application.NewWindow("Preferences bug")

	randomSource := rand.NewSource(time.Now().UnixNano())
	rng := rand.New(randomSource)
	value := rng.Intn(1000)

	label1 := widget.NewLabel(fmt.Sprintf("1st value: %d", application.Preferences().IntWithFallback("one", 0)))
	label2 := widget.NewLabel(fmt.Sprintf("2nd value: %d", application.Preferences().IntWithFallback("two", 0)))
	button := widget.NewButton(fmt.Sprintf("Quit and write %d to both preferences", value), func() {
		application.Quit()
	})
	box := container.New(layout.NewVBoxLayout(), label1, label2, button)
	window.Resize(fyne.NewSize(float32(200), float32(100)))
	window.SetContent(box)

	application.Lifecycle().SetOnStopped(func() {
		application.Preferences().SetInt("one", value)
		application.Preferences().SetInt("two", value)
	})

	window.ShowAndRun()
}
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- I don't know how to test lifecycle triggers; besides, fyne's tests only set up in-memory preferences, so I don't know how to test that the file is saved correctly.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
