### PR TITLE
Don't allocate a slice of windows 60 times per second

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -187,6 +187,10 @@ func (d *gLDriver) runGL() {
 				d.windowLock.Lock()
 				d.windows = newWindows
 				d.windowLock.Unlock()
+
+				if len(newWindows) == 0 {
+					d.Quit()
+				}
 			}
 		}
 	}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -126,8 +126,7 @@ func (d *gLDriver) runGL() {
 			}
 		case <-eventTick.C:
 			d.tryPollEvents()
-			newWindows := []fyne.Window{}
-			reassign := false
+			windowsToRemove := 0
 			for _, win := range d.windowList() {
 				w := win.(*window)
 				if w.viewport == nil {
@@ -135,15 +134,7 @@ func (d *gLDriver) runGL() {
 				}
 
 				if w.viewport.ShouldClose() {
-					reassign = true
-					w.viewLock.Lock()
-					w.visible = false
-					v := w.viewport
-					w.viewLock.Unlock()
-
-					// remove window from window list
-					v.Destroy()
-					w.destroy(d)
+					windowsToRemove++
 					continue
 				}
 
@@ -164,20 +155,38 @@ func (d *gLDriver) runGL() {
 					}
 				}
 
-				newWindows = append(newWindows, win)
-
 				if drawOnMainThread {
 					d.drawSingleFrame()
 				}
 			}
-			if reassign {
+			if windowsToRemove > 0 {
+				oldWindows := d.windowList()
+				newWindows := make([]fyne.Window, 0, len(oldWindows)-windowsToRemove)
+
+				for _, win := range oldWindows {
+					w := win.(*window)
+					if w.viewport == nil {
+						continue
+					}
+
+					if w.viewport.ShouldClose() {
+						w.viewLock.Lock()
+						w.visible = false
+						v := w.viewport
+						w.viewLock.Unlock()
+
+						// remove window from window list
+						v.Destroy()
+						w.destroy(d)
+						continue
+					}
+
+					newWindows = append(newWindows, win)
+				}
+
 				d.windowLock.Lock()
 				d.windows = newWindows
 				d.windowLock.Unlock()
-
-				if len(newWindows) == 0 {
-					d.Quit()
-				}
 			}
 		}
 	}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -279,7 +279,7 @@ func (w *window) destroy(d *gLDriver) {
 	w.DestroyEventQueue()
 	cache.CleanCanvas(w.canvas)
 
-	if w.master || len(w.driver.windowList()) == 1 {
+	if w.master {
 		d.Quit()
 	} else if runtime.GOOS == "darwin" {
 		go d.focusPreviousWindow()

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -279,7 +279,7 @@ func (w *window) destroy(d *gLDriver) {
 	w.DestroyEventQueue()
 	cache.CleanCanvas(w.canvas)
 
-	if w.master {
+	if w.master || len(w.driver.windowList()) == 1 {
 		d.Quit()
 	} else if runtime.GOOS == "darwin" {
 		go d.focusPreviousWindow()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
We were allocating and appending to a slice 60 times per second to modify the window list if windows were supposed to close. This updates the runloop to keep track of how many windows need to be closed and only allocate a slice when we need to.

With this, we should be doing less each iteration of the runloop (especially for applications with many windows) but a little more when removing windows which I think is a worthy tradeoff given closing is a lot less common. I also tuned the allocation of the closing windows slice to only allocate as much as it needs to. However, I am having trouble getting accurate readings in regards to how much effect it has. The numbers are just all over the place and I don't think my system monitor on Linux is accurate enough for CPU usage. I would appreciate if someone could see if they notice a decrease in CPU usage. @dweymouth perhaps?

Updates #2506

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.