### PR TITLE
RadioGroup improvements

### DIFF
--- a/widget/check_group.go
+++ b/widget/check_group.go
@@ -265,3 +265,17 @@ func (r *checkGroupRenderer) updateItems() {
 		item.Refresh()
 	}
 }
+
+func removeDuplicates(options []string) []string {
+	var result []string
+	found := make(map[string]bool)
+
+	for _, option := range options {
+		if _, ok := found[option]; !ok {
+			found[option] = true
+			result = append(result, option)
+		}
+	}
+
+	return result
+}

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -57,7 +57,10 @@ func (r *RadioGroup) CreateRenderer() fyne.WidgetRenderer {
 		})
 	}
 
-	return &radioGroupRenderer{widget.NewBaseRenderer(items), items, r}
+	render := &radioGroupRenderer{widget.NewBaseRenderer(items), items, r}
+	r.updateSelectedIndex()
+	render.updateItems(false)
+	return render
 }
 
 // MinSize returns the size that this widget should not shrink below
@@ -202,11 +205,11 @@ func (r *radioGroupRenderer) MinSize() fyne.Size {
 }
 
 func (r *radioGroupRenderer) Refresh() {
-	r.updateItems()
+	r.updateItems(true)
 	canvas.Refresh(r.radio.super())
 }
 
-func (r *radioGroupRenderer) updateItems() {
+func (r *radioGroupRenderer) updateItems(refresh bool) {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
 			idx := i
@@ -238,7 +241,7 @@ func (r *radioGroupRenderer) updateItems() {
 			changed = true
 		}
 
-		if changed {
+		if refresh && changed {
 			item.Refresh()
 		}
 	}

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -1,6 +1,8 @@
 package widget
 
 import (
+	"log"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/widget"
@@ -18,7 +20,10 @@ type RadioGroup struct {
 	Options    []string
 	Selected   string
 
-	items []*radioItem
+	// this index is ONE-BASED so the default zero-value is unselected
+	// use r.selectedIndex(), r.setSelectedIndex(int) to maniupulate this field
+	// as if it were a zero-based index (with -1 == nothing selected)
+	_selIdx int
 }
 
 var _ fyne.Widget = (*RadioGroup)(nil)
@@ -32,7 +37,6 @@ func NewRadioGroup(options []string, changed func(string)) *RadioGroup {
 		OnChanged: changed,
 	}
 	r.ExtendBaseWidget(r)
-	r.update()
 	return r
 }
 
@@ -46,32 +50,22 @@ func (r *RadioGroup) Append(option string) {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (r *RadioGroup) CreateRenderer() fyne.WidgetRenderer {
 	r.ExtendBaseWidget(r)
-	r.propertyLock.Lock()
-	defer r.propertyLock.Unlock()
 
-	r.update()
-	objects := make([]fyne.CanvasObject, len(r.items))
-	for i, item := range r.items {
-		objects[i] = item
+	items := make([]fyne.CanvasObject, len(r.Options))
+	for i, option := range r.Options {
+		idx := i
+		items[idx] = newRadioItem(option, func(item *radioItem) {
+			r.itemTapped(item, idx)
+		})
 	}
 
-	return &radioGroupRenderer{widget.NewBaseRenderer(objects), r.items, r}
+	return &radioGroupRenderer{widget.NewBaseRenderer(items), items, r}
 }
 
 // MinSize returns the size that this widget should not shrink below
 func (r *RadioGroup) MinSize() fyne.Size {
 	r.ExtendBaseWidget(r)
 	return r.BaseWidget.MinSize()
-}
-
-// Refresh causes this widget to be redrawn in it's current state.
-//
-// Implements: fyne.CanvasObject
-func (r *RadioGroup) Refresh() {
-	r.propertyLock.Lock()
-	r.update()
-	r.propertyLock.Unlock()
-	r.BaseWidget.Refresh()
 }
 
 // SetSelected sets the radio option, it can be used to set a default option.
@@ -81,6 +75,7 @@ func (r *RadioGroup) SetSelected(option string) {
 	}
 
 	r.Selected = option
+	// selectedIndex will be updated on refresh to the first matching item
 
 	if r.OnChanged != nil {
 		r.OnChanged(option)
@@ -89,19 +84,23 @@ func (r *RadioGroup) SetSelected(option string) {
 	r.Refresh()
 }
 
-func (r *RadioGroup) itemTapped(item *radioItem) {
+func (r *RadioGroup) itemTapped(item *radioItem, idx int) {
 	if r.Disabled() {
 		return
 	}
 
-	if r.Selected == item.Label {
+	if r.selectedIndex() == idx {
 		if r.Required {
 			return
 		}
+		log.Printf("trying to unselect item %d", idx)
 		r.Selected = ""
+		r.setSelectedIndex(-1)
 		item.SetSelected(false)
 	} else {
+		log.Printf("trying to select item %d", idx)
 		r.Selected = item.Label
+		r.setSelectedIndex(idx)
 		item.SetSelected(true)
 	}
 
@@ -111,27 +110,47 @@ func (r *RadioGroup) itemTapped(item *radioItem) {
 	r.Refresh()
 }
 
-func (r *RadioGroup) update() {
-	r.Options = removeDuplicates(r.Options)
-	if len(r.items) < len(r.Options) {
-		for i := len(r.items); i < len(r.Options); i++ {
-			item := newRadioItem(r.Options[i], r.itemTapped)
-			r.items = append(r.items, item)
+func (r *RadioGroup) Refresh() {
+	r.updateSelectedIndex()
+	r.BaseWidget.Refresh()
+}
+
+func (r *RadioGroup) selectedIndex() int {
+	return r._selIdx - 1
+}
+
+func (r *RadioGroup) setSelectedIndex(idx int) {
+	r._selIdx = idx + 1
+}
+
+// if selectedIndex does not match the public Selected property,
+// set it to the index of the first radio item whose label matches Selected
+func (r *RadioGroup) updateSelectedIndex() {
+	sel := r.Selected
+	sIdx := r.selectedIndex()
+	if sIdx >= 0 && sIdx < len(r.Options) && r.Options[sIdx] == sel {
+		return // selected index matches Selected
+	}
+	if sIdx == -1 && sel == "" {
+		return // nothing selected
+	}
+
+	sIdx = -1
+	for i, opt := range r.Options {
+		if sel == opt {
+			sIdx = i
+			break
 		}
-	} else if len(r.items) > len(r.Options) {
-		r.items = r.items[:len(r.Options)]
 	}
-	for i, item := range r.items {
-		item.Label = r.Options[i]
-		item.Selected = item.Label == r.Selected
-		item.DisableableWidget.disabled = r.disabled
-		item.Refresh()
-	}
+	r.setSelectedIndex(sIdx)
 }
 
 type radioGroupRenderer struct {
 	widget.BaseRenderer
-	items []*radioItem
+
+	// slice of *radioItem, but using fyne.CanvasObject as the type
+	// so we can directly set it to the BaseRenderer's objects slice
+	items []fyne.CanvasObject
 	radio *RadioGroup
 }
 
@@ -194,34 +213,37 @@ func (r *radioGroupRenderer) Refresh() {
 func (r *radioGroupRenderer) updateItems() {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
-			item := newRadioItem(r.radio.Options[i], r.radio.itemTapped)
-			r.SetObjects(append(r.Objects(), item))
+			idx := i
+			item := newRadioItem(r.radio.Options[idx], func(item *radioItem) {
+				r.radio.itemTapped(item, idx)
+			})
 			r.items = append(r.items, item)
 		}
 		r.Layout(r.radio.Size())
 	} else if len(r.items) > len(r.radio.Options) {
 		total := len(r.radio.Options)
 		r.items = r.items[:total]
-		r.SetObjects(r.Objects()[:total])
 	}
+	r.SetObjects(r.items)
+
 	for i, item := range r.items {
-		item.Label = r.radio.Options[i]
-		item.Selected = item.Label == r.radio.Selected
-		item.disabled = r.radio.disabled
-		item.Refresh()
-	}
-}
+		item := item.(*radioItem)
+		changed := false
+		if l := r.radio.Options[i]; l != item.Label {
+			item.Label = r.radio.Options[i]
+			changed = true
+		}
+		if sel := i == r.radio.selectedIndex(); sel != item.Selected {
+			item.Selected = sel
+			changed = true
+		}
+		if d := r.radio.disabled; d != item.disabled {
+			item.disabled = d
+			changed = true
+		}
 
-func removeDuplicates(options []string) []string {
-	var result []string
-	found := make(map[string]bool)
-
-	for _, option := range options {
-		if _, ok := found[option]; !ok {
-			found[option] = true
-			result = append(result, option)
+		if changed {
+			item.Refresh()
 		}
 	}
-
-	return result
 }

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -1,8 +1,6 @@
 package widget
 
 import (
-	"log"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/widget"
@@ -93,12 +91,10 @@ func (r *RadioGroup) itemTapped(item *radioItem, idx int) {
 		if r.Required {
 			return
 		}
-		log.Printf("trying to unselect item %d", idx)
 		r.Selected = ""
 		r.setSelectedIndex(-1)
 		item.SetSelected(false)
 	} else {
-		log.Printf("trying to select item %d", idx)
 		r.Selected = item.Label
 		r.setSelectedIndex(idx)
 		item.SetSelected(true)

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -42,7 +42,6 @@ func TestRadioGroup_Extended_Unselected(t *testing.T) {
 		selected = sel
 	})
 	radio.Selected = selected
-	radio.Refresh() // sets up selectedIndex
 	extendedRadioGroupTestTapItem(t, radio, 0)
 
 	assert.Equal(t, "", selected)

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -22,7 +22,6 @@ func newextendedRadioGroup(opts []string, f func(string)) *extendedRadioGroup {
 	ret.Options = opts
 	ret.OnChanged = f
 	ret.ExtendBaseWidget(ret)
-	//ret.update() // Not needed for extending Radio but for the tests to be able to access items without creating a renderer first.
 
 	return ret
 }

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -294,7 +294,6 @@ func TestRadioGroup_Required(t *testing.T) {
 	radioGroupTestTapItem(t, radio, 0)
 	assert.Equal(t, "Hi", radio.Selected, "tapping selected option of required radio does nothing")
 	radioGroupTestTapItem(t, radio, 1)
-	//radio.items[1].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), radio.Size().Height-theme.Padding())})
 	assert.Equal(t, "There", radio.Selected)
 }
 

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -46,7 +46,7 @@ func TestRadioGroup_Selected(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi"}, func(sel string) {
 		selected = sel
 	})
-	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radioGroupTestTapItem(t, radio, 0)
 
 	assert.Equal(t, "Hi", selected)
 }
@@ -57,7 +57,8 @@ func TestRadioGroup_Unselected(t *testing.T) {
 		selected = sel
 	})
 	radio.Selected = selected
-	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radio.Refresh() // sets up selectedIndex
+	radioGroupTestTapItem(t, radio, 0)
 
 	assert.Equal(t, "", selected)
 }
@@ -65,7 +66,7 @@ func TestRadioGroup_Unselected(t *testing.T) {
 func TestRadioGroup_DisableWhenSelected(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi"}, nil)
 	radio.SetSelected("Hi")
-	render := test.WidgetRenderer(radio.items[0]).(*radioItemRenderer)
+	render := radioGroupTestItemRenderer(t, radio, 0)
 	icon := fyne.CurrentApp().Settings().Theme().Icon("iconNameRadioButtonFill")
 	assert.Equal(t, "primary_"+icon.Name(), render.icon.Resource.Name())
 
@@ -75,7 +76,7 @@ func TestRadioGroup_DisableWhenSelected(t *testing.T) {
 
 func TestRadioGroup_DisableWhenNotSelected(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi"}, nil)
-	render := test.WidgetRenderer(radio.items[0]).(*radioItemRenderer)
+	render := radioGroupTestItemRenderer(t, radio, 0)
 
 	radio.Disable()
 	resName := render.over.Resource.Name()
@@ -87,7 +88,7 @@ func TestRadioGroup_SelectedOther(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi", "Hi2"}, func(sel string) {
 		selected = sel
 	})
-	radio.items[1].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), radio.MinSize().Height-theme.Padding())})
+	radioGroupTestTapItem(t, radio, 1)
 
 	assert.Equal(t, "Hi2", selected)
 }
@@ -156,8 +157,16 @@ func TestRadioGroup_SetSelectedEmpty(t *testing.T) {
 func TestRadioGroup_DuplicatedOptions(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi", "Hi", "Hi", "Another", "Another"}, nil)
 
-	assert.Equal(t, 2, len(radio.Options))
-	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 5, len(radio.Options))
+	assert.Equal(t, 5, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+
+	radioGroupTestTapItem(t, radio, 1)
+	assert.Equal(t, "Hi", radio.Selected)
+	assert.Equal(t, 1, radio.selectedIndex())
+	item0 := test.WidgetRenderer(radio).Objects()[0].(*radioItem)
+	assert.Equal(t, false, item0.focused)
+	item1 := test.WidgetRenderer(radio).Objects()[0].(*radioItem)
+	assert.Equal(t, false, item1.focused)
 }
 
 func TestRadioGroup_AppendDuplicate(t *testing.T) {
@@ -165,8 +174,8 @@ func TestRadioGroup_AppendDuplicate(t *testing.T) {
 
 	radio.Append("Hi")
 
-	assert.Equal(t, 1, len(radio.Options))
-	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 2, len(radio.Options))
+	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
 }
 
 func TestRadioGroup_Disable(t *testing.T) {
@@ -176,7 +185,7 @@ func TestRadioGroup_Disable(t *testing.T) {
 	})
 
 	radio.Disable()
-	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radioGroupTestTapItem(t, radio, 0)
 
 	assert.Equal(t, "", selected, "RadioGroup should have been disabled.")
 }
@@ -188,11 +197,11 @@ func TestRadioGroup_Enable(t *testing.T) {
 	})
 
 	radio.Disable()
-	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radioGroupTestTapItem(t, radio, 0)
 	assert.Equal(t, "", selected, "Radio should have been disabled.")
 
 	radio.Enable()
-	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radioGroupTestTapItem(t, radio, 0)
 	assert.Equal(t, "Hi", selected, "Radio should have been re-enabled.")
 }
 
@@ -228,9 +237,9 @@ func TestRadioGroup_Hovered(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			radio := NewRadioGroup(tt.options, nil)
 			radio.Horizontal = tt.isHorizontal
-			item1 := radio.items[0]
-			render1 := cache.Renderer(item1).(*radioItemRenderer)
-			render2 := cache.Renderer(radio.items[1]).(*radioItemRenderer)
+			item1 := test.WidgetRenderer(radio).Objects()[0].(*radioItem)
+			render1 := radioGroupTestItemRenderer(t, radio, 0)
+			render2 := radioGroupTestItemRenderer(t, radio, 1)
 
 			assert.False(t, item1.hovered)
 			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
@@ -282,15 +291,16 @@ func TestRadioGroup_Required(t *testing.T) {
 	radio.Resize(radio.MinSize())
 	radio.SetSelected("Hi")
 	require.Equal(t, "Hi", radio.Selected)
-	radio.items[0].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+	radioGroupTestTapItem(t, radio, 0)
 	assert.Equal(t, "Hi", radio.Selected, "tapping selected option of required radio does nothing")
-	radio.items[1].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), radio.Size().Height-theme.Padding())})
+	radioGroupTestTapItem(t, radio, 1)
+	//radio.items[1].Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), radio.Size().Height-theme.Padding())})
 	assert.Equal(t, "There", radio.Selected)
 }
 
 func TestRadioGroupRenderer_ApplyTheme(t *testing.T) {
 	radio := NewRadioGroup([]string{"Test"}, func(string) {})
-	render := cache.Renderer(radio.items[0]).(*radioItemRenderer)
+	render := radioGroupTestItemRenderer(t, radio, 0)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize
@@ -300,4 +310,15 @@ func TestRadioGroupRenderer_ApplyTheme(t *testing.T) {
 	})
 
 	assert.NotEqual(t, textSize, customTextSize)
+}
+
+func radioGroupTestTapItem(t *testing.T, radio *RadioGroup, item int) {
+	t.Helper()
+	renderer := test.WidgetRenderer(radio)
+	radioItem := renderer.Objects()[item].(*radioItem)
+	radioItem.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
+}
+
+func radioGroupTestItemRenderer(t *testing.T, radio *RadioGroup, item int) *radioItemRenderer {
+	return cache.Renderer(test.WidgetRenderer(radio).Objects()[item].(fyne.Widget)).(*radioItemRenderer)
 }

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -57,7 +57,6 @@ func TestRadioGroup_Unselected(t *testing.T) {
 		selected = sel
 	})
 	radio.Selected = selected
-	radio.Refresh() // sets up selectedIndex
 	radioGroupTestTapItem(t, radio, 0)
 
 	assert.Equal(t, "", selected)

--- a/widget/radio_group_test.go
+++ b/widget/radio_group_test.go
@@ -151,6 +151,7 @@ func TestRadioGroup_Layout(t *testing.T) {
 				Options:    tt.options,
 				Selected:   tt.selected,
 			}
+			radio.Refresh() // set up selectedIndex
 			if tt.disabled {
 				radio.Disable()
 			}

--- a/widget/radio_group_test.go
+++ b/widget/radio_group_test.go
@@ -151,7 +151,6 @@ func TestRadioGroup_Layout(t *testing.T) {
 				Options:    tt.options,
 				Selected:   tt.selected,
 			}
-			radio.Refresh() // set up selectedIndex
 			if tt.disabled {
 				radio.Disable()
 			}


### PR DESCRIPTION
### Description:

Fixes: #3786, #3543 (for RadioGroup)

Improvements to RadioGroup
* Now supports multiple items with the same label, the one tapped will be selected only
* Removed slice of `radioItem` from the widget type (only renderer deals with the radioItems)
* Except for the `*_Duplicate*` tests, no test logic is changed; only other test changes are how we access items now that internal impl is different

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
