### PR TITLE
systray: ensure title is not empty

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -46,6 +46,12 @@ func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 				d.SetSystemTrayIcon(theme.BrokenImageIcon())
 			}
 
+			title := fyne.CurrentApp().Metadata().Name
+			if title == "" {
+				title = fyne.CurrentApp().UniqueID()
+			}
+			systray.SetTitle(title)
+
 			// it must be refreshed after init, so an earlier call would have been ineffective
 			d.refreshSystray(m)
 		}, func() {

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -46,9 +46,10 @@ func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 				d.SetSystemTrayIcon(theme.BrokenImageIcon())
 			}
 
-			title := fyne.CurrentApp().Metadata().Name
+			app := fyne.CurrentApp()
+			title := app.Metadata().Name
 			if title == "" {
-				title = fyne.CurrentApp().UniqueID()
+				title = app.UniqueID()
 			}
 			systray.SetTitle(title)
 


### PR DESCRIPTION
### Description:

Some desktop environments like the one provided by Ubuntu 22.04 requires the systray title to be not empty to be displayed. 
This commit ensure the title is always set trying to use the app name from metadata. If the app name is not set will fallback to the app ID

Fixes #3678

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
