### PR TITLE
Call OnChange with every updateText, fixes #4117

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -832,9 +832,8 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 	e.copyToClipboard(clipboard)
 	e.setFieldsAndRefresh(e.eraseSelection)
 	e.propertyLock.Lock()
-	content := e.textProvider().String()
 	if e.OnChanged != nil {
-		e.OnChanged(content)
+		e.OnChanged(e.Text)
 	}
 	e.propertyLock.Unlock()
 	e.Validate()
@@ -1055,9 +1054,8 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 		// clears the selection -- return handled
 		e.setFieldsAndRefresh(e.eraseSelection)
 		e.propertyLock.Lock()
-		content := e.textProvider().String()
 		if e.OnChanged != nil {
-			e.OnChanged(content)
+			e.OnChanged(e.Text)
 		}
 		e.propertyLock.Unlock()
 		e.Validate()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -485,9 +485,11 @@ func (e *Entry) Append(text string) {
 	changed := e.updateText(content)
 	e.propertyLock.Unlock()
 
-	e.Validate()
-	if changed && e.OnChanged != nil {
-		e.OnChanged(content)
+	if changed {
+		e.Validate()
+		if e.OnChanged != nil {
+			e.OnChanged(content)
+		}
 	}
 	e.Refresh()
 }
@@ -669,9 +671,11 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 		e.selecting = false
 	}
 	e.propertyLock.Unlock()
-	e.Validate()
-	if changed && e.OnChanged != nil {
-		e.OnChanged(content)
+	if changed {
+		e.Validate()
+		if e.OnChanged != nil {
+			e.OnChanged(content)
+		}
 	}
 	e.Refresh()
 }
@@ -849,9 +853,11 @@ func (e *Entry) eraseSelection() {
 	content := provider.String()
 	changed := e.updateText(content)
 
-	e.Validate()
-	if changed && e.OnChanged != nil {
-		e.OnChanged(content)
+	if changed {
+		e.Validate()
+		if e.OnChanged != nil {
+			e.OnChanged(content)
+		}
 	}
 }
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -833,7 +833,9 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 	e.setFieldsAndRefresh(e.eraseSelection)
 	e.propertyLock.Lock()
 	content := e.textProvider().String()
-	e.OnChanged(content)
+	if e.OnChanged != nil {
+		e.OnChanged(content)
+	}
 	e.propertyLock.Unlock()
 	e.Validate()
 }
@@ -1054,7 +1056,9 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 		e.setFieldsAndRefresh(e.eraseSelection)
 		e.propertyLock.Lock()
 		content := e.textProvider().String()
-		e.OnChanged(content)
+		if e.OnChanged != nil {
+			e.OnChanged(content)
+		}
 		e.propertyLock.Unlock()
 		e.Validate()
 		return true

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -831,6 +831,11 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 
 	e.copyToClipboard(clipboard)
 	e.setFieldsAndRefresh(e.eraseSelection)
+	e.propertyLock.Lock()
+	content := e.textProvider().String()
+	e.OnChanged(content)
+	e.propertyLock.Unlock()
+	e.Validate()
 }
 
 // eraseSelection removes the current selected region and moves the cursor
@@ -850,15 +855,7 @@ func (e *Entry) eraseSelection() {
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(posA)
 	e.selectRow, e.selectColumn = e.CursorRow, e.CursorColumn
 	e.selecting = false
-	content := provider.String()
-	changed := e.updateText(content)
-
-	if changed {
-		e.Validate()
-		if e.OnChanged != nil {
-			e.OnChanged(content)
-		}
-	}
+	e.updateText(provider.String())
 }
 
 func (e *Entry) getRowCol(p fyne.Position) (int, int) {
@@ -1055,6 +1052,11 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 	case fyne.KeyBackspace, fyne.KeyDelete:
 		// clears the selection -- return handled
 		e.setFieldsAndRefresh(e.eraseSelection)
+		e.propertyLock.Lock()
+		content := e.textProvider().String()
+		e.OnChanged(content)
+		e.propertyLock.Unlock()
+		e.Validate()
 		return true
 	case fyne.KeyReturn, fyne.KeyEnter:
 		if e.MultiLine {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -481,9 +481,13 @@ func (e *Entry) Append(text string) {
 	e.propertyLock.Lock()
 	provider := e.textProvider()
 	provider.insertAt(provider.len(), text)
-	e.updateText(provider.String())
+	changed := e.updateText(provider.String())
 	e.propertyLock.Unlock()
 
+	e.Validate()
+	if changed && e.OnChanged != nil {
+		e.OnChanged(provider.String())
+	}
 	e.Refresh()
 }
 
@@ -658,11 +662,15 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	}
 
 	e.propertyLock.Lock()
-	e.updateText(provider.String())
+	changed := e.updateText(provider.String())
 	if e.CursorRow == e.selectRow && e.CursorColumn == e.selectColumn {
 		e.selecting = false
 	}
 	e.propertyLock.Unlock()
+	e.Validate()
+	if changed && e.OnChanged != nil {
+		e.OnChanged(provider.String())
+	}
 	e.Refresh()
 }
 
@@ -836,7 +844,12 @@ func (e *Entry) eraseSelection() {
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(posA)
 	e.selectRow, e.selectColumn = e.CursorRow, e.CursorColumn
 	e.selecting = false
-	e.updateText(provider.String())
+	changed := e.updateText(provider.String())
+
+	e.Validate()
+	if changed && e.OnChanged != nil {
+		e.OnChanged(provider.String())
+	}
 }
 
 func (e *Entry) getRowCol(p fyne.Position) (int, int) {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -481,12 +481,13 @@ func (e *Entry) Append(text string) {
 	e.propertyLock.Lock()
 	provider := e.textProvider()
 	provider.insertAt(provider.len(), text)
-	changed := e.updateText(provider.String())
+	content := provider.String()
+	changed := e.updateText(content)
 	e.propertyLock.Unlock()
 
 	e.Validate()
 	if changed && e.OnChanged != nil {
-		e.OnChanged(provider.String())
+		e.OnChanged(content)
 	}
 	e.Refresh()
 }
@@ -662,14 +663,15 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	}
 
 	e.propertyLock.Lock()
-	changed := e.updateText(provider.String())
+	content := provider.String()
+	changed := e.updateText(content)
 	if e.CursorRow == e.selectRow && e.CursorColumn == e.selectColumn {
 		e.selecting = false
 	}
 	e.propertyLock.Unlock()
 	e.Validate()
 	if changed && e.OnChanged != nil {
-		e.OnChanged(provider.String())
+		e.OnChanged(content)
 	}
 	e.Refresh()
 }
@@ -844,11 +846,12 @@ func (e *Entry) eraseSelection() {
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(posA)
 	e.selectRow, e.selectColumn = e.CursorRow, e.CursorColumn
 	e.selecting = false
-	changed := e.updateText(provider.String())
+	content := provider.String()
+	changed := e.updateText(content)
 
 	e.Validate()
 	if changed && e.OnChanged != nil {
-		e.OnChanged(provider.String())
+		e.OnChanged(content)
 	}
 }
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -526,6 +526,15 @@ func TestEntry_Notify(t *testing.T) {
 	entry.SetText("Test")
 
 	assert.True(t, changed)
+
+	changed = false
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDelete})
+	assert.True(t, changed)
+
+	changed = false
+	entry.CursorColumn = 1
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyBackspace})
+	assert.True(t, changed)
 }
 
 func TestEntry_OnCopy(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This adds a call to `entry.OnChanged()` every time `entry.updateText` is called.
While I was at it I also added a call to `e.Validate` where I didn't see one.

Fixes #4117 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

