### PR TITLE
Re-add hyperlink colour

### DIFF
--- a/theme/theme.go
+++ b/theme/theme.go
@@ -88,6 +88,11 @@ const (
 	// Since: 2.0
 	ColorNameHover fyne.ThemeColorName = "hover"
 
+	// ColorNameHyperlink is the name of theme lookup for hyperlink color.
+	//
+	// Since: 2.4
+	ColorNameHyperlink fyne.ThemeColorName = "hyperlink"
+
 	// ColorNameInputBackground is the name of theme lookup for background color of an input field.
 	//
 	// Since: 2.0
@@ -356,6 +361,11 @@ func HeaderBackgroundColor() color.Color {
 // HoverColor returns the color used to highlight interactive elements currently under a cursor.
 func HoverColor() color.Color {
 	return safeColorLookup(ColorNameHover, currentVariant())
+}
+
+// HyperlinkColor returns the color used for the Hyperlink widget and hyperlink text elements.
+func HyperlinkColor() color.Color {
+	return safeColorLookup(ColorNameHyperlink, currentVariant())
 }
 
 // IconInlineSize is the standard size of icons which appear within buttons, labels etc.
@@ -627,7 +637,7 @@ func (t *builtinTheme) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.C
 	}
 
 	primary := fyne.CurrentApp().Settings().PrimaryColor()
-	if n == ColorNamePrimary {
+	if n == ColorNamePrimary || n == ColorNameHyperlink {
 		return primaryColorNamed(primary)
 	} else if n == ColorNameFocus {
 		return focusColorNamed(primary)

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -60,7 +60,7 @@ func (hl *Hyperlink) CreateRenderer() fyne.WidgetRenderer {
 	focus.StrokeColor = theme.FocusColor()
 	focus.StrokeWidth = 2
 	focus.Hide()
-	under := canvas.NewRectangle(theme.PrimaryColor())
+	under := canvas.NewRectangle(theme.HyperlinkColor())
 	under.Hide()
 	return &hyperlinkRenderer{hl: hl, objects: []fyne.CanvasObject{hl.provider, focus, under}, focus: focus, under: under}
 }
@@ -190,7 +190,7 @@ func (hl *Hyperlink) syncSegments() {
 	hl.provider.Segments = []RichTextSegment{&TextSegment{
 		Style: RichTextStyle{
 			Alignment: hl.Alignment,
-			ColorName: theme.ColorNamePrimary,
+			ColorName: theme.ColorNameHyperlink,
 			Inline:    true,
 			TextStyle: hl.TextStyle,
 		},
@@ -231,6 +231,6 @@ func (r *hyperlinkRenderer) Refresh() {
 	r.hl.provider.Refresh()
 	r.focus.StrokeColor = theme.FocusColor()
 	r.focus.Hidden = !r.hl.focused
-	r.under.StrokeColor = theme.PrimaryColor()
+	r.under.StrokeColor = theme.HyperlinkColor()
 	r.under.Hidden = !r.hl.hovered
 }


### PR DESCRIPTION
Fixes #3867


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included. (existing tests passing as the colour is the same by default)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
