### PR TITLE
Various layout cleanups and performance improvements

### DIFF
--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -5,11 +5,12 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-// Declare conformity with Layout interface
-var _ fyne.Layout = (*boxLayout)(nil)
-
-type boxLayout struct {
-	horizontal bool
+// NewVBoxLayout returns a vertical box layout for stacking a number of child
+// canvas objects or widgets top to bottom. The objects are always displayed
+// at their vertical MinSize. Use a different layout if the objects are intended
+// to be larger then their vertical MinSize.
+func NewVBoxLayout() fyne.Layout {
+	return vBoxLayout{}
 }
 
 // NewHBoxLayout returns a horizontal box layout for stacking a number of child
@@ -17,39 +18,19 @@ type boxLayout struct {
 // at their horizontal MinSize. Use a different layout if the objects are intended
 // to be larger then their horizontal MinSize.
 func NewHBoxLayout() fyne.Layout {
-	return &boxLayout{true}
+	return hBoxLayout{}
 }
 
-// NewVBoxLayout returns a vertical box layout for stacking a number of child
-// canvas objects or widgets top to bottom. The objects are always displayed
-// at their vertical MinSize. Use a different layout if the objects are intended
-// to be larger then their vertical MinSize.
-func NewVBoxLayout() fyne.Layout {
-	return &boxLayout{false}
-}
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*vBoxLayout)(nil)
 
-func (g *boxLayout) isSpacer(obj fyne.CanvasObject) bool {
-	if !obj.Visible() {
-		return false // invisible spacers don't impact layout
-	}
-
-	spacer, ok := obj.(SpacerObject)
-	if !ok {
-		return false
-	}
-
-	if g.horizontal {
-		return spacer.ExpandHorizontal()
-	}
-
-	return spacer.ExpandVertical()
-}
+type vBoxLayout struct{}
 
 // Layout is called to pack all child objects into a specified size.
-// For a VBoxLayout this will pack objects into a single column where each item
+// This will pack objects into a single column where each item
 // is full width but the height is the minimum required.
 // Any spacers added will pad the view, sharing the space if there are two or more.
-func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+func (v vBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	spacers := 0
 	visibleObjects := 0
 	// Size taken up by visible objects
@@ -59,28 +40,20 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		if !child.Visible() {
 			continue
 		}
-		if g.isSpacer(child) {
+
+		if isVerticalSpacer(child) {
 			spacers++
 			continue
 		}
 
 		visibleObjects++
-		if g.horizontal {
-			total += child.MinSize().Width
-		} else {
-			total += child.MinSize().Height
-		}
+		total += child.MinSize().Height
 	}
 
 	padding := theme.Padding()
 
 	// Amount of space not taken up by visible objects and inter-object padding
-	var extra float32
-	if g.horizontal {
-		extra = size.Width - total - (padding * float32(visibleObjects-1))
-	} else {
-		extra = size.Height - total - (padding * float32(visibleObjects-1))
-	}
+	extra := size.Height - total - (padding * float32(visibleObjects-1))
 
 	// Spacers split extra space equally
 	spacerSize := float32(0)
@@ -94,55 +67,128 @@ func (g *boxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 			continue
 		}
 
-		if g.isSpacer(child) {
-			if g.horizontal {
-				x += spacerSize
-			} else {
-				y += spacerSize
-			}
+		if isVerticalSpacer(child) {
+			y += spacerSize
 			continue
 		}
 		child.Move(fyne.NewPos(x, y))
 
-		if g.horizontal {
-			width := child.MinSize().Width
-			x += padding + width
-			child.Resize(fyne.NewSize(width, size.Height))
-		} else {
-			height := child.MinSize().Height
-			y += padding + height
-			child.Resize(fyne.NewSize(size.Width, height))
-		}
+		height := child.MinSize().Height
+		y += padding + height
+		child.Resize(fyne.NewSize(size.Width, height))
 	}
 }
 
 // MinSize finds the smallest size that satisfies all the child objects.
 // For a BoxLayout this is the width of the widest item and the height is
 // the sum of of all children combined with padding between each.
-func (g *boxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+func (v vBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	minSize := fyne.NewSize(0, 0)
 	addPadding := false
 	padding := theme.Padding()
 	for _, child := range objects {
-		if !child.Visible() || g.isSpacer(child) {
+		if !child.Visible() || isVerticalSpacer(child) {
 			continue
 		}
 
 		childMin := child.MinSize()
-		if g.horizontal {
-			minSize.Height = fyne.Max(childMin.Height, minSize.Height)
-			minSize.Width += childMin.Width
-			if addPadding {
-				minSize.Width += padding
-			}
-		} else {
-			minSize.Width = fyne.Max(childMin.Width, minSize.Width)
-			minSize.Height += childMin.Height
-			if addPadding {
-				minSize.Height += padding
-			}
+		minSize.Width = fyne.Max(childMin.Width, minSize.Width)
+		minSize.Height += childMin.Height
+		if addPadding {
+			minSize.Height += padding
 		}
 		addPadding = true
 	}
 	return minSize
+}
+
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*hBoxLayout)(nil)
+
+type hBoxLayout struct{}
+
+// Layout is called to pack all child objects into a specified size.
+// For a VBoxLayout this will pack objects into a single column where each item
+// is full width but the height is the minimum required.
+// Any spacers added will pad the view, sharing the space if there are two or more.
+func (g hBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	spacers := 0
+	visibleObjects := 0
+	// Size taken up by visible objects
+	total := float32(0)
+
+	for _, child := range objects {
+		if !child.Visible() {
+			continue
+		}
+
+		if isHorizontalSpacer(child) {
+			spacers++
+			continue
+		}
+
+		visibleObjects++
+		total += child.MinSize().Width
+	}
+
+	padding := theme.Padding()
+
+	// Amount of space not taken up by visible objects and inter-object padding
+	extra := size.Width - total - (padding * float32(visibleObjects-1))
+
+	// Spacers split extra space equally
+	spacerSize := float32(0)
+	if spacers > 0 {
+		spacerSize = extra / float32(spacers)
+	}
+
+	x, y := float32(0), float32(0)
+	for _, child := range objects {
+		if !child.Visible() {
+			continue
+		}
+
+		if isHorizontalSpacer(child) {
+			x += spacerSize
+			continue
+		}
+		child.Move(fyne.NewPos(x, y))
+
+		width := child.MinSize().Width
+		x += padding + width
+		child.Resize(fyne.NewSize(width, size.Height))
+	}
+}
+
+// MinSize finds the smallest size that satisfies all the child objects.
+// For a BoxLayout this is the width of the widest item and the height is
+// the sum of of all children combined with padding between each.
+func (g hBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	minSize := fyne.NewSize(0, 0)
+	addPadding := false
+	padding := theme.Padding()
+	for _, child := range objects {
+		if !child.Visible() || isHorizontalSpacer(child) {
+			continue
+		}
+
+		childMin := child.MinSize()
+		minSize.Height = fyne.Max(childMin.Height, minSize.Height)
+		minSize.Width += childMin.Width
+		if addPadding {
+			minSize.Width += padding
+		}
+		addPadding = true
+	}
+	return minSize
+}
+
+func isVerticalSpacer(obj fyne.CanvasObject) bool {
+	spacer, ok := obj.(SpacerObject)
+	return ok && spacer.ExpandVertical()
+}
+
+func isHorizontalSpacer(obj fyne.CanvasObject) bool {
+	spacer, ok := obj.(SpacerObject)
+	return ok && spacer.ExpandHorizontal()
 }

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -62,7 +62,6 @@ func (g *gridLayout) countRows(objects []fyne.CanvasObject) int {
 // size is the ideal cell size and the offset is which col or row its on.
 func getLeading(size float64, offset int) float32 {
 	ret := (size + float64(theme.Padding())) * float64(offset)
-
 	return float32(ret)
 }
 
@@ -139,11 +138,19 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		minSize = minSize.Max(child.MinSize())
 	}
 
+	padding := theme.Padding()
 	if g.horizontal() {
 		minContentSize := fyne.NewSize(minSize.Width*float32(g.Cols), minSize.Height*float32(rows))
-		return minContentSize.Add(fyne.NewSize(theme.Padding()*fyne.Max(float32(g.Cols-1), 0), theme.Padding()*fyne.Max(float32(rows-1), 0)))
+		if rows == 0 {
+			return minContentSize
+		}
+
+		return minContentSize.Add(fyne.NewSize(padding*float32(g.Cols-1), padding*float32(rows-1)))
 	}
 
 	minContentSize := fyne.NewSize(minSize.Width*float32(rows), minSize.Height*float32(g.Cols))
-	return minContentSize.Add(fyne.NewSize(theme.Padding()*fyne.Max(float32(rows-1), 0), theme.Padding()*fyne.Max(float32(g.Cols-1), 0)))
+	if rows == 0 {
+		return minContentSize
+	}
+	return minContentSize.Add(fyne.NewSize(padding*float32(rows-1), padding*float32(g.Cols-1)))
 }

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -139,18 +139,23 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	}
 
 	padding := theme.Padding()
+	var primaryObjects, secondaryObjects int
 	if g.horizontal() {
-		minContentSize := fyne.NewSize(minSize.Width*float32(g.Cols), minSize.Height*float32(rows))
-		if rows == 0 {
-			return minContentSize
-		}
-
-		return minContentSize.Add(fyne.NewSize(padding*float32(g.Cols-1), padding*float32(rows-1)))
+		primaryObjects = g.Cols
+		secondaryObjects = rows
+	} else {
+		primaryObjects = rows
+		secondaryObjects = g.Cols
 	}
 
-	minContentSize := fyne.NewSize(minSize.Width*float32(rows), minSize.Height*float32(g.Cols))
+	width := minSize.Width * float32(primaryObjects)
+	height := minSize.Height * float32(secondaryObjects)
+	xpad := padding * float32(primaryObjects-1)
+	ypad := padding * float32(secondaryObjects-1)
+
+	minContentSize := fyne.NewSize(width, height)
 	if rows == 0 {
 		return minContentSize
 	}
-	return minContentSize.Add(fyne.NewSize(padding*float32(rows-1), padding*float32(g.Cols-1)))
+	return minContentSize.Add(fyne.NewSize(xpad, ypad))
 }

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -78,16 +78,17 @@ func (g *gridLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	rows := g.countRows(objects)
 
 	padding := theme.Padding()
-	padWidth := float32(g.Cols-1) * padding
-	padHeight := float32(rows-1) * padding
-	cellWidth := float64(size.Width-padWidth) / float64(g.Cols)
-	cellHeight := float64(size.Height-padHeight) / float64(rows)
 
-	if !g.horizontal() {
-		padWidth, padHeight = padHeight, padWidth
-		cellWidth = float64(size.Width-padWidth) / float64(rows)
-		cellHeight = float64(size.Height-padHeight) / float64(g.Cols)
+	primaryObjects := rows
+	secondaryObjects := g.Cols
+	if g.horizontal() {
+		primaryObjects, secondaryObjects = secondaryObjects, primaryObjects
 	}
+
+	padWidth := float32(primaryObjects-1) * padding
+	padHeight := float32(secondaryObjects-1) * padding
+	cellWidth := float64(size.Width-padWidth) / float64(primaryObjects)
+	cellHeight := float64(size.Height-padHeight) / float64(secondaryObjects)
 
 	row, col := 0, 0
 	i := 0
@@ -139,13 +140,11 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	}
 
 	padding := theme.Padding()
-	var primaryObjects, secondaryObjects int
+
+	primaryObjects := rows
+	secondaryObjects := g.Cols
 	if g.horizontal() {
-		primaryObjects = g.Cols
-		secondaryObjects = rows
-	} else {
-		primaryObjects = rows
-		secondaryObjects = g.Cols
+		primaryObjects, secondaryObjects = secondaryObjects, primaryObjects
 	}
 
 	width := minSize.Width * float32(primaryObjects)

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -149,12 +149,8 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 
 	width := minSize.Width * float32(primaryObjects)
 	height := minSize.Height * float32(secondaryObjects)
-	xpad := padding * float32(primaryObjects-1)
-	ypad := padding * float32(secondaryObjects-1)
+	xpad := padding * fyne.Max(float32(primaryObjects-1), 0)
+	ypad := padding * fyne.Max(float32(secondaryObjects-1), 0)
 
-	minContentSize := fyne.NewSize(width, height)
-	if rows == 0 {
-		return minContentSize
-	}
-	return minContentSize.Add(fyne.NewSize(xpad, ypad))
+	return fyne.NewSize(width+xpad, height+ypad)
 }

--- a/layout/paddedlayout.go
+++ b/layout/paddedlayout.go
@@ -8,14 +8,13 @@ import (
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*paddedLayout)(nil)
 
-type paddedLayout struct {
-}
+type paddedLayout struct{}
 
 // Layout is called to pack all child objects into a specified size.
 // For PaddedLayout this sets all children to the full size passed minus padding all around.
-func (l *paddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+func (l paddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	padding := theme.Padding()
-	pos := fyne.NewPos(padding, padding)
+	pos := fyne.NewSquareOffsetPos(padding)
 	siz := fyne.NewSize(size.Width-2*padding, size.Height-2*padding)
 	for _, child := range objects {
 		child.Resize(siz)
@@ -25,7 +24,7 @@ func (l *paddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 // MinSize finds the smallest size that satisfies all the child objects.
 // For PaddedLayout this is determined simply as the MinSize of the largest child plus padding all around.
-func (l *paddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
+func (l paddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
 	for _, child := range objects {
 		if !child.Visible() {
 			continue
@@ -41,5 +40,5 @@ func (l *paddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
 //
 // Since: 1.4
 func NewPaddedLayout() fyne.Layout {
-	return &paddedLayout{}
+	return paddedLayout{}
 }

--- a/layout/stacklayout.go
+++ b/layout/stacklayout.go
@@ -6,8 +6,7 @@ import "fyne.io/fyne/v2"
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*stackLayout)(nil)
 
-type stackLayout struct {
-}
+type stackLayout struct{}
 
 // NewStackLayout returns a new StackLayout instance. Objects are stacked
 // on top of each other with later objects on top of those before.

--- a/layout/stacklayout.go
+++ b/layout/stacklayout.go
@@ -16,7 +16,7 @@ type stackLayout struct {
 //
 // Since: 2.4
 func NewStackLayout() fyne.Layout {
-	return &stackLayout{}
+	return stackLayout{}
 }
 
 // NewMaxLayout creates a new MaxLayout instance
@@ -28,7 +28,7 @@ func NewMaxLayout() fyne.Layout {
 
 // Layout is called to pack all child objects into a specified size.
 // For StackLayout this sets all children to the full size passed.
-func (m *stackLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+func (m stackLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	topLeft := fyne.NewPos(0, 0)
 	for _, child := range objects {
 		child.Resize(size)
@@ -38,7 +38,7 @@ func (m *stackLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 // MinSize finds the smallest size that satisfies all the child objects.
 // For StackLayout this is determined simply as the MinSize of the largest child.
-func (m *stackLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+func (m stackLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	minSize := fyne.NewSize(0, 0)
 	for _, child := range objects {
 		if !child.Visible() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR cleans up and improves various parts of layouts for more readable and faster code.

More specifically, it breaks VBox and HBox up into two types instead of one. This does introduce some partial code duplication but it does cut down on allocation for each struct, reduces branching in all MinSize and Layout calls and I do think that the lowerred amount of indentation (from removed if-statements) does make the code more readable. On top of this, I also optimized the isSeparator() call to not check object visibility twice (already checked before the function is called) and it can mow be inlined for improved performance.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.