### PR TITLE
Revert "Merge pull request #4177 from Jacalz/init-cleanup"

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -172,11 +172,9 @@ func (d *gLDriver) Run() {
 func NewGLDriver() fyne.Driver {
 	repository.Register("file", intRepo.NewFileRepository())
 
-	d := &gLDriver{
+	return &gLDriver{
 		done:      make(chan interface{}),
 		drawDone:  make(chan interface{}),
 		animation: &animation.Runner{},
 	}
-	d.initGLFW()
-	return d
 }

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -33,6 +33,7 @@ type runFlag struct {
 var funcQueue = make(chan funcData)
 var drawFuncQueue = make(chan drawData)
 var run = &runFlag{Cond: sync.Cond{L: &sync.Mutex{}}}
+var initOnce = &sync.Once{}
 
 // Arrange that main.main runs on main thread.
 func init() {
@@ -105,6 +106,7 @@ func (d *gLDriver) runGL() {
 	run.L.Unlock()
 	run.Broadcast()
 
+	d.initGLFW()
 	if d.trayStart != nil {
 		d.trayStart()
 	}

--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -12,14 +12,16 @@ import (
 )
 
 func (d *gLDriver) initGLFW() {
-	err := glfw.Init()
-	if err != nil {
-		fyne.LogError("failed to initialise GLFW", err)
-		return
-	}
+	initOnce.Do(func() {
+		err := glfw.Init()
+		if err != nil {
+			fyne.LogError("failed to initialise GLFW", err)
+			return
+		}
 
-	initCursors()
-	d.startDrawThread()
+		initCursors()
+		d.startDrawThread()
+	})
 }
 
 func (d *gLDriver) tryPollEvents() {

--- a/internal/driver/glfw/loop_goxjs.go
+++ b/internal/driver/glfw/loop_goxjs.go
@@ -13,13 +13,15 @@ import (
 )
 
 func (d *gLDriver) initGLFW() {
-	err := glfw.Init(gl.ContextWatcher)
-	if err != nil {
-		fyne.LogError("failed to initialise GLFW", err)
-		return
-	}
+	initOnce.Do(func() {
+		err := glfw.Init(gl.ContextWatcher)
+		if err != nil {
+			fyne.LogError("failed to initialise GLFW", err)
+			return
+		}
 
-	d.startDrawThread()
+		d.startDrawThread()
+	})
 }
 
 func (d *gLDriver) tryPollEvents() {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -947,6 +947,8 @@ func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 		title = defaultTitle
 	}
 	runOnMain(func() {
+		d.initGLFW()
+
 		ret = &window{title: title, decorate: decorate, driver: d}
 		// This queue is destroyed when the window is closed.
 		ret.InitEventQueue()


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This reverts commit d2a24a903f07012497ae2f7f1dd2015c6bd1684c.
Reason for revert: I noticed that it occasionally crashed when trying to set up the change listener for the draw thread because the application hadn't started. For some reason this only happened in `cmd/hello` but not `cmd/fyne_demo` for me. Will re-apply this with a fix for the crash after v2.4.0 has released.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
