### PR TITLE
WIP: idea/suggestion: Add ContainerWidget code to make using containers as widgets easier

### DIFF
--- a/widget/container_widget.go
+++ b/widget/container_widget.go
@@ -1,0 +1,75 @@
+package widget
+
+import (
+	"fyne.io/fyne/v2"
+)
+
+// Container widget helps to use a container as a widget.
+type ContainerWidget struct {
+	BaseWidget
+	*fyne.Container
+}
+
+type ContainerWidgetRenderer struct {
+	*fyne.Container
+}
+
+func (r *ContainerWidgetRenderer) Layout(size fyne.Size) {
+	r.Container.Layout.Layout(r.Container.Objects, size)
+}
+func (r *ContainerWidgetRenderer) MinSize() fyne.Size {
+	return r.Container.MinSize()
+}
+func (r *ContainerWidgetRenderer) Refresh() {
+	r.Container.Refresh()
+}
+func (r *ContainerWidgetRenderer) Objects() []fyne.CanvasObject {
+	return r.Container.Objects
+}
+func (r *ContainerWidgetRenderer) Destroy() {}
+
+var _ fyne.CanvasObject = (*ContainerWidget)(nil)
+var _ fyne.WidgetRenderer = (*ContainerWidgetRenderer)(nil)
+
+// implement CanvasObject interface
+func (t *ContainerWidget) CreateRenderer() fyne.WidgetRenderer {
+	return &ContainerWidgetRenderer{
+		Container: t.Container,
+	}
+}
+
+func (t *ContainerWidget) Hide() {
+	t.Container.Hide()
+}
+
+func (t *ContainerWidget) MinSize() fyne.Size {
+	return t.Container.MinSize()
+}
+
+func (t *ContainerWidget) Move(pos fyne.Position) {
+	t.Container.Move(pos)
+}
+
+func (t *ContainerWidget) Position() fyne.Position {
+	return t.Container.Position()
+}
+
+func (t *ContainerWidget) Refresh() {
+	t.Container.Refresh()
+}
+
+func (t *ContainerWidget) Resize(size fyne.Size) {
+	t.Container.Resize(size)
+}
+
+func (t *ContainerWidget) Show() {
+	t.Container.Show()
+}
+
+func (t *ContainerWidget) Size() fyne.Size {
+	return t.Container.Size()
+}
+
+func (t *ContainerWidget) Visible() bool {
+	return t.Container.Visible()
+}


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Lately I've had the need to wrap containers in widgets, and I came up with some rather simple wrapper code to put a container into a widget.
The more I'm copying this code around, the more I think it could be useful to others as well.

Basic usage looks like this:
```go
type MyWidget struct {
        ContainerWidget
        ...
}
// ... somewhere in the code...
x := &MyWidget{}
x.ExtendBaseWidget(x)
x.Container = container.New(...)
```

This also allows to add methods that can be used to manipulate the state of the widget.
While it looks very simple, it's been proven very useful so far, and since it seems like very common boilerplate code I thought it might be worth having in the widget code.

This isn't polished yet and certainly would need more/better documentation as well as tests I think.
For now it's meant to gather feedback and see if there is any interest in having this.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [ ] Public APIs match existing style and have Since: line.