### PR TITLE
Don't fire callback inside locks, fixes #4516

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -846,11 +846,12 @@ func (e *Entry) cutToClipboard(clipboard fyne.Clipboard) {
 
 	e.copyToClipboard(clipboard)
 	e.setFieldsAndRefresh(e.eraseSelection)
-	e.propertyLock.Lock()
+	e.propertyLock.RLock()
+	content := e.Text
+	e.propertyLock.RUnlock()
 	if e.OnChanged != nil {
-		e.OnChanged(e.Text)
+		e.OnChanged(content)
 	}
-	e.propertyLock.Unlock()
 	e.Validate()
 }
 
@@ -1092,11 +1093,13 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 	case fyne.KeyBackspace, fyne.KeyDelete:
 		// clears the selection -- return handled
 		e.setFieldsAndRefresh(e.eraseSelection)
-		e.propertyLock.Lock()
+
+		e.propertyLock.RLock()
+		content := e.Text
+		e.propertyLock.RUnlock()
 		if e.OnChanged != nil {
-			e.OnChanged(e.Text)
+			e.OnChanged(content)
 		}
-		e.propertyLock.Unlock()
 		e.Validate()
 		return true
 	case fyne.KeyReturn, fyne.KeyEnter:

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1093,7 +1093,6 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 	case fyne.KeyBackspace, fyne.KeyDelete:
 		// clears the selection -- return handled
 		e.setFieldsAndRefresh(e.eraseSelection)
-
 		e.propertyLock.RLock()
 		content := e.Text
 		e.propertyLock.RUnlock()

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -283,6 +283,21 @@ func TestEntry_EraseSelection(t *testing.T) {
 	assert.Equal(t, -1, b)
 }
 
+func TestEntry_CallbackLocking(t *testing.T) {
+	e := &Entry{}
+	called := 0
+	e.OnChanged = func(_ string) {
+		e.propertyLock.Lock()
+		called++ // Just to not have an empty critical section.
+		e.propertyLock.Unlock()
+	}
+
+	test.Type(e, "abc123")
+	e.selectAll()
+	e.TypedKey(&fyne.KeyEvent{Name: fyne.KeyBackspace})
+	assert.Equal(t, 7, called)
+}
+
 func TestEntry_MouseClickAndDragOutsideText(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("A\nB\n")


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This makes sure that we are not calling `OnChanged` when holding locks.
It should fix more cases of deadlock than just reported in the issue.

Fixes #4516

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
