### PR TITLE
Slider: Do not grab focus on tap event

### DIFF
--- a/widget/slider.go
+++ b/widget/slider.go
@@ -103,15 +103,6 @@ func (s *Slider) Dragged(e *fyne.DragEvent) {
 //
 // Since: 2.4
 func (s *Slider) Tapped(e *fyne.PointEvent) {
-	driver := fyne.CurrentApp().Driver()
-	if !s.focused && !driver.Device().IsMobile() {
-		impl := s.super()
-
-		if c := driver.CanvasForObject(impl); c != nil {
-			c.Focus(impl.(fyne.Focusable))
-		}
-	}
-
 	ratio := s.getRatio(e)
 	lastValue := s.Value
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Do not focus the slider if it is interacted with by a tap event. This is inconsistent with other widgets (button, etc) which only become focused by the focus manager with the tab key. Entry of course grabs focus when tapped, but this is because Entry *must* be interacted with the keyboard. Tapping or dragging to change a slider value does not imply that the user wants to further control the slider afterward with the keyboard.

Edit: Looks like check keeps focus after tap, and button does not. I think none but Entry should keep focus after a tap, but whichever way we go we should make it consistent

Fixes #4369 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
