### PR TITLE
cleaned up typedKey methods on entry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -605,13 +605,13 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	case fyne.KeyTab:
 		e.TypedRune('\t')
 	case fyne.KeyUp:
-		e.typedKeyUp(provider, multiLine)
+		e.typedKeyUp(provider)
 	case fyne.KeyDown:
-		e.typedKeyDown(provider, multiLine)
+		e.typedKeyDown(provider)
 	case fyne.KeyLeft:
-		e.typedKeyLeft(provider, multiLine)
+		e.typedKeyLeft(provider)
 	case fyne.KeyRight:
-		e.typedKeyRight(provider, multiLine)
+		e.typedKeyRight(provider)
 	case fyne.KeyEnd:
 		e.propertyLock.Lock()
 		if e.MultiLine {
@@ -653,7 +653,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	e.Refresh()
 }
 
-func (e *Entry) typedKeyUp(provider *RichText, multiLine bool) {
+func (e *Entry) typedKeyUp(provider *RichText) {
 	e.propertyLock.Lock()
 
 	if e.CursorRow > 0 {
@@ -669,7 +669,7 @@ func (e *Entry) typedKeyUp(provider *RichText, multiLine bool) {
 	e.propertyLock.Unlock()
 }
 
-func (e *Entry) typedKeyDown(provider *RichText, multiLine bool) {
+func (e *Entry) typedKeyDown(provider *RichText) {
 	e.propertyLock.Lock()
 	rowLength := provider.rowLength(e.CursorRow)
 
@@ -686,7 +686,7 @@ func (e *Entry) typedKeyDown(provider *RichText, multiLine bool) {
 	e.propertyLock.Unlock()
 }
 
-func (e *Entry) typedKeyLeft(provider *RichText, multiLine bool) {
+func (e *Entry) typedKeyLeft(provider *RichText) {
 	e.propertyLock.Lock()
 	if e.CursorColumn > 0 {
 		e.CursorColumn--
@@ -697,7 +697,7 @@ func (e *Entry) typedKeyLeft(provider *RichText, multiLine bool) {
 	e.propertyLock.Unlock()
 }
 
-func (e *Entry) typedKeyRight(provider *RichText, multiLine bool) {
+func (e *Entry) typedKeyRight(provider *RichText) {
 	e.propertyLock.Lock()
 	if e.MultiLine {
 		rowLength := provider.rowLength(e.CursorRow)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

while skimming the code I found a bunch of methods in `widget.Entry` that take in a bool parameter of `multiLine` but don't use it, so I removed it. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
