### PR TITLE
Add back dummy variable but without a name

### DIFF
--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -322,7 +322,9 @@ func (p *ParagraphSegment) Unselect() {
 // SeparatorSegment includes a horizontal separator in a rich text widget.
 //
 // Since: 2.1
-type SeparatorSegment struct{}
+type SeparatorSegment struct {
+	_ bool // Without this a pointer to SeparatorSegment will always be the same.
+}
 
 // Inline returns false as a separator should be full width.
 func (s *SeparatorSegment) Inline() bool {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This kind of reverts https://github.com/fyne-io/fyne/commit/82b567dd0d7ca7737c5f6a9032054c4876181457 but replaces the variable name with an underscore to basically just use it as struct padding. The change to use `bool` has no size benefit (aligned to one 8 bits for memory lookup reasons) but just seemed clearer to me.

Fixes #4216

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

