### PR TITLE
Fix app.running field only being set if starting with app.Run()

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -6,7 +6,6 @@ package app // import "fyne.io/fyne/v2/app"
 import (
 	"os"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -29,8 +28,6 @@ type fyneApp struct {
 	settings  *settings
 	storage   fyne.Storage
 	prefs     fyne.Preferences
-
-	running uint32 // atomic, 1 == running, 0 == stopped
 }
 
 func (a *fyneApp) CloudProvider() fyne.CloudProvider {
@@ -67,9 +64,7 @@ func (a *fyneApp) NewWindow(title string) fyne.Window {
 }
 
 func (a *fyneApp) Run() {
-	if atomic.CompareAndSwapUint32(&a.running, 0, 1) {
-		a.driver.Run()
-	}
+	a.driver.Run()
 }
 
 func (a *fyneApp) Quit() {
@@ -79,7 +74,6 @@ func (a *fyneApp) Quit() {
 
 	a.driver.Quit()
 	a.settings.stopWatching()
-	atomic.StoreUint32(&a.running, 0)
 }
 
 func (a *fyneApp) Driver() fyne.Driver {

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -169,7 +169,7 @@ func (d *gLDriver) Run() {
 }
 
 // NewGLDriver sets up a new Driver instance implemented using the GLFW Go library and OpenGL bindings.
-func NewGLDriver() fyne.Driver {
+func NewGLDriver() *gLDriver {
 	repository.Register("file", intRepo.NewFileRepository())
 
 	return &gLDriver{

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -104,10 +104,11 @@ func (d *gLDriver) Quit() {
 		}
 		fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).TriggerExitedForeground()
 	}
-	defer func() {
-		recover() // we could be called twice - no safe way to check if d.done is closed
-	}()
-	close(d.done)
+
+	// Only call close once to avoid panic.
+	if atomic.LoadUint32(&running) == 1 {
+		close(d.done)
+	}
 }
 
 func (d *gLDriver) addWindow(w *window) {

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -106,7 +106,7 @@ func (d *gLDriver) Quit() {
 	}
 
 	// Only call close once to avoid panic.
-	if atomic.LoadUint32(&running) == 1 {
+	if atomic.CompareAndSwapUint32(&running, 1, 0) {
 		close(d.done)
 	}
 }

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -40,8 +40,8 @@ type gLDriver struct {
 	windowLock   sync.RWMutex
 	windows      []fyne.Window
 	device       *glDevice
-	done         chan interface{}
-	drawDone     chan interface{}
+	done         chan struct{}
+	drawDone     chan struct{}
 	waitForStart chan struct{}
 
 	animation *animation.Runner
@@ -172,8 +172,8 @@ func NewGLDriver() fyne.Driver {
 	repository.Register("file", intRepo.NewFileRepository())
 
 	return &gLDriver{
-		done:         make(chan interface{}),
-		drawDone:     make(chan interface{}),
+		done:         make(chan struct{}),
+		drawDone:     make(chan struct{}),
 		waitForStart: make(chan struct{}),
 		animation:    &animation.Runner{},
 	}

--- a/internal/driver/glfw/driver_test.go
+++ b/internal/driver/glfw/driver_test.go
@@ -39,7 +39,7 @@ func Test_gLDriver_AbsolutePositionForObject(t *testing.T) {
 	)
 	// We want to test the handling of the canvas' Fyne menu here.
 	// We work around w.SetMainMenu because on MacOS the main menu is a native menu.
-	c := w.Canvas().(*glCanvas)
+	c := w.canvas
 	movl := buildMenuOverlay(mm, w)
 	c.Lock()
 	c.setMenuOverlay(movl)

--- a/internal/driver/glfw/glfw_test.go
+++ b/internal/driver/glfw/glfw_test.go
@@ -35,11 +35,7 @@ func ensureCanvasSize(t *testing.T, w *window, size fyne.Size) {
 func repaintWindow(w *window) {
 	// Wait for GLFW loop to be running.
 	// If we try to paint windows before the context is created, we will end up on the wrong thread.
-	run.L.Lock()
-	for !run.flag {
-		run.Wait()
-	}
-	run.L.Unlock()
+	<-w.driver.waitForStart
 
 	runOnDraw(w, func() {
 		d.(*gLDriver).repaintWindow(w)

--- a/internal/driver/glfw/glfw_test.go
+++ b/internal/driver/glfw/glfw_test.go
@@ -38,7 +38,7 @@ func repaintWindow(w *window) {
 	<-w.driver.waitForStart
 
 	runOnDraw(w, func() {
-		d.(*gLDriver).repaintWindow(w)
+		d.repaintWindow(w)
 	})
 
 	time.Sleep(time.Millisecond * 150) // wait for the frames to be rendered... o

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -108,7 +108,7 @@ func (d *gLDriver) runGL() {
 		select {
 		case <-d.done:
 			eventTick.Stop()
-			d.drawDone <- nil // wait for draw thread to stop
+			d.drawDone <- struct{}{} // wait for draw thread to stop
 			d.Terminate()
 			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerStopped()
 			return

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -109,6 +109,7 @@ func (d *gLDriver) runGL() {
 		case <-d.done:
 			eventTick.Stop()
 			d.drawDone <- struct{}{} // wait for draw thread to stop
+			atomic.StoreUint32(&running, 0)
 			d.Terminate()
 			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerStopped()
 			return

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -41,17 +41,17 @@ func init() {
 func runOnMain(f func()) {
 	// If we are on main just execute - otherwise add it to the main queue and wait.
 	// The "running" variable is normally false when we are on the main thread.
-	onMain := atomic.LoadUint32(&running) == 0
-	if onMain {
+	if onMain := atomic.LoadUint32(&running) == 0; onMain {
 		f()
-	} else {
-		done := common.DonePool.Get().(chan struct{})
-		defer common.DonePool.Put(done)
-
-		funcQueue <- funcData{f: f, done: done}
-
-		<-done
+		return
 	}
+
+	done := common.DonePool.Get().(chan struct{})
+	defer common.DonePool.Put(done)
+
+	funcQueue <- funcData{f: f, done: done}
+
+	<-done
 }
 
 // force a function f to run on the draw thread

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -92,8 +92,6 @@ func (d *gLDriver) drawSingleFrame() {
 }
 
 func (d *gLDriver) runGL() {
-	eventTick := time.NewTicker(time.Second / 60)
-
 	if !atomic.CompareAndSwapUint32(&running, 0, 1) {
 		return // Run was called twice.
 	}
@@ -104,6 +102,7 @@ func (d *gLDriver) runGL() {
 		d.trayStart()
 	}
 	fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerStarted()
+	eventTick := time.NewTicker(time.Second / 60)
 	for {
 		select {
 		case <-d.done:

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -241,7 +241,7 @@ func refreshWindow(w *window) {
 }
 
 func updateGLContext(w *window) {
-	canvas := w.Canvas().(*glCanvas)
+	canvas := w.canvas
 	size := canvas.Size()
 
 	// w.width and w.height are not correct if we are maximised, so figure from canvas

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -114,9 +114,7 @@ func (d *gLDriver) runGL() {
 			return
 		case f := <-funcQueue:
 			f.f()
-			if f.done != nil {
-				f.done <- struct{}{}
-			}
+			f.done <- struct{}{}
 		case <-eventTick.C:
 			d.tryPollEvents()
 			newWindows := []fyne.Window{}
@@ -219,9 +217,7 @@ func (d *gLDriver) startDrawThread() {
 				return
 			case f := <-drawFuncQueue:
 				f.win.RunWithContext(f.f)
-				if f.done != nil {
-					f.done <- struct{}{}
-				}
+				f.done <- struct{}{}
 			case set := <-settingsChange:
 				painter.ClearFontCache()
 				cache.ResetThemeCaches()

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -108,7 +108,6 @@ func (d *gLDriver) runGL() {
 		case <-d.done:
 			eventTick.Stop()
 			d.drawDone <- struct{}{} // wait for draw thread to stop
-			atomic.StoreUint32(&running, 0)
 			d.Terminate()
 			fyne.CurrentApp().Lifecycle().(*app.Lifecycle).TriggerStopped()
 			return

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -5,7 +5,6 @@ import (
 	_ "image/png" // for the icon
 	"math"
 	"runtime"
-	"sync/atomic"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -135,9 +134,7 @@ func (w *window) doShow() {
 		return
 	}
 
-	if atomic.LoadUint32(&running) == 0 {
-		<-w.driver.waitForStart
-	}
+	<-w.driver.waitForStart
 
 	w.createLock.Do(w.create)
 	if w.view() == nil {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -5,6 +5,7 @@ import (
 	_ "image/png" // for the icon
 	"math"
 	"runtime"
+	"sync/atomic"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -134,11 +135,9 @@ func (w *window) doShow() {
 		return
 	}
 
-	run.L.Lock()
-	for !run.flag {
-		run.Wait()
+	if atomic.LoadUint32(&running) == 0 {
+		<-w.driver.waitForStart
 	}
-	run.L.Unlock()
 
 	w.createLock.Do(w.create)
 	if w.view() == nil {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -40,11 +40,7 @@ func TestMain(m *testing.M) {
 	go func() {
 		// Wait for GLFW loop to be running.
 		// If we try to create windows before the context is created, this will fail with an exception.
-		run.L.Lock()
-		for !run.flag {
-			run.Wait()
-		}
-		run.L.Unlock()
+		<-d.(*gLDriver).waitForStart
 
 		initMainMenu()
 		os.Exit(m.Run())

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -36,11 +36,11 @@ func init() {
 // TestMain makes sure that our driver is running on the main thread.
 // This must be done for some of our tests to function correctly.
 func TestMain(m *testing.M) {
-	d.(*gLDriver).initGLFW()
+	d.initGLFW()
 	go func() {
 		// Wait for GLFW loop to be running.
 		// If we try to create windows before the context is created, this will fail with an exception.
-		<-d.(*gLDriver).waitForStart
+		<-d.waitForStart
 
 		initMainMenu()
 		os.Exit(m.Run())
@@ -68,9 +68,14 @@ func TestGLDriver_CreateWindow_EmptyTitle(t *testing.T) {
 }
 
 func TestGLDriver_CreateSplashWindow(t *testing.T) {
-	d := NewGLDriver().(desktop.Driver)
+	d := NewGLDriver()
 	w := d.CreateSplashWindow().(*window)
 	w.create()
+
+	// Verify that the glfw driver implements desktop.Driver.
+	var driver fyne.Driver = d
+	_, ok := driver.(desktop.Driver)
+	assert.True(t, ok)
 
 	assert.Equal(t, 0, w.viewport.GetAttrib(glfw.Decorated))
 	assert.False(t, w.Padded())
@@ -1678,7 +1683,7 @@ func TestWindow_CloseInterception(t *testing.T) {
 	// Note: The #Close() is run asynchronously when the window is notified about the viewport close.
 	// Therefore, we have to wait some time before checking its state via the onClosed callback.
 
-	d := NewGLDriver().(*gLDriver)
+	d := NewGLDriver()
 	t.Run("when closing window with #Close()", func(t *testing.T) {
 		w := d.CreateWindow("test").(*window)
 		w.create()

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -101,7 +101,7 @@ func TestWindow_MinSize_Fixed(t *testing.T) {
 
 func TestWindow_ToggleMainMenuByKeyboard(t *testing.T) {
 	w := createWindow("Test").(*window)
-	c := w.Canvas().(*glCanvas)
+	c := w.canvas
 	m := fyne.NewMainMenu(fyne.NewMenu("File"), fyne.NewMenu("Edit"), fyne.NewMenu("Help"))
 	menuBar := buildMenuOverlay(m, w).(*MenuBar)
 	c.Lock()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This fixes the `app.running` field only being set if running with `app.Run()` and not when using `window.ShowAndRun()`, i.e. it was false for the majority of applications. The glfw driver already had a flag to check if it was running or not. The PR moves the running flag into the mobile driver and cleans up the one we already had in the glfw driver.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.