### PR TITLE
Ensure window is rendered when re-used

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -130,6 +130,10 @@ func (w *window) Show() {
 
 func (w *window) doShow() {
 	if w.view() != nil {
+		runOnDraw(w, func() {
+			w.driver.repaintWindow(w)
+		})
+
 		w.doShowAgain()
 		return
 	}


### PR DESCRIPTION
Fixes #4163

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- GL runtime :(
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

