### PR TITLE
Remove constant debug field from canvas

### DIFF
--- a/internal/debug_disabled.go
+++ b/internal/debug_disabled.go
@@ -1,0 +1,8 @@
+//go:build !debug
+// +build !debug
+
+package internal
+
+// BuildTypeIsDebug is true if built with -tags debug. This value exists as a constant
+// so the Go compiler can deadcode eliminate reflect from non-debug builds.
+const BuildTypeIsDebug = false

--- a/internal/debug_enabled.go
+++ b/internal/debug_enabled.go
@@ -1,0 +1,8 @@
+//go:build debug
+// +build debug
+
+package internal
+
+// BuildTypeIsDebug is true if built with -tags debug. This value exists as a constant
+// so the Go compiler can deadcode eliminate reflect from non-debug builds.
+const BuildTypeIsDebug = true

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -20,10 +20,10 @@ var _ fyne.Canvas = (*glCanvas)(nil)
 type glCanvas struct {
 	common.Canvas
 
-	content       fyne.CanvasObject
-	menu          fyne.CanvasObject
-	padded, debug bool
-	size          fyne.Size
+	content fyne.CanvasObject
+	menu    fyne.CanvasObject
+	padded  bool
+	size    fyne.Size
 
 	onTypedRune func(rune)
 	onTypedKey  func(*fyne.KeyEvent)
@@ -298,7 +298,7 @@ func (c *glCanvas) paint(size fyne.Size) {
 			}
 		}
 
-		if c.debug {
+		if internal.BuildTypeIsDebug {
 			c.DrawDebugOverlay(node.Obj(), pos, size)
 		}
 	}
@@ -339,6 +339,5 @@ func newCanvas() *glCanvas {
 	c := &glCanvas{scale: 1.0, texScale: 1.0, padded: true}
 	c.Initialize(c, c.overlayChanged)
 	c.setContent(&canvas.Rectangle{FillColor: theme.BackgroundColor()})
-	c.debug = fyne.CurrentApp().Settings().BuildType() == fyne.BuildDebug
 	return c
 }

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -30,8 +30,8 @@ type mobileCanvas struct {
 	scale            float32
 	size             fyne.Size
 
-	touched       map[int]mobile.Touchable
-	padded, debug bool
+	touched map[int]mobile.Touchable
+	padded  bool
 
 	onTypedRune func(rune)
 	onTypedKey  func(event *fyne.KeyEvent)
@@ -50,7 +50,6 @@ type mobileCanvas struct {
 // NewCanvas creates a new gomobile mobileCanvas. This is a mobileCanvas that will render on a mobile device using OpenGL.
 func NewCanvas() fyne.Canvas {
 	ret := &mobileCanvas{padded: true}
-	ret.debug = fyne.CurrentApp().Settings().BuildType() == fyne.BuildDebug
 	ret.scale = fyne.CurrentDevice().SystemScaleForWindow(nil) // we don't need a window parameter on mobile
 	ret.touched = make(map[int]mobile.Touchable)
 	ret.lastTapDownPos = make(map[int]fyne.Position)

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -315,7 +315,7 @@ func (d *mobileDriver) paintWindow(window fyne.Window, size fyne.Size) {
 			}
 		}
 
-		if c.debug {
+		if internal.BuildTypeIsDebug {
 			c.DrawDebugOverlay(node.Obj(), pos, size)
 		}
 	}

--- a/internal/painter/gl/gl.go
+++ b/internal/painter/gl/gl.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"runtime"
 
-	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 )
 
 const floatSize = 4
@@ -17,7 +17,7 @@ const max16bit = float32(255 * 255)
 // Receives a function as parameter, to lazily get the error code only when
 // needed, avoiding unneeded overhead.
 func logGLError(getError func() uint32) {
-	if fyne.CurrentApp().Settings().BuildType() != fyne.BuildDebug {
+	if !internal.BuildTypeIsDebug {
 		return
 	}
 


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This clears out a small amount of memory usage by moving a build-constant field to a global constant variable. Most importantly, it makes Go have a better time deadcode eliminating methods that we only want to compile in for debug (especially the reflect code that gets the name of the canvasobject).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

