### PR TITLE
Fix memory leak in fontSize cache

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -45,6 +45,7 @@ func Clean(canvasRefreshed bool) {
 		return
 	}
 	destroyExpiredSvgs(now)
+	destroyExpiredFontMetrics(now)
 	if canvasRefreshed {
 		// Destroy renderers on canvas refresh to avoid flickering screen.
 		destroyExpiredRenderers(now)

--- a/internal/cache/text.go
+++ b/internal/cache/text.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"sync"
+	"time"
 
 	"fyne.io/fyne/v2"
 )
@@ -12,6 +13,7 @@ var (
 )
 
 type fontMetric struct {
+	expiringCache
 	size     fyne.Size
 	baseLine float32
 }
@@ -31,13 +33,34 @@ func GetFontMetrics(text string, fontSize float32, style fyne.TextStyle) (size f
 	if !ok {
 		return fyne.Size{Width: 0, Height: 0}, 0
 	}
+	ret.setAlive()
 	return ret.size, ret.baseLine
 }
 
 // SetFontMetrics stores a calculated font size and baseline for parameters that were missing from the cache.
 func SetFontMetrics(text string, fontSize float32, style fyne.TextStyle, size fyne.Size, base float32) {
 	ent := fontSizeEntry{text, fontSize, style}
+	metric := fontMetric{size: size, baseLine: base}
+	metric.setAlive()
 	fontSizeLock.Lock()
-	fontSizeCache[ent] = fontMetric{size: size, baseLine: base}
+	fontSizeCache[ent] = metric
+	fontSizeLock.Unlock()
+}
+
+// destroyExpiredFontMetrics destroys expired fontSizeCache entries
+func destroyExpiredFontMetrics(now time.Time) {
+	expiredObjs := make([]fontSizeEntry, 0, 50)
+	fontSizeLock.RLock()
+	for k, v := range fontSizeCache {
+		if v.isExpired(now) {
+			expiredObjs = append(expiredObjs, k)
+		}
+	}
+	fontSizeLock.RUnlock()
+
+	fontSizeLock.Lock()
+	for _, k := range expiredObjs {
+		delete(fontSizeCache, k)
+	}
 	fontSizeLock.Unlock()
 }


### PR DESCRIPTION
### Description:
The fontSizeCache which stores size information for a given string and font size+style was only cleaned out on settings change. Since it stores arbitrary strings from user code it would be a slow leak over time especially for text-heavy apps.

This PR makes the cache entries expire with the standard expiry time and adds the cleanup to the Clean task that is run on paint events. I am open to discussion if the cleaning should be done on a different schedule and/or the expiry should be adjusted.

Fixes #4108 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
