### PR TITLE
Reduce CPU consumption of Entry cursor by around 80%

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -519,6 +519,7 @@ func (e *Entry) SelectedText() string {
 // Since: 2.2
 func (e *Entry) SetMinRowsVisible(count int) {
 	e.multiLineRows = count
+	e.Refresh()
 }
 
 // SetPlaceHolder sets the text that will be displayed if the entry is otherwise empty

--- a/widget/entry_cursor_anim_test.go
+++ b/widget/entry_cursor_anim_test.go
@@ -21,7 +21,7 @@ func TestEntryCursorAnim(t *testing.T) {
 	alphaEquals := func(color1, color2 color.Color) bool {
 		_, _, _, a1 := col.ToNRGBA(color1)
 		_, _, _, a2 := col.ToNRGBA(color2)
-		return a1 == a2
+		return uint8(a1>>8) == uint8(a2>>8) // only check 8bit colour channels
 	}
 
 	cursor := canvas.NewRectangle(color.Black)

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -438,6 +438,7 @@ func TestEntry_MinSize(t *testing.T) {
 
 	min = entry.MinSize()
 	entry.ActionItem = canvas.NewCircle(color.Black)
+	entry.Refresh()
 	assert.Equal(t, min.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0)), entry.MinSize())
 }
 
@@ -462,6 +463,7 @@ func TestEntryMultiline_MinSize(t *testing.T) {
 
 	min = entry.MinSize()
 	entry.ActionItem = canvas.NewCircle(color.Black)
+	entry.Refresh()
 	assert.Equal(t, min.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0)), entry.MinSize())
 }
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1777,6 +1777,7 @@ func TestMultiLineEntry_MinSize(t *testing.T) {
 	assert.True(t, multiMin.Height > singleMin.Height)
 
 	multi.MultiLine = false
+	multi.Refresh()
 	multiMin = multi.MinSize()
 	assert.Equal(t, singleMin.Height, multiMin.Height)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Reduce CPU load by around 80% by fading over only 1/5th the time.
Also avoid re-calculating MinSize when the visible content has not changed.

Fixes #1946, #4156

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
