### PR TITLE
Add missed truncation mode for hyperlink

### DIFF
--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -22,6 +22,10 @@ type Hyperlink struct {
 	Alignment fyne.TextAlign // The alignment of the Text
 	Wrapping  fyne.TextWrap  // The wrapping of the Text
 	TextStyle fyne.TextStyle // The style of the hyperlink text
+	// The truncation mode of the hyperlink
+	//
+	// Since: 2.5
+	Truncation fyne.TextTruncation
 
 	// OnTapped overrides the default `fyne.OpenURL` call when the link is tapped
 	//
@@ -187,6 +191,7 @@ func (hl *Hyperlink) openURL() {
 
 func (hl *Hyperlink) syncSegments() {
 	hl.provider.Wrapping = hl.Wrapping
+	hl.provider.Truncation = hl.Truncation
 	hl.provider.Segments = []RichTextSegment{&TextSegment{
 		Style: RichTextStyle{
 			Alignment: hl.Alignment,

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
@@ -141,6 +142,23 @@ func TestHyperlink_SetUrl(t *testing.T) {
 	assert.Nil(t, err)
 	hyperlink.SetURL(sURL)
 	assert.Equal(t, sURL, hyperlink.URL)
+}
+
+func TestHyperlink_Truncate(t *testing.T) {
+	hyperlink := &Hyperlink{Text: "TestingWithLongText"}
+	hyperlink.CreateRenderer()
+	hyperlink.Resize(fyne.NewSize(100, 20))
+
+	r := test.WidgetRenderer(hyperlink.provider)
+	assert.Equal(t, "TestingWithLongText", r.Objects()[0].(*canvas.Text).Text)
+
+	hyperlink.Truncation = fyne.TextTruncateClip
+	hyperlink.Refresh()
+	assert.Equal(t, "TestingWith", r.Objects()[0].(*canvas.Text).Text)
+
+	hyperlink.Truncation = fyne.TextTruncateEllipsis
+	hyperlink.Refresh()
+	assert.Equal(t, "TestingWi…", r.Objects()[0].(*canvas.Text).Text)
 }
 
 func TestHyperlink_CreateRendererDoesNotAffectSize(t *testing.T) {


### PR DESCRIPTION


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
