### PR TITLE
Usage of deprecated commands would crash due to nil AppData

### DIFF
--- a/cmd/fyne/commands/command.go
+++ b/cmd/fyne/commands/command.go
@@ -17,35 +17,35 @@ type Command interface {
 type Getter = commands.Getter
 
 // NewGetter returns a command that can handle the download and install of GUI apps built using Fyne.
-// It depends on a Go and C compiler installed at this stage and takes a single, package, parameter to identify the app.
+// It depends on a Go and C compiler installed.
 func NewGetter() *Getter {
-	return &Getter{}
+	return commands.NewGetter()
 }
 
 // NewBundler returns a command that can bundle resources into Go code.
 //
 // Deprecated: A better version will be exposed in the future.
 func NewBundler() Command {
-	return &commands.Bundler{}
+	return commands.NewBundler()
 }
 
 // NewInstaller returns an install command that can install locally built Fyne apps.
 //
 // Deprecated: A better version will be exposed in the future.
 func NewInstaller() Command {
-	return &commands.Installer{}
+	return commands.NewInstaller()
 }
 
 // NewPackager returns a packager command that can wrap executables into full GUI app packages.
 //
 // Deprecated: A better version will be exposed in the future.
 func NewPackager() Command {
-	return &commands.Packager{}
+	return commands.NewPackager()
 }
 
 // NewReleaser returns a command that can adapt app packages for distribution.
 //
 // Deprecated: A better version will be exposed in the future.
 func NewReleaser() Command {
-	return &commands.Releaser{}
+	return commands.NewReleaser()
 }

--- a/cmd/fyne/commands/command_test.go
+++ b/cmd/fyne/commands/command_test.go
@@ -1,0 +1,8 @@
+package commands
+
+import "testing"
+
+func TestNewGetter(t *testing.T) {
+	g := NewGetter()
+	g.SetAppID("io.fyne.text") // would crash if not set up internally correctly
+}

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -33,9 +33,14 @@ type Builder struct {
 	runner runner
 }
 
+// NewBuilder returns a command that can handle the build of GUI apps built using Fyne.
+func NewBuilder() *Builder {
+	return &Builder{appData: &appData{}}
+}
+
 // Build returns the cli command for building fyne applications
 func Build() *cli.Command {
-	b := &Builder{appData: &appData{}}
+	b := NewBuilder()
 
 	return &cli.Command{
 		Name:        "build",

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -69,6 +69,11 @@ type Bundler struct {
 	noheader       bool
 }
 
+// NewBundler returns a command that can handle the bundling assets into a GUI app binary.
+func NewBundler() *Bundler {
+	return &Bundler{}
+}
+
 // AddFlags adds all the command line flags for passing to the Bundler.
 //
 // Deprecated: Access to the individual cli commands are being removed.

--- a/cmd/fyne/internal/commands/get.go
+++ b/cmd/fyne/internal/commands/get.go
@@ -50,7 +50,7 @@ type Getter struct {
 }
 
 // NewGetter returns a command that can handle the download and install of GUI apps built using Fyne.
-// It depends on a Go and C compiler installed at this stage and takes a single, package, parameter to identify the app.
+// It depends on a Go and C compiler installed at this stage.
 func NewGetter() *Getter {
 	return &Getter{appData: &appData{}}
 }

--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -17,7 +17,7 @@ import (
 
 // Install returns the cli command for installing fyne applications
 func Install() *cli.Command {
-	i := &Installer{appData: &appData{}}
+	i := NewInstaller()
 
 	return &cli.Command{
 		Name:  "install",
@@ -71,6 +71,11 @@ type Installer struct {
 	installDir, srcDir, os string
 	Packager               *Packager
 	release                bool
+}
+
+// NewInstaller returns a command that can install a GUI apps built using Fyne from local source code.
+func NewInstaller() *Installer {
+	return &Installer{appData: &appData{}}
 }
 
 // AddFlags adds the flags for interacting with the Installer.

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -31,7 +31,7 @@ const (
 
 // Package returns the cli command for packaging fyne applications
 func Package() *cli.Command {
-	p := &Packager{appData: &appData{}}
+	p := NewPackager()
 
 	return &cli.Command{
 		Name:        "package",
@@ -138,6 +138,11 @@ type Packager struct {
 
 	customMetadata      keyValueFlag
 	linuxAndBSDMetadata *metadata.LinuxAndBSD
+}
+
+// NewPackager returns a command that can handle the packaging a GUI apps built using Fyne from local source code.
+func NewPackager() *Packager {
+	return &Packager{appData: &appData{}}
 }
 
 // AddFlags adds the flags for interacting with the package command.

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -28,8 +28,7 @@ var macAppStoreCategories = []string{
 
 // Release returns the cli command for bundling release builds of fyne applications
 func Release() *cli.Command {
-	r := &Releaser{}
-	r.appData = &appData{}
+	r := NewReleaser()
 
 	return &cli.Command{
 		Name:  "release",
@@ -147,6 +146,13 @@ type Releaser struct {
 	keyPass      string
 	developer    string
 	password     string
+}
+
+// NewReleaser returns a command that can handle the packaging a GUI apps for release from local Fyne source code.
+func NewReleaser() *Releaser {
+	r := &Releaser{}
+	r.appData = &appData{}
+	return r
 }
 
 // AddFlags adds the flags for interacting with the release command.


### PR DESCRIPTION
This is an issue also for usage of the not-deprecated `Getter`

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
