### PR TITLE
Update Glfw to v3.3.9 and improve Wayland support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fyne-io/glfw-js v0.0.0-20220120001248-ee7290d23504
 	github.com/fyne-io/image v0.0.0-20220602074514-4956b0afb3d2
 	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6
-	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231124074035-2de0cf0c80af
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231223183121-56fa3ac82ce7
 	github.com/go-ole/go-ole v1.2.6
 	github.com/go-text/render v0.0.0-20230619120952-35bccb6164b8
 	github.com/go-text/typesetting v0.0.0-20230616162802-9c17dd34aa4a

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231124074035-2de0cf0c80af h1:zclgNFqP+NXDgGX2BiDvIonxKIom8j65wQlOyFtyujc=
-github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231124074035-2de0cf0c80af/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231223183121-56fa3ac82ce7 h1:7tf/0aw5DxRQjr7WaNqgtjidub6v21L2cogKIbMcTYw=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231223183121-56fa3ac82ce7/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-text/render v0.0.0-20230619120952-35bccb6164b8 h1:VkKnvzbvHqgEfm351rfr8Uclu5fnwq8HP2ximUzJsBM=

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal/app"
+	"fyne.io/fyne/v2/internal/build"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/driver"
 	"fyne.io/fyne/v2/internal/driver/common"
@@ -148,13 +149,15 @@ func (w *window) doShow() {
 		view := w.view()
 		view.SetTitle(w.title)
 
-		if w.centered {
+		if !build.IsWayland && w.centered {
 			w.doCenterOnScreen() // lastly center if that was requested
 		}
 		view.Show()
 
 		// save coordinates
-		w.xpos, w.ypos = view.GetPos()
+		if !build.IsWayland {
+			w.xpos, w.ypos = view.GetPos()
+		}
 
 		if w.fullScreen { // this does not work if called before viewport.Show()
 			go func() {
@@ -973,7 +976,9 @@ func (w *window) doShowAgain() {
 		}
 
 		view := w.view()
-		view.SetPos(w.xpos, w.ypos)
+		if !build.IsWayland {
+			view.SetPos(w.xpos, w.ypos)
+		}
 		view.Show()
 		w.viewLock.Lock()
 		w.visible = true

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -592,10 +592,6 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
-	if runtime.GOOS == "darwin" && scancode == 0x69 { // TODO remove once fixed upstream glfw/glfw#1786
-		code = glfw.KeyPrintScreen
-	}
-
 	ret := glfwKeyToKeyName(code)
 	if ret != fyne.KeyUnknown {
 		return ret

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -134,6 +134,10 @@ func (w *window) SetFullScreen(full bool) {
 }
 
 func (w *window) CenterOnScreen() {
+	if build.IsWayland {
+		return
+	}
+
 	w.centered = true
 
 	if w.view() != nil {
@@ -192,6 +196,10 @@ func (w *window) RequestFocus() {
 
 func (w *window) SetIcon(icon fyne.Resource) {
 	w.icon = icon
+	if build.IsWayland {
+		return
+	}
+
 	if icon == nil {
 		appIcon := fyne.CurrentApp().Icon()
 		if appIcon != nil {
@@ -265,24 +273,26 @@ func (w *window) fitContent() {
 }
 
 func (w *window) getMonitorForWindow() *glfw.Monitor {
-	x, y := w.xpos, w.ypos
-	if w.fullScreen {
-		x, y = w.viewport.GetPos()
-	}
-	xOff := x + (w.width / 2)
-	yOff := y + (w.height / 2)
-
-	for _, monitor := range glfw.GetMonitors() {
-		x, y := monitor.GetPos()
-
-		if x > xOff || y > yOff {
-			continue
+	if !build.IsWayland {
+		x, y := w.xpos, w.ypos
+		if w.fullScreen {
+			x, y = w.viewport.GetPos()
 		}
-		if videoMode := monitor.GetVideoMode(); x+videoMode.Width <= xOff || y+videoMode.Height <= yOff {
-			continue
-		}
+		xOff := x + (w.width / 2)
+		yOff := y + (w.height / 2)
 
-		return monitor
+		for _, monitor := range glfw.GetMonitors() {
+			x, y := monitor.GetPos()
+
+			if x > xOff || y > yOff {
+				continue
+			}
+			if videoMode := monitor.GetVideoMode(); x+videoMode.Width <= xOff || y+videoMode.Height <= yOff {
+				continue
+			}
+
+			return monitor
+		}
 	}
 
 	// try built-in function to detect monitor if above logic didn't succeed

--- a/internal/driver/glfw/window_goxjs.go
+++ b/internal/driver/glfw/window_goxjs.go
@@ -394,10 +394,6 @@ func keyCodeToKeyName(code string) fyne.KeyName {
 }
 
 func keyToName(code glfw.Key, scancode int) fyne.KeyName {
-	if runtime.GOOS == "darwin" && scancode == 0x69 { // TODO remove once fixed upstream glfw/glfw#1786
-		code = glfw.KeyPrintScreen
-	}
-
 	ret := glfwKeyToKeyName(code)
 	if ret != fyne.KeyUnknown {
 		return ret


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Glfw 3.3.9 includes a bunch of fixed and improvements. Most notably, it now uses `libdecor` on Wayland meaning that the decorations work and are much more usable. I've also removed some workarounds (I personally asked for one of Andrew's several year old commits to be backported upstream) and made sure to silence the majority of warnings/errors that are printed when running on Wayland.  

There are still weird scaling and other issues but Wayland should now be quite usable (and now more than enough that you can actually use the app enough to fix the other issues) :)

For #1851

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
