### PR TITLE
Doctab crash (3909) temporary dirty fix

### DIFF
--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -363,6 +363,13 @@ func (r *docTabsRenderer) buildTabButtons(count int, buttons *fyne.Container) {
 
 func (r *docTabsRenderer) scrollToSelected() {
 	buttons := r.scroller.Content.(*fyne.Container)
+
+	// https://github.com/fyne-io/fyne/issues/3909
+	// very dirty temporary fix to this crash!
+	if r.docTabs.current < 0 || r.docTabs.current >= len(buttons.Objects) {
+		return
+	}
+
 	button := buttons.Objects[r.docTabs.current]
 	pos := button.Position()
 	size := button.Size()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
This is a dirty temporary fix to the impossible to reproduce crash I'm still encountering.

Fixes #3909

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
