### PR TITLE
Support CTRL + Backspace for deleting word in Entry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -941,10 +941,27 @@ func (e *Entry) registerShortcut() {
 		e.selecting = false
 		moveWord(se)
 	}
+	removeWord := func(se fyne.Shortcut) {
+		row := e.textProvider().row(e.CursorRow)
+		start, end := getTextWhitespaceRegion(row, e.CursorColumn, true)
+		if start == -1 || end == -1 {
+			return
+		}
+
+		e.propertyLock.Lock()
+		pos := e.cursorTextPos()
+		e.textProvider().deleteFromTo(start, pos)
+		e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos - 1)
+		e.propertyLock.Unlock()
+
+		e.updateTextAndRefresh(e.textProvider().String())
+	}
+
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierShortcutDefault}, unselectMoveWord)
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}, selectMoveWord)
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault}, unselectMoveWord)
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}, selectMoveWord)
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}, removeWord)
 }
 
 func (e *Entry) requestFocus() {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -941,7 +941,7 @@ func (e *Entry) registerShortcut() {
 		e.selecting = false
 		moveWord(se)
 	}
-	removeWord := func(se fyne.Shortcut) {
+	removeWordLeft := func(_ fyne.Shortcut) {
 		row := e.textProvider().row(e.CursorRow)
 		start, end := getTextWhitespaceRegion(row, e.CursorColumn, true)
 		if start == -1 || end == -1 {
@@ -956,12 +956,29 @@ func (e *Entry) registerShortcut() {
 
 		e.updateTextAndRefresh(e.textProvider().String())
 	}
+	removeWordRight := func(_ fyne.Shortcut) {
+		row := e.textProvider().row(e.CursorRow)
+		start, end := getTextWhitespaceRegion(row, e.CursorColumn, true)
+		if start == -1 || end == -1 {
+			return
+		}
+
+		e.propertyLock.Lock()
+		pos := e.cursorTextPos()
+		e.textProvider().deleteFromTo(pos, end)
+		e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
+		e.propertyLock.Unlock()
+
+		e.updateTextAndRefresh(e.textProvider().String())
+	}
 
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierShortcutDefault}, unselectMoveWord)
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}, selectMoveWord)
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault}, unselectMoveWord)
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}, selectMoveWord)
-	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}, removeWord)
+
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}, removeWordLeft)
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyDelete, Modifier: fyne.KeyModifierShortcutDefault}, removeWordRight)
 }
 
 func (e *Entry) requestFocus() {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -944,8 +944,8 @@ func (e *Entry) registerShortcut() {
 	}
 	removeWordLeft := func(_ fyne.Shortcut) {
 		row := e.textProvider().row(e.CursorRow)
-		start, end := getTextWhitespaceRegion(row, e.CursorColumn, true)
-		if start == -1 || end == -1 {
+		start, _ := getTextWhitespaceRegion(row, e.CursorColumn, true)
+		if start == -1 {
 			return
 		}
 
@@ -959,8 +959,8 @@ func (e *Entry) registerShortcut() {
 	}
 	removeWordRight := func(_ fyne.Shortcut) {
 		row := e.textProvider().row(e.CursorRow)
-		start, end := getTextWhitespaceRegion(row, e.CursorColumn, true)
-		if start == -1 || end == -1 {
+		_, end := getTextWhitespaceRegion(row, e.CursorColumn, true)
+		if end == -1 {
 			return
 		}
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"image/color"
 	"math"
+	"runtime"
 	"strings"
 	"time"
 	"unicode"
@@ -977,8 +978,13 @@ func (e *Entry) registerShortcut() {
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault}, unselectMoveWord)
 	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}, selectMoveWord)
 
-	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}, removeWordLeft)
-	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyDelete, Modifier: fyne.KeyModifierShortcutDefault}, removeWordRight)
+	deleteModifier := fyne.KeyModifierControl
+	if runtime.GOOS == "darwin" {
+		deleteModifier = fyne.KeyModifierAlt
+	}
+
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: deleteModifier}, removeWordLeft)
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyDelete, Modifier: deleteModifier}, removeWordRight)
 }
 
 func (e *Entry) requestFocus() {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -197,6 +197,21 @@ func TestEntry_Control_Word(t *testing.T) {
 	// unselect when no shift press
 	entry.TypedShortcut(nextWord)
 	assert.Equal(t, "", entry.SelectedText())
+
+	// delete word when pressing backspace
+	deleteWord := &desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}
+	entry.SetText("word1 word2 word3")
+	entry.TypedShortcut(deleteWord)
+	assert.Equal(t, "word1 word2 ", entry.Text)
+	entry.TypedShortcut(deleteWord)
+	assert.Equal(t, "word1 ", entry.Text)
+	entry.TypedShortcut(deleteWord)
+	assert.Equal(t, "", entry.Text)
+
+	// Deleting with nothing to delete does nothing
+	entry.TypedShortcut(deleteWord)
+	assert.Equal(t, "", entry.Text)
+
 }
 
 func TestEntry_CursorColumn_Wrap(t *testing.T) {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -2,6 +2,7 @@ package widget_test
 
 import (
 	"image/color"
+	"runtime"
 	"testing"
 	"time"
 
@@ -198,8 +199,14 @@ func TestEntry_Control_Word(t *testing.T) {
 	entry.TypedShortcut(nextWord)
 	assert.Equal(t, "", entry.SelectedText())
 
+	// Modifer is Alt on macOS
+	deleteModifier := fyne.KeyModifierControl
+	if runtime.GOOS == "darwin" {
+		deleteModifier = fyne.KeyModifierAlt
+	}
+
 	// delete word to the left when pressing backspace
-	deleteWordLeft := &desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}
+	deleteWordLeft := &desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: deleteModifier}
 	entry.SetText("word1 word2 word3")
 	entry.TypedShortcut(deleteWordLeft)
 	assert.Equal(t, "word1 word2 ", entry.Text)
@@ -213,7 +220,7 @@ func TestEntry_Control_Word(t *testing.T) {
 	assert.Equal(t, "", entry.Text)
 
 	// delete word to the left when pressing backspace
-	deleteWordRight := &desktop.CustomShortcut{KeyName: fyne.KeyDelete, Modifier: fyne.KeyModifierShortcutDefault}
+	deleteWordRight := &desktop.CustomShortcut{KeyName: fyne.KeyDelete, Modifier: deleteModifier}
 	entry.SetText("word1 word2 word3")
 	entry.CursorRow = 0
 	entry.CursorColumn = 0

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -198,18 +198,34 @@ func TestEntry_Control_Word(t *testing.T) {
 	entry.TypedShortcut(nextWord)
 	assert.Equal(t, "", entry.SelectedText())
 
-	// delete word when pressing backspace
-	deleteWord := &desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}
+	// delete word to the left when pressing backspace
+	deleteWordLeft := &desktop.CustomShortcut{KeyName: fyne.KeyBackspace, Modifier: fyne.KeyModifierShortcutDefault}
 	entry.SetText("word1 word2 word3")
-	entry.TypedShortcut(deleteWord)
+	entry.TypedShortcut(deleteWordLeft)
 	assert.Equal(t, "word1 word2 ", entry.Text)
-	entry.TypedShortcut(deleteWord)
+	entry.TypedShortcut(deleteWordLeft)
 	assert.Equal(t, "word1 ", entry.Text)
-	entry.TypedShortcut(deleteWord)
+	entry.TypedShortcut(deleteWordLeft)
 	assert.Equal(t, "", entry.Text)
 
 	// Deleting with nothing to delete does nothing
-	entry.TypedShortcut(deleteWord)
+	entry.TypedShortcut(deleteWordLeft)
+	assert.Equal(t, "", entry.Text)
+
+	// delete word to the left when pressing backspace
+	deleteWordRight := &desktop.CustomShortcut{KeyName: fyne.KeyDelete, Modifier: fyne.KeyModifierShortcutDefault}
+	entry.SetText("word1 word2 word3")
+	entry.CursorRow = 0
+	entry.CursorColumn = 0
+	entry.TypedShortcut(deleteWordRight)
+	assert.Equal(t, " word2 word3", entry.Text)
+	entry.TypedShortcut(deleteWordRight)
+	assert.Equal(t, " word3", entry.Text)
+	entry.TypedShortcut(deleteWordRight)
+	assert.Equal(t, "", entry.Text)
+
+	// Deleting with nothing to delete does nothing
+	entry.TypedShortcut(deleteWordRight)
 	assert.Equal(t, "", entry.Text)
 
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This adds support for pressing `ctrl + backspace` for deleting a whole word.
Opening as draft until I have added support for `ctrl + delete` for deleting a whole word to the left as well.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
