### PR TITLE
Fix progressbar text having the wrong color sometimes

### DIFF
--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -30,7 +30,8 @@ func (p *progressRenderer) MinSize() fyne.Size {
 		tsize = fyne.MeasureText("100%", p.label.TextSize, p.label.TextStyle)
 	}
 
-	return fyne.NewSize(tsize.Width+theme.InnerPadding()*2, tsize.Height+theme.InnerPadding()*2)
+	padding := theme.InnerPadding() * 2
+	return fyne.NewSize(tsize.Width+padding, tsize.Height+padding)
 }
 
 func (p *progressRenderer) updateBar() {

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -76,6 +76,7 @@ func (p *progressRenderer) Refresh() {
 	p.updateBar()
 	p.background.Refresh()
 	p.bar.Refresh()
+	p.label.Refresh()
 	canvas.Refresh(p.progress.super())
 }
 
@@ -127,7 +128,7 @@ func (p *ProgressBar) CreateRenderer() fyne.WidgetRenderer {
 	background.CornerRadius = theme.InputRadiusSize()
 	bar := canvas.NewRectangle(theme.PrimaryColor())
 	bar.CornerRadius = theme.InputRadiusSize()
-	label := canvas.NewText("0%", theme.ForegroundColor())
+	label := canvas.NewText("0%", theme.BackgroundColor())
 	label.Alignment = fyne.TextAlignCenter
 	return &progressRenderer{widget.NewBaseRenderer([]fyne.CanvasObject{background, bar, label}), background, bar, label, p}
 }

--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -97,6 +97,11 @@ func TestProgressRenderer_ApplyTheme(t *testing.T) {
 	bar := NewProgressBar()
 	render := test.WidgetRenderer(bar).(*progressRenderer)
 
+	oldLabelColor := render.label.Color
+	render.Refresh()
+	newLabelColor := render.label.Color
+	assert.Equal(t, oldLabelColor, newLabelColor)
+
 	textSize := render.label.TextSize
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I noticed in Rymdport that the text color flickered from white to black after being rendered for the first time. There have also been reports of the text having a different color sometimes which I assume relates to the fact that we never refreshed the label.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
