### PR TITLE
Avoid allocating a new slice on every call to drawSingleFrame

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -73,7 +73,7 @@ func runOnDraw(w *window, f func()) {
 // window canvases that are dirty on a single frame.
 // So its memory impact should be negligible and does not
 // need periodic shrinking.
-var refreshingCanvases = make([]fyne.Canvas, 0)
+var refreshingCanvases []fyne.Canvas
 
 func (d *gLDriver) drawSingleFrame() {
 	for _, win := range d.windowList() {

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -67,8 +67,15 @@ func runOnDraw(w *window, f func()) {
 	<-done
 }
 
+// Preallocate to avoid allocations on every drawSingleFrame.
+// Note that the capacity of this slice can only grow,
+// but its length will never be longer than the total number of
+// window canvases that are dirty on a single frame.
+// So its memory impact should be negligible and does not
+// need periodic shrinking.
+var refreshingCanvases = make([]fyne.Canvas, 0)
+
 func (d *gLDriver) drawSingleFrame() {
-	refreshingCanvases := make([]fyne.Canvas, 0)
 	for _, win := range d.windowList() {
 		w := win.(*window)
 		w.viewLock.RLock()
@@ -89,6 +96,12 @@ func (d *gLDriver) drawSingleFrame() {
 		refreshingCanvases = append(refreshingCanvases, canvas)
 	}
 	cache.CleanCanvases(refreshingCanvases)
+
+	// cleanup refreshingCanvases slice
+	for i := 0; i < len(refreshingCanvases); i++ {
+		refreshingCanvases[i] = nil
+	}
+	refreshingCanvases = refreshingCanvases[:0]
 }
 
 func (d *gLDriver) runGL() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Preallocate a slice to reuse to avoid memory allocations in a tight loop

Side note - after testing this in Supersonic for awhile it seems like the GC is more inclined to give excess memory back to the OS now since we're not allocating so frequently :)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
