### PR TITLE
Unwrap multiple layers of themed resources

### DIFF
--- a/theme/icons.go
+++ b/theme/icons.go
@@ -659,7 +659,7 @@ func (res *ThemedResource) Name() string {
 		prefix += "_"
 	}
 
-	return string(prefix) + res.source.Name()
+	return string(prefix) + unwrapResource(res.source).Name()
 }
 
 // Content returns the underlying content of the resource adapted to the current text color.
@@ -669,7 +669,7 @@ func (res *ThemedResource) Content() []byte {
 		name = ColorNameForeground
 	}
 
-	return svg.Colorize(res.source.Content(), safeColorLookup(name, currentVariant()))
+	return svg.Colorize(unwrapResource(res.source).Content(), safeColorLookup(name, currentVariant()))
 }
 
 // Error returns a different resource for indicating an error.
@@ -691,13 +691,13 @@ func NewInvertedThemedResource(orig fyne.Resource) *InvertedThemedResource {
 
 // Name returns the underlying resource name (used for caching).
 func (res *InvertedThemedResource) Name() string {
-	return "inverted_" + res.source.Name()
+	return "inverted_" + unwrapResource(res.source).Name()
 }
 
 // Content returns the underlying content of the resource adapted to the current background color.
 func (res *InvertedThemedResource) Content() []byte {
 	clr := BackgroundColor()
-	return svg.Colorize(res.source.Content(), clr)
+	return svg.Colorize(unwrapResource(res.source).Content(), clr)
 }
 
 // Original returns the underlying resource that this inverted themed resource was adapted from
@@ -719,12 +719,12 @@ func NewErrorThemedResource(orig fyne.Resource) *ErrorThemedResource {
 
 // Name returns the underlying resource name (used for caching).
 func (res *ErrorThemedResource) Name() string {
-	return "error_" + res.source.Name()
+	return "error_" + unwrapResource(res.source).Name()
 }
 
 // Content returns the underlying content of the resource adapted to the current background color.
 func (res *ErrorThemedResource) Content() []byte {
-	return svg.Colorize(res.source.Content(), ErrorColor())
+	return svg.Colorize(unwrapResource(res.source).Content(), ErrorColor())
 }
 
 // Original returns the underlying resource that this error themed resource was adapted from
@@ -746,12 +746,12 @@ func NewPrimaryThemedResource(orig fyne.Resource) *PrimaryThemedResource {
 
 // Name returns the underlying resource name (used for caching).
 func (res *PrimaryThemedResource) Name() string {
-	return "primary_" + res.source.Name()
+	return "primary_" + unwrapResource(res.source).Name()
 }
 
 // Content returns the underlying content of the resource adapted to the current background color.
 func (res *PrimaryThemedResource) Content() []byte {
-	return svg.Colorize(res.source.Content(), PrimaryColor())
+	return svg.Colorize(unwrapResource(res.source).Content(), PrimaryColor())
 }
 
 // Original returns the underlying resource that this primary themed resource was adapted from
@@ -767,12 +767,12 @@ type DisabledResource struct {
 
 // Name returns the resource source name prefixed with `disabled_` (used for caching)
 func (res *DisabledResource) Name() string {
-	return "disabled_" + res.source.Name()
+	return "disabled_" + unwrapResource(res.source).Name()
 }
 
 // Content returns the disabled style content of the correct resource for the current theme
 func (res *DisabledResource) Content() []byte {
-	return svg.Colorize(res.source.Content(), DisabledColor())
+	return svg.Colorize(unwrapResource(res.source).Content(), DisabledColor())
 }
 
 // NewDisabledResource creates a resource that adapts to the current theme's DisabledColor setting.
@@ -1275,4 +1275,24 @@ func safeIconLookup(n fyne.ThemeIconName) fyne.Resource {
 		return fallbackIcon
 	}
 	return icon
+}
+
+// recursively "unwraps" the source of the given resource to extract
+// the "base" resource - to avoid recolorizing SVG multiple times
+// if we for example have a ThemedResource wrapped in an ErrorThemedResource
+func unwrapResource(res fyne.Resource) fyne.Resource {
+	switch res := res.(type) {
+	case *DisabledResource:
+		return unwrapResource(res.source)
+	case *ErrorThemedResource:
+		return unwrapResource(res.source)
+	case *InvertedThemedResource:
+		return unwrapResource(res.source)
+	case *PrimaryThemedResource:
+		return unwrapResource(res.source)
+	case *ThemedResource:
+		return unwrapResource(res.source)
+	default:
+		return res
+	}
 }

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -1305,18 +1305,20 @@ func safeIconLookup(n fyne.ThemeIconName) fyne.Resource {
 // the "base" resource - to avoid recolorizing SVG multiple times
 // if we for example have a ThemedResource wrapped in an ErrorThemedResource
 func unwrapResource(res fyne.Resource) fyne.Resource {
-	switch res := res.(type) {
-	case *DisabledResource:
-		return unwrapResource(res.source)
-	case *ErrorThemedResource:
-		return unwrapResource(res.source)
-	case *InvertedThemedResource:
-		return unwrapResource(res.source)
-	case *PrimaryThemedResource:
-		return unwrapResource(res.source)
-	case *ThemedResource:
-		return unwrapResource(res.source)
-	default:
-		return res
+	for {
+		switch typedRes := res.(type) {
+		case *DisabledResource:
+			res = typedRes.source
+		case *ErrorThemedResource:
+			res = typedRes.source
+		case *InvertedThemedResource:
+			res = typedRes.source
+		case *PrimaryThemedResource:
+			res = typedRes.source
+		case *ThemedResource:
+			res = typedRes.source
+		default:
+			return res
+		}
 	}
 }

--- a/theme/icons_test.go
+++ b/theme/icons_test.go
@@ -462,3 +462,21 @@ func Test_GridIcon_FileSource(t *testing.T) {
 	result := GridIcon().Name()
 	assert.Equal(t, "foreground_grid.svg", result)
 }
+
+func Test_UnwrapResource(t *testing.T) {
+	source := helperNewStaticResource()
+	res := NewThemedResource(
+		NewErrorThemedResource(
+			NewInvertedThemedResource(
+				NewDisabledResource(source),
+			),
+		),
+	)
+
+	// check that resource name only has the top-level themed prefix
+	assert.Equal(t, "foreground_content-remove.svg", res.Name())
+
+	unwrapped := unwrapResource(res)
+	_, ok := unwrapped.(*fyne.StaticResource)
+	assert.True(t, ok, "unwrap did not return base resource type")
+}

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"fmt"
 	"image/color"
+	"strings"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -78,7 +79,7 @@ func TestButton_DisabledIcon(t *testing.T) {
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
 
 	button.Disable()
-	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", theme.CancelIcon().Name()))
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
 
 	button.Enable()
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
@@ -91,7 +92,7 @@ func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 
 	// assert we are using the disabled original icon
 	button.Disable()
-	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", theme.CancelIcon().Name()))
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
 
 	// re-enable, then change the icon
 	button.Enable()
@@ -100,8 +101,7 @@ func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 
 	// assert we are using the disabled new icon
 	button.Disable()
-	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", theme.SearchIcon().Name()))
-
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
 }
 
 func TestButton_DisabledIconChangedDirectly(t *testing.T) {

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -92,7 +92,8 @@ func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 
 	// assert we are using the disabled original icon
 	button.Disable()
-	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
+	cancelBaseName := strings.TrimPrefix(theme.CancelIcon().Name(), "foreground_")
+	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", cancelBaseName))
 
 	// re-enable, then change the icon
 	button.Enable()
@@ -101,7 +102,9 @@ func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 
 	// assert we are using the disabled new icon
 	button.Disable()
-	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
+	searchBaseName := strings.TrimPrefix(theme.SearchIcon().Name(), "foreground_")
+	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", searchBaseName))
+
 }
 
 func TestButton_DisabledIconChangedDirectly(t *testing.T) {
@@ -111,7 +114,8 @@ func TestButton_DisabledIconChangedDirectly(t *testing.T) {
 
 	// assert we are using the disabled original icon
 	button.Disable()
-	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", theme.CancelIcon().Name()))
+	cancelBaseName := strings.TrimPrefix(theme.CancelIcon().Name(), "foreground_")
+	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", cancelBaseName))
 
 	// re-enable, then change the icon
 	button.Enable()
@@ -121,7 +125,8 @@ func TestButton_DisabledIconChangedDirectly(t *testing.T) {
 
 	// assert we are using the disabled new icon
 	button.Disable()
-	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", theme.SearchIcon().Name()))
+	searchBaseName := strings.TrimPrefix(theme.SearchIcon().Name(), "foreground_")
+	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", searchBaseName))
 
 }
 

--- a/widget/check_internal_test.go
+++ b/widget/check_internal_test.go
@@ -1,8 +1,8 @@
 package widget
 
 import (
-	"fmt"
 	"image/color"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,19 +47,19 @@ func TestCheck_DisabledWhenChecked(t *testing.T) {
 	check.SetChecked(true)
 	render := test.WidgetRenderer(check).(*checkRenderer)
 
-	assert.Equal(t, fmt.Sprintf("primary_%v", theme.CheckButtonCheckedIcon().Name()), render.icon.Resource.Name())
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "primary_"))
 
 	check.Disable()
-	assert.Equal(t, fmt.Sprintf("disabled_%v", theme.CheckButtonCheckedIcon().Name()), render.icon.Resource.Name())
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
 }
 
 func TestCheck_DisabledWhenUnchecked(t *testing.T) {
 	check := NewCheck("Hi", nil)
 	render := test.WidgetRenderer(check).(*checkRenderer)
-	assert.Equal(t, fmt.Sprintf("inputBorder_%v", theme.CheckButtonIcon().Name()), render.icon.Resource.Name())
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "inputBorder_"))
 
 	check.Disable()
-	assert.Equal(t, fmt.Sprintf("disabled_%v", theme.CheckButtonIcon().Name()), render.icon.Resource.Name())
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
 }
 
 func TestCheckIsDisabledByDefault(t *testing.T) {

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -1,8 +1,8 @@
 package widget
 
 import (
-	"fmt"
 	"image/color"
+	"strings"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -66,11 +66,10 @@ func TestRadioGroup_DisableWhenSelected(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi"}, nil)
 	radio.SetSelected("Hi")
 	render := test.WidgetRenderer(radio.items[0]).(*radioItemRenderer)
-	icon := fyne.CurrentApp().Settings().Theme().Icon("iconNameRadioButtonFill")
-	assert.Equal(t, "primary_"+icon.Name(), render.icon.Resource.Name())
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "primary_"))
 
 	radio.Disable()
-	assert.Equal(t, fmt.Sprintf("disabled_%v", icon.Name()), render.icon.Resource.Name())
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"))
 }
 
 func TestRadioGroup_DisableWhenNotSelected(t *testing.T) {
@@ -79,7 +78,7 @@ func TestRadioGroup_DisableWhenNotSelected(t *testing.T) {
 
 	radio.Disable()
 	resName := render.over.Resource.Name()
-	assert.Equal(t, resName, fmt.Sprintf("disabled_%v", theme.RadioButtonIcon().Name()))
+	assert.True(t, strings.HasPrefix(resName, "disabled_"))
 }
 
 func TestRadioGroup_SelectedOther(t *testing.T) {


### PR DESCRIPTION

### Description:

This PR adds a new `unwrapResource` function to retrieve the "base" resource from a nested chain of themed resource types, and calls it in the Name and Content functions of all ThemedResource types to achieve two improvements:

* Avoid multiple calls to svg.Colorize, that allocate excess memory and waste CPU
* Avoid caching multiple versions of the same SVG rasterization with differing prefix names like "error_foreground_base-resource.svg" and "error_base-resource.svg".

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

