### PR TITLE
Process events in runloop only when needed

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -174,7 +174,7 @@ func (d *gLDriver) CurrentKeyModifiers() fyne.KeyModifier {
 
 func (d *gLDriver) catchTerm() {
 	terminateSignal := make(chan os.Signal, 1)
-	signal.Notify(terminateSignal, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(terminateSignal, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 
 	<-terminateSignal
 	d.Quit()

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -119,7 +119,8 @@ func (d *gLDriver) runGL() {
 
 	postEmptyEvent()
 
-	for {
+	eventTick := time.NewTicker(time.Second / 60) // TODO: Why does it not work without this?
+	for range eventTick.C {
 		d.waitForEvents()
 
 		if atomic.LoadUint32(&d.mainDone) == 1 {

--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -24,16 +24,21 @@ func (d *gLDriver) initGLFW() {
 	})
 }
 
-func (d *gLDriver) tryPollEvents() {
+// waitForEvents() will block until one or more events occur.
+func (*gLDriver) waitForEvents() {
 	defer func() {
 		if r := recover(); r != nil {
 			fyne.LogError(fmt.Sprint("GLFW poll event error: ", r), nil)
 		}
 	}()
 
-	glfw.PollEvents() // This call blocks while window is being resized, which prevents freeDirtyTextures from being called
+	glfw.WaitEvents()
 }
 
-func (d *gLDriver) Terminate() {
+func postEmptyEvent() {
+	glfw.PostEmptyEvent()
+}
+
+func (*gLDriver) terminate() {
 	glfw.Terminate()
 }

--- a/internal/driver/glfw/loop_goxjs.go
+++ b/internal/driver/glfw/loop_goxjs.go
@@ -24,16 +24,20 @@ func (d *gLDriver) initGLFW() {
 	})
 }
 
-func (d *gLDriver) tryPollEvents() {
+func (*gLDriver) waitForEvents() {
 	defer func() {
 		if r := recover(); r != nil {
 			fyne.LogError(fmt.Sprint("GLFW poll event error: ", r), nil)
 		}
 	}()
 
-	glfw.PollEvents() // This call blocks while window is being resized, which prevents freeDirtyTextures from being called
+	glfw.WaitEvents()
 }
 
-func (d *gLDriver) Terminate() {
+func postEmptyEvent() {
+	glfw.PostEmptyEvent()
+}
+
+func (*gLDriver) terminate() {
 	glfw.Terminate()
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR changes the run loop to use `glfw.WaitEvents()` instead and use `glfw.PostEmptyEvent()` when necessary to only ever process events when there are any to process.

This specific PR is a rebase of https://github.com/fyne-io/fyne/pull/4173. It was easier to start fresh.

Fixes #2506 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
