### PR TITLE
Make staticcheck checks more agressive

### DIFF
--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -653,21 +653,21 @@ func TestCreateNewFolderInDir(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(inputPopup)
 	assert.NotNil(t, inputPopup)
 
-	folderNameInputUi := inputPopup.Content.(*fyne.Container)
+	folderNameInputUI := inputPopup.Content.(*fyne.Container)
 
-	folderNameInputTitle := folderNameInputUi.Objects[4].(*widget.Label)
+	folderNameInputTitle := folderNameInputUI.Objects[4].(*widget.Label)
 	assert.Equal(t, "New Folder", folderNameInputTitle.Text)
 
-	folderNameInputLabel := folderNameInputUi.Objects[2].(*widget.Form).Items[0].Text
+	folderNameInputLabel := folderNameInputUI.Objects[2].(*widget.Form).Items[0].Text
 	assert.Equal(t, "Name", folderNameInputLabel)
 
-	folderNameInputEntry := folderNameInputUi.Objects[2].(*widget.Form).Items[0].Widget.(*widget.Entry)
+	folderNameInputEntry := folderNameInputUI.Objects[2].(*widget.Form).Items[0].Widget.(*widget.Entry)
 	assert.Equal(t, "", folderNameInputEntry.Text)
 
-	folderNameInputCancel := folderNameInputUi.Objects[3].(*fyne.Container).Objects[0].(*widget.Button)
+	folderNameInputCancel := folderNameInputUI.Objects[3].(*fyne.Container).Objects[0].(*widget.Button)
 	assert.Equal(t, "Cancel", folderNameInputCancel.Text)
 	assert.Equal(t, theme.CancelIcon(), folderNameInputCancel.Icon)
 
-	folderNameInputCreate := folderNameInputUi.Objects[3].(*fyne.Container).Objects[1].(*widget.Button)
+	folderNameInputCreate := folderNameInputUI.Objects[3].(*fyne.Container).Objects[1].(*widget.Button)
 	assert.Equal(t, theme.ConfirmIcon(), folderNameInputCreate.Icon)
 }

--- a/internal/async/chan_go1.21.go
+++ b/internal/async/chan_go1.21.go
@@ -8,7 +8,7 @@ import "fyne.io/fyne/v2"
 // Func objects. A channel must be closed via Close method
 type UnboundedFuncChan = UnboundedChan[func()]
 
-// NewUnboundedInterfaceChan returns a unbounded channel, of func(), with unlimited capacity.
+// NewUnboundedFuncChan returns a unbounded channel, of func(), with unlimited capacity.
 func NewUnboundedFuncChan() *UnboundedFuncChan {
 	return NewUnboundedChan[func()]()
 }
@@ -31,7 +31,7 @@ func NewUnboundedCanvasObjectChan() *UnboundedChan[fyne.CanvasObject] {
 	return NewUnboundedChan[fyne.CanvasObject]()
 }
 
-// UnboundedFuncChan is a channel with an unbounded buffer for caching
+// UnboundedChan is a channel with an unbounded buffer for caching
 // Func objects. A channel must be closed via Close method.
 type UnboundedChan[T any] struct {
 	in, out chan T
@@ -39,7 +39,7 @@ type UnboundedChan[T any] struct {
 	q       []T
 }
 
-// NewUnboundedFuncChan returns a unbounded channel with unlimited capacity.
+// NewUnboundedChan returns a unbounded channel with unlimited capacity.
 func NewUnboundedChan[T any]() *UnboundedChan[T] {
 	ch := &UnboundedChan[T]{
 		// The size of Func, Interface, and CanvasObject are all less than 16 bytes, we use 16 to fit

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,1 +1,1 @@
-checks = ["inherit", "-SA1019"]
+checks = ["inherit", "-SA1019", "ST1003", "ST1016", "ST1020", "ST1021", "ST1022"]

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -524,7 +524,7 @@ func (e *Entry) SetText(text string) {
 	e.propertyLock.Unlock()
 }
 
-// Appends the text to the end of the entry
+// Append appends the text to the end of the entry.
 //
 // Since: 2.4
 func (e *Entry) Append(text string) {

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -94,7 +94,7 @@ func (s *Slider) DragEnd() {
 	}
 }
 
-// DragEnd is called when a drag event occurs.
+// Dragged is called when a drag event occurs.
 func (s *Slider) Dragged(e *fyne.DragEvent) {
 	if s.disabled {
 		return


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Poorly chosen identifiers, consistent receiver names in struct methods, and exported APIs should have comments beginning with type name. These are the checks that now are running as well.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
