### PR TITLE
Fix keybinding for Entry shortcuts on Mac OS

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"image/color"
 	"math"
+	"runtime"
 	"strings"
 	"time"
 	"unicode"
@@ -954,10 +955,15 @@ func (e *Entry) registerShortcut() {
 		e.selecting = false
 		moveWord(se)
 	}
-	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierShortcutDefault}, unselectMoveWord)
-	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}, selectMoveWord)
-	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault}, unselectMoveWord)
-	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}, selectMoveWord)
+
+	moveWordModifier := fyne.KeyModifierShortcutDefault
+	if runtime.GOOS == "darwin" {
+		moveWordModifier = fyne.KeyModifierAlt
+	}
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: moveWordModifier}, unselectMoveWord)
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: moveWordModifier | fyne.KeyModifierShift}, selectMoveWord)
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: moveWordModifier}, unselectMoveWord)
+	e.shortcut.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: moveWordModifier | fyne.KeyModifierShift}, selectMoveWord)
 }
 
 func (e *Entry) requestFocus() {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -970,6 +970,7 @@ func (e *Entry) registerShortcut() {
 
 		// Cmd+left, Cmd+right shortcuts behave like Home and End keys on Mac OS
 		shortcutHomeEnd := func(s fyne.Shortcut) {
+			e.selecting = false
 			if s.(*desktop.CustomShortcut).KeyName == fyne.KeyLeft {
 				e.typedKeyHome()
 			} else {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -2,6 +2,7 @@ package widget_test
 
 import (
 	"image/color"
+	"runtime"
 	"testing"
 	"time"
 
@@ -163,8 +164,13 @@ func TestEntry_Control_Word(t *testing.T) {
 	entry.CursorRow = 0
 	entry.CursorColumn = 0
 
+	moveWordModifier := fyne.KeyModifierShortcutDefault
+	if runtime.GOOS == "darwin" {
+		moveWordModifier = fyne.KeyModifierAlt
+	}
+
 	// ctrl-right to move on
-	nextWord := &desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault}
+	nextWord := &desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: moveWordModifier}
 	entry.TypedShortcut(nextWord)
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 1, entry.CursorColumn)
@@ -176,7 +182,7 @@ func TestEntry_Control_Word(t *testing.T) {
 	assert.Equal(t, 2, entry.CursorColumn)
 
 	// ctrl-left to move back
-	prevWord := &desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierShortcutDefault}
+	prevWord := &desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: moveWordModifier}
 	entry.TypedShortcut(prevWord)
 	assert.Equal(t, 1, entry.CursorRow)
 	assert.Equal(t, 0, entry.CursorColumn)
@@ -188,7 +194,7 @@ func TestEntry_Control_Word(t *testing.T) {
 	entry.SetText("word1 word2 word3")
 	entry.CursorRow = 0
 	entry.CursorColumn = 3
-	selectNextWord := &desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierShortcutDefault | fyne.KeyModifierShift}
+	selectNextWord := &desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: moveWordModifier | fyne.KeyModifierShift}
 	entry.TypedShortcut(selectNextWord)
 	assert.Equal(t, "d1", entry.SelectedText())
 	entry.TypedShortcut(selectNextWord)

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -744,7 +744,7 @@ func TestEntry_OnKeyDown_DeleteNewline(t *testing.T) {
 }
 
 func TestEntry_OnKeyDown_HomeEnd(t *testing.T) {
-	entry := &widget.Entry{}
+	entry := widget.NewEntry()
 	entry.SetText("Hi")
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 0, entry.CursorColumn)
@@ -758,6 +758,18 @@ func TestEntry_OnKeyDown_HomeEnd(t *testing.T) {
 	entry.TypedKey(home)
 	assert.Equal(t, 0, entry.CursorRow)
 	assert.Equal(t, 0, entry.CursorColumn)
+
+	if runtime.GOOS == "darwin" {
+		endShortcut := &desktop.CustomShortcut{KeyName: fyne.KeyRight, Modifier: fyne.KeyModifierSuper}
+		entry.TypedShortcut(endShortcut)
+		assert.Equal(t, 0, entry.CursorRow)
+		assert.Equal(t, 2, entry.CursorColumn)
+
+		homeShortcut := &desktop.CustomShortcut{KeyName: fyne.KeyLeft, Modifier: fyne.KeyModifierSuper}
+		entry.TypedShortcut(homeShortcut)
+		assert.Equal(t, 0, entry.CursorRow)
+		assert.Equal(t, 0, entry.CursorColumn)
+	}
 }
 
 func TestEntry_OnKeyDown_Insert(t *testing.T) {


### PR DESCRIPTION
### Description:
On Mac, Alt is the modifier used for moving left and right by words in text entries, instead of Cmd. Also, Cmd+Left/Cmd+Right behave like home and end on Mac (since most Mac keyboards don't have home/end)

As a follow-up, Cmd+Shift+Left/Right should select from the cursor position to the beginning/end of the line, but we don't have those shortcuts in for the other platforms yet either so that can be done as a separate task

Fixes #2462

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

