### PR TITLE
Clean up and simplify form dialog code

### DIFF
--- a/dialog/form.go
+++ b/dialog/form.go
@@ -28,24 +28,14 @@ func (d *FormDialog) Submit() {
 	d.hideWithResponse(true)
 }
 
-// validateItems acts as a validation edge state handler that will respond to an individual widget's validation
-// state before checking all others to determine the net validation state. If the error passed is not nil, then the
-// confirm button will be disabled. If the error parameter is nil, then all other Validatable widgets in items are
-// checked as well to determine whether the confirm button should be disabled.
-// This method is passed to each Validatable widget's SetOnValidationChanged method in items by NewForm.
-func (d *FormDialog) validateItems(err error) {
+// setSubmitState is intended to run when the form validation changes to
+// enable/disable the submit button accordingly.
+func (d *FormDialog) setSubmitState(err error) {
 	if err != nil {
 		d.confirm.Disable()
 		return
 	}
-	for _, item := range d.items {
-		if validatable, ok := item.Widget.(fyne.Validatable); ok {
-			if err := validatable.Validate(); err != nil {
-				d.confirm.Disable()
-				return
-			}
-		}
-	}
+
 	d.confirm.Enable()
 }
 
@@ -74,9 +64,8 @@ func NewForm(title, confirm, dismiss string, items []*widget.FormItem, callback 
 		cancel:  d.dismiss,
 	}
 
-	formDialog.validateItems(nil)
-
-	form.SetOnValidationChanged(formDialog.validateItems)
+	formDialog.setSubmitState(form.Validate())
+	form.SetOnValidationChanged(formDialog.setSubmitState)
 
 	d.create(container.NewGridWithColumns(2, d.dismiss, confirmBtn))
 	return formDialog


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This was noticed as part of some research around #4147. The bug is still there but changes the behavior now that we trust what the form is telling us about the validation status. Having it this way makes it easier to debug an actual fix for the bug.

This simplification can be made because there is no need to actually re-validate once the form tells us what the status has changed to. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- Covered by existing tests. Behaves the same (but faster) for non extended entry widgets.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.