### PR TITLE
generic list binding

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -89,6 +89,12 @@ type Untyped interface {
 	Set(interface{}) error
 }
 
+type Typed[E any] interface {
+	DataItem
+	Get() (E, error)
+	Set(E) error
+}
+
 // NewUntyped returns a bindable interface{} value that is managed internally.
 //
 // Since: 2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module fyne.io/fyne/v2
 
-go 1.17
+go 1.20
 
 require (
 	fyne.io/systray v1.10.1-0.20230722100817-88df1e0ffa9a


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

implement (experimental) generic list binding.

I implemented two new interfaces List and ExternalList which are identical to their untyped counterparts, except that all types which were `interface{}` are now replaced by a type parameter. the original interfaces are now just using the new implementation with a hardcoded type `any`. thus allowing using the old api as before and using the new generic api at the same time. the implementation itself virtually didn't change.

I noticed there are no tests for the existing untyped implementation? this change should keep them green if they were tests for it. let me know if I missed something.

this is meant as a demo/proof of concept how generics could be used to get rid of `interface{}` apis, which require type annotations everywhere. all other binding implementations could be updated in a similar fashion.

caveats:

- for generics we need to support at least go 1.18
- before go 1.20, the `any` type didn't satisfy `comparable`, which is annoying if we want to use the new implementation for the old api (used in this demo but could be changed to be 1.18 compatible)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Updated the vendor folder (using `go mod vendor`).
- [ ] Check for binary size increases when importing new modules.
