### PR TITLE
Fix accidental truncation when multi-byte runes had ellipsis trunc

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -1017,8 +1017,8 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 			}
 		default:
 			if trunc == fyne.TextTruncateEllipsis {
-				txt := seg.Text[low:high]
-				end, full := truncateLimit(txt, seg.Visual().(*canvas.Text), int(measureWidth), []rune{'…'})
+				txt := []rune(seg.Text)[low:high]
+				end, full := truncateLimit(string(txt), seg.Visual().(*canvas.Text), int(measureWidth), []rune{'…'})
 				high = low + end
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 				reuse++

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -969,6 +969,16 @@ func TestText_lineBounds(t *testing.T) {
 			},
 			ellipses: 1,
 		},
+		{
+			name:  "Multi_byte_ellipsis_not_truncated",
+			text:  "🪃 234",
+			trunc: fyne.TextTruncateEllipsis,
+			wrap:  fyne.TextWrapOff,
+			want: [][2]int{
+				{0, 5},
+			},
+			ellipses: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #4283

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
