### PR TITLE
Fix to remove systray id from Windows and macOS

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -46,12 +46,16 @@ func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 				d.SetSystemTrayIcon(theme.BrokenImageIcon())
 			}
 
-			app := fyne.CurrentApp()
-			title := app.Metadata().Name
-			if title == "" {
-				title = app.UniqueID()
+			// Some XDG systray crash without a title (See #3678)
+			if runtime.GOOS == "linux" || runtime.GOOS == "openbsd" || runtime.GOOS == "freebsd" || runtime.GOOS == "netbsd" {
+				app := fyne.CurrentApp()
+				title := app.Metadata().Name
+				if title == "" {
+					title = app.UniqueID()
+				}
+
+				systray.SetTitle(title)
 			}
-			systray.SetTitle(title)
 
 			// it must be refreshed after init, so an earlier call would have been ineffective
 			d.refreshSystray(m)


### PR DESCRIPTION
Fixes #4416

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- this is essentially "unfixing" for systems that were not impacted before but have been negatively by the old change
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
