### PR TITLE
Move to a truncate mode separate to wrapping

### DIFF
--- a/text.go
+++ b/text.go
@@ -13,6 +13,22 @@ const (
 	TextAlignTrailing
 )
 
+// TextTruncation controls how a `Label` or `Entry` will truncate its text.
+// The default value is `TextTruncateOff` which will not truncate.
+//
+// Since: 2.4
+type TextTruncation int
+
+const (
+	TextTruncateOff TextTruncation = iota
+	TextTruncateClip
+	// TextTruncateEllipsis is like regular truncation except that an ellipses (…) will be inserted
+	// wherever text has been shortened to fit.
+	//
+	// Since: 2.4
+	TextTruncateEllipsis
+)
+
 // TextWrap represents how text longer than the widget's width will be wrapped.
 type TextWrap int
 
@@ -21,12 +37,9 @@ const (
 	TextWrapOff TextWrap = iota
 	// TextTruncate trims the text to the widget's width, no wrapping is applied.
 	// If an entry is asked to truncate it will provide scrolling capabilities.
-	TextTruncate
-	// TextTruncateEllipsis is like regular truncation except that an ellipses (…) will be inserted
-	// wherever text has been shortened to fit.
 	//
-	// Since: 2.4
-	TextTruncateEllipsis
+	// Deprecated: Use `TextTruncateClip` value of the widget `Truncation` field instead
+	TextTruncate
 	// TextWrapBreak trims the line of characters to the widget's width adding the excess as new line.
 	// An Entry with text wrapping will scroll vertically if there is not enough space for all the text.
 	TextWrapBreak

--- a/text.go
+++ b/text.go
@@ -20,7 +20,10 @@ const (
 type TextTruncation int
 
 const (
+	// TextTruncateOff means no truncation will be applied, it is the default.
+	// This means that the minimum size of a text block will be the space required to display it fully.
 	TextTruncateOff TextTruncation = iota
+	// TextTruncateClip will truncate text when it reaches the end of the available space.
 	TextTruncateClip
 	// TextTruncateEllipsis is like regular truncation except that an ellipses (…) will be inserted
 	// wherever text has been shortened to fit.

--- a/widget/label.go
+++ b/widget/label.go
@@ -11,9 +11,10 @@ import (
 type Label struct {
 	BaseWidget
 	Text       string
-	Alignment  fyne.TextAlign // The alignment of the Text
-	Wrapping   fyne.TextWrap  // The wrapping of the Text
-	TextStyle  fyne.TextStyle // The style of the label text
+	Alignment  fyne.TextAlign      // The alignment of the text
+	Wrapping   fyne.TextWrap       // The wrapping of the text
+	TextStyle  fyne.TextStyle      // The style of the label text
+	Truncation fyne.TextTruncation // The truncation mode of the text
 	provider   *RichText
 	Importance Importance
 
@@ -145,6 +146,7 @@ func (l *Label) syncSegments() {
 	}
 
 	l.provider.Wrapping = l.Wrapping
+	l.provider.Truncation = l.Truncation
 	l.provider.Segments[0].(*TextSegment).Style = RichTextStyle{
 		Alignment: l.Alignment,
 		ColorName: color,

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -110,7 +110,7 @@ func (t *RichText) Resize(size fyne.Size) {
 	t.propertyLock.RLock()
 	baseSize := t.size
 	segments := t.Segments
-	skipResize := !t.minCache.IsZero() && size.Width >= t.minCache.Width && size.Height >= t.minCache.Height && t.Wrapping == fyne.TextWrapOff
+	skipResize := !t.minCache.IsZero() && size.Width >= t.minCache.Width && size.Height >= t.minCache.Height && t.Wrapping == fyne.TextWrapOff && t.Truncation == fyne.TextTruncateOff
 	t.propertyLock.RUnlock()
 	if baseSize == size {
 		return
@@ -537,6 +537,7 @@ func (r *textRenderer) MinSize() fyne.Size {
 	r.obj.propertyLock.RLock()
 	bounds := r.obj.rowBounds
 	wrap := r.obj.Wrapping
+	trunc := r.obj.Truncation
 	scroll := r.obj.Scroll
 	objs := r.Objects()
 	if r.obj.scr != nil {
@@ -572,7 +573,7 @@ func (r *textRenderer) MinSize() fyne.Size {
 			rowWidth += min.Width
 		}
 
-		if wrap == fyne.TextWrapOff {
+		if wrap == fyne.TextWrapOff && trunc == fyne.TextTruncateOff {
 			width = fyne.Max(width, rowWidth)
 		}
 		height += rowHeight

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -863,8 +863,9 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 		switch wrap {
 		case fyne.TextTruncate:
 			if trunc == fyne.TextTruncateEllipsis {
-				end, full := truncateLimit(seg.Text, seg.Visual().(*canvas.Text), int(firstWidth), []rune{'…'})
-				high = end
+				txt := seg.Text[low:high]
+				end, full := truncateLimit(txt, seg.Visual().(*canvas.Text), int(measureWidth), []rune{'…'})
+				high = low + end
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 				reuse++
 			} else {

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -577,7 +577,8 @@ func (r *textRenderer) MinSize() fyne.Size {
 		if trunc == fyne.TextTruncateClip {
 			return minBounds
 		} else if trunc == fyne.TextTruncateEllipsis {
-			return minBounds.AddWidthHeight(charMinSize.Width, 0) // TODO avoid this approximation?
+			ellipsisSize := fyne.MeasureText("…", theme.TextSize(), fyne.TextStyle{})
+			return minBounds.AddWidthHeight(ellipsisSize.Width, 0)
 		}
 	}
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -982,7 +982,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 				high = low + end
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 				reuse++
-			} else {
+			} else if trunc == fyne.TextTruncateClip {
 				high = binarySearch(widthChecker, low, high)
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -896,7 +896,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 		case fyne.TextWrapBreak:
 			for low < high {
 				measured := measurer(text[low:high])
-				if yPos+measured.Height > max.Height {
+				if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
 					return bounds
 				}
 
@@ -925,7 +925,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 			for low < high {
 				sub := text[low:high]
 				measured := measurer(sub)
-				if yPos+measured.Height > max.Height {
+				if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
 					return bounds
 				}
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -552,20 +552,24 @@ func (r *textRenderer) MinSize() fyne.Size {
 	r.obj.propertyLock.RUnlock()
 
 	charMinSize := r.obj.charMinSize(false, fyne.TextStyle{})
-	if trunc != fyne.TextTruncateOff && r.obj.Scroll == widget.ScrollNone {
-		minBounds := charMinSize.Add(fyne.NewSize(theme.InnerPadding()*2, theme.InnerPadding()*2).Subtract(r.obj.inset).Subtract(r.obj.inset))
-		if trunc == fyne.TextTruncateClip {
-			return minBounds
-		} else if trunc == fyne.TextTruncateEllipsis {
-			return minBounds.AddWidthHeight(charMinSize.Width, 0) // TODO avoid this approximation?
-		}
-	}
-
 	min := r.obj.prop.MinSize()
 	if min.Height < 2 { // prop (Rectangle) defaults to 1 min
 		min = r.calculateMin(bounds, wrap, objs, charMinSize)
 		if r.obj.scr != nil {
 			r.obj.prop.SetMinSize(min)
+		}
+	}
+
+	if trunc != fyne.TextTruncateOff && r.obj.Scroll == widget.ScrollNone {
+		minBounds := charMinSize
+		if wrap == fyne.TextWrapOff {
+			minBounds.Height = min.Height
+		}
+		minBounds = minBounds.Add(fyne.NewSize(theme.InnerPadding()*2, theme.InnerPadding()*2).Subtract(r.obj.inset).Subtract(r.obj.inset))
+		if trunc == fyne.TextTruncateClip {
+			return minBounds
+		} else if trunc == fyne.TextTruncateEllipsis {
+			return minBounds.AddWidthHeight(charMinSize.Width, 0) // TODO avoid this approximation?
 		}
 	}
 
@@ -987,7 +991,6 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
 			}
-			return bounds
 		}
 	}
 	return bounds

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -572,8 +572,9 @@ func (r *textRenderer) MinSize() fyne.Size {
 		minBounds := charMinSize
 		if wrap == fyne.TextWrapOff {
 			minBounds.Height = min.Height
+		} else {
+			minBounds = minBounds.Add(fyne.NewSize(theme.InnerPadding()*2, theme.InnerPadding()*2).Subtract(r.obj.inset).Subtract(r.obj.inset))
 		}
-		minBounds = minBounds.Add(fyne.NewSize(theme.InnerPadding()*2, theme.InnerPadding()*2).Subtract(r.obj.inset).Subtract(r.obj.inset))
 		if trunc == fyne.TextTruncateClip {
 			return minBounds
 		} else if trunc == fyne.TextTruncateEllipsis {

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -36,11 +36,11 @@ func BenchmarkText_splitLines(b *testing.B) {
 func benchmarkTextLineBounds(wrap fyne.TextWrap, b *testing.B) {
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}
-	measurer := func(text []rune) float32 {
-		return fyne.MeasureText(string(text), textSize, textStyle).Width
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), textSize, textStyle)
 	}
 	for n := 0; n < b.N; n++ {
-		lineBounds(&TextSegment{Text: loremIpsum}, wrap, fyne.TextTruncateOff, 10, 10, measurer)
+		lineBounds(&TextSegment{Text: loremIpsum}, wrap, fyne.TextTruncateOff, 10, fyne.NewSize(10, 14), measurer)
 	}
 }
 

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -40,7 +40,7 @@ func benchmarkTextLineBounds(wrap fyne.TextWrap, b *testing.B) {
 		return fyne.MeasureText(string(text), textSize, textStyle).Width
 	}
 	for n := 0; n < b.N; n++ {
-		lineBounds(&TextSegment{Text: loremIpsum}, wrap, 10, 10, measurer)
+		lineBounds(&TextSegment{Text: loremIpsum}, wrap, fyne.TextTruncateOff, 10, 10, measurer)
 	}
 }
 

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -601,6 +601,15 @@ func TestText_lineBounds(t *testing.T) {
 			},
 		},
 		{
+			name:  "Multiple_Short_TruncateEllipsis",
+			text:  "foo\nbar",
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 3},
+				{4, 7},
+			},
+		},
+		{
 			name: "Multiple_Short_WrapBreak",
 			text: "foo\nbar",
 			wrap: fyne.TextWrapBreak,
@@ -640,6 +649,16 @@ func TestText_lineBounds(t *testing.T) {
 		},
 		{
 			name:  "Multiple_Long_TruncateClip",
+			text:  "foobar\nfoobar foobar foobar\nfoobar foobar",
+			trunc: fyne.TextTruncateClip,
+			want: [][2]int{
+				{0, 6},
+				{7, 17},
+				{28, 38},
+			},
+		},
+		{
+			name:  "Multiple_Long_TruncateEllipsis",
 			text:  "foobar\nfoobar foobar foobar\nfoobar foobar",
 			trunc: fyne.TextTruncateClip,
 			want: [][2]int{
@@ -707,6 +726,17 @@ func TestText_lineBounds(t *testing.T) {
 			},
 		},
 		{
+			name:  "Multiple_Contiguous_Long_TruncateEllipsis",
+			text:  "foobar\nfoobarfoobarfoobar\nfoobarfoobar\n",
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 6},
+				{7, 14},
+				{26, 33},
+				{39, 39},
+			},
+		},
+		{
 			name: "Multiple_Contiguous_Long_WrapBreak",
 			text: "foobar\nfoobarfoobarfoobar\nfoobarfoobar\n",
 			wrap: fyne.TextWrapBreak,
@@ -763,6 +793,16 @@ func TestText_lineBounds(t *testing.T) {
 			},
 		},
 		{
+			name:  "Multiple_Trailing_Short_TruncateEllipsis",
+			text:  "foo\nbar\n",
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 3},
+				{4, 7},
+				{8, 8},
+			},
+		},
+		{
 			name: "Multiple_Trailing_Short_WrapBreak",
 			text: "foo\nbar\n",
 			wrap: fyne.TextWrapBreak,
@@ -812,6 +852,17 @@ func TestText_lineBounds(t *testing.T) {
 				{0, 6},
 				{7, 17},
 				{28, 38},
+				{42, 42},
+			},
+		},
+		{
+			name:  "Multiple_Trailing_Long_TruncateEllipsis",
+			text:  "foobar\nfoobar foobar foobar\nfoobar foobar\n",
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 6},
+				{7, 15},
+				{28, 36},
 				{42, 42},
 			},
 		},
@@ -879,11 +930,19 @@ func TestText_lineBounds_variable_char_width(t *testing.T) {
 			},
 		},
 		{
-			name:  "IM_Truncate",
+			name:  "IM_TruncateClip",
 			text:  "iiiiiiiiiimmmmmmmmmm",
 			trunc: fyne.TextTruncateClip,
 			want: [][2]int{
 				{0, 12},
+			},
+		},
+		{
+			name:  "IM_TruncateEllipsis",
+			text:  "iiiiiiiiiimmmmmmmmmm",
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 8},
 			},
 		},
 		{

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -542,7 +542,7 @@ func TestText_lineBounds(t *testing.T) {
 			},
 		},
 		{
-			name:  "Single_Long_Truncate",
+			name:  "Single_Long_TruncateClip",
 			text:  "foobar foobar",
 			trunc: fyne.TextTruncateClip,
 			want: [][2]int{
@@ -554,7 +554,7 @@ func TestText_lineBounds(t *testing.T) {
 			text:  "foobar foobar",
 			trunc: fyne.TextTruncateEllipsis,
 			want: [][2]int{
-				{0, 9},
+				{0, 8},
 			},
 			ellipses: 1,
 		},
@@ -667,8 +667,8 @@ func TestText_lineBounds(t *testing.T) {
 			trunc: fyne.TextTruncateEllipsis,
 			want: [][2]int{
 				{0, 6},
-				{7, 16},
-				{28, 37},
+				{7, 15},
+				{28, 36},
 			},
 			ellipses: 2,
 		},
@@ -736,8 +736,8 @@ func TestText_lineBounds(t *testing.T) {
 			trunc: fyne.TextTruncateEllipsis,
 			want: [][2]int{
 				{0, 6},
-				{7, 16},
-				{26, 35},
+				{7, 14},
+				{26, 33},
 				{39, 39},
 			},
 			ellipses: 2,
@@ -839,6 +839,17 @@ func TestText_lineBounds(t *testing.T) {
 			},
 		},
 		{
+			name:  "Multiple_Trailing_Short_WrapTruncateEllipsis",
+			text:  "foo\nbar\nbaz",
+			wrap:  fyne.TextWrapBreak,
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 3},
+				{4, 7},
+			},
+			ellipses: 0,
+		},
+		{
 			name: "Multiple_Trailing_Long_WrapOff",
 			text: "foobar\nfoobar foobar foobar\nfoobar foobar\n",
 			wrap: fyne.TextWrapOff,
@@ -877,8 +888,8 @@ func TestText_lineBounds(t *testing.T) {
 			trunc: fyne.TextTruncateEllipsis,
 			want: [][2]int{
 				{0, 6},
-				{7, 16},
-				{28, 37},
+				{7, 15},
+				{28, 36},
 				{42, 42},
 			},
 			ellipses: 2,
@@ -920,11 +931,35 @@ func TestText_lineBounds(t *testing.T) {
 				{4, 14},
 			},
 		},
+		{
+			name:  "Multiple_Trailing_Long_WrapTruncateEllipsis",
+			text:  "foo\nfoobar foobar foobar\nbazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			wrap:  fyne.TextWrapBreak,
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 3},
+				{4, 14},
+				{14, 23},
+			},
+			ellipses: 1,
+		},
+		{
+			name:  "Multiple_Trailing_Long_WrapWordTruncateEllipsis",
+			text:  "foo\nfoobar foobar foobar\nbaz",
+			wrap:  fyne.TextWrapWord,
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 3},
+				{4, 10},
+				{11, 17},
+			},
+			ellipses: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ellipses := 0
-			got, _ := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 76, fyne.NewSize(76, 84), measurer)
+			got, _ := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 76, fyne.NewSize(76, 64), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -425,8 +425,8 @@ func TestText_splitLines(t *testing.T) {
 }
 
 func TestText_lineBounds(t *testing.T) {
-	measurer := func(text []rune) float32 {
-		return fyne.MeasureText(string(text), 14, fyne.TextStyle{}).Width
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), 14, fyne.TextStyle{})
 	}
 	tests := []struct {
 		name  string
@@ -896,7 +896,7 @@ func TestText_lineBounds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 76, 76, measurer)
+			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 76, fyne.NewSize(76, 84), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)
@@ -968,12 +968,12 @@ func TestText_lineBounds_variable_char_width(t *testing.T) {
 	}
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}
-	measurer := func(text []rune) float32 {
-		return fyne.MeasureText(string(text), textSize, textStyle).Width
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), textSize, textStyle)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 46, 46, measurer)
+			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 46, fyne.NewSize(46, 84), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -823,6 +823,16 @@ func TestText_lineBounds(t *testing.T) {
 			},
 		},
 		{
+			name:  "Multiple_Trailing_Short_WrapTruncateClip",
+			text:  "foo\nbar\nbaz",
+			wrap:  fyne.TextWrapBreak,
+			trunc: fyne.TextTruncateClip,
+			want: [][2]int{
+				{0, 3},
+				{4, 7},
+			},
+		},
+		{
 			name: "Multiple_Trailing_Long_WrapOff",
 			text: "foobar\nfoobar foobar foobar\nfoobar foobar\n",
 			wrap: fyne.TextWrapOff,
@@ -893,10 +903,20 @@ func TestText_lineBounds(t *testing.T) {
 				{42, 42},
 			},
 		},
+		{
+			name:  "Multiple_Trailing_Long_WrapTruncateClip",
+			text:  "foo\nfoobar foobar foobar\nbaz",
+			wrap:  fyne.TextWrapBreak,
+			trunc: fyne.TextTruncateClip,
+			want: [][2]int{
+				{0, 3},
+				{4, 14},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 76, fyne.NewSize(76, 84), measurer)
+			got, _ := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 76, fyne.NewSize(76, 84), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)
@@ -973,7 +993,7 @@ func TestText_lineBounds_variable_char_width(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 46, fyne.NewSize(46, 84), measurer)
+			got, _ := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 46, fyne.NewSize(46, 184), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)


### PR DESCRIPTION
This avoids combinatorial explosion when we start to wrap AND truncate

Tasks:

- [x] Fix API to add multiple truncate modes to different wrap modes
- [x] Fix ellipsis mode for multi-line non-wrapped
- [x] Add support for truncation on wrap (use space available)
- [x] Add ellipsis support when truncating wrapped content

Possibly a future PR as this is not actually an API change (as this requires more discussion and is not actually an API change):
- [ ] Update Entry API for the "force no scroll" truncation mode (uses TextWrapOff at the moment, TextWrapTruncate is the scroll version)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
