### PR TITLE
Release memory references for removed stack items

### DIFF
--- a/internal/clip.go
+++ b/internal/clip.go
@@ -15,8 +15,10 @@ func (c *ClipStack) Pop() *ClipItem {
 		return nil
 	}
 
-	ret := c.clips[len(c.clips)-1]
-	c.clips = c.clips[:len(c.clips)-1]
+	top := len(c.clips) - 1
+	ret := c.clips[top]
+	c.clips[top] = nil // release memory reference
+	c.clips = c.clips[:top]
 	return ret
 }
 

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -582,6 +582,7 @@ func (o *overlayStack) add(overlay fyne.CanvasObject) {
 func (o *overlayStack) remove(overlay fyne.CanvasObject) {
 	o.OverlayStack.Remove(overlay)
 	overlayCount := len(o.List())
+	o.renderCaches[overlayCount] = nil // release memory reference to removed element
 	o.renderCaches = o.renderCaches[:overlayCount]
 }
 

--- a/internal/driver/common/canvas_test.go
+++ b/internal/driver/common/canvas_test.go
@@ -356,6 +356,21 @@ func TestCanvas_walkTree(t *testing.T) {
 	assert.Nil(t, nodes[6].nextSibling)
 }
 
+func TestCanvas_OverlayStack(t *testing.T) {
+	o := &overlayStack{}
+	a := canvas.NewRectangle(color.Black)
+	b := canvas.NewCircle(color.Black)
+	c := canvas.NewRectangle(color.White)
+	o.Add(a)
+	o.Add(b)
+	o.Add(c)
+	assert.Equal(t, 3, len(o.List()))
+	o.Remove(c)
+	assert.Equal(t, 2, len(o.List()))
+	o.Remove(a)
+	assert.Equal(t, 0, len(o.List()))
+}
+
 func deleteAt(c *fyne.Container, index int) {
 	if index < len(c.Objects)-1 {
 		c.Objects = append(c.Objects[:index], c.Objects[index+1:]...)

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -75,13 +75,23 @@ func (s *OverlayStack) Remove(overlay fyne.CanvasObject) {
 	s.propertyLock.Lock()
 	defer s.propertyLock.Unlock()
 
+	overlayIdx := -1
 	for i, o := range s.overlays {
 		if o == overlay {
-			s.overlays = s.overlays[:i]
-			s.focusManagers = s.focusManagers[:i]
+			overlayIdx = i
 			break
 		}
 	}
+	if overlayIdx == -1 {
+		return
+	}
+	// set removed elements in backing array to nil to release memory references
+	for i := overlayIdx; i < len(s.overlays); i++ {
+		s.overlays[i] = nil
+		s.focusManagers[i] = nil
+	}
+	s.overlays = s.overlays[:overlayIdx]
+	s.focusManagers = s.focusManagers[:overlayIdx]
 }
 
 // Top returns the top-most overlay of the stack.


### PR DESCRIPTION
### Description:
In various internal stacks implemented using slices, elements were removed by re-slicing to the new range, without nilling out the removed items. This causes a memory reference to be retained to the removed items until they are overwritten by future pushes to the stack. This PR nils out removed stack items to immediately release memory references.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

