### PR TITLE
Complete keyboard handling for all collection widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 
 * Go 1.17 or later is now required.
 * Icons for macOS bundles are now padded and rounded, disable with "-use-raw-icon"
+* Focus handling for List/Tree/Table are now at the parent widget not child elements
 
 
 ## 2.3.5 - 6 June 2023

--- a/cmd/fyne_demo/tutorials/collection.go
+++ b/cmd/fyne_demo/tutorials/collection.go
@@ -21,6 +21,44 @@ func collectionScreen(_ fyne.Window) fyne.CanvasObject {
 	return container.NewCenter(content)
 }
 
+func makeGridWrapTab(_ fyne.Window) fyne.CanvasObject {
+	data := make([]string, 1000)
+	for i := range data {
+		data[i] = "Test Item " + strconv.Itoa(i)
+	}
+
+	icon := widget.NewIcon(nil)
+	label := widget.NewLabel("Select An Item From The List")
+	vbox := container.NewVBox(icon, label)
+
+	grid := widget.NewGridWrap(
+		func() int {
+			return len(data)
+		},
+		func() fyne.CanvasObject {
+			text := widget.NewLabel("Template Object")
+			text.Alignment = fyne.TextAlignCenter
+			return container.NewVBox(container.NewPadded(widget.NewIcon(theme.DocumentIcon())), text)
+		},
+		func(id widget.ListItemID, item fyne.CanvasObject) {
+			item.(*fyne.Container).Objects[1].(*widget.Label).SetText(data[id])
+		},
+	)
+	grid.OnSelected = func(id widget.ListItemID) {
+		label.SetText(data[id])
+		icon.SetResource(theme.DocumentIcon())
+	}
+	grid.OnUnselected = func(id widget.ListItemID) {
+		label.SetText("Select An Item From The List")
+		icon.SetResource(nil)
+	}
+	grid.Select(15)
+
+	split := container.NewHSplit(grid, container.NewCenter(vbox))
+	split.Offset = 0.6
+	return split
+}
+
 func makeListTab(_ fyne.Window) fyne.CanvasObject {
 	data := make([]string, 1000)
 	for i := range data {

--- a/cmd/fyne_demo/tutorials/data.go
+++ b/cmd/fyne_demo/tutorials/data.go
@@ -150,6 +150,11 @@ var (
 			makeTreeTab,
 			true,
 		},
+		"gridwrap": {"GridWrap",
+			"A grid based arrangement of cached elements that wraps rows to fit.",
+			makeGridWrapTab,
+			true,
+		},
 		"dialogs": {"Dialogs",
 			"Work with dialogs.",
 			dialogScreen,
@@ -175,7 +180,7 @@ var (
 	// TutorialIndex  defines how our tutorials should be laid out in the index tree
 	TutorialIndex = map[string][]string{
 		"":            {"welcome", "canvas", "animations", "icons", "widgets", "collections", "containers", "dialogs", "windows", "binding", "advanced"},
-		"collections": {"list", "table", "tree"},
+		"collections": {"list", "table", "tree", "gridwrap"},
 		"containers":  {"apptabs", "border", "box", "center", "doctabs", "grid", "scroll", "split"},
 		"widgets":     {"accordion", "button", "card", "entry", "form", "input", "progress", "text", "toolbar"},
 	}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -536,7 +536,20 @@ func (w *window) processMouseClicked(button desktop.MouseButton, action action, 
 	}
 
 	if wid, ok := co.(fyne.Focusable); !ok || wid != w.canvas.Focused() {
-		w.canvas.Unfocus()
+		ignore := false
+		_, _, _ = w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) bool {
+			switch object.(type) {
+			case fyne.Focusable:
+				ignore = true
+				return true
+			}
+
+			return false
+		})
+
+		if !ignore { // if a parent item under the mouse has focus then ignore this tap unfocus
+			w.canvas.Unfocus()
+		}
 	}
 
 	w.mouseLock.Lock()

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -511,13 +511,14 @@ func (l *gridWrapLayout) setupGridItem(li *gridWrapItem, id GridWrapItemID, focu
 		f(id, li.child)
 	}
 	li.onTapped = func() {
+		// TODO l.list.RefreshItem(t.currentFocus)
 		canvas := fyne.CurrentApp().Driver().CanvasForObject(l.list)
 		if canvas != nil {
 			canvas.Focus(l.list)
 		}
 
-		l.list.Select(id)
 		l.list.currentFocus = id
+		l.list.Select(id)
 	}
 }
 

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -3,10 +3,60 @@ package widget
 import (
 	"testing"
 
-	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
 )
+
+func TestGridWrap_Focus(t *testing.T) {
+	defer test.NewApp()
+	list := createGridWrap(100)
+	window := test.NewWindow(list)
+	defer window.Close()
+	window.Resize(list.MinSize().Max(fyne.NewSize(150, 200)))
+
+	canvas := window.Canvas().(test.WindowlessCanvas)
+	assert.Nil(t, canvas.Focused())
+
+	canvas.FocusNext()
+	assert.NotNil(t, canvas.Focused())
+	assert.Equal(t, 0, canvas.Focused().(*GridWrap).currentFocus)
+
+	children := list.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).children
+	assert.True(t, children[0].(*gridWrapItem).hovered)
+	assert.False(t, children[1].(*gridWrapItem).hovered)
+	assert.False(t, children[6].(*gridWrapItem).hovered)
+	assert.False(t, children[7].(*gridWrapItem).hovered)
+
+	list.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
+	assert.False(t, children[0].(*gridWrapItem).hovered)
+	assert.False(t, children[1].(*gridWrapItem).hovered)
+	assert.True(t, children[6].(*gridWrapItem).hovered)
+	assert.False(t, children[7].(*gridWrapItem).hovered)
+
+	list.TypedKey(&fyne.KeyEvent{Name: fyne.KeyRight})
+	assert.False(t, children[0].(*gridWrapItem).hovered)
+	assert.False(t, children[1].(*gridWrapItem).hovered)
+	assert.False(t, children[6].(*gridWrapItem).hovered)
+	assert.True(t, children[7].(*gridWrapItem).hovered)
+
+	list.TypedKey(&fyne.KeyEvent{Name: fyne.KeyLeft})
+	assert.False(t, children[0].(*gridWrapItem).hovered)
+	assert.False(t, children[1].(*gridWrapItem).hovered)
+	assert.True(t, children[6].(*gridWrapItem).hovered)
+	assert.False(t, children[7].(*gridWrapItem).hovered)
+
+	list.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
+	assert.True(t, children[0].(*gridWrapItem).hovered)
+	assert.False(t, children[1].(*gridWrapItem).hovered)
+	assert.False(t, children[6].(*gridWrapItem).hovered)
+	assert.False(t, children[7].(*gridWrapItem).hovered)
+
+	canvas.Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+	assert.True(t, children[0].(*gridWrapItem).selected)
+}
 
 func TestGridWrap_New(t *testing.T) {
 	g := createGridWrap(1000)

--- a/widget/list.go
+++ b/widget/list.go
@@ -278,7 +278,6 @@ func (l *List) TypedKey(event *fyne.KeyEvent) {
 		l.scrollTo(l.currentFocus)
 		l.RefreshItem(l.currentFocus)
 	}
-	// TODO up/down
 }
 
 // TypedRune is called if a text event happens while this listItem is focused.
@@ -610,6 +609,11 @@ func (l *listLayout) setupListItem(li *listItem, id ListItemID, focus bool) {
 		f(id, li.child)
 	}
 	li.onTapped = func() {
+		canvas := fyne.CurrentApp().Driver().CanvasForObject(l.list)
+		if canvas != nil {
+			canvas.Focus(l.list)
+		}
+
 		l.list.currentFocus = id
 		l.list.Select(id)
 	}

--- a/widget/list.go
+++ b/widget/list.go
@@ -18,6 +18,7 @@ type ListItemID = int
 
 // Declare conformity with Widget interface.
 var _ fyne.Widget = (*List)(nil)
+var _ fyne.Focusable = (*List)(nil)
 
 // List is a widget that pools list items for performance and
 // lays the items out in a vertical direction inside of a scroller.
@@ -33,6 +34,8 @@ type List struct {
 	OnSelected   func(id ListItemID)                         `json:"-"`
 	OnUnselected func(id ListItemID)                         `json:"-"`
 
+	currentFocus  ListItemID
+	focused       bool
 	scroller      *widget.Scroll
 	selected      []ListItemID
 	itemMin       fyne.Size
@@ -86,6 +89,23 @@ func (l *List) CreateRenderer() fyne.WidgetRenderer {
 	return newListRenderer(objects, l, l.scroller, layout)
 }
 
+// FocusGained is called after this listItem has gained focus.
+//
+// Implements: fyne.Focusable
+func (l *List) FocusGained() {
+	l.focused = true
+	l.scrollTo(l.currentFocus)
+	l.RefreshItem(l.currentFocus)
+}
+
+// FocusLost is called after this listItem has lost focus.
+//
+// Implements: fyne.Focusable
+func (l *List) FocusLost() {
+	l.focused = false
+	l.RefreshItem(l.currentFocus)
+}
+
 // MinSize returns the size that this widget should not shrink below.
 func (l *List) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
@@ -103,13 +123,8 @@ func (l *List) RefreshItem(id ListItemID) {
 	l.BaseWidget.Refresh()
 	lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
 	visible := lo.visible
-	canvas := fyne.CurrentApp().Driver().CanvasForObject(lo.list)
-	var focused fyne.Focusable
-	if canvas != nil {
-		focused = canvas.Focused()
-	}
 	if item, ok := visible[id]; ok {
-		lo.setupListItem(item, id, focused == item)
+		lo.setupListItem(item, id, l.focused && l.currentFocus == id)
 	}
 }
 
@@ -237,6 +252,40 @@ func (l *List) ScrollToBottom() {
 func (l *List) ScrollToTop() {
 	l.scrollTo(0)
 	l.Refresh()
+}
+
+// TypedKey is called if a key event happens while this listItem is focused.
+//
+// Implements: fyne.Focusable
+func (l *List) TypedKey(event *fyne.KeyEvent) {
+	switch event.Name {
+	case fyne.KeySpace:
+		l.Select(l.currentFocus)
+	case fyne.KeyDown:
+		if f := l.Length; f != nil && l.currentFocus >= f()-1 {
+			return
+		}
+		l.RefreshItem(l.currentFocus)
+		l.currentFocus++
+		l.scrollTo(l.currentFocus)
+		l.RefreshItem(l.currentFocus)
+	case fyne.KeyUp:
+		if l.currentFocus <= 0 {
+			return
+		}
+		l.RefreshItem(l.currentFocus)
+		l.currentFocus--
+		l.scrollTo(l.currentFocus)
+		l.RefreshItem(l.currentFocus)
+	}
+	// TODO up/down
+}
+
+// TypedRune is called if a text event happens while this listItem is focused.
+//
+// Implements: fyne.Focusable
+func (l *List) TypedRune(_ rune) {
+	// intentionally left blank
 }
 
 // Unselect removes the item identified by the given ID from the selection.
@@ -369,7 +418,6 @@ func (l *listRenderer) Refresh() {
 }
 
 // Declare conformity with interfaces.
-var _ fyne.Focusable = (*listItem)(nil)
 var _ fyne.Widget = (*listItem)(nil)
 var _ fyne.Tappable = (*listItem)(nil)
 var _ desktop.Hoverable = (*listItem)(nil)
@@ -405,22 +453,6 @@ func (li *listItem) CreateRenderer() fyne.WidgetRenderer {
 	return &listItemRenderer{widget.NewBaseRenderer(objects), li}
 }
 
-// FocusGained is called after this listItem has gained focus.
-//
-// Implements: fyne.Focusable
-func (li *listItem) FocusGained() {
-	li.hovered = true
-	li.Refresh()
-}
-
-// FocusLost is called after this listItem has lost focus.
-//
-// Implements: fyne.Focusable
-func (li *listItem) FocusLost() {
-	li.hovered = false
-	li.Refresh()
-}
-
 // MinSize returns the size that this widget should not shrink below.
 func (li *listItem) MinSize() fyne.Size {
 	li.ExtendBaseWidget(li)
@@ -450,27 +482,6 @@ func (li *listItem) Tapped(*fyne.PointEvent) {
 		li.Refresh()
 		li.onTapped()
 	}
-}
-
-// TypedKey is called if a key event happens while this listItem is focused.
-//
-// Implements: fyne.Focusable
-func (li *listItem) TypedKey(event *fyne.KeyEvent) {
-	switch event.Name {
-	case fyne.KeySpace:
-		li.selected = true
-		li.Refresh()
-		if li.onTapped != nil {
-			li.onTapped()
-		}
-	}
-}
-
-// TypedRune is called if a text event happens while this listItem is focused.
-//
-// Implements: fyne.Focusable
-func (li *listItem) TypedRune(_ rune) {
-	// intentionally left blank
 }
 
 // Declare conformity with the WidgetRenderer interface.
@@ -599,6 +610,7 @@ func (l *listLayout) setupListItem(li *listItem, id ListItemID, focus bool) {
 		f(id, li.child)
 	}
 	li.onTapped = func() {
+		l.list.currentFocus = id
 		l.list.Select(id)
 	}
 }
@@ -652,16 +664,8 @@ func (l *listLayout) updateList(newOnly bool) {
 
 	l.visible = visible
 
-	var focused fyne.Focusable
-	canvas := fyne.CurrentApp().Driver().CanvasForObject(l.list)
-	if canvas != nil {
-		focused = canvas.Focused()
-	}
 	for id, old := range wasVisible {
 		if _, ok := l.visible[id]; !ok {
-			if focused == old {
-				canvas.Focus(nil)
-			}
 			l.itemPool.Release(old)
 		}
 	}
@@ -677,12 +681,12 @@ func (l *listLayout) updateList(newOnly bool) {
 	if newOnly {
 		for row, obj := range visible {
 			if _, ok := wasVisible[row]; !ok {
-				l.setupListItem(obj, row, focused == obj)
+				l.setupListItem(obj, row, l.list.focused && l.list.currentFocus == row)
 			}
 		}
 	} else {
 		for row, obj := range visible {
-			l.setupListItem(obj, row, focused == obj)
+			l.setupListItem(obj, row, l.list.focused && l.list.currentFocus == row)
 		}
 	}
 }

--- a/widget/list.go
+++ b/widget/list.go
@@ -16,7 +16,7 @@ import (
 // ListItemID uniquely identifies an item within a list.
 type ListItemID = int
 
-// Declare conformity with Widget interface.
+// Declare conformity with interfaces.
 var _ fyne.Widget = (*List)(nil)
 var _ fyne.Focusable = (*List)(nil)
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -89,7 +89,7 @@ func (l *List) CreateRenderer() fyne.WidgetRenderer {
 	return newListRenderer(objects, l, l.scroller, layout)
 }
 
-// FocusGained is called after this listItem has gained focus.
+// FocusGained is called after this List has gained focus.
 //
 // Implements: fyne.Focusable
 func (l *List) FocusGained() {
@@ -98,7 +98,7 @@ func (l *List) FocusGained() {
 	l.RefreshItem(l.currentFocus)
 }
 
-// FocusLost is called after this listItem has lost focus.
+// FocusLost is called after this List has lost focus.
 //
 // Implements: fyne.Focusable
 func (l *List) FocusLost() {
@@ -254,7 +254,7 @@ func (l *List) ScrollToTop() {
 	l.Refresh()
 }
 
-// TypedKey is called if a key event happens while this listItem is focused.
+// TypedKey is called if a key event happens while this List is focused.
 //
 // Implements: fyne.Focusable
 func (l *List) TypedKey(event *fyne.KeyEvent) {
@@ -280,7 +280,7 @@ func (l *List) TypedKey(event *fyne.KeyEvent) {
 	}
 }
 
-// TypedRune is called if a text event happens while this listItem is focused.
+// TypedRune is called if a text event happens while this List is focused.
 //
 // Implements: fyne.Focusable
 func (l *List) TypedRune(_ rune) {

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -518,37 +518,25 @@ func TestList_Focus(t *testing.T) {
 
 	canvas.FocusNext()
 	assert.NotNil(t, canvas.Focused())
-	assert.True(t, canvas.Focused().(*listItem).hovered)
-	assert.False(t, canvas.Focused().(*listItem).selected)
+	assert.Equal(t, 0, canvas.Focused().(*List).currentFocus)
 
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children
 	assert.True(t, children[0].(*listItem).hovered)
 	assert.False(t, children[1].(*listItem).hovered)
 	assert.False(t, children[2].(*listItem).hovered)
-	assert.Equal(t, children[0].(*listItem), canvas.Focused().(*listItem))
 
-	canvas.FocusNext()
-	assert.NotNil(t, canvas.Focused())
-	assert.True(t, canvas.Focused().(*listItem).hovered)
-	assert.False(t, canvas.Focused().(*listItem).selected)
+	list.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
 	assert.False(t, children[0].(*listItem).hovered)
 	assert.True(t, children[1].(*listItem).hovered)
 	assert.False(t, children[2].(*listItem).hovered)
-	assert.NotEqual(t, children[0].(*listItem), canvas.Focused().(*listItem))
-	assert.Equal(t, children[1].(*listItem), canvas.Focused().(*listItem))
 
-	canvas.FocusPrevious()
-	assert.NotNil(t, canvas.Focused())
-	assert.True(t, canvas.Focused().(*listItem).hovered)
-	assert.False(t, canvas.Focused().(*listItem).selected)
+	list.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
 	assert.True(t, children[0].(*listItem).hovered)
 	assert.False(t, children[1].(*listItem).hovered)
 	assert.False(t, children[2].(*listItem).hovered)
-	assert.Equal(t, children[0].(*listItem), canvas.Focused().(*listItem))
-	assert.NotEqual(t, children[1].(*listItem), canvas.Focused().(*listItem))
 
 	canvas.Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
-	assert.True(t, canvas.Focused().(*listItem).selected)
+	assert.True(t, children[0].(*listItem).selected)
 }
 
 func createList(items int) *List {

--- a/widget/table.go
+++ b/widget/table.go
@@ -196,9 +196,8 @@ func (t *Table) DragEnd() {
 // Implements: fyne.Focusable
 func (t *Table) FocusGained() {
 	t.focused = true
-	t.hoveredCell = &t.currentFocus
 	t.ScrollTo(t.currentFocus)
-	t.Refresh() // TODO RefreshItem(t.currentFocus)
+	t.Refresh() // TODO t.RefreshItem(t.currentFocus)
 }
 
 // FocusLost is called after this Table has lost focus.
@@ -315,20 +314,18 @@ func (t *Table) TypedKey(event *fyne.KeyEvent) {
 				return
 			}
 		}
-		t.Refresh() //Item(t.currentFocus)
+		// TODO t.RefreshItem(t.currentFocus)
 		t.currentFocus.Row++
-		t.hoveredCell = &t.currentFocus
 		t.ScrollTo(t.currentFocus)
-		t.Refresh() // TODO RefreshItem(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
 	case fyne.KeyLeft:
 		if t.currentFocus.Col <= 0 {
 			return
 		}
-		t.Refresh() //Item(t.currentFocus)
+		// TODO t.RefreshItem(t.currentFocus)
 		t.currentFocus.Col--
-		t.hoveredCell = &t.currentFocus
 		t.ScrollTo(t.currentFocus)
-		t.Refresh() // TODO RefreshItem(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
 	case fyne.KeyRight:
 		if f := t.Length; f != nil {
 			_, cols := f()
@@ -336,20 +333,18 @@ func (t *Table) TypedKey(event *fyne.KeyEvent) {
 				return
 			}
 		}
-		t.Refresh() // TODO RefreshItem(t.currentFocus)
+		// TODO t.RefreshItem(t.currentFocus)
 		t.currentFocus.Col++
-		t.hoveredCell = &t.currentFocus
 		t.ScrollTo(t.currentFocus)
-		t.Refresh() // TODO RefreshItem(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
 	case fyne.KeyUp:
 		if t.currentFocus.Row <= 0 {
 			return
 		}
-		t.Refresh() // TODO RefreshItem(t.currentFocus)
+		// TODO t.RefreshItem(t.currentFocus)
 		t.currentFocus.Row--
-		t.hoveredCell = &t.currentFocus
 		t.ScrollTo(t.currentFocus)
-		t.Refresh() // TODO RefreshItem(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
 	}
 }
 
@@ -1347,8 +1342,10 @@ func (r *tableCellsRenderer) moveIndicators() {
 	} else {
 		r.moveMarker(r.marker, r.cells.t.selectedCell.Row, r.cells.t.selectedCell.Col, offX, offY, minCol, minRow, visibleColWidths, visibleRowHeights)
 	}
-	if r.cells.t.hoveredCell == nil {
+	if r.cells.t.hoveredCell == nil && !r.cells.t.focused {
 		r.moveMarker(r.hover, -1, -1, offX, offY, minCol, minRow, visibleColWidths, visibleRowHeights)
+	} else if r.cells.t.focused {
+		r.moveMarker(r.hover, r.cells.t.currentFocus.Row, r.cells.t.currentFocus.Col, offX, offY, minCol, minRow, visibleColWidths, visibleRowHeights)
 	} else {
 		r.moveMarker(r.hover, r.cells.t.hoveredCell.Row, r.cells.t.hoveredCell.Col, offX, offY, minCol, minRow, visibleColWidths, visibleRowHeights)
 	}

--- a/widget/table.go
+++ b/widget/table.go
@@ -539,11 +539,13 @@ func (t *Table) Tapped(e *fyne.PointEvent) {
 	}
 	t.Select(TableCellID{row, col})
 
+	// TODO t.RefreshItem(t.currentFocus)
 	canvas := fyne.CurrentApp().Driver().CanvasForObject(t)
 	if canvas != nil {
 		canvas.Focus(t)
 	}
 	t.currentFocus = TableCellID{row, col}
+	t.Refresh() // TODO t.RefreshItem(t.currentFocus)
 }
 
 // columnAt returns a positive integer (or 0) for the column that is found at the `pos` X position.

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -127,24 +127,23 @@ func TestTable_Focus(t *testing.T) {
 
 	canvas.FocusNext()
 	assert.NotNil(t, canvas.Focused())
-	assert.Equal(t, TableCellID{0, 0}, canvas.Focused().(*Table).currentFocus)
-
-	assert.Equal(t, &TableCellID{0, 0}, table.hoveredCell)
+	assert.Equal(t, table, canvas.Focused())
+	assert.Equal(t, TableCellID{0, 0}, table.currentFocus)
 
 	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
-	assert.Equal(t, &TableCellID{1, 0}, table.hoveredCell)
+	assert.Equal(t, TableCellID{1, 0}, table.currentFocus)
 
 	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyRight})
-	assert.Equal(t, &TableCellID{1, 1}, table.hoveredCell)
+	assert.Equal(t, TableCellID{1, 1}, table.currentFocus)
 
 	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyLeft})
-	assert.Equal(t, &TableCellID{1, 0}, table.hoveredCell)
+	assert.Equal(t, TableCellID{1, 0}, table.currentFocus)
 
 	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
-	assert.Equal(t, &TableCellID{0, 0}, table.hoveredCell)
+	assert.Equal(t, TableCellID{0, 0}, table.currentFocus)
 
 	canvas.Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
-	assert.Equal(t, table.selectedCell, &TableCellID{0, 0})
+	assert.Equal(t, &TableCellID{0, 0}, table.selectedCell)
 }
 
 func TestTable_Headers(t *testing.T) {
@@ -623,6 +622,7 @@ func TestTable_Selection(t *testing.T) {
 		selectedRow = id.Row
 	}
 	test.TapCanvas(w.Canvas(), fyne.NewPos(35, 58))
+	w.Canvas().Unfocus() // don't include table focus in test
 	assert.Equal(t, 0, table.selectedCell.Col)
 	assert.Equal(t, 1, table.selectedCell.Row)
 	assert.Equal(t, 0, selectedCol)

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -105,6 +105,48 @@ func TestTable_Filled(t *testing.T) {
 	test.AssertImageMatches(t, "table/filled.png", w.Canvas().Capture())
 }
 
+func TestTable_Focus(t *testing.T) {
+	defer test.NewApp()
+
+	table := NewTable(
+		func() (int, int) { return 5, 5 },
+		func() fyne.CanvasObject {
+			r := canvas.NewRectangle(color.Black)
+			r.SetMinSize(fyne.NewSize(30, 20))
+			r.Resize(fyne.NewSize(30, 20))
+			return r
+		},
+		func(TableCellID, fyne.CanvasObject) {})
+
+	window := test.NewWindow(table)
+	defer window.Close()
+	window.Resize(table.MinSize().Max(fyne.NewSize(300, 200)))
+
+	canvas := window.Canvas().(test.WindowlessCanvas)
+	assert.Nil(t, canvas.Focused())
+
+	canvas.FocusNext()
+	assert.NotNil(t, canvas.Focused())
+	assert.Equal(t, TableCellID{0, 0}, canvas.Focused().(*Table).currentFocus)
+
+	assert.Equal(t, &TableCellID{0, 0}, table.hoveredCell)
+
+	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
+	assert.Equal(t, &TableCellID{1, 0}, table.hoveredCell)
+
+	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyRight})
+	assert.Equal(t, &TableCellID{1, 1}, table.hoveredCell)
+
+	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyLeft})
+	assert.Equal(t, &TableCellID{1, 0}, table.hoveredCell)
+
+	table.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
+	assert.Equal(t, &TableCellID{0, 0}, table.hoveredCell)
+
+	canvas.Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+	assert.Equal(t, table.selectedCell, &TableCellID{0, 0})
+}
+
 func TestTable_Headers(t *testing.T) {
 	table := NewTableWithHeaders(
 		func() (int, int) { return 5, 5 },

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -134,6 +134,14 @@ func (t *Tree) IsBranchOpen(uid TreeNodeID) bool {
 //
 // Implements: fyne.Focusable
 func (t *Tree) FocusGained() {
+	if t.currentFocus == "" {
+		if childUIDs := t.ChildUIDs; childUIDs != nil {
+			if ids := childUIDs(""); len(ids) > 0 {
+				t.currentFocus = ids[0]
+			}
+		}
+	}
+
 	t.focused = true
 	t.ScrollTo(t.currentFocus)
 	t.Refresh() // TODO RefreshItem(t.currentFocus)

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -12,6 +12,8 @@ import (
 // TreeNodeID represents the unique id of a tree node.
 type TreeNodeID = string
 
+// Declare conformity with interfaces
+var _ fyne.Focusable = (*Tree)(nil)
 var _ fyne.Widget = (*Tree)(nil)
 
 // Tree widget displays hierarchical data.
@@ -32,6 +34,8 @@ type Tree struct {
 	UpdateNode     func(uid TreeNodeID, branch bool, node fyne.CanvasObject) `json:"-"` // Called to update the given CanvasObject to represent the data at the given TreeNodeID
 
 	branchMinSize fyne.Size
+	currentFocus  TreeNodeID
+	focused       bool
 	leafMinSize   fyne.Size
 	offset        fyne.Position
 	open          map[TreeNodeID]bool
@@ -126,6 +130,23 @@ func (t *Tree) IsBranchOpen(uid TreeNodeID) bool {
 	return t.open[uid]
 }
 
+// FocusGained is called after this Tree has gained focus.
+//
+// Implements: fyne.Focusable
+func (t *Tree) FocusGained() {
+	t.focused = true
+	t.ScrollTo(t.currentFocus)
+	t.Refresh() // TODO RefreshItem(t.currentFocus)
+}
+
+// FocusLost is called after this Tree has lost focus.
+//
+// Implements: fyne.Focusable
+func (t *Tree) FocusLost() {
+	t.focused = false
+	t.Refresh() //Item(t.currentFocus)
+}
+
 // MinSize returns the size that this widget should not shrink below.
 func (t *Tree) MinSize() fyne.Size {
 	t.ExtendBaseWidget(t)
@@ -135,7 +156,7 @@ func (t *Tree) MinSize() fyne.Size {
 // OpenAllBranches opens all branches in the tree.
 func (t *Tree) OpenAllBranches() {
 	t.ensureOpenMap()
-	t.walkAll(func(uid string, branch bool, depth int) {
+	t.walkAll(func(uid, parent TreeNodeID, branch bool, depth int) {
 		if branch {
 			t.propertyLock.Lock()
 			t.open[uid] = true
@@ -252,6 +273,75 @@ func (t *Tree) ToggleBranch(uid string) {
 	}
 }
 
+// TypedKey is called if a key event happens while this Tree is focused.
+//
+// Implements: fyne.Focusable
+func (t *Tree) TypedKey(event *fyne.KeyEvent) {
+	switch event.Name {
+	case fyne.KeySpace:
+		t.Select(t.currentFocus)
+	case fyne.KeyDown:
+		// TODO t.RefreshItem(t.currentFocus)
+		next := false
+		t.walk(t.Root, "", 0, func(id, p TreeNodeID, _ bool, _ int) {
+			if next {
+				t.currentFocus = id
+				next = false
+			} else if id == t.currentFocus {
+				next = true
+			}
+		})
+
+		t.ScrollTo(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
+	case fyne.KeyLeft:
+		t.walk(t.Root, "", 0, func(id, p TreeNodeID, _ bool, _ int) {
+			if id == t.currentFocus && p != "" {
+				t.currentFocus = p
+			}
+		})
+
+		// TODO t.RefreshItem(t.currentFocus)
+		t.ScrollTo(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
+	case fyne.KeyRight:
+		if t.IsBranch(t.currentFocus) {
+			t.OpenBranch(t.currentFocus)
+		}
+		children := []TreeNodeID{}
+		if childUIDs := t.ChildUIDs; childUIDs != nil {
+			children = childUIDs(t.currentFocus)
+		}
+
+		if len(children) > 0 {
+			t.currentFocus = children[0]
+		}
+
+		// TODO t.RefreshItem(t.currentFocus)
+		t.ScrollTo(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
+	case fyne.KeyUp:
+		// TODO t.RefreshItem(t.currentFocus)
+		previous := ""
+		t.walk(t.Root, "", 0, func(id, p TreeNodeID, _ bool, _ int) {
+			if id == t.currentFocus && previous != "" {
+				t.currentFocus = previous
+			}
+			previous = id
+		})
+
+		t.ScrollTo(t.currentFocus)
+		t.Refresh() // TODO t.RefreshItem(t.currentFocus)
+	}
+}
+
+// TypedRune is called if a text event happens while this Tree is focused.
+//
+// Implements: fyne.Focusable
+func (t *Tree) TypedRune(_ rune) {
+	// intentionally left blank
+}
+
 // Unselect marks the specified node to be not selected.
 func (t *Tree) Unselect(uid TreeNodeID) {
 	if len(t.selected) == 0 || t.selected[0] != uid {
@@ -293,7 +383,7 @@ func (t *Tree) ensureOpenMap() {
 
 func (t *Tree) findBottom() (y float32, size fyne.Size) {
 	sep := theme.Padding()
-	t.walkAll(func(id TreeNodeID, branch bool, _ int) {
+	t.walkAll(func(id, _ TreeNodeID, branch bool, _ int) {
 		size = t.leafMinSize
 		if branch {
 			size = t.branchMinSize
@@ -319,7 +409,7 @@ func (t *Tree) findBottom() (y float32, size fyne.Size) {
 }
 
 func (t *Tree) offsetAndSize(uid TreeNodeID) (y float32, size fyne.Size, found bool) {
-	t.walkAll(func(id TreeNodeID, branch bool, _ int) {
+	t.walkAll(func(id, _ TreeNodeID, branch bool, _ int) {
 		m := t.leafMinSize
 		if branch {
 			m = t.branchMinSize
@@ -352,26 +442,26 @@ func (t *Tree) offsetUpdated(pos fyne.Position) {
 	t.scroller.Content.Refresh()
 }
 
-func (t *Tree) walk(uid string, depth int, onNode func(string, bool, int)) {
+func (t *Tree) walk(uid, parent TreeNodeID, depth int, onNode func(TreeNodeID, TreeNodeID, bool, int)) {
 	if isBranch := t.IsBranch; isBranch != nil {
 		if isBranch(uid) {
-			onNode(uid, true, depth)
+			onNode(uid, parent, true, depth)
 			if t.IsBranchOpen(uid) {
 				if childUIDs := t.ChildUIDs; childUIDs != nil {
 					for _, c := range childUIDs(uid) {
-						t.walk(c, depth+1, onNode)
+						t.walk(c, uid, depth+1, onNode)
 					}
 				}
 			}
 		} else {
-			onNode(uid, false, depth)
+			onNode(uid, parent, false, depth)
 		}
 	}
 }
 
 // walkAll visits every open node of the tree and calls the given callback with TreeNodeID, whether node is branch, and the depth of node.
-func (t *Tree) walkAll(onNode func(TreeNodeID, bool, int)) {
-	t.walk(t.Root, 0, onNode)
+func (t *Tree) walkAll(onNode func(TreeNodeID, TreeNodeID, bool, int)) {
+	t.walk(t.Root, "", 0, onNode)
 }
 
 var _ fyne.WidgetRenderer = (*treeRenderer)(nil)
@@ -489,7 +579,7 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 	separatorOff := (pad + separatorThickness) / 2
 	y := float32(0)
 	// walkAll open branches and obtain nodes to render in scroller's viewport
-	r.treeContent.tree.walkAll(func(uid string, isBranch bool, depth int) {
+	r.treeContent.tree.walkAll(func(uid, _ string, isBranch bool, depth int) {
 		// Root node is not rendered unless it has been customized
 		if r.treeContent.tree.Root == "" {
 			depth = depth - 1
@@ -590,7 +680,7 @@ func (r *treeContentRenderer) MinSize() (min fyne.Size) {
 	r.treeContent.propertyLock.Lock()
 	defer r.treeContent.propertyLock.Unlock()
 
-	r.treeContent.tree.walkAll(func(uid string, isBranch bool, depth int) {
+	r.treeContent.tree.walkAll(func(uid, _ string, isBranch bool, depth int) {
 		// Root node is not rendered unless it has been customized
 		if r.treeContent.tree.Root == "" {
 			depth = depth - 1
@@ -717,6 +807,11 @@ func (n *treeNode) MouseOut() {
 
 func (n *treeNode) Tapped(*fyne.PointEvent) {
 	n.tree.Select(n.uid)
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(n.tree)
+	if canvas != nil {
+		canvas.Focus(n.tree)
+	}
+	n.tree.currentFocus = n.uid
 }
 
 func (n *treeNode) partialRefresh() {
@@ -794,7 +889,7 @@ func (r *treeNodeRenderer) partialRefresh() {
 	if len(r.treeNode.tree.selected) > 0 && r.treeNode.uid == r.treeNode.tree.selected[0] {
 		r.background.FillColor = theme.SelectionColor()
 		r.background.Show()
-	} else if r.treeNode.hovered {
+	} else if r.treeNode.hovered || (r.treeNode.tree.focused && r.treeNode.tree.currentFocus == r.treeNode.uid) {
 		r.background.FillColor = theme.HoverColor()
 		r.background.Show()
 	} else {

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -814,12 +814,17 @@ func (n *treeNode) MouseOut() {
 }
 
 func (n *treeNode) Tapped(*fyne.PointEvent) {
+	//if n.tree.currentFocus != "" {
+	//	n.tree.RefreshItem(n.tree.currentFocus)
+	//}
+
 	n.tree.Select(n.uid)
 	canvas := fyne.CurrentApp().Driver().CanvasForObject(n.tree)
 	if canvas != nil {
 		canvas.Focus(n.tree)
 	}
 	n.tree.currentFocus = n.uid
+	n.tree.Refresh() // TODO n.Refresh()
 }
 
 func (n *treeNode) partialRefresh() {

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -161,6 +161,39 @@ func TestTree(t *testing.T) {
 	})
 }
 
+func TestTree_Focus(t *testing.T) {
+	var treeData = map[string][]string{
+		"":    {"foo", "bar"},
+		"foo": {"foobar", "barbar"},
+	}
+	tree := NewTreeWithStrings(treeData)
+	window := test.NewWindow(tree)
+	defer window.Close()
+	window.Resize(tree.MinSize().Max(fyne.NewSize(150, 200)))
+
+	canvas := window.Canvas().(test.WindowlessCanvas)
+	assert.Nil(t, canvas.Focused())
+
+	canvas.FocusNext()
+	assert.NotNil(t, canvas.Focused())
+	assert.Equal(t, "foo", canvas.Focused().(*Tree).currentFocus)
+
+	tree.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
+	assert.Equal(t, "bar", canvas.Focused().(*Tree).currentFocus)
+
+	tree.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
+	assert.Equal(t, "foo", canvas.Focused().(*Tree).currentFocus)
+
+	tree.TypedKey(&fyne.KeyEvent{Name: fyne.KeyRight})
+	assert.Equal(t, "foobar", canvas.Focused().(*Tree).currentFocus)
+
+	tree.TypedKey(&fyne.KeyEvent{Name: fyne.KeyLeft})
+	assert.Equal(t, "foo", canvas.Focused().(*Tree).currentFocus)
+
+	canvas.Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+	assert.Equal(t, "foo", tree.selected[0])
+}
+
 func TestTree_Indentation(t *testing.T) {
 	data := make(map[string][]string)
 	tree := NewTreeWithStrings(data)

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -54,7 +54,7 @@ func TestTree(t *testing.T) {
 	t.Run("Initializer_Empty", func(t *testing.T) {
 		tree := &Tree{}
 		var nodes []string
-		tree.walkAll(func(uid string, branch bool, depth int) {
+		tree.walkAll(func(uid, _ string, branch bool, depth int) {
 			nodes = append(nodes, uid)
 		})
 		assert.Equal(t, 0, len(nodes))
@@ -82,7 +82,7 @@ func TestTree(t *testing.T) {
 		tree.OpenBranch("c")
 		var branches []string
 		var leaves []string
-		tree.walkAll(func(uid string, branch bool, depth int) {
+		tree.walkAll(func(uid, _ string, branch bool, depth int) {
 			if branch {
 				branches = append(branches, uid)
 			} else {
@@ -122,7 +122,7 @@ func TestTree(t *testing.T) {
 		tree.OpenBranch("c")
 		var branches []string
 		var leaves []string
-		tree.walkAll(func(uid string, branch bool, depth int) {
+		tree.walkAll(func(uid, _ string, branch bool, depth int) {
 			if branch {
 				branches = append(branches, uid)
 			} else {
@@ -146,7 +146,7 @@ func TestTree(t *testing.T) {
 		tree.OpenBranch("foo")
 		var branches []string
 		var leaves []string
-		tree.walkAll(func(uid string, branch bool, depth int) {
+		tree.walkAll(func(uid, _ string, branch bool, depth int) {
 			if branch {
 				branches = append(branches, uid)
 			} else {
@@ -624,7 +624,7 @@ func TestTree_Walk(t *testing.T) {
 		tree.OpenBranch("E")
 		var branches []string
 		var leaves []string
-		tree.walkAll(func(uid string, branch bool, depth int) {
+		tree.walkAll(func(uid, _ string, branch bool, depth int) {
 			if branch {
 				branches = append(branches, uid)
 			} else {
@@ -651,7 +651,7 @@ func TestTree_Walk(t *testing.T) {
 		tree := NewTreeWithStrings(data)
 		var branches []string
 		var leaves []string
-		tree.walkAll(func(uid string, branch bool, depth int) {
+		tree.walkAll(func(uid, _ string, branch bool, depth int) {
 			if branch {
 				branches = append(branches, uid)
 			} else {


### PR DESCRIPTION
This was a 2-parter really:

1) Fix list widget so that the focus could move through all elements
2) Add the same handling for Table and Tree as well

Now all of them focus as 1 item and use arrow keys to move the focus around internally.
This is a change for anyone who had extended Lists, but mostly they had to work around this so the change is a positive one.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
