### PR TITLE
Remove call to Refresh() inside fileItemRenderer.Layout()

### DIFF
--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -102,7 +102,6 @@ func (s *fileItemRenderer) Layout(size fyne.Size) {
 		s.text.Resize(fyne.NewSize(size.Width, textMin.Height))
 		s.text.Move(fyne.NewPos(fileInlineIconSize, (size.Height-textMin.Height)/2))
 	}
-	s.text.Refresh()
 }
 
 func (s *fileItemRenderer) MinSize() fyne.Size {


### PR DESCRIPTION
### Description:
Calling `Refresh()` on the item label inside `fileItemRenerer.Layout()` causes a crash due to a race condition where `Layout` and `Refresh` occur at the same time.

Fixes #4260 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
