### PR TITLE
Ensure our menu test code for native menus runs on the right thread

### DIFF
--- a/internal/driver/glfw/menu_darwin_test.go
+++ b/internal/driver/glfw/menu_darwin_test.go
@@ -16,7 +16,9 @@ func TestDarwinMenu(t *testing.T) {
 	setExceptionCallback(func(msg string) { t.Error("Obj-C exception:", msg) })
 	defer setExceptionCallback(nil)
 
-	resetMainMenu()
+	runOnMain(func() {
+		resetMainMenu()
+	})
 
 	w := createWindow("Test").(*window)
 
@@ -58,7 +60,9 @@ func TestDarwinMenu(t *testing.T) {
 	menuSettings := fyne.NewMenu("Settings", itemSettings, fyne.NewMenuItemSeparator(), itemMoreSetings)
 
 	mainMenu := fyne.NewMainMenu(menuEdit, menuHelp, menuMore, menuSettings)
-	setupNativeMenu(w, mainMenu)
+	runOnMain(func() {
+		setupNativeMenu(w, mainMenu)
+	})
 
 	mm := testDarwinMainMenu()
 	// The custom “Preferences” menu should be moved to the system app menu completely.
@@ -246,13 +250,17 @@ func TestDarwinMenu_specialKeyShortcuts(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			resetMainMenu()
+			runOnMain(func() {
+				resetMainMenu()
+			})
 			w := createWindow("Test").(*window)
 			item := fyne.NewMenuItem("Special", func() {})
 			item.Shortcut = &desktop.CustomShortcut{KeyName: tt.key, Modifier: fyne.KeyModifierShortcutDefault}
 			menu := fyne.NewMenu("Special", item)
 			mainMenu := fyne.NewMainMenu(menu)
-			setupNativeMenu(w, mainMenu)
+			runOnMain(func() {
+				setupNativeMenu(w, mainMenu)
+			})
 
 			mm := testDarwinMainMenu()
 			m := testNSMenuItemSubmenu(testNSMenuItemAtIndex(mm, 1))


### PR DESCRIPTION
The main code was all correct already.
Fixes #4572

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included. <- fixes existing
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
