### PR TITLE
Move to js GOOS flag from gopherjs to be consistent with tags

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -142,7 +142,7 @@ func checkVersion(output string, versionConstraint *version.ConstraintGroup) err
 }
 
 func isWeb(goos string) bool {
-	return goos == "gopherjs" || goos == "wasm"
+	return goos == "js" || goos == "wasm"
 }
 
 func checkGoVersion(runner runner, versionConstraint *version.ConstraintGroup) error {
@@ -202,7 +202,7 @@ func (b *Builder) build() error {
 		goos = targetOS()
 	}
 
-	if goos == "gopherjs" && runtime.GOOS == "windows" {
+	if goos == "js" && runtime.GOOS == "windows" {
 		return errors.New("gopherjs doesn't support Windows. Only wasm target is supported for the web output. You can also use fyne-cross to solve this")
 	}
 
@@ -267,7 +267,7 @@ func (b *Builder) build() error {
 		tags = append(tags, "release")
 	}
 	if len(tags) > 0 {
-		if goos == "gopherjs" {
+		if goos == "js" {
 			args = append(args, "--tags")
 		} else {
 			args = append(args, "-tags")
@@ -285,7 +285,7 @@ func (b *Builder) build() error {
 		versionConstraint = version.NewConstrainGroupFromString(">=1.17")
 		env = append(env, "GOARCH=wasm")
 		env = append(env, "GOOS=js")
-	} else if goos == "gopherjs" {
+	} else if goos == "js" {
 		_, err := b.runner.runOutput("version")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Can not execute `gopherjs version`. Please do `go install github.com/gopherjs/gopherjs@latest`.\n")
@@ -364,7 +364,7 @@ func (b *Builder) updateAndGetGoExecutable(goos string) runner {
 			fyneGoModRunner = newCommand(goBin)
 			b.runner = fyneGoModRunner
 		} else {
-			if goos != "gopherjs" {
+			if goos != "js" {
 				b.runner = newCommand("go")
 			} else {
 				b.runner = newCommand("gopherjs")

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -201,7 +201,7 @@ func Test_BuildGopherJSReleaseVersion(t *testing.T) {
 	}
 
 	gopherJSBuildTest := &testCommandRuns{runs: expected, t: t}
-	b := &Builder{appData: &appData{}, os: "gopherjs", srcdir: "myTest", release: true, runner: gopherJSBuildTest}
+	b := &Builder{appData: &appData{}, os: "js", srcdir: "myTest", release: true, runner: gopherJSBuildTest}
 	err := b.build()
 	if runtime.GOOS == "windows" {
 		assert.NotNil(t, err)

--- a/cmd/fyne/internal/commands/package-web.go
+++ b/cmd/fyne/internal/commands/package-web.go
@@ -39,7 +39,7 @@ func (p *Packager) packageWasm() error {
 }
 
 func (p *Packager) packageGopherJS() error {
-	appDir := util.EnsureSubDir(p.dir, "gopherjs")
+	appDir := util.EnsureSubDir(p.dir, "js")
 
 	tpl := webData{
 		AppName:      p.Name,

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -41,7 +41,7 @@ func Package() *cli.Command {
 			&cli.StringFlag{
 				Name:        "target",
 				Aliases:     []string{"os"},
-				Usage:       "The mobile platform to target (android, android/arm, android/arm64, android/amd64, android/386, ios, iossimulator, wasm, gopherjs, web).",
+				Usage:       "The mobile platform to target (android, android/arm, android/arm64, android/amd64, android/386, ios, iossimulator, wasm, js, web).",
 				Destination: &p.os,
 			},
 			&cli.StringFlag{
@@ -248,7 +248,7 @@ func (p *Packager) buildPackage(runner runner, tags []string) ([]string, error) 
 	}
 
 	bGopherJS := &Builder{
-		os:      "gopherjs",
+		os:      "js",
 		srcdir:  p.srcDir,
 		target:  p.exe + ".js",
 		release: p.release,
@@ -327,7 +327,7 @@ func (p *Packager) doPackage(runner runner) error {
 		return p.packageIOS(p.os, tags)
 	case "wasm":
 		return p.packageWasm()
-	case "gopherjs":
+	case "js":
 		return p.packageGopherJS()
 	case "web":
 		return p.packageWeb()

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -343,7 +343,7 @@ func Test_buildPackageGopherJS(t *testing.T) {
 
 	p := &Packager{
 		appData: &appData{},
-		os:      "gopherjs",
+		os:      "js",
 		srcDir:  "myTest",
 		exe:     "myTest.js",
 		release: true,
@@ -394,7 +394,7 @@ func Test_PackageGopherJS(t *testing.T) {
 			Name: "myTest",
 			icon: "myTest.png",
 		},
-		os:     "gopherjs",
+		os:     "js",
 		srcDir: "myTest",
 		dir:    "myTestTarget",
 		exe:    "myTest.js",
@@ -409,7 +409,7 @@ func Test_PackageGopherJS(t *testing.T) {
 
 	expectedEnsureSubDirRuns := mockEnsureSubDirRuns{
 		expected: []mockEnsureSubDir{
-			{"myTestTarget", "gopherjs", "myTestTarget/gopherjs"},
+			{"myTestTarget", "js", "myTestTarget/js"},
 		},
 	}
 	utilEnsureSubDirMock = func(parent, name string) string {
@@ -428,12 +428,12 @@ func Test_PackageGopherJS(t *testing.T) {
 
 	expectedWriteFileRuns := mockWriteFileRuns{
 		expected: []mockWriteFile{
-			{filepath.Join("myTestTarget", "gopherjs", "index.html"), nil},
-			{filepath.Join("myTestTarget", "gopherjs", "spinner_light.gif"), nil},
-			{filepath.Join("myTestTarget", "gopherjs", "spinner_dark.gif"), nil},
-			{filepath.Join("myTestTarget", "gopherjs", "light.css"), nil},
-			{filepath.Join("myTestTarget", "gopherjs", "dark.css"), nil},
-			{filepath.Join("myTestTarget", "gopherjs", "webgl-debug.js"), nil},
+			{filepath.Join("myTestTarget", "js", "index.html"), nil},
+			{filepath.Join("myTestTarget", "js", "spinner_light.gif"), nil},
+			{filepath.Join("myTestTarget", "js", "spinner_dark.gif"), nil},
+			{filepath.Join("myTestTarget", "js", "light.css"), nil},
+			{filepath.Join("myTestTarget", "js", "dark.css"), nil},
+			{filepath.Join("myTestTarget", "js", "webgl-debug.js"), nil},
 		},
 	}
 	utilWriteFileMock = func(target string, _ []byte) error {
@@ -442,8 +442,8 @@ func Test_PackageGopherJS(t *testing.T) {
 
 	expectedCopyFileRuns := mockCopyFileRuns{
 		expected: []mockCopyFile{
-			{source: "myTest.png", target: filepath.Join("myTestTarget", "gopherjs", "icon.png")},
-			{source: "myTest.js", target: filepath.Join("myTestTarget", "gopherjs", "myTest.js")},
+			{source: "myTest.png", target: filepath.Join("myTestTarget", "js", "icon.png")},
+			{source: "myTest.js", target: filepath.Join("myTestTarget", "js", "myTest.js")},
 		},
 	}
 	utilCopyFileMock = func(source, target string) error {


### PR DESCRIPTION
Let's not be beholden to gophers if we find a different path for js output...

If this is approved we can back-port to v2.4.1 before web is officially supported and we are locked in.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
