### PR TITLE
Correctly align mobile menu content

### DIFF
--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/driver/mobile"
 	"fyne.io/fyne/v2/internal/app"
 	"fyne.io/fyne/v2/internal/driver"
@@ -167,6 +168,9 @@ func (c *mobileCanvas) setMenu(menu fyne.CanvasObject) {
 }
 
 func (c *mobileCanvas) setWindowHead(head fyne.CanvasObject) {
+	if c.padded {
+		head = container.NewPadded(head)
+	}
 	c.windowHead = head
 	c.SetMobileWindowHeadTree(head)
 }

--- a/internal/driver/mobile/menu.go
+++ b/internal/driver/mobile/menu.go
@@ -55,6 +55,9 @@ func (c *mobileCanvas) showMenu(menu *fyne.MainMenu) {
 	for _, item := range menu.Items {
 		panel.Add(newMenuLabel(item, panel, c))
 	}
+	if c.padded {
+		panel = container.NewPadded(panel)
+	}
 
 	bg := canvas.NewRectangle(theme.BackgroundColor())
 	shadow := canvas.NewHorizontalGradient(theme.ShadowColor(), color.Transparent)

--- a/internal/driver/mobile/menu_test.go
+++ b/internal/driver/mobile/menu_test.go
@@ -32,6 +32,7 @@ func TestMobileCanvas_DismissBar(t *testing.T) {
 
 func TestMobileCanvas_DismissMenu(t *testing.T) {
 	c := NewCanvas().(*mobileCanvas)
+	c.padded = false
 	c.SetContent(canvas.NewRectangle(theme.BackgroundColor()))
 	menu := fyne.NewMainMenu(
 		fyne.NewMenu("Test", fyne.NewMenuItem("TapMe", func() {})))


### PR DESCRIPTION
Fix it so the mobile menu button aligns with the inside of the canvas, not the window edge

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
