### PR TITLE
Improve performance when creating progressbar renderers

### DIFF
--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var globalProgressRenderer fyne.WidgetRenderer
+
+func BenchmarkProgressbar(b *testing.B) {
+	var renderer fyne.WidgetRenderer
+	widget := &ProgressBar{}
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		renderer = widget.CreateRenderer()
+	}
+
+	// Avoid having the value optimized out by the compiler.
+	globalProgressRenderer = renderer
+}
+
 func TestNewProgressBarWithData(t *testing.T) {
 	val := binding.NewFloat()
 	val.Set(0.4)

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -19,8 +19,8 @@ const (
 
 type infProgressRenderer struct {
 	widget.BaseRenderer
-	background, bar *canvas.Rectangle
-	animation       *fyne.Animation
+	background, bar canvas.Rectangle
+	animation       fyne.Animation
 	running         bool
 	progress        *ProgressBarInfinite
 }
@@ -52,7 +52,7 @@ func (p *infProgressRenderer) updateBar(done float32) {
 
 	p.bar.Resize(barSize)
 	p.bar.Move(barPos)
-	canvas.Refresh(p.bar)
+	canvas.Refresh(&p.bar)
 }
 
 // Layout the components of the infinite progress bar
@@ -65,11 +65,13 @@ func (p *infProgressRenderer) Refresh() {
 	if p.isRunning() {
 		return // we refresh from the goroutine
 	}
+	cornerRadius := theme.InputRadiusSize()
+	primaryColor := theme.PrimaryColor()
 
-	p.background.FillColor = progressBackgroundColor()
-	p.background.CornerRadius = theme.InputRadiusSize()
-	p.bar.FillColor = theme.PrimaryColor()
-	p.bar.CornerRadius = theme.InputRadiusSize()
+	p.background.FillColor = progressBlendColor(primaryColor)
+	p.background.CornerRadius = cornerRadius
+	p.bar.FillColor = primaryColor
+	p.bar.CornerRadius = cornerRadius
 	p.background.Refresh()
 	p.bar.Refresh()
 	canvas.Refresh(p.progress.super())
@@ -90,7 +92,8 @@ func (p *infProgressRenderer) start() {
 
 	p.progress.propertyLock.Lock()
 	defer p.progress.propertyLock.Unlock()
-	p.animation = fyne.NewAnimation(time.Second*3, p.updateBar)
+	p.animation.Duration = time.Second * 3
+	p.animation.Tick = p.updateBar
 	p.animation.Curve = fyne.AnimationLinear
 	p.animation.RepeatCount = fyne.AnimationRepeatForever
 	p.running = true
@@ -157,16 +160,24 @@ func (p *ProgressBarInfinite) MinSize() fyne.Size {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 	p.ExtendBaseWidget(p)
-	background := canvas.NewRectangle(progressBackgroundColor())
-	background.CornerRadius = theme.InputRadiusSize()
-	bar := canvas.NewRectangle(theme.PrimaryColor())
-	bar.CornerRadius = theme.InputRadiusSize()
+
+	primaryColor := theme.PrimaryColor()
+	cornerRadius := theme.InputRadiusSize()
+
 	render := &infProgressRenderer{
-		BaseRenderer: widget.NewBaseRenderer([]fyne.CanvasObject{background, bar}),
-		background:   background,
-		bar:          bar,
-		progress:     p,
+		background: canvas.Rectangle{
+			FillColor:    progressBlendColor(primaryColor),
+			CornerRadius: cornerRadius,
+		},
+		bar: canvas.Rectangle{
+			FillColor:    primaryColor,
+			CornerRadius: cornerRadius,
+		},
+		progress: p,
 	}
+
+	render.SetObjects([]fyne.CanvasObject{&render.background, &render.bar})
+
 	render.start()
 	return render
 }

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var globalProgressInfRenderer fyne.WidgetRenderer
+
+func BenchmarkProgressbarInf(b *testing.B) {
+	var renderer fyne.WidgetRenderer
+	widget := &ProgressBarInfinite{}
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		renderer = widget.CreateRenderer()
+	}
+
+	// Avoid having the value optimized out by the compiler.
+	globalProgressInfRenderer = renderer
+}
+
 func TestProgressBarInfinite_Creation(t *testing.T) {
 	bar := NewProgressBarInfinite()
 	// ticker should start automatically


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Around a 30+% performance improvement generally. Caches some icon values and allocates the canvas objects inline into the outer struct instead of allocating them in multiple places. We cal likely apply similar changes in many more places and avoid allocating the struct in one place and then allocate each canvas object in a different place. Less for the GC to handle and we run less of a risk for nil pointer de-references.

Benchstat output over 10 runs:
```
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
                 │   old.txt   │               new.txt               │
                 │   sec/op    │   sec/op     vs base                │
Progressbar-8      491.7n ± 5%   287.4n ± 3%  -41.55% (p=0.000 n=10)
ProgressbarInf-8   491.8n ± 6%   392.5n ± 2%  -20.21% (p=0.000 n=10)
geomean            491.8n        335.8n       -31.71%

                 │  old.txt   │              new.txt               │
                 │    B/op    │    B/op     vs base                │
Progressbar-8      452.0 ± 0%   420.0 ± 0%   -7.08% (p=0.000 n=10)
ProgressbarInf-8   452.0 ± 0%   356.0 ± 0%  -21.24% (p=0.000 n=10)
geomean            452.0        386.7       -14.45%

                 │  old.txt   │              new.txt               │
                 │ allocs/op  │ allocs/op   vs base                │
Progressbar-8      7.000 ± 0%   4.000 ± 0%  -42.86% (p=0.000 n=10)
ProgressbarInf-8   7.000 ± 0%   5.000 ± 0%  -28.57% (p=0.000 n=10)
geomean            7.000        4.472       -36.11%
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
