### PR TITLE
Fix #4260: Synchronize access to fileDialog.data file list

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -57,7 +57,7 @@ type fileDialog struct {
 	view viewLayout
 
 	data     []fyne.URI
-	dataLock *sync.RWMutex
+	dataLock sync.RWMutex
 
 	win        *widget.PopUp
 	selected   fyne.URI
@@ -604,7 +604,7 @@ func (f *FileDialog) effectiveStartingDir() fyne.ListableURI {
 }
 
 func showFile(file *FileDialog) *fileDialog {
-	d := &fileDialog{file: file, initialFileName: file.initialFileName, dataLock: &sync.RWMutex{}}
+	d := &fileDialog{file: file, initialFileName: file.initialFileName}
 	ui := d.makeUI()
 	size := ui.MinSize().Add(fyne.NewSize(fileIconCellWidth*2+theme.Padding()*6+theme.Padding(),
 		(fileIconSize+fileTextSize)+theme.Padding()*6))

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -54,7 +55,9 @@ type fileDialog struct {
 	showHidden       bool
 
 	view viewLayout
-	data []fyne.URI
+
+	data     []fyne.URI
+	dataLock *sync.RWMutex
 
 	win        *widget.PopUp
 	selected   fyne.URI
@@ -334,7 +337,9 @@ func (f *fileDialog) loadFavorites() {
 }
 
 func (f *fileDialog) refreshDir(dir fyne.ListableURI) {
+	f.dataLock.Lock()
 	f.data = nil
+	f.dataLock.Unlock()
 
 	files, err := dir.List()
 	if err != nil {
@@ -366,7 +371,10 @@ func (f *fileDialog) refreshDir(dir fyne.ListableURI) {
 			icons = append(icons, file)
 		}
 	}
+
+	f.dataLock.Lock()
 	f.data = icons
+	f.dataLock.Unlock()
 
 	f.files.Refresh()
 	f.filesScroll.Offset = fyne.NewPos(0, 0)
@@ -480,20 +488,42 @@ func (f *fileDialog) setSelected(file fyne.URI, id int) {
 func (f *fileDialog) setView(view viewLayout) {
 	f.view = view
 	count := func() int {
+		f.dataLock.RLock()
+		defer f.dataLock.RUnlock()
+
 		return len(f.data)
 	}
 	template := func() fyne.CanvasObject {
 		return f.newFileItem(storage.NewFileURI("./tempfile"), true, false)
 	}
 	update := func(id widget.GridWrapItemID, o fyne.CanvasObject) {
+		f.dataLock.RLock()
+
+		if id >= len(f.data) {
+			f.dataLock.RUnlock()
+			return
+		}
+
 		dir := f.data[id]
+		f.dataLock.RUnlock()
+
 		parent := id == 0 && len(dir.Path()) < len(f.dir.Path())
 		_, isDir := dir.(fyne.ListableURI)
 		o.(*fileDialogItem).setLocation(dir, isDir || parent, parent)
 	}
 	choose := func(id int) {
+		f.dataLock.RLock()
+
+		if id >= len(f.data) {
+			f.dataLock.RUnlock()
+			return
+		}
+
+		file := f.data[id]
+		f.dataLock.RUnlock()
+
 		f.selectedID = id
-		f.setSelected(f.data[id], id)
+		f.setSelected(file, id)
 	}
 	if f.view == gridView {
 		grid := widget.NewGridWrap(count, template, update)
@@ -574,7 +604,7 @@ func (f *FileDialog) effectiveStartingDir() fyne.ListableURI {
 }
 
 func showFile(file *FileDialog) *fileDialog {
-	d := &fileDialog{file: file, initialFileName: file.initialFileName}
+	d := &fileDialog{file: file, initialFileName: file.initialFileName, dataLock: &sync.RWMutex{}}
 	ui := d.makeUI()
 	size := ui.MinSize().Add(fyne.NewSize(fileIconCellWidth*2+theme.Padding()*6+theme.Padding(),
 		(fileIconSize+fileTextSize)+theme.Padding()*6))

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestFileItem_Name(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
+	f := &fileDialog{file: &FileDialog{}}
 	_ = f.makeUI()
 
 	item := f.newFileItem(storage.NewFileURI("/path/to/filename.txt"), false, false)
@@ -43,7 +42,7 @@ func TestFileItem_Name(t *testing.T) {
 }
 
 func TestFileItem_FolderName(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
+	f := &fileDialog{file: &FileDialog{}}
 	_ = f.makeUI()
 
 	item := f.newFileItem(storage.NewFileURI("/path/to/foldername/"), true, false)
@@ -62,7 +61,7 @@ func TestFileItem_FolderName(t *testing.T) {
 }
 
 func TestNewFileItem(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
+	f := &fileDialog{file: &FileDialog{}}
 	_ = f.makeUI()
 	item := f.newFileItem(storage.NewFileURI("/path/to/filename.txt"), false, false)
 
@@ -70,7 +69,7 @@ func TestNewFileItem(t *testing.T) {
 }
 
 func TestNewFileItem_Folder(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
+	f := &fileDialog{file: &FileDialog{}}
 	_ = f.makeUI()
 	currentDir, _ := filepath.Abs(".")
 	currentLister, err := storage.ListerForURI(storage.NewFileURI(currentDir))
@@ -91,7 +90,7 @@ func TestNewFileItem_Folder(t *testing.T) {
 }
 
 func TestNewFileItem_ParentFolder(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
+	f := &fileDialog{file: &FileDialog{}}
 	_ = f.makeUI()
 	currentDir, _ := filepath.Abs(".")
 	currentLister, err := storage.ListerForURI(storage.NewFileURI(currentDir))

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestFileItem_Name(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}}
+	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
 	_ = f.makeUI()
 
 	item := f.newFileItem(storage.NewFileURI("/path/to/filename.txt"), false, false)
@@ -42,7 +43,7 @@ func TestFileItem_Name(t *testing.T) {
 }
 
 func TestFileItem_FolderName(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}}
+	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
 	_ = f.makeUI()
 
 	item := f.newFileItem(storage.NewFileURI("/path/to/foldername/"), true, false)
@@ -61,7 +62,7 @@ func TestFileItem_FolderName(t *testing.T) {
 }
 
 func TestNewFileItem(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}}
+	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
 	_ = f.makeUI()
 	item := f.newFileItem(storage.NewFileURI("/path/to/filename.txt"), false, false)
 
@@ -69,7 +70,7 @@ func TestNewFileItem(t *testing.T) {
 }
 
 func TestNewFileItem_Folder(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}}
+	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
 	_ = f.makeUI()
 	currentDir, _ := filepath.Abs(".")
 	currentLister, err := storage.ListerForURI(storage.NewFileURI(currentDir))
@@ -90,7 +91,7 @@ func TestNewFileItem_Folder(t *testing.T) {
 }
 
 func TestNewFileItem_ParentFolder(t *testing.T) {
-	f := &fileDialog{file: &FileDialog{}}
+	f := &fileDialog{file: &FileDialog{}, dataLock: &sync.RWMutex{}}
 	_ = f.makeUI()
 	currentDir, _ := filepath.Abs(".")
 	currentLister, err := storage.ListerForURI(storage.NewFileURI(currentDir))


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
This change adds a RWMutex to synchronize access to the `fileDialog.data` file list.
The `refreshDir` function clears and rebuilds `fileDialog.data`, meanwhile, several other functions are indexing into it.
This allowed for scenarios where `fileDialog.data` was either nil or smaller than expected when indexing into it.

Fixes #4260 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
