### PR TITLE
Close an open branch with the left-key on a tree

### DIFF
--- a/widget/tree.go
+++ b/widget/tree.go
@@ -348,11 +348,17 @@ func (t *Tree) TypedKey(event *fyne.KeyEvent) {
 		t.ScrollTo(t.currentFocus)
 		t.RefreshItem(t.currentFocus)
 	case fyne.KeyLeft:
-		t.walk(t.Root, "", 0, func(id, p TreeNodeID, _ bool, _ int) {
-			if id == t.currentFocus && p != "" {
-				t.currentFocus = p
-			}
-		})
+		// If the current focus is on a branch which is open, just close it
+		if t.IsBranch(t.currentFocus) && t.IsBranchOpen(t.currentFocus) {
+			t.CloseBranch(t.currentFocus)
+		} else {
+			// Every other case should move the focus to the current parent node
+			t.walk(t.Root, "", 0, func(id, p TreeNodeID, _ bool, _ int) {
+				if id == t.currentFocus && p != "" {
+					t.currentFocus = p
+				}
+			})
+		}
 
 		t.RefreshItem(t.currentFocus)
 		t.ScrollTo(t.currentFocus)


### PR DESCRIPTION
### Description:
This change allows to close a branch in a tree with the left-key but keeps the focus on it. With an additional left-key, it will (as before) go up to the next parent node.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
