### PR TITLE
Lock and unlock less for BaseWidget.Move

### DIFF
--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -72,9 +72,10 @@ func (w *Base) Position() fyne.Position {
 func (w *Base) Move(pos fyne.Position) {
 	w.propertyLock.Lock()
 	w.position = pos
+	impl := w.impl
 	w.propertyLock.Unlock()
 
-	Repaint(w.super())
+	Repaint(impl)
 }
 
 // MinSize for the widget - it should never be resized below this value.

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -74,9 +74,10 @@ func (w *BaseWidget) Position() fyne.Position {
 func (w *BaseWidget) Move(pos fyne.Position) {
 	w.propertyLock.Lock()
 	w.position = pos
+	impl := w.impl
 	w.propertyLock.Unlock()
 
-	internalWidget.Repaint(w.super())
+	internalWidget.Repaint(impl)
 }
 
 // MinSize for the widget - it should never be resized below this value.


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Instead of first locking to set size and then locking again to get the implementation we can do it while we hold the first lock. This also matches the behaviour in all other methods.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.