### PR TITLE
We must support API 33 from Aug 31

### DIFF
--- a/cmd/fyne/internal/mobile/binres/binres.go
+++ b/cmd/fyne/internal/mobile/binres/binres.go
@@ -483,6 +483,24 @@ func resolveElements(elms []*Element, pool, bxPool *Pool) {
 				b := el.attrs[j].Name.Resolve(bxPool)
 				return a < b
 			})
+		} else if el.Name.Resolve(bxPool) == "activity" {
+			// As above the android manifest seems to be very delicate - name must be first then exported before configChanges
+			sort.Slice(el.attrs, func(i, j int) bool {
+				a := el.attrs[i].Name.Resolve(bxPool)
+				if a == "name" {
+					return true
+				}
+
+				b := el.attrs[j].Name.Resolve(bxPool)
+				if a == "exported" {
+					return b != "name"
+				}
+
+				if b == "name" {
+					return false
+				}
+				return a < b
+			})
 		}
 
 		for _, child := range el.Children {

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -150,7 +150,7 @@ func runBuildImpl(cmd *command) (*packages.Package, error) {
 			}
 			return pkg, nil
 		}
-		target := 31
+		target := 33
 		if !buildRelease {
 			target = 29 // TODO once we have gomobile debug signing working for v2 android signs
 		}


### PR DESCRIPTION
Should have been simple but another issue in the go mobile binary XML output took a while to resolve...

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
