### PR TITLE
Optimize radio item renderer to be created 50% faster

### DIFF
--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -37,19 +37,8 @@ type radioItem struct {
 //
 // Implements: fyne.Widget
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
-	focusIndicator := canvas.NewCircle(color.Transparent)
-	icon := canvas.NewImageFromResource(theme.RadioButtonFillIcon())
-	over := canvas.NewImageFromResource(theme.NewThemedResource(theme.RadioButtonIcon()))
-	label := canvas.NewText(i.Label, theme.ForegroundColor())
-	label.Alignment = fyne.TextAlignLeading
-	r := &radioItemRenderer{
-		BaseRenderer:   widget.NewBaseRenderer([]fyne.CanvasObject{focusIndicator, icon, over, label}),
-		focusIndicator: focusIndicator,
-		icon:           icon,
-		over:           over,
-		item:           i,
-		label:          label,
-	}
+	r := &radioItemRenderer{item: i, label: canvas.Text{Alignment: fyne.TextAlignLeading}}
+	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, &r.label})
 	r.update()
 	return r
 }
@@ -149,11 +138,11 @@ func (i *radioItem) toggle() {
 
 type radioItemRenderer struct {
 	widget.BaseRenderer
+	item *radioItem
 
-	focusIndicator *canvas.Circle
-	icon, over     *canvas.Image
-	item           *radioItem
-	label          *canvas.Text
+	focusIndicator canvas.Circle
+	icon, over     canvas.Image
+	label          canvas.Text
 }
 
 func (r *radioItemRenderer) Layout(size fyne.Size) {
@@ -191,10 +180,11 @@ func (r *radioItemRenderer) Refresh() {
 
 func (r *radioItemRenderer) update() {
 	r.label.Text = r.item.Label
-	r.label.Color = theme.ForegroundColor()
 	r.label.TextSize = theme.TextSize()
 	if r.item.Disabled() {
 		r.label.Color = theme.DisabledColor()
+	} else {
+		r.label.Color = theme.ForegroundColor()
 	}
 
 	out := theme.NewThemedResource(theme.RadioButtonIcon())

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var globalRadioRenderer fyne.WidgetRenderer
+
+func BenchmarkRadioCreateRenderer(b *testing.B) {
+	var renderer fyne.WidgetRenderer
+	widget := &radioItem{}
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		renderer = widget.CreateRenderer()
+	}
+
+	// Avoid having the value optimized out by the compiler.
+	globalRadioRenderer = renderer
+}
+
 func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
 	item := newRadioItem("Hello", nil)
 	render := test.WidgetRenderer(item).(*radioItemRenderer)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Instead of allocating one struct for the renderer and one struct for each canvas object that is part of the renderer, we can embed the types into the renderer and just allocate the larger struct once. This makes for less allocations but we are also theoretically helping the processor cache by keeping the items closer together in memory instead of in different locations. I also made sure to avoid setting a few fields twice. Doing this makes the code not only cleaner but also almost 50% faster (likely due to fewer allocations but using the fields later on might also be faster) for creating the renderer.

```
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
                      │   old.txt   │               new.txt               │
                      │   sec/op    │   sec/op     vs base                │
RadioCreateRenderer-8   664.0n ± 2%   351.4n ± 2%  -47.09% (p=0.000 n=10)

                      │  old.txt   │              new.txt              │
                      │    B/op    │    B/op     vs base               │
RadioCreateRenderer-8   736.0 ± 0%   704.0 ± 0%  -4.35% (p=0.000 n=10)

                      │  old.txt   │              new.txt               │
                      │ allocs/op  │ allocs/op   vs base                │
RadioCreateRenderer-8   9.000 ± 0%   4.000 ± 0%  -55.56% (p=0.000 n=10)
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

