### PR TITLE
Remove lint:ignore remark from valid error

### DIFF
--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -322,10 +322,7 @@ func (p *ParagraphSegment) Unselect() {
 // SeparatorSegment includes a horizontal separator in a rich text widget.
 //
 // Since: 2.1
-type SeparatorSegment struct {
-	//lint:ignore U1000 This is required due to language design.
-	dummy uint8 // without this a pointer to SeparatorSegment will always be the same
-}
+type SeparatorSegment struct{}
 
 // Inline returns false as a separator should be full width.
 func (s *SeparatorSegment) Inline() bool {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

It seems like the comment about it always pointing to the same struct was incorrect. I double-checked with out compiler expert @changkun and it does indeed not seem correct per the code example that he graciously provided:

```go
package main

import "fmt"

type a struct{}
type b struct{ _ int }

func main() {
	x := &a{}
	y := &a{}

	w := &b{}
	z := &b{}
	fmt.Println(x == y, w == z) // false false
	fmt.Println(reflect.DeepEqual(x, y), reflect.DeepEqual(w, z)) // false false
}
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.