### PR TITLE
Allow tapped events with mouse movement to reach underlying widgets in Scroll

### DIFF
--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -55,7 +55,6 @@ func (r *scrollBarRenderer) Refresh() {
 }
 
 var _ desktop.Hoverable = (*scrollBar)(nil)
-var _ fyne.Draggable = (*scrollBar)(nil)
 
 type scrollBar struct {
 	Base
@@ -400,21 +399,6 @@ func (s *Scroll) ScrollToBottom() {
 // ScrollToTop will scroll content to container top
 func (s *Scroll) ScrollToTop() {
 	s.scrollBy(0, -s.Offset.Y)
-}
-
-// DragEnd will stop scrolling on mobile has stopped
-func (s *Scroll) DragEnd() {
-}
-
-// Dragged will scroll on any drag - bar or otherwise - for mobile
-func (s *Scroll) Dragged(e *fyne.DragEvent) {
-	if !fyne.CurrentDevice().IsMobile() {
-		return
-	}
-
-	if s.updateOffset(e.Dragged.DX, e.Dragged.DY) {
-		s.refreshWithoutOffsetUpdate()
-	}
 }
 
 // MinSize returns the smallest size this widget can shrink to


### PR DESCRIPTION
### Description:
Remove Draggable interface from internal/widget/scroll to ensure that it won't unnecessarily swallow tap events if the mouse moves during the tap. Scrolling for mobile has been handled by the driver directly for awhile so the Draggable interface for mobile was redundant.

Fixes #4384 

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
