### PR TITLE
Update canvas.go - Length check added to fix panic out of range

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -582,8 +582,10 @@ func (o *overlayStack) add(overlay fyne.CanvasObject) {
 func (o *overlayStack) remove(overlay fyne.CanvasObject) {
 	o.OverlayStack.Remove(overlay)
 	overlayCount := len(o.List())
-	o.renderCaches[overlayCount] = nil // release memory reference to removed element
-	o.renderCaches = o.renderCaches[:overlayCount]
+	if len(o.renderCaches) > overlayCount {
+		o.renderCaches[overlayCount] = nil // release memory reference to removed element
+		o.renderCaches = o.renderCaches[:overlayCount]
+	}
 }
 
 type renderCacheTree struct {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses. --> 
I recently started using PopUp messages in my app, and in a specific scenario, I encountered a panic due to an index out of range error when using a PopUp simultaneously with a Dialog in the same window.

The fix is simple. Despite the questionable usage of PopUps and Dialogs in this particular case, I believe that adding a length check contributes to stability improvement.

#### Panic message:
panic: runtime error: index out of range [1] with length 1

goroutine 27 [running]:
fyne.io/fyne/v2/internal/driver/common.(*overlayStack).remove(0xc002a8f710, {0x7ff676ac6118, 0xc00bb8a900})
	C:/Users/Agustin/go/pkg/mod/fyne.io/fyne/v2@v2.4.3/internal/driver/common/canvas.go:585 +0xd7
fyne.io/fyne/v2/internal/driver/common.(*overlayStack).Remove(0xc002a8f710, {0x7ff676ac6118, 0xc00bb8a900})
	C:/Users/Agustin/go/pkg/mod/fyne.io/fyne/v2@v2.4.3/internal/driver/common/canvas.go:574 +0x12e
fyne.io/fyne/v2/widget.(*PopUp).Hide(0xc00bb8a900)
	C:/Users/Agustin/go/pkg/mod/fyne.io/fyne/v2@v2.4.3/widget/popup.go:28 +0x56

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
