### PR TITLE
Add multi-select for list

### DIFF
--- a/cmd/fyne_demo/tutorials/collection.go
+++ b/cmd/fyne_demo/tutorials/collection.go
@@ -96,7 +96,27 @@ func makeListTab(_ fyne.Window) fyne.CanvasObject {
 	list.SetItemHeight(5, 50)
 	list.SetItemHeight(6, 50)
 
-	return container.NewHSplit(list, container.NewCenter(hbox))
+	split := container.NewHSplit(list, container.NewCenter(hbox))
+	radio := widget.NewRadioGroup([]string{"Single", "Multiple", "None"}, func(sel string) {
+		switch sel {
+		case "Single":
+			list.SelectionMode = widget.SelectionSingle
+		case "Multiple":
+			list.SelectionMode = widget.SelectionMultiple
+		case "None":
+			list.SelectionMode = widget.SelectionNone
+		}
+	})
+	radio.Horizontal = true
+	radio.Selected = "Single"
+
+	return container.NewBorder(
+		container.NewHBox(widget.NewLabel("Selection:"), radio),
+		nil,
+		nil,
+		nil,
+		split,
+	)
 }
 
 func makeTableTab(_ fyne.Window) fyne.CanvasObject {

--- a/widget/selectionmode.go
+++ b/widget/selectionmode.go
@@ -1,0 +1,23 @@
+package widget
+
+// SelectionMode represents the selection mode of a collection widget
+//
+// Since: 2.5
+type SelectionMode int
+
+const (
+	// SelectionSingle allows only one item to be selected at a time
+	//
+	// Since: 2.5
+	SelectionSingle SelectionMode = iota
+
+	// SelectionMultiple allows multiple items to be selected at a time
+	//
+	// Since 2.5
+	SelectionMultiple
+
+	// SelectionNone disables selection
+	//
+	// Since 2.5
+	SelectionNone
+)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

* Adds new enum widget.SelectionMode (values: SelectionSingle, SelectionMultiple, SelectionNone)
  - This only effects the tap/key handling, not the programmatic APIs
* Adds tap/key handling for multi-select, respecting SelectionMode setting
* Adds a few new APIs related to multi-select
  - `SelectOnly(ListItemID)`
  - `SelectAll()`
  - `SetSelection([]ListItemID)`
* The `list.Select` API now adds to the selection (which is what the documentation said), rather than replacing it

### TODO/ Concerns:
* tests
* This uses a slice of IDs to keep track of selection, and creates a new selection slice on any unselect operation. This makes thread-safety fairly easy, but comes with some performance tradeoffs:
  - Repeatedly unselecting items causes a lot of memory churn (UnselectAll is implemented efficiently)
  - **setupListItem** is now **O(n)** in number of selected items. This is a potential concern
  - Notifying onSelected/onUnselected callbacks is **O(n^2)** in operations that select multiple IDs at once (SelectAll, SetSelection)

<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #2575 (for list)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
