### PR TITLE
Hyperlink: Invoke OnTapped callback when typing space bar while focused

### DIFF
--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -172,7 +172,7 @@ func (hl *Hyperlink) TypedRune(rune) {
 // TypedKey is a hook called by the input handling logic on key events if this object is focused.
 func (hl *Hyperlink) TypedKey(ev *fyne.KeyEvent) {
 	if ev.Name == fyne.KeySpace {
-		hl.openURL()
+		hl.Tapped(nil)
 	}
 }
 

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -93,6 +93,19 @@ func TestHyperlink_OnTapped(t *testing.T) {
 	assert.Equal(t, 1, tapped)
 }
 
+func TestHyperlink_KeyboardOnTapped(t *testing.T) {
+	tapped := 0
+	link := &Hyperlink{Text: "Test"}
+	link.TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+	assert.Equal(t, 0, tapped)
+
+	link.OnTapped = func() {
+		tapped++
+	}
+	link.TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+	assert.Equal(t, 1, tapped)
+}
+
 func TestHyperlink_Resize(t *testing.T) {
 	hyperlink := &Hyperlink{Text: "Test"}
 	hyperlink.CreateRenderer()


### PR DESCRIPTION
### Description:
The Hyperlink widget can be activated by typing the space bar while focused in addition to tapping it, but the key event handler did not invoke the user-supplied OnTapped callback if set.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

