### PR TITLE
Add canvas refresh to richtext renderer refresh

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -707,6 +707,7 @@ func (r *textRenderer) Refresh() {
 	r.obj.propertyLock.Unlock()
 
 	r.Layout(r.obj.Size())
+	canvas.Refresh(r.obj.super())
 }
 
 func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign, xPos, yPos, lineWidth float32) (float32, float32) {


### PR DESCRIPTION
### Description:

Ensures refresh happens even when segment slice completely replaced. Looks like `TextRenderer.Refresh()` only calls `canvas.Refresh(...)` on the canvas texts in the text segments, and only when they already exist in the cache, so I added a `canvas.Refresh(r.obj.super())` to make sure it always happens, even when the text segment is completely replace by a new instance.
Tests not included because I couldn't replicate the issue in a test, looks like the `testDriver` and `glDriver` have a different impl of `CanvasForObject(obj)` where the `testDriver` never returns `nil` so it never doesn't refresh.

Fixes #4298 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
