### PR TITLE
Add warning and success resource helpers

### DIFF
--- a/theme/icons.go
+++ b/theme/icons.go
@@ -585,7 +585,20 @@ type ThemedResource struct {
 	ColorName fyne.ThemeColorName
 }
 
+// NewColoredResource creates a resource that adapts to the current theme setting using
+// the color named in the constructor.
+//
+// Since: 2.4
+func NewColoredResource(src fyne.Resource, name fyne.ThemeColorName) *ThemedResource {
+	return &ThemedResource{
+		source:    src,
+		ColorName: name,
+	}
+}
+
 // NewSuccessThemedResource creates a resource that adapts to the current theme success color.
+//
+// Since: 2.4
 func NewSuccessThemedResource(src fyne.Resource) *ThemedResource {
 	return &ThemedResource{
 		source:    src,
@@ -602,6 +615,8 @@ func NewThemedResource(src fyne.Resource) *ThemedResource {
 }
 
 // NewWarningThemedResource creates a resource that adapts to the current theme warning color.
+//
+// Since: 2.4
 func NewWarningThemedResource(src fyne.Resource) *ThemedResource {
 	return &ThemedResource{
 		source:    src,

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -585,10 +585,27 @@ type ThemedResource struct {
 	ColorName fyne.ThemeColorName
 }
 
+// NewSuccessThemedResource creates a resource that adapts to the current theme success color.
+func NewSuccessThemedResource(src fyne.Resource) *ThemedResource {
+	return &ThemedResource{
+		source:    src,
+		ColorName: ColorNameSuccess,
+	}
+}
+
 // NewThemedResource creates a resource that adapts to the current theme setting.
+// By default this will match the foreground color, but it can be changed using the `ColorName` field.
 func NewThemedResource(src fyne.Resource) *ThemedResource {
 	return &ThemedResource{
 		source: src,
+	}
+}
+
+// NewWarningThemedResource creates a resource that adapts to the current theme warning color.
+func NewWarningThemedResource(src fyne.Resource) *ThemedResource {
+	return &ThemedResource{
+		source:    src,
+		ColorName: ColorNameWarning,
 	}
 }
 
@@ -661,7 +678,7 @@ func NewErrorThemedResource(orig fyne.Resource) *ErrorThemedResource {
 
 // Name returns the underlying resource name (used for caching).
 func (res *ErrorThemedResource) Name() string {
-	return "error-" + res.source.Name()
+	return "error_" + res.source.Name()
 }
 
 // Content returns the underlying content of the resource adapted to the current background color.

--- a/theme/icons_test.go
+++ b/theme/icons_test.go
@@ -60,6 +60,18 @@ func TestNewThemedResource_StaticResourceSupport(t *testing.T) {
 	assert.Equal(t, name, custom.Name())
 }
 
+func TestNewColoredResource(t *testing.T) {
+	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
+	source := helperNewStaticResource()
+	custom := NewColoredResource(source, ColorNameSuccess)
+
+	assert.Equal(t, ColorNameSuccess, custom.ColorName)
+	assert.Equal(t, custom.Name(), fmt.Sprintf("success_%v", source.Name()))
+
+	custom = NewColoredResource(source, ColorNamePrimary)
+	assert.Equal(t, custom.Name(), fmt.Sprintf("primary_%v", source.Name()))
+}
+
 func TestNewDisabledResource(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	source := helperNewStaticResource()

--- a/theme/icons_test.go
+++ b/theme/icons_test.go
@@ -129,14 +129,27 @@ func TestThemedResource_Content_BlackFillIsUpdated(t *testing.T) {
 	assert.NotEqual(t, staticResource.Content(), themedResource.Content())
 }
 
+func TestThemedResource_Error(t *testing.T) {
+	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
+	source := helperNewStaticResource()
+	custom := NewThemedResource(source)
+	custom.ColorName = ColorNameError
+
+	assert.Equal(t, custom.Name(), fmt.Sprintf("error_%v", source.Name()))
+	custom2 := NewErrorThemedResource(source)
+	assert.Equal(t, custom2.Name(), fmt.Sprintf("error_%v", source.Name()))
+}
+
 func TestThemedResource_Success(t *testing.T) {
 	fyne.CurrentApp().Settings().SetTheme(DarkTheme())
 	source := helperNewStaticResource()
 	custom := NewThemedResource(source)
 	custom.ColorName = ColorNameSuccess
-	name := custom.Name()
 
-	assert.Equal(t, name, fmt.Sprintf("success_%v", source.Name()))
+	assert.Equal(t, custom.Name(), fmt.Sprintf("success_%v", source.Name()))
+
+	custom = NewSuccessThemedResource(source)
+	assert.Equal(t, custom.Name(), fmt.Sprintf("success_%v", source.Name()))
 }
 
 func TestThemedResource_Warning(t *testing.T) {
@@ -144,9 +157,10 @@ func TestThemedResource_Warning(t *testing.T) {
 	source := helperNewStaticResource()
 	custom := NewThemedResource(source)
 	custom.ColorName = ColorNameWarning
-	name := custom.Name()
 
-	assert.Equal(t, name, fmt.Sprintf("warning_%v", source.Name()))
+	assert.Equal(t, custom.Name(), fmt.Sprintf("warning_%v", source.Name()))
+	custom = NewWarningThemedResource(source)
+	assert.Equal(t, custom.Name(), fmt.Sprintf("warning_%v", source.Name()))
 }
 
 func TestDisabledResource_Name(t *testing.T) {


### PR DESCRIPTION
For parity this is added in 2.4. A future release (possibly soon) will deprecate many theme methods and move to `theme.ColorNamed` or similar API to avoid the growing package.

Fixes #4040

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
