### PR TITLE
Don't allocate new slices on each animation tick

### DIFF
--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -47,6 +47,8 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 		t.Error("animation was not ticked")
 	}
 	run.Stop(a)
+	// Animations are really stopped asynchronously
+	time.Sleep(time.Second/60 + 100*time.Millisecond)
 	run.animationMutex.Lock()
 	assert.Zero(t, len(run.animations))
 	run.animationMutex.Unlock()

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -47,9 +47,9 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 		t.Error("animation was not ticked")
 	}
 	run.Stop(a)
-	run.animationMutex.RLock()
+	run.animationMutex.Lock()
 	assert.Zero(t, len(run.animations))
-	run.animationMutex.RUnlock()
+	run.animationMutex.Unlock()
 }
 
 func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
@@ -90,7 +90,7 @@ func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
 	wg.Wait()
 	// animations stopped inside tick are really stopped in the next runner cycle
 	time.Sleep(time.Second/60 + 100*time.Millisecond)
-	run.animationMutex.RLock()
+	run.animationMutex.Lock()
 	assert.Zero(t, len(run.animations))
-	run.animationMutex.RUnlock()
+	run.animationMutex.Unlock()
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

Another try at fixing the excess allocations in the animation runner in a simpler way than #4451, with no public API change. This does not address the non-idempotency of starting an animation (one can still be started twice), but aims only to avoid the performance penalty of allocating slices every tick.

Fixes #4445 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

