### PR TITLE
Reduce string allocations in mimetype code

### DIFF
--- a/internal/repository/mime/mime.go
+++ b/internal/repository/mime/mime.go
@@ -1,0 +1,18 @@
+package mime
+
+import (
+	"strings"
+)
+
+// Split spits the mimetype into its main type and subtype.
+func Split(mimeTypeFull string) (mimeType, mimeSubType string) {
+	// Replace with strings.Cut() when Go 1.18 is our new base version.
+	separatorIndex := strings.IndexByte(mimeTypeFull, '/')
+	if separatorIndex == -1 || mimeTypeFull[separatorIndex+1:] == "" {
+		return "", "" // Empty or only one part. Ignore.
+	}
+
+	mimeType = mimeTypeFull[:separatorIndex]
+	mimeSubType = mimeTypeFull[separatorIndex+1:]
+	return
+}

--- a/internal/repository/mime/mime.go
+++ b/internal/repository/mime/mime.go
@@ -1,8 +1,6 @@
 package mime
 
-import (
-	"strings"
-)
+import "strings"
 
 // Split spits the mimetype into its main type and subtype.
 func Split(mimeTypeFull string) (mimeType, mimeSubType string) {

--- a/internal/repository/mime/mime_test.go
+++ b/internal/repository/mime/mime_test.go
@@ -1,0 +1,21 @@
+package mime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitMimeType(t *testing.T) {
+	main, sub := Split("text/plain")
+	assert.Equal(t, "text", main)
+	assert.Equal(t, "plain", sub)
+
+	main, sub = Split("text/")
+	assert.Empty(t, main)
+	assert.Empty(t, sub)
+
+	main, sub = Split("")
+	assert.Empty(t, main)
+	assert.Empty(t, sub)
+}

--- a/storage/repository/uri.go
+++ b/storage/repository/uri.go
@@ -30,7 +30,6 @@ func (u *uri) Name() string {
 }
 
 func (u *uri) MimeType() string {
-
 	mimeTypeFull := mime.TypeByExtension(u.Extension())
 	if mimeTypeFull == "" {
 		mimeTypeFull = "text/plain"
@@ -50,7 +49,12 @@ func (u *uri) MimeType() string {
 		}
 	}
 
-	return strings.Split(mimeTypeFull, ";")[0]
+	// Replace with strings.Cut() when Go 1.18 is our new base version.
+	semicolonIndex := strings.IndexByte(mimeTypeFull, ';')
+	if semicolonIndex == -1 {
+		return mimeTypeFull
+	}
+	return mimeTypeFull[:semicolonIndex]
 }
 
 func (u *uri) Scheme() string {

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -1,10 +1,9 @@
 package widget
 
 import (
-	"strings"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/repository/mime"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
@@ -99,7 +98,8 @@ func (i *FileIcon) lookupIcon(uri fyne.URI) fyne.Resource {
 		return theme.FolderIcon()
 	}
 
-	switch splitMimeType(uri) {
+	mainMimeType, _ := mime.Split(uri.MimeType())
+	switch mainMimeType {
 	case "application":
 		return theme.FileApplicationIcon()
 	case "audio":
@@ -200,12 +200,4 @@ func trimmedExtension(uri fyne.URI) string {
 		ext = ext[:5]
 	}
 	return ext
-}
-
-func splitMimeType(uri fyne.URI) string {
-	mimeTypeSplit := strings.Split(uri.MimeType(), "/")
-	if len(mimeTypeSplit) <= 1 {
-		return ""
-	}
-	return mimeTypeSplit[0]
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The code handling mimetypes was using strings.Split() to split the string and that allocates. We can use strings.IndexByte() to get an index and subslice instead. I also refactored some code to avoid duplicating part of the logic.

The new internal/repository/mime package exists to avoid cyclic imports.

NOTE: The split logic is slightly different because a second / would be includes as part of the subtype now but as far as I can see from reading the spec (https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-0.21.html) it should not be a problem as the format is "mainType/subType:weight" so there should not be any more separators, I think. I also did a ripgrep `cat /usr/share/mime/globs2 | rg "\d\d:\w+/.+/"` on my local mime database and nothing contains a second slash.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

