### PR TITLE
internal/driver: Avoid calling slow functions in succession

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -283,11 +283,9 @@ func (c *Canvas) FreeDirtyTextures() (freed uint64) {
 		}
 	}
 
-	cache.RangeExpiredTexturesFor(c.impl, func(obj fyne.CanvasObject) {
-		if c.painter != nil {
-			c.painter.Free(obj)
-		}
-	})
+	if c.painter != nil {
+		cache.RangeExpiredTexturesFor(c.impl, c.painter.Free)
+	}
 	return
 }
 

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -96,8 +96,9 @@ func (c *glCanvas) Padded() bool {
 func (c *glCanvas) PixelCoordinateForPosition(pos fyne.Position) (int, int) {
 	c.RLock()
 	texScale := c.texScale
+	scale := c.scale
 	c.RUnlock()
-	multiple := c.Scale() * texScale
+	multiple := scale * texScale
 	scaleInt := func(x float32) int {
 		return int(math.Round(float64(x * multiple)))
 	}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -213,10 +213,7 @@ func (w *window) Close() {
 		w.viewLock.Unlock()
 		w.viewport.SetShouldClose(true)
 
-		painter := w.canvas.Painter()
-		cache.RangeTexturesFor(w.canvas, func(obj fyne.CanvasObject) {
-			painter.Free(obj)
-		})
+		cache.RangeTexturesFor(w.canvas, w.canvas.Painter().Free)
 	})
 
 	w.canvas.WalkTrees(nil, func(node *common.RenderCacheNode, _ fyne.Position) {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -119,8 +119,9 @@ func (w *window) calculatedScale() float32 {
 }
 
 func (w *window) detectTextureScale() float32 {
-	winWidth, _ := w.view().GetSize()
-	texWidth, _ := w.view().GetFramebufferSize()
+	view := w.view()
+	winWidth, _ := view.GetSize()
+	texWidth, _ := view.GetFramebufferSize()
 	return float32(texWidth) / float32(winWidth)
 }
 
@@ -145,15 +146,16 @@ func (w *window) doShow() {
 		w.viewLock.Lock()
 		w.visible = true
 		w.viewLock.Unlock()
-		w.view().SetTitle(w.title)
+		view := w.view()
+		view.SetTitle(w.title)
 
 		if w.centered {
 			w.doCenterOnScreen() // lastly center if that was requested
 		}
-		w.view().Show()
+		view.Show()
 
 		// save coordinates
-		w.xpos, w.ypos = w.view().GetPos()
+		w.xpos, w.ypos = view.GetPos()
 
 		if w.fullScreen { // this does not work if called before viewport.Show()
 			go func() {
@@ -164,8 +166,8 @@ func (w *window) doShow() {
 	})
 
 	// show top canvas element
-	if w.canvas.Content() != nil {
-		w.canvas.Content().Show()
+	if content := w.canvas.Content(); content != nil {
+		content.Show()
 
 		runOnDraw(w, func() {
 			w.driver.repaintWindow(w)
@@ -188,8 +190,8 @@ func (w *window) Hide() {
 		v.Hide()
 
 		// hide top canvas element
-		if w.canvas.Content() != nil {
-			w.canvas.Content().Hide()
+		if content := w.canvas.Content(); content != nil {
+			content.Hide()
 		}
 	})
 }
@@ -210,8 +212,10 @@ func (w *window) Close() {
 		w.closing = true
 		w.viewLock.Unlock()
 		w.viewport.SetShouldClose(true)
+
+		painter := w.canvas.Painter()
 		cache.RangeTexturesFor(w.canvas, func(obj fyne.CanvasObject) {
-			w.canvas.Painter().Free(obj)
+			painter.Free(obj)
 		})
 	})
 
@@ -968,12 +972,13 @@ func (w *window) doShowAgain() {
 
 	runOnMain(func() {
 		// show top canvas element
-		if w.canvas.Content() != nil {
-			w.canvas.Content().Show()
+		if content := w.canvas.Content(); content != nil {
+			content.Show()
 		}
 
-		w.view().SetPos(w.xpos, w.ypos)
-		w.view().Show()
+		view := w.view()
+		view.SetPos(w.xpos, w.ypos)
+		view.Show()
 		w.viewLock.Lock()
 		w.visible = true
 		w.viewLock.Unlock()

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -278,7 +278,7 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 		if x > xOff || y > yOff {
 			continue
 		}
-		if x+monitor.GetVideoMode().Width <= xOff || y+monitor.GetVideoMode().Height <= yOff {
+		if videoMode := monitor.GetVideoMode(); x+videoMode.Width <= xOff || y+videoMode.Height <= yOff {
 			continue
 		}
 

--- a/internal/driver/mobile/window.go
+++ b/internal/driver/mobile/window.go
@@ -161,10 +161,7 @@ func (w *window) Close() {
 		d.windows = append(d.windows[:pos], d.windows[pos+1:]...)
 	}
 
-	painter := w.canvas.Painter()
-	cache.RangeTexturesFor(w.canvas, func(obj fyne.CanvasObject) {
-		painter.Free(obj)
-	})
+	cache.RangeTexturesFor(w.canvas, w.canvas.Painter().Free)
 
 	w.canvas.WalkTrees(nil, func(node *common.RenderCacheNode, _ fyne.Position) {
 		if wid, ok := node.Obj().(fyne.Widget); ok {

--- a/internal/driver/mobile/window.go
+++ b/internal/driver/mobile/window.go
@@ -161,8 +161,9 @@ func (w *window) Close() {
 		d.windows = append(d.windows[:pos], d.windows[pos+1:]...)
 	}
 
+	painter := w.canvas.Painter()
 	cache.RangeTexturesFor(w.canvas, func(obj fyne.CanvasObject) {
-		w.canvas.Painter().Free(obj)
+		painter.Free(obj)
 	})
 
 	w.canvas.WalkTrees(nil, func(node *common.RenderCacheNode, _ fyne.Position) {


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This avoids various cases where we were calling "slow" (C-calls for glfw or locking mutexes) functions multiple times in a row. Lets save the value and use it instead.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
