### PR TITLE
Fix regression causing flickery windows when hiding

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -801,10 +801,6 @@ func (w *window) processCharInput(char rune) {
 
 func (w *window) processFocused(focus bool) {
 	if focus {
-		// On Mac OS, hidden windows can be re-shown from the dock icon, which issues
-		// a GLFW window focus callback. We need to make sure the run loop is re-activated.
-		go w.doShow()
-
 		if curWindow == nil {
 			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerEnteredForeground()
 		}


### PR DESCRIPTION

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This reverts commit 5bac179573ed3b525dbd68ff1c991f0b3c18fa9b.

Reason for revert: This code runs when hiding and closing windows as well. Always doing a show results in flickering when trying to hide a second window by pressing a button inside that window. I don't know of a better solution so I just revert the PR for now to avoid the bug.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.