### PR TITLE
Modified docTabsRenderer.updateIndicator to resolve Issue #4220

### DIFF
--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -388,7 +388,7 @@ func (r *docTabsRenderer) scrollToSelected() {
 func (r *docTabsRenderer) updateIndicator(animate bool) {
 	if r.docTabs.current < 0 {
 		r.indicator.FillColor = color.Transparent
-		r.indicator.Refresh()
+		r.moveIndicator(fyne.NewPos(0, 0), fyne.NewSize(0, 0), animate)
 		return
 	}
 


### PR DESCRIPTION
### Description:
As described in Issue #4220, the representation of DocTabs in test.AssertObjectRendersToMarkup is different when DocTabs is initially created and after a tab has been added and removed: the size of the indicator is not returned to zero after the last tab is removed.

Fixes #4220
Modified docTabsRenderer.updateInidcator() for the case in which docTabs.current is less than 0 (i.e. there are no tabs). For this case, modified the function to  call docTabsRenderer.moveIndicator (pos 0,0, size 0,0). This gives a consistent rendering both when DocTabs is first rendered and after tabs have been added and then removed.

Rendering Tests are included with the issue - it was unclear to me whether the addition of rendering tests to the source code would be appropriate. All existing tests were run successfully

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
