### PR TITLE
fixed entry OnChanged callback in propery lock

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -489,12 +489,13 @@ func (e *Entry) Append(text string) {
 	provider.insertAt(provider.len(), text)
 	content := provider.String()
 	changed := e.updateText(content)
+	cb := e.OnChanged
 	e.propertyLock.Unlock()
 
 	if changed {
 		e.Validate()
-		if e.OnChanged != nil {
-			e.OnChanged(content)
+		if cb != nil {
+			cb(content)
 		}
 	}
 	e.Refresh()
@@ -668,11 +669,12 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	if e.CursorRow == e.selectRow && e.CursorColumn == e.selectColumn {
 		e.selecting = false
 	}
+	cb := e.OnChanged
 	e.propertyLock.Unlock()
 	if changed {
 		e.Validate()
-		if e.OnChanged != nil {
-			e.OnChanged(content)
+		if cb != nil {
+			cb(content)
 		}
 	}
 	e.Refresh()
@@ -846,10 +848,11 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 	e.copyToClipboard(clipboard)
 	e.setFieldsAndRefresh(e.eraseSelection)
 	e.propertyLock.Lock()
-	if e.OnChanged != nil {
-		e.OnChanged(e.Text)
-	}
+	cb := e.OnChanged
 	e.propertyLock.Unlock()
+	if cb != nil {
+		cb(e.Text)
+	}
 	e.Validate()
 }
 
@@ -1091,10 +1094,11 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 		// clears the selection -- return handled
 		e.setFieldsAndRefresh(e.eraseSelection)
 		e.propertyLock.Lock()
-		if e.OnChanged != nil {
-			e.OnChanged(e.Text)
-		}
+		cb := e.OnChanged
 		e.propertyLock.Unlock()
+		if cb != nil {
+			cb(e.Text)
+		}
 		e.Validate()
 		return true
 	case fyne.KeyReturn, fyne.KeyEnter:

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -847,9 +847,9 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 
 	e.copyToClipboard(clipboard)
 	e.setFieldsAndRefresh(e.eraseSelection)
-	e.propertyLock.Lock()
+	e.propertyLock.RLock()
 	cb := e.OnChanged
-	e.propertyLock.Unlock()
+	e.propertyLock.RUnlock()
 	if cb != nil {
 		cb(e.Text)
 	}
@@ -1093,9 +1093,9 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 	case fyne.KeyBackspace, fyne.KeyDelete:
 		// clears the selection -- return handled
 		e.setFieldsAndRefresh(e.eraseSelection)
-		e.propertyLock.Lock()
+		e.propertyLock.RLock()
 		cb := e.OnChanged
-		e.propertyLock.Unlock()
+		e.propertyLock.RUnlock()
 		if cb != nil {
 			cb(e.Text)
 		}


### PR DESCRIPTION
entry callback was in a property lock when selecting and deleting or cutting, my bad, fixed.

Fixes #4209  

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
