### PR TITLE
Reduce allocations in list scroll updates

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -123,7 +123,10 @@ func (l *List) RefreshItem(id ListItemID) {
 	}
 	l.BaseWidget.Refresh()
 	lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
-	if item, ok := lo.searchVisible(lo.visible, id); ok {
+	lo.renderLock.RLock() // ensures we are not changing visible info in render code during the search
+	item, ok := lo.searchVisible(lo.visible, id)
+	lo.renderLock.RUnlock()
+	if ok {
 		lo.setupListItem(item, id, l.focused && l.currentFocus == id)
 	}
 }
@@ -537,7 +540,7 @@ type listLayout struct {
 	visible           []itemAndID
 	wasVisible        []itemAndID
 	visibleRowHeights []float32
-	renderLock        sync.Mutex
+	renderLock        sync.RWMutex
 }
 
 func newListLayout(list *List) fyne.Layout {

--- a/widget/list.go
+++ b/widget/list.go
@@ -664,6 +664,7 @@ func (l *listLayout) updateList(newOnly bool) {
 		return
 	}
 
+	oldVisibleLen := len(l.visible)
 	l.visible = l.visible[:0]
 	oldChildrenLen := len(l.children)
 	l.children = l.children[:0]
@@ -690,6 +691,7 @@ func (l *listLayout) updateList(newOnly bool) {
 		l.children = append(l.children, c)
 	}
 	l.nilOldSliceData(l.children, len(l.children), oldChildrenLen)
+	l.nilOldVisibleSliceData(l.visible, len(l.visible), oldVisibleLen)
 
 	for _, wasVis := range wasVisible {
 		if _, ok := l.searchVisible(l.visible, wasVis.id); !ok {
@@ -778,6 +780,15 @@ func (l *listLayout) nilOldSliceData(objs []fyne.CanvasObject, len, oldLen int) 
 		objs = objs[:oldLen] // gain view into old data
 		for i := len; i < oldLen; i++ {
 			objs[i] = nil
+		}
+	}
+}
+
+func (l *listLayout) nilOldVisibleSliceData(objs []itemAndID, len, oldLen int) {
+	if oldLen > len {
+		objs = objs[:oldLen] // gain view into old data
+		for i := len; i < oldLen; i++ {
+			objs[i].item = nil
 		}
 	}
 }

--- a/widget/list.go
+++ b/widget/list.go
@@ -663,16 +663,15 @@ func (l *listLayout) updateList(newOnly bool) {
 		row := index + minRow
 		size := fyne.NewSize(width, itemHeight)
 
-		visIdx := l.searchVisible(l.wasVisible, row)
 		var c *listItem
-		if visIdx < 0 {
+		if idx := l.searchVisible(l.wasVisible, row); idx < 0 {
 			c = l.getItem()
 			if c == nil {
 				continue
 			}
 			c.Resize(size)
 		} else {
-			c = l.wasVisible[visIdx].item
+			c = l.wasVisible[idx].item
 		}
 
 		c.Move(fyne.NewPos(0, y))

--- a/widget/list.go
+++ b/widget/list.go
@@ -642,10 +642,7 @@ func (l *listLayout) updateList(newOnly bool) {
 		fyne.LogError("Missing UpdateCell callback required for List", nil)
 	}
 
-	for i := 0; i < len(l.wasVisible); i++ {
-		l.wasVisible[i].item = nil
-	}
-	l.wasVisible = l.wasVisible[:0]
+	l.wasVisible = l.wasVisible[:0] // data already nilled out at end of this func
 	l.wasVisible = append(l.wasVisible, l.visible...)
 
 	l.list.propertyLock.Lock()

--- a/widget/list.go
+++ b/widget/list.go
@@ -692,7 +692,6 @@ func (l *listLayout) updateList(newOnly bool) {
 	for _, wasVis := range l.wasVisible {
 		if _, ok := l.searchVisible(l.visible, wasVis.id); !ok {
 			l.itemPool.Release(wasVis.item)
-			wasVis.item = nil
 		}
 	}
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"fmt"
 	"math"
+	"sort"
 	"sync"
 
 	"fyne.io/fyne/v2"
@@ -746,19 +747,10 @@ func (l *listLayout) updateSeparators() {
 
 // invariant: visible is in ascending order of IDs
 func (l *listLayout) searchVisible(visible []itemAndID, id ListItemID) (*listItem, bool) {
-	// binary search
-	low := 0
-	high := len(visible) - 1
-	for low <= high {
-		mid := (low + high) / 2
-		if visible[mid].id == id {
-			return visible[mid].item, true
-		}
-		if visible[mid].id > id {
-			high = mid - 1
-		} else {
-			low = mid + 1
-		}
+	ln := len(visible)
+	idx := sort.Search(ln, func(i int) bool { return visible[i].id >= id })
+	if idx < ln && visible[idx].id == id {
+		return visible[idx].item, true
 	}
 	return nil, false
 }

--- a/widget/list.go
+++ b/widget/list.go
@@ -752,10 +752,20 @@ func (l *listLayout) updateSeparators() {
 	}
 }
 
+// invariant: visible is in ascending order of IDs
 func (l *listLayout) searchVisible(visible []itemAndID, id ListItemID) int {
-	for i, v := range visible {
-		if v.id == id {
-			return i
+	// binary search
+	low := 0
+	high := len(visible) - 1
+	for low <= high {
+		mid := (low + high) / 2
+		if visible[mid].id == id {
+			return mid
+		}
+		if visible[mid].id > id {
+			high = mid - 1
+		} else {
+			low = mid + 1
 		}
 	}
 	return -1

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -275,22 +275,24 @@ func TestList_Select(t *testing.T) {
 	assert.Equal(t, float32(0), list.offsetY)
 	list.Select(50)
 	assert.Equal(t, 988, int(list.offsetY))
-	visible := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).visible
-	assert.Equal(t, visible[50].background.FillColor, theme.SelectionColor())
-	assert.True(t, visible[50].background.Visible())
+	lo := list.scroller.Content.(*fyne.Container).Layout.(*listLayout)
+	visible50 := lo.visible[lo.searchVisible(lo.visible, 50)].item
+	assert.Equal(t, visible50.background.FillColor, theme.SelectionColor())
+	assert.True(t, visible50.background.Visible())
 
 	list.Select(5)
 	assert.Equal(t, 195, int(list.offsetY))
-	visible = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).visible
-	assert.Equal(t, visible[5].background.FillColor, theme.SelectionColor())
-	assert.True(t, visible[5].background.Visible())
+	visible5 := lo.visible[lo.searchVisible(lo.visible, 5)].item
+	assert.Equal(t, visible5.background.FillColor, theme.SelectionColor())
+	assert.True(t, visible5.background.Visible())
 
 	list.Select(6)
 	assert.Equal(t, 195, int(list.offsetY))
-	visible = list.scroller.Content.(*fyne.Container).Layout.(*listLayout).visible
-	assert.False(t, visible[5].background.Visible())
-	assert.Equal(t, visible[6].background.FillColor, theme.SelectionColor())
-	assert.True(t, visible[6].background.Visible())
+	visible5 = lo.visible[lo.searchVisible(lo.visible, 5)].item
+	visible6 := lo.visible[lo.searchVisible(lo.visible, 6)].item
+	assert.False(t, visible5.background.Visible())
+	assert.Equal(t, visible6.background.FillColor, theme.SelectionColor())
+	assert.True(t, visible6.background.Visible())
 }
 
 func TestList_Unselect(t *testing.T) {

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -276,20 +276,20 @@ func TestList_Select(t *testing.T) {
 	list.Select(50)
 	assert.Equal(t, 988, int(list.offsetY))
 	lo := list.scroller.Content.(*fyne.Container).Layout.(*listLayout)
-	visible50 := lo.visible[lo.searchVisible(lo.visible, 50)].item
+	visible50, _ := lo.searchVisible(lo.visible, 50)
 	assert.Equal(t, visible50.background.FillColor, theme.SelectionColor())
 	assert.True(t, visible50.background.Visible())
 
 	list.Select(5)
 	assert.Equal(t, 195, int(list.offsetY))
-	visible5 := lo.visible[lo.searchVisible(lo.visible, 5)].item
+	visible5, _ := lo.searchVisible(lo.visible, 5)
 	assert.Equal(t, visible5.background.FillColor, theme.SelectionColor())
 	assert.True(t, visible5.background.Visible())
 
 	list.Select(6)
 	assert.Equal(t, 195, int(list.offsetY))
-	visible5 = lo.visible[lo.searchVisible(lo.visible, 5)].item
-	visible6 := lo.visible[lo.searchVisible(lo.visible, 6)].item
+	visible5, _ = lo.searchVisible(lo.visible, 5)
+	visible6, _ := lo.searchVisible(lo.visible, 6)
 	assert.False(t, visible5.background.Visible())
 	assert.Equal(t, visible6.background.FillColor, theme.SelectionColor())
 	assert.True(t, visible6.background.Visible())


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Previously, we were allocating at least 3 new slices and one new map on every call to updateList.

This PR re-uses the same allocated slice capacity to place the objects that will be drawn each update, and switches to using slices with reusable capacity instead of maps to keep track of what's visible. Since we only expect max 50 or so list rows to ever be visible - and also we can use binary search since we always insert things in ascending row order - this should be even faster than maps.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
