### PR TITLE
Avoid unnecessary atomic app loads

### DIFF
--- a/canvas/canvas.go
+++ b/canvas/canvas.go
@@ -4,11 +4,12 @@ import "fyne.io/fyne/v2"
 
 // Refresh instructs the containing canvas to refresh the specified obj.
 func Refresh(obj fyne.CanvasObject) {
-	if fyne.CurrentApp() == nil || fyne.CurrentApp().Driver() == nil {
+	app := fyne.CurrentApp()
+	if app == nil || app.Driver() == nil {
 		return
 	}
 
-	c := fyne.CurrentApp().Driver().CanvasForObject(obj)
+	c := app.Driver().CanvasForObject(obj)
 	if c != nil {
 		c.Refresh(obj)
 	}
@@ -16,11 +17,12 @@ func Refresh(obj fyne.CanvasObject) {
 
 // repaint instructs the containing canvas to redraw, even if nothing changed.
 func repaint(obj fyne.CanvasObject) {
-	if fyne.CurrentApp() == nil || fyne.CurrentApp().Driver() == nil {
+	app := fyne.CurrentApp()
+	if app == nil || app.Driver() == nil {
 		return
 	}
 
-	c := fyne.CurrentApp().Driver().CanvasForObject(obj)
+	c := app.Driver().CanvasForObject(obj)
 	if c != nil {
 		if paint, ok := c.(interface{ SetDirty() }); ok {
 			paint.SetDirty()

--- a/canvas/line.go
+++ b/canvas/line.go
@@ -58,8 +58,8 @@ func (l *Line) Move(pos fyne.Position) {
 	deltaX := pos.X - oldPos.X
 	deltaY := pos.Y - oldPos.Y
 
-	l.Position1 = l.Position1.Add(fyne.NewPos(deltaX, deltaY))
-	l.Position2 = l.Position2.Add(fyne.NewPos(deltaX, deltaY))
+	l.Position1 = l.Position1.AddXY(deltaX, deltaY)
+	l.Position2 = l.Position2.AddXY(deltaX, deltaY)
 	repaint(l)
 }
 

--- a/canvas/text.go
+++ b/canvas/text.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
 )
 
 // Declare conformity with CanvasObject interface
@@ -64,13 +65,9 @@ func (t *Text) Refresh() {
 
 // NewText returns a new Text implementation
 func NewText(text string, color color.Color) *Text {
-	size := float32(0)
-	if app := fyne.CurrentApp(); app != nil { // nil app possible if app not started
-		size = app.Settings().Theme().Size("text") // manually name the size to avoid import loop
-	}
 	return &Text{
 		Color:    color,
 		Text:     text,
-		TextSize: size,
+		TextSize: theme.TextSize(),
 	}
 }

--- a/canvas/text.go
+++ b/canvas/text.go
@@ -65,8 +65,8 @@ func (t *Text) Refresh() {
 // NewText returns a new Text implementation
 func NewText(text string, color color.Color) *Text {
 	size := float32(0)
-	if fyne.CurrentApp() != nil { // nil app possible if app not started
-		size = fyne.CurrentApp().Settings().Theme().Size("text") // manually name the size to avoid import loop
+	if app := fyne.CurrentApp(); app != nil { // nil app possible if app not started
+		size = app.Settings().Theme().Size("text") // manually name the size to avoid import loop
 	}
 	return &Text{
 		Color:    color,

--- a/container.go
+++ b/container.go
@@ -198,11 +198,12 @@ func (c *Container) layout() {
 // repaint instructs the containing canvas to redraw, even if nothing changed.
 // This method is a duplicate of what is in `canvas/canvas.go` to avoid a dependency loop or public API.
 func repaint(obj *Container) {
-	if CurrentApp() == nil || CurrentApp().Driver() == nil {
+	app := CurrentApp()
+	if app == nil || app.Driver() == nil {
 		return
 	}
 
-	c := CurrentApp().Driver().CanvasForObject(obj)
+	c := app.Driver().CanvasForObject(obj)
 	if c != nil {
 		if paint, ok := c.(interface{ SetDirty() }); ok {
 			paint.SetDirty()

--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -163,11 +163,12 @@ func (w *Base) super() fyne.Widget {
 // Repaint instructs the containing canvas to redraw, even if nothing changed.
 // This method is a duplicate of what is in `canvas/canvas.go` to avoid a dependency loop or public API.
 func Repaint(obj fyne.CanvasObject) {
-	if fyne.CurrentApp() == nil || fyne.CurrentApp().Driver() == nil {
+	app := fyne.CurrentApp()
+	if app == nil || app.Driver() == nil {
 		return
 	}
 
-	c := fyne.CurrentApp().Driver().CanvasForObject(obj)
+	c := app.Driver().CanvasForObject(obj)
 	if c != nil {
 		if paint, ok := c.(interface{ SetDirty() }); ok {
 			paint.SetDirty()


### PR DESCRIPTION

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I'm not a huge fan of this repaint function (that inline interface check looks strange) but we can at least change three atomic app lookups to one.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
