### PR TITLE
Add the ability to disable ToolbarActions #2306

### DIFF
--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -36,16 +36,22 @@ func (t *ToolbarAction) SetIcon(icon fyne.Resource) {
 }
 
 // Enable this ToolbarAction, updating any style or features appropriately.
+//
+// Since: 2.5
 func (t *ToolbarAction) Enable() {
 	t.button.Enable()
 }
 
 // Disable this ToolbarAction so that it cannot be interacted with, updating any style appropriately.
+//
+// Since: 2.5
 func (t *ToolbarAction) Disable() {
 	t.button.Disable()
 }
 
 // Disabled returns true if this ToolbarAction is currently disabled or false if it can currently be interacted with.
+//
+// Since: 2.5
 func (t *ToolbarAction) Disabled() bool {
 	return t.button.Disabled()
 }

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -22,6 +22,7 @@ type ToolbarAction struct {
 
 // ToolbarObject gets a button to render this ToolbarAction
 func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
+	t.button.Icon = t.Icon
 	t.button.OnTapped = t.OnActivated
 	return t.button
 }

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -13,42 +13,17 @@ type ToolbarItem interface {
 	ToolbarObject() fyne.CanvasObject
 }
 
-type toolbarActionButton struct {
-	Button
-
-	t *ToolbarAction
-}
-
-func newToolbarActionButton(t *ToolbarAction) *toolbarActionButton {
-	b := &toolbarActionButton{t: t}
-	b.ExtendBaseWidget(b)
-	return b
-}
-
-func (b *toolbarActionButton) Refresh() {
-	b.Icon = b.t.Icon
-	b.OnTapped = b.t.OnActivated
-
-	if b.t.Disabled {
-		b.Button.Disable()
-	} else {
-		b.Button.Enable()
-	}
-}
-
 // ToolbarAction is push button style of ToolbarItem
 type ToolbarAction struct {
 	Icon        fyne.Resource
 	OnActivated func() `json:"-"`
-	// Since: 2.5
-	Disabled bool
+	button      *Button
 }
 
 // ToolbarObject gets a button to render this ToolbarAction
 func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
-	b := newToolbarActionButton(t)
-	b.Refresh()
-	return b
+	t.button.OnTapped = t.OnActivated
+	return t.button
 }
 
 // SetIcon updates the icon on a ToolbarItem
@@ -56,11 +31,37 @@ func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
 // Since: 2.2
 func (t *ToolbarAction) SetIcon(icon fyne.Resource) {
 	t.Icon = icon
+	t.button.SetIcon(t.Icon)
+	t.button.Refresh()
+}
+
+// Enable this ToolbarAction, updating any style or features appropriately.
+//
+// Since: 2.5
+func (t *ToolbarAction) Enable() {
+	t.button.Enable()
+}
+
+// Disable this ToolbarAction so that it cannot be interacted with, updating any style appropriately.
+//
+// Since: 2.5
+func (t *ToolbarAction) Disable() {
+	t.button.Disable()
+}
+
+// Disabled returns true if this ToolbarAction is currently disabled or false if it can currently be interacted with.
+//
+// Since: 2.5
+func (t *ToolbarAction) Disabled() bool {
+	return t.button.Disabled()
 }
 
 // NewToolbarAction returns a new push button style ToolbarItem
 func NewToolbarAction(icon fyne.Resource, onActivated func()) *ToolbarAction {
-	return &ToolbarAction{Icon: icon, OnActivated: onActivated}
+	button := NewButtonWithIcon("", icon, onActivated)
+	button.Importance = LowImportance
+
+	return &ToolbarAction{Icon:icon, OnActivated: onActivated, button: button}
 }
 
 // ToolbarSpacer is a blank, stretchable space for a toolbar.

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -32,7 +32,6 @@ func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
 func (t *ToolbarAction) SetIcon(icon fyne.Resource) {
 	t.Icon = icon
 	t.button.SetIcon(t.Icon)
-	t.button.Refresh()
 }
 
 // Enable this ToolbarAction, updating any style or features appropriately.

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -17,14 +17,13 @@ type ToolbarItem interface {
 type ToolbarAction struct {
 	Icon        fyne.Resource
 	OnActivated func() `json:"-"`
+	button      *Button
 }
 
 // ToolbarObject gets a button to render this ToolbarAction
 func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
-	button := NewButtonWithIcon("", t.Icon, t.OnActivated)
-	button.Importance = LowImportance
-
-	return button
+	t.button.OnTapped = t.OnActivated
+	return t.button
 }
 
 // SetIcon updates the icon on a ToolbarItem
@@ -32,12 +31,31 @@ func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
 // Since: 2.2
 func (t *ToolbarAction) SetIcon(icon fyne.Resource) {
 	t.Icon = icon
-	t.ToolbarObject().Refresh()
+	t.button.SetIcon(t.Icon)
+	t.button.Refresh()
+}
+
+// Enable this ToolbarAction, updating any style or features appropriately.
+func (t *ToolbarAction) Enable() {
+	t.button.Enable()
+}
+
+// Disable this ToolbarAction so that it cannot be interacted with, updating any style appropriately.
+func (t *ToolbarAction) Disable() {
+	t.button.Disable()
+}
+
+// Disabled returns true if this ToolbarAction is currently disabled or false if it can currently be interacted with.
+func (t *ToolbarAction) Disabled() bool {
+	return t.button.Disabled()
 }
 
 // NewToolbarAction returns a new push button style ToolbarItem
 func NewToolbarAction(icon fyne.Resource, onActivated func()) *ToolbarAction {
-	return &ToolbarAction{icon, onActivated}
+	button := NewButtonWithIcon("", icon, onActivated)
+	button.Importance = LowImportance
+
+	return &ToolbarAction{Icon:icon, OnActivated: onActivated, button: button}
 }
 
 // ToolbarSpacer is a blank, stretchable space for a toolbar.

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -19,6 +19,12 @@ type toolbarActionButton struct {
 	t *ToolbarAction
 }
 
+func newToolbarActionButton(t *ToolbarAction) *toolbarActionButton {
+	b := &toolbarActionButton{t: t}
+	b.ExtendBaseWidget(b)
+	return b
+}
+
 func (b *toolbarActionButton) Refresh() {
 	b.Icon = b.t.Icon
 	b.OnTapped = b.t.OnActivated
@@ -40,7 +46,7 @@ type ToolbarAction struct {
 
 // ToolbarObject gets a button to render this ToolbarAction
 func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
-	b := &toolbarActionButton{t: t}
+	b := newToolbarActionButton(t)
 	b.Refresh()
 	return b
 }

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -17,22 +17,16 @@ type ToolbarItem interface {
 type ToolbarAction struct {
 	Icon        fyne.Resource
 	OnActivated func() `json:"-"`
-	button      *Button
+	button      Button
 }
 
 // ToolbarObject gets a button to render this ToolbarAction
 func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
-	if t.button == nil {
-		// lazy initialization of the button, when the ToolbarAction 
-		// has not been created via the constructor
-		t.button = createToolbarActionButton(t.Icon, t.OnActivated)
-	} else {
-		// synchronize properties
-		t.button.Icon = t.Icon
-		t.button.OnTapped = t.OnActivated
-	}
-
-	return t.button
+	// synchronize properties
+	t.button.Icon = t.Icon
+	t.button.OnTapped = t.OnActivated
+	
+	return &t.button
 }
 
 // SetIcon updates the icon on a ToolbarItem
@@ -64,16 +58,10 @@ func (t *ToolbarAction) Disabled() bool {
 	return t.button.Disabled()
 }
 
-func createToolbarActionButton(icon fyne.Resource, onActivated func()) *Button {
-	button := NewButtonWithIcon("", icon, onActivated)
-	button.Importance = LowImportance
-
-	return button
-}
 
 // NewToolbarAction returns a new push button style ToolbarItem
 func NewToolbarAction(icon fyne.Resource, onActivated func()) *ToolbarAction {
-	return &ToolbarAction{Icon: icon, OnActivated: onActivated, button: createToolbarActionButton(icon, onActivated)}
+	return &ToolbarAction{Icon: icon, OnActivated: onActivated}
 }
 
 // ToolbarSpacer is a blank, stretchable space for a toolbar.

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -22,8 +22,16 @@ type ToolbarAction struct {
 
 // ToolbarObject gets a button to render this ToolbarAction
 func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
-	t.button.Icon = t.Icon
-	t.button.OnTapped = t.OnActivated
+	if t.button == nil {
+		// lazy initialization of the button, when the ToolbarAction 
+		// has not been created via the constructor
+		t.button = createToolbarActionButton(t.Icon, t.OnActivated)
+	} else {
+		// synchronize properties
+		t.button.Icon = t.Icon
+		t.button.OnTapped = t.OnActivated
+	}
+
 	return t.button
 }
 
@@ -56,12 +64,16 @@ func (t *ToolbarAction) Disabled() bool {
 	return t.button.Disabled()
 }
 
-// NewToolbarAction returns a new push button style ToolbarItem
-func NewToolbarAction(icon fyne.Resource, onActivated func()) *ToolbarAction {
+func createToolbarActionButton(icon fyne.Resource, onActivated func()) *Button {
 	button := NewButtonWithIcon("", icon, onActivated)
 	button.Importance = LowImportance
 
-	return &ToolbarAction{Icon:icon, OnActivated: onActivated, button: button}
+	return button
+}
+
+// NewToolbarAction returns a new push button style ToolbarItem
+func NewToolbarAction(icon fyne.Resource, onActivated func()) *ToolbarAction {
+	return &ToolbarAction{Icon: icon, OnActivated: onActivated, button: createToolbarActionButton(icon, onActivated)}
 }
 
 // ToolbarSpacer is a blank, stretchable space for a toolbar.

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -25,7 +25,7 @@ func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
 	// synchronize properties
 	t.button.Icon = t.Icon
 	t.button.OnTapped = t.OnActivated
-	
+
 	return &t.button
 }
 
@@ -57,7 +57,6 @@ func (t *ToolbarAction) Disable() {
 func (t *ToolbarAction) Disabled() bool {
 	return t.button.Disabled()
 }
-
 
 // NewToolbarAction returns a new push button style ToolbarItem
 func NewToolbarAction(icon fyne.Resource, onActivated func()) *ToolbarAction {

--- a/widget/toolbar.go
+++ b/widget/toolbar.go
@@ -13,17 +13,36 @@ type ToolbarItem interface {
 	ToolbarObject() fyne.CanvasObject
 }
 
+type toolbarActionButton struct {
+	Button
+
+	t *ToolbarAction
+}
+
+func (b *toolbarActionButton) Refresh() {
+	b.Icon = b.t.Icon
+	b.OnTapped = b.t.OnActivated
+
+	if b.t.Disabled {
+		b.Button.Disable()
+	} else {
+		b.Button.Enable()
+	}
+}
+
 // ToolbarAction is push button style of ToolbarItem
 type ToolbarAction struct {
 	Icon        fyne.Resource
 	OnActivated func() `json:"-"`
-	button      *Button
+	// Since: 2.5
+	Disabled bool
 }
 
 // ToolbarObject gets a button to render this ToolbarAction
 func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
-	t.button.OnTapped = t.OnActivated
-	return t.button
+	b := &toolbarActionButton{t: t}
+	b.Refresh()
+	return b
 }
 
 // SetIcon updates the icon on a ToolbarItem
@@ -31,37 +50,11 @@ func (t *ToolbarAction) ToolbarObject() fyne.CanvasObject {
 // Since: 2.2
 func (t *ToolbarAction) SetIcon(icon fyne.Resource) {
 	t.Icon = icon
-	t.button.SetIcon(t.Icon)
-	t.button.Refresh()
-}
-
-// Enable this ToolbarAction, updating any style or features appropriately.
-//
-// Since: 2.5
-func (t *ToolbarAction) Enable() {
-	t.button.Enable()
-}
-
-// Disable this ToolbarAction so that it cannot be interacted with, updating any style appropriately.
-//
-// Since: 2.5
-func (t *ToolbarAction) Disable() {
-	t.button.Disable()
-}
-
-// Disabled returns true if this ToolbarAction is currently disabled or false if it can currently be interacted with.
-//
-// Since: 2.5
-func (t *ToolbarAction) Disabled() bool {
-	return t.button.Disabled()
 }
 
 // NewToolbarAction returns a new push button style ToolbarItem
 func NewToolbarAction(icon fyne.Resource, onActivated func()) *ToolbarAction {
-	button := NewButtonWithIcon("", icon, onActivated)
-	button.Importance = LowImportance
-
-	return &ToolbarAction{Icon:icon, OnActivated: onActivated, button: button}
+	return &ToolbarAction{Icon: icon, OnActivated: onActivated}
 }
 
 // ToolbarSpacer is a blank, stretchable space for a toolbar.

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -46,11 +46,11 @@ func TestToolbar_Replace(t *testing.T) {
 	toolbar := NewToolbar(NewToolbarAction(icon, func() {}))
 	assert.Equal(t, 1, len(toolbar.Items))
 	render := test.WidgetRenderer(toolbar)
-	assert.Equal(t, icon, render.Objects()[0].(*toolbarActionButton).Icon)
+	assert.Equal(t, icon, render.Objects()[0].(*Button).Icon)
 
 	toolbar.Items[0] = NewToolbarAction(theme.HelpIcon(), func() {})
 	toolbar.Refresh()
-	assert.NotEqual(t, icon, render.Objects()[0].(*toolbarActionButton).Icon)
+	assert.NotEqual(t, icon, render.Objects()[0].(*Button).Icon)
 }
 
 func TestToolbar_ItemPositioning(t *testing.T) {
@@ -64,7 +64,7 @@ func TestToolbar_ItemPositioning(t *testing.T) {
 	toolbar.Refresh()
 	var items []fyne.CanvasObject
 	for _, o := range test.LaidOutObjects(toolbar) {
-		if b, ok := o.(*toolbarActionButton); ok {
+		if b, ok := o.(*Button); ok {
 			items = append(items, b)
 		}
 	}
@@ -94,38 +94,27 @@ func (t *toolbarLabel) ToolbarObject() fyne.CanvasObject {
 func TestToolbarAction_Disable(t *testing.T) {
 	testIcon := theme.InfoIcon()
 	toolbarAction := NewToolbarAction(testIcon, nil)
-	object := toolbarAction.ToolbarObject().(*toolbarActionButton)
-
-	assert.False(t, object.Disabled())
-
-	toolbarAction.Disabled = true
-	object.Refresh()
-
-	assert.True(t, object.Disabled())
+	toolbarAction.Disable()
+	assert.NotEqual(t, false, toolbarAction.Disabled())
+	assert.Equal(t, true, toolbarAction.Disabled())
 }
 
 func TestToolbarAction_Enable(t *testing.T) {
 	testIcon := theme.InfoIcon()
 	toolbarAction := NewToolbarAction(testIcon, nil)
-	object := toolbarAction.ToolbarObject().(*toolbarActionButton)
-	toolbarAction.Disabled = true
-	object.Refresh()
-
-	assert.True(t, object.Disabled())
-
-	toolbarAction.Disabled = false
-	object.Refresh()
-
-	assert.False(t, object.Disabled())
+	toolbarAction.Disable()
+	toolbarAction.Enable()
+	assert.NotEqual(t, true, toolbarAction.Disabled())
+	assert.Equal(t, false, toolbarAction.Disabled())
 }
 
 func TestToolbarAction_UpdateOnActivated(t *testing.T) {
 	activated := false
 
 	testIcon := theme.InfoIcon()
-	toolbarAction := NewToolbarAction(testIcon, func() { activated = true })
+	toolbarAction := NewToolbarAction(testIcon, func() {activated = true})
 
-	test.Tap(toolbarAction.ToolbarObject().(*toolbarActionButton))
+	test.Tap(toolbarAction.ToolbarObject().(*Button))
 
 	assert.True(t, activated)
 
@@ -133,7 +122,7 @@ func TestToolbarAction_UpdateOnActivated(t *testing.T) {
 
 	toolbarAction.OnActivated = func() {}
 
-	test.Tap(toolbarAction.ToolbarObject().(*toolbarActionButton))
+	test.Tap(toolbarAction.ToolbarObject().(*Button))
 
 	assert.False(t, activated)
 }

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -112,7 +112,7 @@ func TestToolbarAction_UpdateOnActivated(t *testing.T) {
 	activated := false
 
 	testIcon := theme.InfoIcon()
-	toolbarAction := NewToolbarAction(testIcon, func() {activated = true})
+	toolbarAction := NewToolbarAction(testIcon, func() { activated = true })
 
 	test.Tap(toolbarAction.ToolbarObject().(*Button))
 
@@ -125,4 +125,11 @@ func TestToolbarAction_UpdateOnActivated(t *testing.T) {
 	test.Tap(toolbarAction.ToolbarObject().(*Button))
 
 	assert.False(t, activated)
+}
+
+func TestToolbarAction_DefaultCreation(t *testing.T) {
+	testIcon := theme.InfoIcon()
+	toolbarAction := ToolbarAction{Icon: testIcon}
+	obj := toolbarAction.ToolbarObject()
+	assert.Equal(t, testIcon, obj.(*Button).Icon)
 }

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -107,3 +107,22 @@ func TestToolbarAction_Enable(t *testing.T) {
 	assert.NotEqual(t, true, toolbarAction.Disabled())
 	assert.Equal(t, false, toolbarAction.Disabled())
 }
+
+func TestToolbarAction_UpdateOnActivated(t *testing.T) {
+	activated := false
+
+	testIcon := theme.InfoIcon()
+	toolbarAction := NewToolbarAction(testIcon, func() {activated = true})
+
+	test.Tap(toolbarAction.ToolbarObject().(*Button))
+
+	assert.True(t, activated)
+
+	activated = false
+
+	toolbarAction.OnActivated = func() {}
+
+	test.Tap(toolbarAction.ToolbarObject().(*Button))
+
+	assert.False(t, activated)
+}

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -120,6 +120,7 @@ func TestToolbarAction_UpdateOnActivated(t *testing.T) {
 
 	activated = false
 
+	// verify that changes are synchronized as well
 	toolbarAction.OnActivated = func() {}
 
 	test.Tap(toolbarAction.ToolbarObject().(*Button))

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -90,3 +90,20 @@ type toolbarLabel struct {
 func (t *toolbarLabel) ToolbarObject() fyne.CanvasObject {
 	return t.Label
 }
+
+func TestToolbarAction_Disable(t *testing.T) {
+	testIcon := theme.InfoIcon()
+	toolbarAction := NewToolbarAction(testIcon, nil)
+	toolbarAction.Disable()
+	assert.NotEqual(t, false, toolbarAction.Disabled())
+	assert.Equal(t, true, toolbarAction.Disabled())
+}
+
+func TestToolbarAction_Enable(t *testing.T) {
+	testIcon := theme.InfoIcon()
+	toolbarAction := NewToolbarAction(testIcon, nil)
+	toolbarAction.Disable()
+	toolbarAction.Enable()
+	assert.NotEqual(t, true, toolbarAction.Disabled())
+	assert.Equal(t, false, toolbarAction.Disabled())
+}

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -46,11 +46,11 @@ func TestToolbar_Replace(t *testing.T) {
 	toolbar := NewToolbar(NewToolbarAction(icon, func() {}))
 	assert.Equal(t, 1, len(toolbar.Items))
 	render := test.WidgetRenderer(toolbar)
-	assert.Equal(t, icon, render.Objects()[0].(*Button).Icon)
+	assert.Equal(t, icon, render.Objects()[0].(*toolbarActionButton).Icon)
 
 	toolbar.Items[0] = NewToolbarAction(theme.HelpIcon(), func() {})
 	toolbar.Refresh()
-	assert.NotEqual(t, icon, render.Objects()[0].(*Button).Icon)
+	assert.NotEqual(t, icon, render.Objects()[0].(*toolbarActionButton).Icon)
 }
 
 func TestToolbar_ItemPositioning(t *testing.T) {
@@ -64,7 +64,7 @@ func TestToolbar_ItemPositioning(t *testing.T) {
 	toolbar.Refresh()
 	var items []fyne.CanvasObject
 	for _, o := range test.LaidOutObjects(toolbar) {
-		if b, ok := o.(*Button); ok {
+		if b, ok := o.(*toolbarActionButton); ok {
 			items = append(items, b)
 		}
 	}
@@ -94,27 +94,38 @@ func (t *toolbarLabel) ToolbarObject() fyne.CanvasObject {
 func TestToolbarAction_Disable(t *testing.T) {
 	testIcon := theme.InfoIcon()
 	toolbarAction := NewToolbarAction(testIcon, nil)
-	toolbarAction.Disable()
-	assert.NotEqual(t, false, toolbarAction.Disabled())
-	assert.Equal(t, true, toolbarAction.Disabled())
+	object := toolbarAction.ToolbarObject().(*toolbarActionButton)
+
+	assert.False(t, object.Disabled())
+
+	toolbarAction.Disabled = true
+	object.Refresh()
+
+	assert.True(t, object.Disabled())
 }
 
 func TestToolbarAction_Enable(t *testing.T) {
 	testIcon := theme.InfoIcon()
 	toolbarAction := NewToolbarAction(testIcon, nil)
-	toolbarAction.Disable()
-	toolbarAction.Enable()
-	assert.NotEqual(t, true, toolbarAction.Disabled())
-	assert.Equal(t, false, toolbarAction.Disabled())
+	object := toolbarAction.ToolbarObject().(*toolbarActionButton)
+	toolbarAction.Disabled = true
+	object.Refresh()
+
+	assert.True(t, object.Disabled())
+
+	toolbarAction.Disabled = false
+	object.Refresh()
+
+	assert.False(t, object.Disabled())
 }
 
 func TestToolbarAction_UpdateOnActivated(t *testing.T) {
 	activated := false
 
 	testIcon := theme.InfoIcon()
-	toolbarAction := NewToolbarAction(testIcon, func() {activated = true})
+	toolbarAction := NewToolbarAction(testIcon, func() { activated = true })
 
-	test.Tap(toolbarAction.ToolbarObject().(*Button))
+	test.Tap(toolbarAction.ToolbarObject().(*toolbarActionButton))
 
 	assert.True(t, activated)
 
@@ -122,7 +133,7 @@ func TestToolbarAction_UpdateOnActivated(t *testing.T) {
 
 	toolbarAction.OnActivated = func() {}
 
-	test.Tap(toolbarAction.ToolbarObject().(*Button))
+	test.Tap(toolbarAction.ToolbarObject().(*toolbarActionButton))
 
 	assert.False(t, activated)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Added ability to disable ToolbarActions.
I chose to embed the button directly, since it already handles the disable-state logic.
Also, since the button is returned as a pointer, no separate refreshing logic is required. This seems to have been an issue with previous PRs for this issue.

Please let me know if the "Since:" comment with version 2.5 is fine, or if you prefer another version.

I don't necessarily like that the state of Icon & OnActivated are now essentially duplicated (once in the ToolbarAction and once in the underlying Button itself), but I did not want to break backward compatibility by changing the public interface. Let me know what your thoughts are on this.

Fixes https://github.com/fyne-io/fyne/issues/2306

I have tested the code using the following addition to the fyne-demo (`cmd/fyne_demo/tutorials/widget.go`):
```
func makeToolbarTab(_ fyne.Window) fyne.CanvasObject {
	paste := widget.NewToolbarAction(theme.ContentPasteIcon(), func() { fmt.Println("Paste") })

	t := widget.NewToolbar(widget.NewToolbarAction(theme.MailComposeIcon(), func() { fmt.Println("New") }),
		widget.NewToolbarSeparator(),
		widget.NewToolbarSpacer(),
		widget.NewToolbarAction(theme.ConfirmIcon(), func() {
			if paste.Disabled() {
				paste.Enable()
			} else {
				paste.Disable()
			}
		}),
		widget.NewToolbarSpacer(),
		widget.NewToolbarAction(theme.ContentCutIcon(), func() { fmt.Println("Cut") }),
		widget.NewToolbarAction(theme.ContentCopyIcon(), func() { fmt.Println("Copy") }),
		paste,
	)

	return container.NewBorder(t, nil, nil, nil)
}
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
