### PR TITLE
Fix potential infinite loop (create renderer -> refresh -> create renderer) in menu item

### DIFF
--- a/widget/menu_item.go
+++ b/widget/menu_item.go
@@ -106,7 +106,7 @@ func (i *menuItem) CreateRenderer() fyne.WidgetRenderer {
 		text:          text,
 		background:    background,
 	}
-	r.Refresh() // ensure text and icon resources match state
+	r.updateVisuals()
 	return r
 }
 
@@ -290,7 +290,7 @@ func (r *menuItemRenderer) MinSize() fyne.Size {
 	return r.minSize
 }
 
-func (r *menuItemRenderer) Refresh() {
+func (r *menuItemRenderer) updateVisuals() {
 	if fyne.CurrentDevice().IsMobile() {
 		r.background.Hide()
 	} else if r.i.isActive() {
@@ -311,9 +311,13 @@ func (r *menuItemRenderer) Refresh() {
 	} else {
 		r.checkIcon.Hide()
 	}
-	r.refreshIcon(r.checkIcon, theme.ConfirmIcon())
-	r.refreshIcon(r.expandIcon, theme.MenuExpandIcon())
-	r.refreshIcon(r.icon, r.i.Item.Icon)
+	r.updateIcon(r.checkIcon, theme.ConfirmIcon())
+	r.updateIcon(r.expandIcon, theme.MenuExpandIcon())
+	r.updateIcon(r.icon, r.i.Item.Icon)
+}
+
+func (r *menuItemRenderer) Refresh() {
+	r.updateVisuals()
 	canvas.Refresh(r.i)
 }
 
@@ -331,7 +335,7 @@ func (r *menuItemRenderer) minSizeUnchanged() bool {
 		r.lastThemePadding == theme.InnerPadding()
 }
 
-func (r *menuItemRenderer) refreshIcon(img *canvas.Image, rsc fyne.Resource) {
+func (r *menuItemRenderer) updateIcon(img *canvas.Image, rsc fyne.Resource) {
 	if img == nil {
 		return
 	}
@@ -340,7 +344,6 @@ func (r *menuItemRenderer) refreshIcon(img *canvas.Image, rsc fyne.Resource) {
 	} else {
 		img.Resource = rsc
 	}
-	img.Refresh()
 }
 
 func (r *menuItemRenderer) refreshText(text *canvas.Text) {


### PR DESCRIPTION
This was uncommon but could happen.
CreateRenderer should never initiate a Refresh as it can always reach this infinite loop.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- not possible in test driver with its threading model
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
