### PR TITLE
Glfw remove old workaround

### DIFF
--- a/internal/driver/glfw/clipboard.go
+++ b/internal/driver/glfw/clipboard.go
@@ -16,9 +16,7 @@ import (
 var _ fyne.Clipboard = (*clipboard)(nil)
 
 // clipboard represents the system clipboard
-type clipboard struct {
-	window *glfw.Window
-}
+type clipboard struct{}
 
 // Content returns the clipboard content
 func (c *clipboard) Content() string {
@@ -64,12 +62,6 @@ func (c *clipboard) SetContent(content string) {
 
 func (c *clipboard) setContent(content string) {
 	runOnMain(func() {
-		defer func() {
-			if r := recover(); r != nil {
-				fyne.LogError("GLFW clipboard error (details above)", nil)
-			}
-		}()
-
 		glfw.SetClipboardString(content)
 	})
 }

--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -26,6 +26,7 @@ func (d *gLDriver) initGLFW() {
 
 func (d *gLDriver) tryPollEvents() {
 	defer func() {
+		// See https://github.com/glfw/glfw/issues/1785 and https://github.com/fyne-io/fyne/issues/1024.
 		if r := recover(); r != nil {
 			fyne.LogError(fmt.Sprint("GLFW poll event error: ", r), nil)
 		}

--- a/internal/driver/glfw/loop_goxjs.go
+++ b/internal/driver/glfw/loop_goxjs.go
@@ -26,6 +26,7 @@ func (d *gLDriver) initGLFW() {
 
 func (d *gLDriver) tryPollEvents() {
 	defer func() {
+		// See https://github.com/glfw/glfw/issues/1785 and https://github.com/fyne-io/fyne/issues/1024.
 		if r := recover(); r != nil {
 			fyne.LogError(fmt.Sprint("GLFW poll event error: ", r), nil)
 		}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -229,14 +229,7 @@ func (w *window) ShowAndRun() {
 
 // Clipboard returns the system clipboard
 func (w *window) Clipboard() fyne.Clipboard {
-	if w.view() == nil {
-		return nil
-	}
-
-	if w.clipboard == nil {
-		w.clipboard = &clipboard{window: w.viewport}
-	}
-	return w.clipboard
+	return &clipboard{}
 }
 
 func (w *window) Content() fyne.CanvasObject {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -77,8 +77,6 @@ type window struct {
 	icon         fyne.Resource
 	mainmenu     *fyne.MainMenu
 
-	clipboard fyne.Clipboard
-
 	master     bool
 	fullScreen bool
 	centered   bool


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

See https://github.com/fyne-io/fyne/pull/1136. The clipboard no longer crashes when pasting empy content (also verified locally). The clipboard also no longer require access to the window struct. Clean up the code. As the clipboard no longer needs the viewport, we can also remove a possible crash when getting a clipboard from a window that has yet to be set up.

I also added a comment to a workaround that is still needed.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.