### PR TITLE
Cleanup GLFW init to avoid needing a sync.Once

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -172,9 +172,11 @@ func (d *gLDriver) Run() {
 func NewGLDriver() fyne.Driver {
 	repository.Register("file", intRepo.NewFileRepository())
 
-	return &gLDriver{
+	d := &gLDriver{
 		done:      make(chan interface{}),
 		drawDone:  make(chan interface{}),
 		animation: &animation.Runner{},
 	}
+	d.initGLFW()
+	return d
 }

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -33,7 +33,6 @@ type runFlag struct {
 var funcQueue = make(chan funcData)
 var drawFuncQueue = make(chan drawData)
 var run = &runFlag{Cond: sync.Cond{L: &sync.Mutex{}}}
-var initOnce = &sync.Once{}
 
 // Arrange that main.main runs on main thread.
 func init() {
@@ -106,7 +105,6 @@ func (d *gLDriver) runGL() {
 	run.L.Unlock()
 	run.Broadcast()
 
-	d.initGLFW()
 	if d.trayStart != nil {
 		d.trayStart()
 	}

--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -12,16 +12,14 @@ import (
 )
 
 func (d *gLDriver) initGLFW() {
-	initOnce.Do(func() {
-		err := glfw.Init()
-		if err != nil {
-			fyne.LogError("failed to initialise GLFW", err)
-			return
-		}
+	err := glfw.Init()
+	if err != nil {
+		fyne.LogError("failed to initialise GLFW", err)
+		return
+	}
 
-		initCursors()
-		d.startDrawThread()
-	})
+	initCursors()
+	d.startDrawThread()
 }
 
 func (d *gLDriver) tryPollEvents() {

--- a/internal/driver/glfw/loop_goxjs.go
+++ b/internal/driver/glfw/loop_goxjs.go
@@ -13,15 +13,13 @@ import (
 )
 
 func (d *gLDriver) initGLFW() {
-	initOnce.Do(func() {
-		err := glfw.Init(gl.ContextWatcher)
-		if err != nil {
-			fyne.LogError("failed to initialise GLFW", err)
-			return
-		}
+	err := glfw.Init(gl.ContextWatcher)
+	if err != nil {
+		fyne.LogError("failed to initialise GLFW", err)
+		return
+	}
 
-		d.startDrawThread()
-	})
+	d.startDrawThread()
 }
 
 func (d *gLDriver) tryPollEvents() {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -947,8 +947,6 @@ func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 		title = defaultTitle
 	}
 	runOnMain(func() {
-		d.initGLFW()
-
 		ret = &window{title: title, decorate: decorate, driver: d}
 		// This queue is destroyed when the window is closed.
 		ret.InitEventQueue()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

We previously called `glfw.Init()` before doing anything that needed it to be called (i.e. when creating a window and when starting the run loop) which led to init running multiple times. The solution was to protect it using a `sync.Once`  but I realized that  we can avoid it by just doing init on driver creation instead. This cleans up the code and makes window creation slightly faster as an added benefit.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.