### PR TITLE
Reduce allocations in GridWrap on scroll updates

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -650,7 +650,7 @@ func (l *gridWrapLayout) updateGrid(refresh bool) {
 	for i := 0; i < len(visible); i++ {
 		visible[i].item = nil
 	}
-	*wasVisiblePtr = wasVisible // Copy the stack header over to the heap
+	*wasVisiblePtr = wasVisible // Copy the slice header over to the heap
 	*visiblePtr = visible
 	l.slicePool.Put(wasVisiblePtr)
 	l.slicePool.Put(visiblePtr)

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -23,7 +23,7 @@ func TestGridWrap_Focus(t *testing.T) {
 	assert.NotNil(t, canvas.Focused())
 	assert.Equal(t, 0, canvas.Focused().(*GridWrap).currentFocus)
 
-	children := list.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).children
+	children := list.scroller.Content.(*fyne.Container).Objects
 	assert.True(t, children[0].(*gridWrapItem).hovered)
 	assert.False(t, children[1].(*gridWrapItem).hovered)
 	assert.False(t, children[6].(*gridWrapItem).hovered)
@@ -182,7 +182,7 @@ func TestGridWrap_RefreshItem(t *testing.T) {
 	data[2] = "Replace"
 	list.RefreshItem(2)
 
-	children := list.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).children
+	children := list.scroller.Content.(*fyne.Container).Objects
 	assert.Equal(t, children[1].(*gridWrapItem).child.(*Label).Text, "Text")
 	assert.Equal(t, children[2].(*gridWrapItem).child.(*Label).Text, "Replace")
 }


### PR DESCRIPTION
### Description:

Similar to #4398 but for the GridWrap widget.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
