### PR TITLE
Check widget: Only respond to hover and tap over the checkbox or label

### DIFF
--- a/widget/check.go
+++ b/widget/check.go
@@ -112,14 +112,11 @@ func (c *Check) MouseMoved(me *desktop.MouseEvent) {
 	}
 
 	oldHovered := c.hovered
-	if c.minSize.Width == 0 && c.minSize.Height == 0 {
-		c.hovered = true
-	} else if me.Position.X <= c.minSize.Width && me.Position.Y <= c.minSize.Height {
-		c.hovered = true
-	} else {
-		// mouse outside the active area of the widget
-		c.hovered = false
-	}
+
+	// only hovered if cached minSize has not been initialized (test code)
+	// or the pointer is within the "active" area of the widget (its minSize)
+	c.hovered = c.minSize.IsZero() ||
+		(me.Position.X <= c.minSize.Width && me.Position.Y <= c.minSize.Height)
 
 	if oldHovered != c.hovered {
 		c.Refresh()
@@ -131,7 +128,7 @@ func (c *Check) Tapped(pe *fyne.PointEvent) {
 	if c.Disabled() {
 		return
 	}
-	if c.minSize.Height > 0 && c.minSize.Width > 0 &&
+	if !c.minSize.IsZero() &&
 		(pe.Position.X > c.minSize.Width || pe.Position.Y > c.minSize.Height) {
 		// tapped outside the active area of the widget
 		return

--- a/widget/check_internal_test.go
+++ b/widget/check_internal_test.go
@@ -210,6 +210,38 @@ func TestCheck_Hovered(t *testing.T) {
 	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
 }
 
+func TestCheck_HoveredOutsideActiveArea(t *testing.T) {
+	check := NewCheck("Test", func(on bool) {})
+	w := test.NewWindow(check)
+	defer w.Close()
+	render := test.WidgetRenderer(check).(*checkRenderer)
+
+	check.SetChecked(true)
+	assert.False(t, check.hovered)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
+
+	ms := check.MinSize()
+	check.MouseIn(&desktop.MouseEvent{PointEvent: fyne.PointEvent{
+		Position: fyne.NewPos(ms.Width+2, 1),
+	}})
+	assert.False(t, check.hovered)
+	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
+}
+
+func TestCheck_TappedOutsideActiveArea(t *testing.T) {
+	check := NewCheck("Test", func(on bool) {})
+	w := test.NewWindow(check)
+	defer w.Close()
+
+	check.SetChecked(true)
+
+	ms := check.MinSize()
+	check.Tapped(&fyne.PointEvent{
+		Position: fyne.NewPos(ms.Width+2, 1),
+	})
+	assert.True(t, check.Checked)
+}
+
 func TestCheck_TypedRune(t *testing.T) {
 	check := NewCheck("Test", func(on bool) {})
 	w := test.NewWindow(check)


### PR DESCRIPTION
### Description:

Fixes #4527, related to #4320 

Updates the Check widget to only respond to hover and tap events over either the checkbox or the label area of the widget. If the widget is wider or taller because it is placed in a container that maximizes its size, ignore events outside the "active" area of the widget.

The first commit of this PR just reordered the functions in `check.go` in a way that made more sense (resulting in an inflated line count diff relative to the actual code change). To review, you may wish to only look at the second commit.

Note: the behavior can be tested with fyne_demo. Before this change the check widget could be toggled by tapping far to the right, well beyond the end of the label. With the behavior, tapping/hovering in that area of the widget (which intuitively to the user is not part of the widget at all) does nothing

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
