### PR TITLE
FileDialog view layout preference

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -208,12 +208,12 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 		title = label + " Folder"
 	}
 
-	view := fyne.CurrentApp().Preferences().Int(viewLayoutKey)
-	if view != int(listView) {
-		view = int(gridView)
+	view := viewLayout(fyne.CurrentApp().Preferences().Int(viewLayoutKey))
+	if view != listView {
+		view = gridView
 	}
 
-	f.setView(viewLayout(view))
+	f.setView(view)
 
 	f.loadFavorites()
 

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -206,7 +206,13 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 		title = label + " Folder"
 	}
 
-	f.setView(gridView)
+	viewPreference := fyne.CurrentApp().Preferences().StringWithFallback("fileDialogViewLayout", "grid")
+	if viewPreference == "grid" {
+		f.setView(gridView)
+	} else {
+		f.setView(listView)
+	}
+
 	f.loadFavorites()
 
 	f.favoritesList = widget.NewList(
@@ -230,8 +236,15 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 		f.optionsMenu(fyne.CurrentApp().Driver().AbsolutePositionForObject(optionsButton), optionsButton.Size())
 	})
 
+	var toggleViewButtonIcon fyne.Resource
+	if f.view == gridView {
+		toggleViewButtonIcon = theme.ListIcon()
+	} else {
+		toggleViewButtonIcon = theme.GridIcon()
+	}
+
 	var toggleViewButton *widget.Button
-	toggleViewButton = widget.NewButtonWithIcon("", theme.ListIcon(), func() {
+	toggleViewButton = widget.NewButtonWithIcon("", toggleViewButtonIcon, func() {
 		if f.view == gridView {
 			f.setView(listView)
 			toggleViewButton.SetIcon(theme.GridIcon())
@@ -499,10 +512,12 @@ func (f *fileDialog) setView(view viewLayout) {
 		grid := widget.NewGridWrap(count, template, update)
 		grid.OnSelected = choose
 		f.files = grid
+		fyne.CurrentApp().Preferences().SetString("fileDialogViewLayout", "grid")
 	} else {
 		list := widget.NewList(count, template, update)
 		list.OnSelected = choose
 		f.files = list
+		fyne.CurrentApp().Preferences().SetString("fileDialogViewLayout", "list")
 	}
 	if f.dir != nil {
 		f.refreshDir(f.dir)

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -23,6 +23,8 @@ const (
 	listView
 )
 
+const viewLayoutKey = "fyne:fileDialogViewLayout"
+
 type textWidget interface {
 	fyne.Widget
 	SetText(string)
@@ -206,12 +208,12 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 		title = label + " Folder"
 	}
 
-	viewPreference := fyne.CurrentApp().Preferences().StringWithFallback("fileDialogViewLayout", "grid")
-	if viewPreference == "grid" {
-		f.setView(gridView)
-	} else {
-		f.setView(listView)
+	view := fyne.CurrentApp().Preferences().Int(viewLayoutKey)
+	if view != int(listView) {
+		view = int(gridView)
 	}
+
+	f.setView(viewLayout(view))
 
 	f.loadFavorites()
 
@@ -492,6 +494,8 @@ func (f *fileDialog) setSelected(file fyne.URI, id int) {
 
 func (f *fileDialog) setView(view viewLayout) {
 	f.view = view
+	fyne.CurrentApp().Preferences().SetInt(viewLayoutKey, int(view))
+
 	count := func() int {
 		return len(f.data)
 	}
@@ -512,12 +516,10 @@ func (f *fileDialog) setView(view viewLayout) {
 		grid := widget.NewGridWrap(count, template, update)
 		grid.OnSelected = choose
 		f.files = grid
-		fyne.CurrentApp().Preferences().SetString("fileDialogViewLayout", "grid")
 	} else {
 		list := widget.NewList(count, template, update)
 		list.OnSelected = choose
 		f.files = list
-		fyne.CurrentApp().Preferences().SetString("fileDialogViewLayout", "list")
 	}
 	if f.dir != nil {
 		f.refreshDir(f.dir)

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -504,6 +504,54 @@ func TestView(t *testing.T) {
 	assert.Equal(t, "Dismiss", dismiss.Text)
 }
 
+func TestViewPreferences(t *testing.T) {
+	win := test.NewWindow(widget.NewLabel("Content"))
+
+	const viewLayoutKey string = "fileDialogViewLayout"
+
+	prefs := fyne.CurrentApp().Preferences()
+
+	// ensure viewLayout preference is not set to a valid value
+	prefs.SetString(viewLayoutKey, "")
+	prefs.RemoveValue(viewLayoutKey)
+
+	// viewLayout preference should not be set
+	viewLayout := prefs.StringWithFallback(viewLayoutKey, "")
+	assert.Equal(t, viewLayout, "")
+
+	dlg := NewFileOpen(func(reader fyne.URIReadCloser, err error) {
+		assert.Nil(t, err)
+		assert.Nil(t, reader)
+	}, win)
+
+	dlg.Show()
+
+	popup := win.Canvas().Overlays().Top().(*widget.PopUp)
+	defer win.Canvas().Overlays().Remove(popup)
+	assert.NotNil(t, popup)
+
+	ui := popup.Content.(*fyne.Container)
+	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
+
+	// viewLayout preference should be 'grid'
+	viewLayout = prefs.String(viewLayoutKey)
+	assert.Equal(t, viewLayout, "grid")
+
+	// toggle view
+	test.Tap(toggleViewButton)
+
+	// viewLayout preference should be 'list'
+	viewLayout = prefs.String(viewLayoutKey)
+	assert.Equal(t, viewLayout, "list")
+
+	// toggle view
+	test.Tap(toggleViewButton)
+
+	// viewLayout preference should be 'grid' again
+	viewLayout = prefs.String(viewLayoutKey)
+	assert.Equal(t, viewLayout, "grid")
+}
+
 func TestFileFavorites(t *testing.T) {
 	win := test.NewWindow(widget.NewLabel("Content"))
 

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -507,17 +507,10 @@ func TestView(t *testing.T) {
 func TestViewPreferences(t *testing.T) {
 	win := test.NewWindow(widget.NewLabel("Content"))
 
-	const viewLayoutKey string = "fileDialogViewLayout"
-
 	prefs := fyne.CurrentApp().Preferences()
 
-	// ensure viewLayout preference is not set to a valid value
-	prefs.SetString(viewLayoutKey, "")
-	prefs.RemoveValue(viewLayoutKey)
-
-	// viewLayout preference should not be set
-	viewLayout := prefs.StringWithFallback(viewLayoutKey, "")
-	assert.Equal(t, viewLayout, "")
+	// set viewLayout to an invalid value to verify that this situation is handled properly
+	prefs.SetInt(viewLayoutKey, -1)
 
 	dlg := NewFileOpen(func(reader fyne.URIReadCloser, err error) {
 		assert.Nil(t, err)
@@ -534,22 +527,22 @@ func TestViewPreferences(t *testing.T) {
 	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
 
 	// viewLayout preference should be 'grid'
-	viewLayout = prefs.String(viewLayoutKey)
-	assert.Equal(t, viewLayout, "grid")
+	view := viewLayout(prefs.Int(viewLayoutKey))
+	assert.Equal(t, gridView, view)
 
 	// toggle view
 	test.Tap(toggleViewButton)
 
 	// viewLayout preference should be 'list'
-	viewLayout = prefs.String(viewLayoutKey)
-	assert.Equal(t, viewLayout, "list")
+	view = viewLayout(prefs.Int(viewLayoutKey))
+	assert.Equal(t, listView, view)
 
 	// toggle view
 	test.Tap(toggleViewButton)
 
 	// viewLayout preference should be 'grid' again
-	viewLayout = prefs.String(viewLayoutKey)
-	assert.Equal(t, viewLayout, "grid")
+	view = viewLayout(prefs.Int(viewLayoutKey))
+	assert.Equal(t, gridView, view)
 }
 
 func TestFileFavorites(t *testing.T) {


### PR DESCRIPTION
### Description:
Prior to this change, the FileDialog always started with grid view regardless of the previously selected view. This pull request adds a `fileDialogViewLayout` key to app preferences to save the last view layout selected. The next time a FileDialog is show it will start with the last view layout selected by the user.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
