### PR TITLE
Minor driver cleanup

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -24,7 +24,7 @@ type fyneApp struct {
 	uniqueID string
 
 	cloud     fyne.CloudProvider
-	lifecycle fyne.Lifecycle
+	lifecycle app.Lifecycle
 	settings  *settings
 	storage   fyne.Storage
 	prefs     fyne.Preferences
@@ -97,7 +97,7 @@ func (a *fyneApp) Preferences() fyne.Preferences {
 }
 
 func (a *fyneApp) Lifecycle() fyne.Lifecycle {
-	return a.lifecycle
+	return &a.lifecycle
 }
 
 func (a *fyneApp) newDefaultPreferences() *preferences {
@@ -131,11 +131,11 @@ func makeStoreDocs(id string, s *store) *internal.Docs {
 }
 
 func newAppWithDriver(d fyne.Driver, id string) fyne.App {
-	newApp := &fyneApp{uniqueID: id, driver: d, lifecycle: &app.Lifecycle{}}
+	newApp := &fyneApp{uniqueID: id, driver: d}
 	fyne.SetCurrentApp(newApp)
 
 	newApp.prefs = newApp.newDefaultPreferences()
-	newApp.lifecycle.(*app.Lifecycle).SetOnStoppedHookExecuted(func() {
+	newApp.lifecycle.SetOnStoppedHookExecuted(func() {
 		if prefs, ok := newApp.prefs.(*preferences); ok {
 			prefs.forceImmediateSave()
 		}

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -41,12 +41,12 @@ const doubleTapDelay = 300 * time.Millisecond
 type gLDriver struct {
 	windowLock   sync.RWMutex
 	windows      []fyne.Window
-	device       *glDevice
+	device       glDevice
 	done         chan struct{}
 	drawDone     chan struct{}
 	waitForStart chan struct{}
 
-	animation *animation.Runner
+	animation animation.Runner
 
 	currentKeyModifiers fyne.KeyModifier // desktop driver only
 
@@ -91,11 +91,7 @@ func (d *gLDriver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position
 }
 
 func (d *gLDriver) Device() fyne.Device {
-	if d.device == nil {
-		d.device = &glDevice{}
-	}
-
-	return d.device
+	return &d.device
 }
 
 func (d *gLDriver) Quit() {
@@ -127,18 +123,19 @@ func (d *gLDriver) focusPreviousWindow() {
 	wins := d.windows
 	d.windowLock.RUnlock()
 
-	var chosen fyne.Window
+	var chosen *window
 	for _, w := range wins {
-		if !w.(*window).visible {
+		win := w.(*window)
+		if !win.visible {
 			continue
 		}
-		chosen = w
-		if w.(*window).master {
+		chosen = win
+		if win.master {
 			break
 		}
 	}
 
-	if chosen == nil || chosen.(*window).view() == nil {
+	if chosen == nil || chosen.view() == nil {
 		return
 	}
 	chosen.RequestFocus()
@@ -181,6 +178,5 @@ func NewGLDriver() *gLDriver {
 		done:         make(chan struct{}),
 		drawDone:     make(chan struct{}),
 		waitForStart: make(chan struct{}),
-		animation:    &animation.Runner{},
 	}
 }

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -41,7 +41,6 @@ const doubleTapDelay = 300 * time.Millisecond
 type gLDriver struct {
 	windowLock   sync.RWMutex
 	windows      []fyne.Window
-	device       glDevice
 	done         chan struct{}
 	drawDone     chan struct{}
 	waitForStart chan struct{}
@@ -91,7 +90,7 @@ func (d *gLDriver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position
 }
 
 func (d *gLDriver) Device() fyne.Device {
-	return &d.device
+	return &glDevice{}
 }
 
 func (d *gLDriver) Quit() {

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -50,8 +50,8 @@ type mobileDriver struct {
 	glctx gl.Context
 
 	windows     []fyne.Window
-	device      *device
-	animation   *animation.Runner
+	device      device
+	animation   animation.Runner
 	currentSize size.Event
 
 	theme           fyne.ThemeVariant
@@ -540,11 +540,7 @@ func (d *mobileDriver) typeUpCanvas(_ *mobileCanvas, _ rune, _ key.Code, _ key.M
 }
 
 func (d *mobileDriver) Device() fyne.Device {
-	if d.device == nil {
-		d.device = &device{}
-	}
-
-	return d.device
+	return &d.device
 }
 
 func (d *mobileDriver) SetOnConfigurationChanged(f func(*Configuration)) {
@@ -559,8 +555,7 @@ func (d *mobileDriver) DoubleTapDelay() time.Duration {
 // Mobile extension and OpenGL bindings.
 func NewGoMobileDriver() fyne.Driver {
 	d := &mobileDriver{
-		theme:     fyne.ThemeVariant(2), // unspecified
-		animation: &animation.Runner{},
+		theme: fyne.ThemeVariant(2), // unspecified
 	}
 
 	registerRepository(d)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

It was a failure to reapply the init changes. Too many problems surface. I kept the other improvements from the PR and cleaned up some more things.

- The animation runner struct object didn't need to be a pointer. This allows us to not manually create the object, which in turn means that we get rid of some code and the constructor for the GLDriver is thus now inlineable.
- A macOS-specific function got updated to avoid multiple interface casts.
- The `glDevice` struct does not need to part of the driver. It is an empty struct, we can just return it each time someone asks for it.

~~This replaces my previous PR which had to be reverted due to an issue with the application not having started. This cleans up some of the init code to avoid calling init multiple times (when starting and when creating a new windows). It also includes an extra change to set up the device field more coherently.~~

~~Replaces #4177~~

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
