### PR TITLE
Cache theme.InnerPadding() in entry MinSize

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1487,8 +1487,9 @@ func (r *entryRenderer) MinSize() fyne.Size {
 		return r.entry.content.MinSize().Add(fyne.NewSize(0, theme.InputBorderSize()*2))
 	}
 
+	innerPadding := theme.InnerPadding()
 	charMin := r.entry.placeholderProvider().charMinSize(r.entry.Password, r.entry.TextStyle)
-	minSize := charMin.Add(fyne.NewSquareSize(theme.InnerPadding()))
+	minSize := charMin.Add(fyne.NewSquareSize(innerPadding))
 
 	if r.entry.MultiLine {
 		count := r.entry.multiLineRows
@@ -1496,10 +1497,10 @@ func (r *entryRenderer) MinSize() fyne.Size {
 			count = multiLineRows
 		}
 
-		minSize.Height = charMin.Height*float32(count) + theme.InnerPadding()
+		minSize.Height = charMin.Height*float32(count) + innerPadding
 	}
 
-	return minSize.Add(fyne.NewSize(theme.InnerPadding()*2, theme.InnerPadding()))
+	return minSize.Add(fyne.NewSize(innerPadding*2, innerPadding))
 }
 
 func (r *entryRenderer) Objects() []fyne.CanvasObject {


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Just avoiding multiple calls for looking up theme.InnerPadding().

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
