### PR TITLE
Allow the compiler to optimize out platform specific dead code

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -27,15 +27,13 @@ import (
 // influence of a garbage collector.
 var mainGoroutineID uint64
 
-var (
-	curWindow *window
-	isWayland = false
-)
+var curWindow *window
 
 // Declare conformity with Driver
 var _ fyne.Driver = (*gLDriver)(nil)
 
-var drawOnMainThread bool // A workaround on Apple M1, just use 1 thread until fixed upstream
+// A workaround on Apple M1/M2, just use 1 thread until fixed upstream.
+const drawOnMainThread bool = runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
 
 type gLDriver struct {
 	windowLock sync.RWMutex

--- a/internal/driver/glfw/driver_notwayland.go
+++ b/internal/driver/glfw/driver_notwayland.go
@@ -1,0 +1,6 @@
+//go:build !wayland
+// +build !wayland
+
+package glfw
+
+const isWayland = false

--- a/internal/driver/glfw/driver_wayland.go
+++ b/internal/driver/glfw/driver_wayland.go
@@ -3,6 +3,4 @@
 
 package glfw
 
-func init() {
-	isWayland = true
-}
+const isWayland = true

--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -5,7 +5,6 @@ package glfw
 
 import (
 	"fmt"
-	"runtime"
 
 	"fyne.io/fyne/v2"
 
@@ -14,10 +13,6 @@ import (
 
 func (d *gLDriver) initGLFW() {
 	initOnce.Do(func() {
-		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-			drawOnMainThread = true
-		}
-
 		err := glfw.Init()
 		if err != nil {
 			fyne.LogError("failed to initialise GLFW", err)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Using constants for `drawOnMainThread` and `isWayland` allows the prove pass in the compiler to remove dead code. This means that any specific code for Wayland (mostly future work there) or M1/M2 doesn't get compiled in on other platforms. This improves binary sizes and improves performance by avoiding branching in some cases.

FYI: I verified on https://go.godbolt.org using a similar code structure that this indeed makes it now optimize out more dead code. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
