### PR TITLE
Fix possible crash in atomic function pointers

### DIFF
--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -51,7 +51,7 @@ func (l *Lifecycle) SetOnStopped(f func()) {
 // TriggerEnteredForeground will call the focus gained hook, if one is registered.
 func (l *Lifecycle) TriggerEnteredForeground() {
 	f := l.onForeground.Load()
-	if f == nil {
+	if f == nil || *f == nil {
 		return
 	}
 
@@ -61,7 +61,7 @@ func (l *Lifecycle) TriggerEnteredForeground() {
 // TriggerExitedForeground will call the focus lost hook, if one is registered.
 func (l *Lifecycle) TriggerExitedForeground() {
 	f := l.onBackground.Load()
-	if f == nil {
+	if f == nil || *f == nil {
 		return
 	}
 
@@ -71,7 +71,7 @@ func (l *Lifecycle) TriggerExitedForeground() {
 // TriggerStarted will call the started hook, if one is registered.
 func (l *Lifecycle) TriggerStarted() {
 	f := l.onStarted.Load()
-	if f == nil {
+	if f == nil || *f == nil {
 		return
 	}
 
@@ -82,7 +82,7 @@ func (l *Lifecycle) TriggerStarted() {
 // and an internal stopped hook after that.
 func (l *Lifecycle) TriggerStopped() {
 	f := l.onStopped.Load()
-	if f != nil {
+	if f != nil && *f != nil {
 		(*f)()
 	}
 

--- a/internal/app/lifecycle_test.go
+++ b/internal/app/lifecycle_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLifecycle(t *testing.T) {
+	life := &Lifecycle{}
+
+	// Not setting anything should not panic.
+	assert.NotPanics(t, life.TriggerEnteredForeground)
+	assert.NotPanics(t, life.TriggerExitedForeground)
+	assert.NotPanics(t, life.TriggerStarted)
+	assert.NotPanics(t, life.TriggerStopped)
+
+	var entered, exited, start, stop, hookedStop bool
+	life.SetOnEnteredForeground(func() { entered = true })
+	life.TriggerEnteredForeground()
+	assert.True(t, entered)
+
+	life.SetOnExitedForeground(func() { exited = true })
+	life.TriggerExitedForeground()
+	assert.True(t, exited)
+
+	life.SetOnStarted(func() { start = true })
+	life.TriggerStarted()
+	assert.True(t, start)
+
+	life.SetOnStopped(func() { stop = true })
+	life.TriggerStopped()
+	assert.True(t, stop)
+
+	stop = false
+	life.SetOnStoppedHookExecuted(func() { hookedStop = true })
+	life.TriggerStopped()
+	assert.True(t, stop && hookedStop)
+
+	// Setting back to nil should not panic.
+	life.SetOnEnteredForeground(nil)
+	life.SetOnExitedForeground(nil)
+	life.SetOnStarted(nil)
+	life.SetOnStopped(nil)
+	life.SetOnStoppedHookExecuted(nil)
+
+	assert.NotPanics(t, life.TriggerEnteredForeground)
+	assert.NotPanics(t, life.TriggerExitedForeground)
+	assert.NotPanics(t, life.TriggerStarted)
+	assert.NotPanics(t, life.TriggerStopped)
+}

--- a/widget/bind_helper.go
+++ b/widget/bind_helper.go
@@ -20,7 +20,7 @@ type basicBinder struct {
 func (binder *basicBinder) Bind(data binding.DataItem) {
 	listener := binding.NewDataListener(func() { // NB: listener captures `data` but always calls the up-to-date callback
 		f := binder.callback.Load()
-		if f == nil {
+		if f == nil || *f == nil {
 			return
 		}
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes a few cases where we could crash due to two sources of nil.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
