### PR TITLE
Added AppendLine method to widget.Entry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -474,26 +474,17 @@ func (e *Entry) SetText(text string) {
 	e.updateCursorAndSelection()
 }
 
-// AppendLine appends the text to the end of the entry adding a new line if the entry isn't empty,
-// or a space if multiline isn't enabled
+// Appends the text to the end of the entry
 //
 // Since: 2.4
-func (e *Entry) AppendLine(text string) {
-	e.propertyLock.RLock()
-	ml := e.MultiLine
-	st := e.Text
-	e.propertyLock.RUnlock()
+func (e *Entry) Append(text string) {
+	e.propertyLock.Lock()
+	provider := e.textProvider()
+	provider.insertAt(provider.len(), text)
+	e.updateText(provider.String())
+	e.propertyLock.Unlock()
 
-	delim := "\n"
-	if !ml {
-		delim = " "
-	}
-	if st != "" {
-		st += delim
-	}
-	st += text
-
-	e.SetText(st)
+	e.Refresh()
 }
 
 // Tapped is called when this entry has been tapped. We update the cursor position in

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -474,6 +474,28 @@ func (e *Entry) SetText(text string) {
 	e.updateCursorAndSelection()
 }
 
+// AppendLine appends the text to the end of the entry adding a new line if the entry isn't empty,
+// or a space if multiline isn't enabled
+//
+// Since: 2.4
+func (e *Entry) AppendLine(text string) {
+	e.propertyLock.RLock()
+	ml := e.MultiLine
+	st := e.Text
+	e.propertyLock.RUnlock()
+
+	delim := "\n"
+	if !ml {
+		delim = " "
+	}
+	if st != "" {
+		st += delim
+	}
+	st += text
+
+	e.SetText(st)
+}
+
 // Tapped is called when this entry has been tapped. We update the cursor position in
 // device-specific callbacks (MouseDown() and TouchDown()).
 //

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1483,19 +1483,19 @@ func TestEntry_SetTextStyle(t *testing.T) {
 	test.AssertRendersToMarkup(t, "entry/set_text_style_italic.xml", c)
 }
 
-func TestEntry_AppendLine(t *testing.T) {
+func TestEntry_Append(t *testing.T) {
 	entry := widget.NewEntry()
 
-	entry.AppendLine("line")
-	assert.Equal(t, entry.Text, "line")
-	entry.AppendLine("no line")
-	assert.Equal(t, entry.Text, "line no line")
+	entry.Append("abc")
+	assert.Equal(t, entry.Text, "abc")
+	entry.Append(" def")
+	assert.Equal(t, entry.Text, "abc def")
 
 	entry.SetText("")
 	entry.MultiLine = true
 
-	entry.AppendLine("first line")
-	entry.AppendLine("second line")
+	entry.Append("first line")
+	entry.Append("\nsecond line")
 	assert.Equal(t, entry.Text, "first line\nsecond line")
 }
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1483,6 +1483,22 @@ func TestEntry_SetTextStyle(t *testing.T) {
 	test.AssertRendersToMarkup(t, "entry/set_text_style_italic.xml", c)
 }
 
+func TestEntry_AppendLine(t *testing.T) {
+	entry := widget.NewEntry()
+
+	entry.AppendLine("line")
+	assert.Equal(t, entry.Text, "line")
+	entry.AppendLine("no line")
+	assert.Equal(t, entry.Text, "line no line")
+
+	entry.SetText("")
+	entry.MultiLine = true
+
+	entry.AppendLine("first line")
+	entry.AppendLine("second line")
+	assert.Equal(t, entry.Text, "first line\nsecond line")
+}
+
 func TestEntry_Submit(t *testing.T) {
 	t.Run("Callback", func(t *testing.T) {
 		var submission string


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Added an `AppendLine` method to `entry`, to make appending to multiline entry easier.
Wasn't sure what to do if the entry isn't multiline so I set it to append with a space instead of a newline. Come to think of it maybe I should make the method just `Append`?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
