### PR TITLE
Fix conflict of struct name itemAndID

### DIFF
--- a/app/app_goxjs.go
+++ b/app/app_goxjs.go
@@ -56,11 +56,17 @@ func (app *fyneApp) SendNotification(n *fyne.Notification) {
 func rootConfigDir() string {
 	return "/data/"
 }
+
+var themeChanged = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+	if len(args) > 0 && args[0].Type() == js.TypeObject {
+		fyne.CurrentApp().Settings().(*settings).setupTheme()
+	}
+	return nil
+})
+
 func watchTheme() {
-	js.Global().Call("matchMedia", "(prefers-color-scheme: dark)").Call("addEventListener", "change", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		if len(args) > 0 && args[0].Type() == js.TypeObject {
-			fyne.CurrentApp().Settings().(*settings).setupTheme()
-		}
-		return nil
-	}))
+	js.Global().Call("matchMedia", "(prefers-color-scheme: dark)").Call("addEventListener", "change", themeChanged)
+}
+func stopWatching() {
+	js.Global().Call("matchMedia", "(prefers-color-scheme: dark)").Call("removeEventListener", "change", themeChanged)
 }

--- a/app/app_goxjs.go
+++ b/app/app_goxjs.go
@@ -6,14 +6,61 @@
 package app
 
 import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"syscall/js"
+
 	"fyne.io/fyne/v2"
 )
 
-func (app *fyneApp) SendNotification(_ *fyne.Notification) {
-	// TODO #2735
-	fyne.LogError("Sending notification is not supported yet.", nil)
+func (app *fyneApp) SendNotification(n *fyne.Notification) {
+	window := js.Global().Get("window")
+	if window.IsUndefined() {
+		fyne.LogError("Current browser does not support notifications.", nil)
+		return
+	}
+	notification := window.Get("Notification")
+	if window.IsUndefined() {
+		fyne.LogError("Current browser does not support notifications.", nil)
+		return
+	}
+	// check permission
+	permission := notification.Get("permission")
+	showNotification := func() {
+		icon := app.icon.Content()
+		base64Str := base64.StdEncoding.EncodeToString(icon)
+		mimeType := http.DetectContentType(icon)
+		base64Img := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Str)
+		notification.New(n.Title, map[string]interface{}{
+			"body": n.Content,
+			"icon": base64Img,
+		})
+		fyne.LogError("done show...", nil)
+	}
+	if permission.Type() != js.TypeString || permission.String() != "granted" {
+		// need to request for permission
+		notification.Call("requestPermission", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+			if len(args) > 0 && args[0].Type() == js.TypeString && args[0].String() == "granted" {
+				showNotification()
+			} else {
+				fyne.LogError("User rejected the request for notifications.", nil)
+			}
+			return nil
+		}))
+	} else {
+		showNotification()
+	}
 }
 
 func rootConfigDir() string {
 	return "/data/"
+}
+func watchTheme() {
+	js.Global().Call("matchMedia", "(prefers-color-scheme: dark)").Call("addEventListener", "change", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) > 0 && args[0].Type() == js.TypeObject {
+			fyne.CurrentApp().Settings().(*settings).setupTheme()
+		}
+		return nil
+	}))
 }

--- a/app/settings_goxjs.go
+++ b/app/settings_goxjs.go
@@ -22,4 +22,5 @@ func (s *settings) watchSettings() {
 }
 
 func (s *settings) stopWatching() {
+	stopWatching()
 }

--- a/app/settings_goxjs.go
+++ b/app/settings_goxjs.go
@@ -18,6 +18,7 @@ func watchFile(path string, callback func()) {
 }
 
 func (s *settings) watchSettings() {
+	watchTheme()
 }
 
 func (s *settings) stopWatching() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.  -->
When build in the develop branch, got error:
```
../../widget/list.go:529:6: itemAndID redeclared in this block
../../widget/gridwrap.go:467:6: other declaration of itemAndID
```
This is because two structure uses the same name in the same package.
I renamed these two structures.
### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

