### PR TITLE
Support building with mobile tag on OpenBSD

### DIFF
--- a/internal/driver/mobile/app/app.go
+++ b/internal/driver/mobile/app/app.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build freebsd || linux || darwin || windows
-// +build freebsd linux darwin windows
+//go:build freebsd || linux || darwin || windows || openbsd
+// +build freebsd linux darwin windows || openbsd
 
 package app
 

--- a/internal/driver/mobile/app/app.go
+++ b/internal/driver/mobile/app/app.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build freebsd || linux || darwin || windows || openbsd
-// +build freebsd linux darwin windows || openbsd
+// +build freebsd linux darwin windows openbsd
 
 package app
 

--- a/internal/driver/mobile/app/x11.c
+++ b/internal/driver/mobile/app/x11.c
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux && !android) || freebsd
-// +build linux,!android freebsd
+//go:build (linux && !android) || freebsd || openbsd
+// +build linux,!android freebsd openbsd
 
 #include "_cgo_export.h"
 #include <EGL/egl.h>

--- a/internal/driver/mobile/app/x11.go
+++ b/internal/driver/mobile/app/x11.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux && !android) || freebsd
-// +build linux,!android freebsd
+//go:build (linux && !android) || freebsd || openbsd
+// +build linux,!android freebsd openbsd
 
 package app
 
@@ -16,6 +16,7 @@ than screens with touch panels.
 /*
 #cgo LDFLAGS: -lEGL -lGLESv2 -lX11
 #cgo freebsd CFLAGS: -I/usr/local/include/
+#cgo openbsd CFLAGS: -I/usr/X11R6/include/
 
 void createWindow(void);
 void processEvents(void);


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
This PR add support for building with the mobile tag on OpenBSD.
Without the following happens when trying to run `fyne_demo`:

```
$ go run -tags mobile main.go
# fyne.io/fyne/v2/internal/driver/mobile/app
../../internal/driver/mobile/app/keyboard.go:26:3: undefined: theApp
../../internal/driver/mobile/app/keyboard.go:29:3: undefined: theApp
../../internal/driver/mobile/app/keyboard.go:35:2: undefined: theApp
../../internal/driver/mobile/app/keyboard.go:39:2: undefined: theApp
```

With the changes it builds and runs just as intended.