### PR TITLE
Make starting animations idempotent and improve runner performance

### DIFF
--- a/animation.go
+++ b/animation.go
@@ -1,6 +1,8 @@
 package fyne
 
-import "time"
+import (
+	"time"
+)
 
 // AnimationCurve represents an animation algorithm for calculating the progress through a timeline.
 // Custom animations can be provided by implementing the "func(float32) float32" definition.
@@ -42,6 +44,8 @@ type Animation struct {
 	Duration    time.Duration
 	RepeatCount int
 	Tick        func(float32)
+
+	stopped bool
 }
 
 // NewAnimation creates a very basic animation where the callback function will be called for every
@@ -55,12 +59,20 @@ func NewAnimation(d time.Duration, fn func(float32)) *Animation {
 
 // Start registers the animation with the application run-loop and starts its execution.
 func (a *Animation) Start() {
+	a.stopped = false
 	CurrentApp().Driver().StartAnimation(a)
 }
 
 // Stop will end this animation and remove it from the run-loop.
 func (a *Animation) Stop() {
-	CurrentApp().Driver().StopAnimation(a)
+	a.stopped = true
+}
+
+// Stopped returns true if this animation has been stopped or has completed running.
+//
+// Since: 2.5
+func (a *Animation) Stopped() bool {
+	return a.stopped
 }
 
 func animationEaseIn(val float32) float32 {

--- a/driver.go
+++ b/driver.go
@@ -26,7 +26,12 @@ type Driver interface {
 	Quit()
 
 	// StartAnimation registers a new animation with this driver and requests it be started.
-	StartAnimation(*Animation)
+	//
+	// Deprecated: Use a.Start() instead.
+	StartAnimation(a *Animation)
+
 	// StopAnimation stops an animation and unregisters from this driver.
-	StopAnimation(*Animation)
+	//
+	// Deprecated: Use a.Stop() instead.
+	StopAnimation(a *Animation)
 }

--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -1,7 +1,6 @@
 package animation
 
 import (
-	"sync/atomic"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -14,7 +13,6 @@ type anim struct {
 	reverse     bool
 	start       time.Time
 	total       int64
-	stopped     uint32 // atomic, 0 == false 1 == true
 }
 
 func newAnim(a *fyne.Animation) *anim {
@@ -22,12 +20,4 @@ func newAnim(a *fyne.Animation) *anim {
 	animate.total = animate.end.Sub(animate.start).Milliseconds()
 	animate.repeatsLeft = a.RepeatCount
 	return animate
-}
-
-func (a *anim) setStopped() {
-	atomic.StoreUint32(&a.stopped, 1)
-}
-
-func (a *anim) isStopped() bool {
-	return atomic.LoadUint32(&a.stopped) == 1
 }

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -49,7 +49,7 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 	}
 	a.Stop()
 	run.animationMutex.Lock()
-	assert.True(t, a.Stopped(), "animation was not stopped")
+	assert.True(t, a.State() == fyne.AnimationStateStopped, "animation was not stopped")
 	run.animationMutex.Unlock()
 }
 

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -47,10 +47,10 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Error("animation was not ticked")
 	}
-	run.Stop(a)
-	run.animationMutex.RLock()
-	assert.Zero(t, len(run.animations))
-	run.animationMutex.RUnlock()
+	a.Stop()
+	run.animationMutex.Lock()
+	assert.True(t, a.Stopped(), "animation was not stopped")
+	run.animationMutex.Unlock()
 }
 
 func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
@@ -64,7 +64,7 @@ func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
 		Tick:     func(f float32) {},
 	}
 	run.Start(a)
-	run.Stop(a)
+	a.Stop()
 
 	// stopping animation inside tick function
 	for i := 0; i < 10; i++ {
@@ -73,7 +73,7 @@ func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
 		b = &fyne.Animation{
 			Duration: time.Second,
 			Tick: func(d float32) {
-				run.Stop(b)
+				b.Stop()
 				wg.Done()
 			}}
 		run.Start(b)
@@ -86,12 +86,12 @@ func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
 		Tick:     func(f float32) {},
 	}
 	run.Start(c)
-	run.Stop(c)
+	c.Stop()
 
 	wg.Wait()
 	// animations stopped inside tick are really stopped in the next runner cycle
 	time.Sleep(time.Second/60 + 100*time.Millisecond)
-	run.animationMutex.RLock()
+	run.animationMutex.Lock()
 	assert.Zero(t, len(run.animations))
-	run.animationMutex.RUnlock()
+	run.animationMutex.Unlock()
 }

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -48,9 +48,7 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 		t.Error("animation was not ticked")
 	}
 	a.Stop()
-	run.animationMutex.Lock()
 	assert.True(t, a.State() == fyne.AnimationStateStopped, "animation was not stopped")
-	run.animationMutex.Unlock()
 }
 
 func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -19,9 +19,9 @@ type Runner struct {
 // Start will register the passed application and initiate its ticking.
 func (r *Runner) Start(a *fyne.Animation) {
 	r.animationMutex.Lock()
-	defer r.animationMutex.Unlock()
-
 	r.pendingAnimations = append(r.pendingAnimations, newAnim(a))
+	r.animationMutex.Unlock()
+
 	if !r.runnerStarted {
 		r.runnerStarted = true
 		r.runAnimations()

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -38,9 +38,9 @@ func (r *Runner) runAnimations() {
 			// tick currently running animations
 			newList := r.animations[:0] // references same underlying backing array
 			for _, a := range r.animations {
-				if s := a.a.Stopped(); !s && r.tickAnimation(a) {
+				if stopped := a.a.State() == fyne.AnimationStateStopped; !stopped && r.tickAnimation(a) {
 					newList = append(newList, a) // still running
-				} else if !s {
+				} else if !stopped {
 					a.a.Stop() // mark as stopped (completed running)
 				}
 			}

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -36,7 +36,9 @@ func (r *Runner) runAnimations() {
 			<-draw.C
 
 			// tick currently running animations
-			newList := r.animations[:0] // references same underlying backing array
+			// use technique from https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+			// to filter the still-running animations for the next iteration without allocating a new slice
+			newList := r.animations[:0]
 			for _, a := range r.animations {
 				if stopped := a.a.State() == fyne.AnimationStateStopped; !stopped && r.tickAnimation(a) {
 					newList = append(newList, a) // still running
@@ -56,7 +58,7 @@ func (r *Runner) runAnimations() {
 
 			done = len(newList) == 0
 			for i := len(newList); i < len(r.animations); i++ {
-				r.animations[i] = nil
+				r.animations[i] = nil // nil out extra slice capacity
 			}
 			r.animations = newList
 		}

--- a/internal/driver/glfw/animation.go
+++ b/internal/driver/glfw/animation.go
@@ -3,6 +3,10 @@ package glfw
 import "fyne.io/fyne/v2"
 
 func (d *gLDriver) StartAnimation(a *fyne.Animation) {
+	a.Start()
+}
+
+func (d *gLDriver) StartAnimationPrivate(a *fyne.Animation) {
 	d.animation.Start(a)
 }
 

--- a/internal/driver/glfw/animation.go
+++ b/internal/driver/glfw/animation.go
@@ -7,5 +7,5 @@ func (d *gLDriver) StartAnimation(a *fyne.Animation) {
 }
 
 func (d *gLDriver) StopAnimation(a *fyne.Animation) {
-	d.animation.Stop(a)
+	a.Stop()
 }

--- a/internal/driver/mobile/animation.go
+++ b/internal/driver/mobile/animation.go
@@ -7,5 +7,5 @@ func (d *mobileDriver) StartAnimation(a *fyne.Animation) {
 }
 
 func (d *mobileDriver) StopAnimation(a *fyne.Animation) {
-	d.animation.Stop(a)
+	a.Stop()
 }

--- a/internal/driver/mobile/animation.go
+++ b/internal/driver/mobile/animation.go
@@ -3,6 +3,10 @@ package mobile
 import "fyne.io/fyne/v2"
 
 func (d *mobileDriver) StartAnimation(a *fyne.Animation) {
+	a.Start()
+}
+
+func (d *mobileDriver) StartAnimationPrivate(a *fyne.Animation) {
 	d.animation.Start(a)
 }
 

--- a/test/testdriver.go
+++ b/test/testdriver.go
@@ -112,6 +112,11 @@ func (d *testDriver) StopAnimation(a *fyne.Animation) {
 	// currently no animations in test app, do nothing
 }
 
+func (d *testDriver) StartAnimationPrivate(a *fyne.Animation) {
+	/// currently no animations in test app, we just initialise it and leave
+	a.Tick(1.0)
+}
+
 func (d *testDriver) Quit() {
 	// no-op
 }

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -650,7 +650,7 @@ func (l *gridWrapLayout) updateGrid(refresh bool) {
 	for i := 0; i < len(visible); i++ {
 		visible[i].item = nil
 	}
-	*wasVisiblePtr = wasVisible // Copy the stack header over to the heap
+	*wasVisiblePtr = wasVisible // Copy the slice header over to the heap
 	*visiblePtr = visible
 	l.slicePool.Put(wasVisiblePtr)
 	l.slicePool.Put(visiblePtr)

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -23,7 +23,7 @@ func TestGridWrap_Focus(t *testing.T) {
 	assert.NotNil(t, canvas.Focused())
 	assert.Equal(t, 0, canvas.Focused().(*GridWrap).currentFocus)
 
-	children := list.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).children
+	children := list.scroller.Content.(*fyne.Container).Objects
 	assert.True(t, children[0].(*gridWrapItem).hovered)
 	assert.False(t, children[1].(*gridWrapItem).hovered)
 	assert.False(t, children[6].(*gridWrapItem).hovered)
@@ -182,7 +182,7 @@ func TestGridWrap_RefreshItem(t *testing.T) {
 	data[2] = "Replace"
 	list.RefreshItem(2)
 
-	children := list.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).children
+	children := list.scroller.Content.(*fyne.Container).Objects
 	assert.Equal(t, children[1].(*gridWrapItem).child.(*Label).Text, "Text")
 	assert.Equal(t, children[2].(*gridWrapItem).child.(*Label).Text, "Replace")
 }


### PR DESCRIPTION
### Description:
This PR does the following:

* Introduces a new public API `animation.State()` which returns the state of an animation (not started, running, stopped). We use this internally as well
* Makes starting animations idempotent. Starting an animation again while it is running is a no-op.
* Improves performance of the animation runner:
  - Start is O(1) amortized
  - Stop is O(1) (down from O(n))
  - the runner is zero-alloc

Fixes #4445 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
