### PR TITLE
Attempt to make Container fully thread-safe

### DIFF
--- a/container.go
+++ b/container.go
@@ -92,6 +92,7 @@ func (c *Container) AddObject(o CanvasObject) {
 func (c *Container) Hide() {
 	c.lock.Lock()
 	if c.Hidden {
+		c.lock.Unlock()
 		return
 	}
 

--- a/container.go
+++ b/container.go
@@ -86,6 +86,9 @@ func (c *Container) Hide() {
 // MinSize calculates the minimum size of a Container.
 // This is delegated to the Layout, if specified, otherwise it will mimic MaxLayout.
 func (c *Container) MinSize() Size {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	if c.Layout != nil {
 		return c.Layout.MinSize(c.Objects)
 	}
@@ -111,11 +114,13 @@ func (c *Container) Position() Position {
 
 // Refresh causes this object to be redrawn in it's current state
 func (c *Container) Refresh() {
+	c.lock.Lock()
 	c.layout()
 
 	for _, child := range c.Objects {
 		child.Refresh()
 	}
+	c.lock.Unlock()
 
 	// this is basically just canvas.Refresh(c) without the package loop
 	o := CurrentApp().Driver().CanvasForObject(c)
@@ -129,12 +134,13 @@ func (c *Container) Refresh() {
 // This method is not intended to be used inside a loop, to remove all the elements.
 // It is much more efficient to call RemoveAll() instead.
 func (c *Container) Remove(rem CanvasObject) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	if len(c.Objects) == 0 {
 		return
 	}
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	for i, o := range c.Objects {
 		if o != rem {
 			continue
@@ -154,12 +160,18 @@ func (c *Container) Remove(rem CanvasObject) {
 //
 // Since: 2.2
 func (c *Container) RemoveAll() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	c.Objects = nil
 	c.layout()
 }
 
 // Resize sets a new size for the Container.
 func (c *Container) Resize(size Size) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	if c.size == size {
 		return
 	}
@@ -170,6 +182,9 @@ func (c *Container) Resize(size Size) {
 
 // Show sets this container, and all its children, to be visible.
 func (c *Container) Show() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	if !c.Hidden {
 		return
 	}

--- a/container.go
+++ b/container.go
@@ -1,6 +1,8 @@
 package fyne
 
-import "sync"
+import (
+	"sync"
+)
 
 // Declare conformity to CanvasObject
 var _ CanvasObject = (*Container)(nil)
@@ -48,7 +50,9 @@ func NewContainerWithLayout(layout Layout, objects ...CanvasObject) *Container {
 	}
 
 	ret.size = layout.MinSize(objects)
-	ret.layout()
+	if layout != nil {
+		layout.Layout(objects, ret.size)
+	}
 	return ret
 }
 
@@ -61,9 +65,20 @@ func (c *Container) Add(add CanvasObject) {
 	}
 
 	c.lock.Lock()
-	defer c.lock.Unlock()
 	c.Objects = append(c.Objects, add)
-	c.layout()
+	layout := c.Layout
+	size := c.size
+	var obj []CanvasObject
+	if layout != nil {
+		copyPtr := containerSlicePool.CopyOf(c.Objects)
+		defer containerSlicePool.Put(copyPtr)
+		obj = *copyPtr
+	}
+	c.lock.Unlock()
+
+	if layout != nil {
+		layout.Layout(obj, size)
+	}
 }
 
 // AddObject adds another CanvasObject to the set this Container holds.
@@ -75,11 +90,13 @@ func (c *Container) AddObject(o CanvasObject) {
 
 // Hide sets this container, and all its children, to be not visible.
 func (c *Container) Hide() {
+	c.lock.Lock()
 	if c.Hidden {
 		return
 	}
 
 	c.Hidden = true
+	c.lock.Unlock()
 	repaint(c)
 }
 
@@ -87,14 +104,18 @@ func (c *Container) Hide() {
 // This is delegated to the Layout, if specified, otherwise it will mimic MaxLayout.
 func (c *Container) MinSize() Size {
 	c.lock.Lock()
-	defer c.lock.Unlock()
+	copyPtr := containerSlicePool.CopyOf(c.Objects)
+	defer containerSlicePool.Put(copyPtr)
+	obj := *copyPtr
+	layout := c.Layout
+	c.lock.Unlock()
 
-	if c.Layout != nil {
-		return c.Layout.MinSize(c.Objects)
+	if layout != nil {
+		return c.Layout.MinSize(obj)
 	}
 
 	minSize := NewSize(1, 1)
-	for _, child := range c.Objects {
+	for _, child := range obj {
 		minSize = minSize.Max(child.MinSize())
 	}
 
@@ -103,24 +124,36 @@ func (c *Container) MinSize() Size {
 
 // Move the container (and all its children) to a new position, relative to its parent.
 func (c *Container) Move(pos Position) {
+	c.lock.Lock()
 	c.position = pos
+	c.lock.Unlock()
 	repaint(c)
 }
 
 // Position gets the current position of this Container, relative to its parent.
 func (c *Container) Position() Position {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.position
 }
 
 // Refresh causes this object to be redrawn in it's current state
 func (c *Container) Refresh() {
 	c.lock.Lock()
-	c.layout()
+	copyPtr := containerSlicePool.CopyOf(c.Objects)
+	defer containerSlicePool.Put(copyPtr)
+	obj := *copyPtr
+	layout := c.Layout
+	size := c.size
+	c.lock.Unlock()
 
-	for _, child := range c.Objects {
+	if layout != nil {
+		layout.Layout(obj, size)
+	}
+
+	for _, child := range obj {
 		child.Refresh()
 	}
-	c.lock.Unlock()
 
 	// this is basically just canvas.Refresh(c) without the package loop
 	o := CurrentApp().Driver().CanvasForObject(c)
@@ -135,9 +168,9 @@ func (c *Container) Refresh() {
 // It is much more efficient to call RemoveAll() instead.
 func (c *Container) Remove(rem CanvasObject) {
 	c.lock.Lock()
-	defer c.lock.Unlock()
 
 	if len(c.Objects) == 0 {
+		c.lock.Unlock()
 		return
 	}
 
@@ -151,7 +184,19 @@ func (c *Container) Remove(rem CanvasObject) {
 		copy(removed[i:], c.Objects[i+1:])
 
 		c.Objects = removed
-		c.layout()
+		layout := c.Layout
+		size := c.size
+		var obj []CanvasObject
+		if layout != nil {
+			copyPtr := containerSlicePool.CopyOf(c.Objects)
+			defer containerSlicePool.Put(copyPtr)
+			obj = *copyPtr
+		}
+		c.lock.Unlock()
+
+		if layout != nil {
+			layout.Layout(obj, size)
+		}
 		return
 	}
 }
@@ -161,23 +206,38 @@ func (c *Container) Remove(rem CanvasObject) {
 // Since: 2.2
 func (c *Container) RemoveAll() {
 	c.lock.Lock()
-	defer c.lock.Unlock()
-
 	c.Objects = nil
-	c.layout()
+	layout := c.Layout
+	size := c.size
+	c.lock.Unlock()
+
+	if layout != nil {
+		layout.Layout(nil, size)
+	}
 }
 
 // Resize sets a new size for the Container.
 func (c *Container) Resize(size Size) {
 	c.lock.Lock()
-	defer c.lock.Unlock()
 
 	if c.size == size {
+		c.lock.Unlock()
 		return
 	}
 
+	var obj []CanvasObject
 	c.size = size
-	c.layout()
+	layout := c.Layout
+	if layout != nil {
+		copyPtr := containerSlicePool.CopyOf(c.Objects)
+		defer containerSlicePool.Put(copyPtr)
+		obj = *copyPtr
+	}
+	c.lock.Unlock()
+
+	if layout != nil {
+		layout.Layout(obj, size)
+	}
 }
 
 // Show sets this container, and all its children, to be visible.
@@ -194,20 +254,16 @@ func (c *Container) Show() {
 
 // Size returns the current size of this container.
 func (c *Container) Size() Size {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.size
 }
 
 // Visible returns true if the container is currently visible, false otherwise.
 func (c *Container) Visible() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return !c.Hidden
-}
-
-func (c *Container) layout() {
-	if c.Layout == nil {
-		return
-	}
-
-	c.Layout.Layout(c.Objects, c.size)
 }
 
 // repaint instructs the containing canvas to redraw, even if nothing changed.
@@ -224,4 +280,95 @@ func repaint(obj *Container) {
 			paint.SetDirty()
 		}
 	}
+}
+
+var containerSlicePool canvasObjectSlicePool
+
+// A tiered pool of []CanvasObject slices
+// see https://github.com/golang/go/issues/27735 for why a single sync.Pool
+// is a potential memory leak, as well as discussions for other alternatives
+type canvasObjectSlicePool struct {
+	xsPool sync.Pool // holds slices with length [xsPooledSliceMinSize, sPooledSliceMinSize)
+	sPool  sync.Pool // etc
+	mPool  sync.Pool
+	lPool  sync.Pool
+	xlPool sync.Pool // holds slices with length [xlPooledSliceMinSize, xlPooledSliceMaxSize]
+}
+
+const (
+	xsPooledSliceMinSize = 8
+	sPooledSliceMinSize  = 16
+	mPooledSliceMinSize  = 32
+	lPooledSliceMinSize  = 64
+	xlPooledSliceMinSize = 256
+	xlPooledSliceMaxSize = 2048
+	// do not pool slices of more than xlPooledSliceMaxSize
+)
+
+// Get gets a pointer to a slice of at least the given capacity from the pool,
+// allocating a new slice if needed. The slice may have any length, but it is
+// always safe to re-slice to a new length that is <= capacity.
+func (s *canvasObjectSlicePool) Get(capacity int) *[]CanvasObject {
+	var obj any
+	switch {
+	case capacity <= xsPooledSliceMinSize:
+		obj = s.xsPool.Get()
+	case capacity <= sPooledSliceMinSize:
+		obj = s.sPool.Get()
+	case capacity <= mPooledSliceMinSize:
+		obj = s.mPool.Get()
+	case capacity <= lPooledSliceMinSize:
+		obj = s.lPool.Get()
+	default:
+		obj = s.xlPool.Get()
+	}
+
+	if obj == nil {
+		if capacity < xsPooledSliceMinSize {
+			capacity = xsPooledSliceMinSize
+		}
+		tmp := make([]CanvasObject, 0, capacity)
+		obj = &tmp
+	}
+	slice := obj.(*[]CanvasObject)
+	if cap(*slice) < capacity {
+		// can only happen in xl pool - reallocate a longer slice
+		tmp := make([]CanvasObject, 0, capacity)
+		slice = &tmp
+	}
+	return slice
+}
+
+// Put releases the given slice pointer into the pool.
+func (s *canvasObjectSlicePool) Put(slice *[]CanvasObject) {
+	*slice = (*slice)[:0]
+	switch c := cap(*slice); {
+	case c < xsPooledSliceMinSize:
+		return // don't pool a slice too small
+	case c < sPooledSliceMinSize:
+		s.xsPool.Put(slice)
+	case c < mPooledSliceMinSize:
+		s.sPool.Put(slice)
+	case c < lPooledSliceMinSize:
+		s.mPool.Put(slice)
+	case c < xlPooledSliceMinSize:
+		s.lPool.Put(slice)
+	case c <= xlPooledSliceMaxSize:
+		s.xlPool.Put(slice)
+	default:
+		return // don't pool a slice too large
+	}
+}
+
+// CopyOf is a convenience method that gets a slice from the pool
+// of capacity at least len(slice), and copies the contents of slice
+// into the new slice, before returning its pointer.
+func (s *canvasObjectSlicePool) CopyOf(slice []CanvasObject) *[]CanvasObject {
+	l := len(slice)
+	ptr := s.Get(l)
+	cp := *ptr
+	cp = cp[:l]
+	copy(cp, slice)
+	*ptr = cp
+	return ptr
 }

--- a/container.go
+++ b/container.go
@@ -111,7 +111,7 @@ func (c *Container) MinSize() Size {
 	c.lock.Unlock()
 
 	if layout != nil {
-		return c.Layout.MinSize(obj)
+		return layout.MinSize(obj)
 	}
 
 	minSize := NewSize(1, 1)

--- a/container_test.go
+++ b/container_test.go
@@ -165,6 +165,26 @@ func TestContainer_Show(t *testing.T) {
 	assert.True(t, container.Visible())
 }
 
+func TestSlicePool(t *testing.T) {
+	containerSlicePool = canvasObjectSlicePool{}
+
+	slice := make([]CanvasObject, 23)
+	containerSlicePool.Put(&slice)
+	got := *containerSlicePool.Get(12)
+
+	// make sure we got back the same slice
+	assert.Equal(t, 23, cap(got))
+
+	slice = []CanvasObject{
+		&dummyObject{size: NewSquareSize(5)},
+		&dummyObject{size: NewSquareSize(8)},
+		&dummyObject{size: NewSquareSize(15)}}
+	copyPtr := containerSlicePool.CopyOf(slice)
+	copy := *copyPtr
+	assert.ElementsMatch(t, slice, copy)
+
+}
+
 type customLayout struct {
 }
 


### PR DESCRIPTION
### Description:
This is an attempt to make Container fully thread-safe, as long as user code never directly accesses the `Objects` property after construction (and uses the provided methods instead). In order to do this the Objects slice must frequently be copied while holding a lock before proceeding into an operation that cannot be done under lock (ie calls user code) due to risk of deadlock. To avoid generating lots of garbage we pool the `[]CanvasObject` slices in a tiered pool system.

This PR is using copy-on-read, or more precisely, copy-before-reading-in-non-critical-section ;) for the Objects slice. It adds an O(n) factor to various container operations, but has bounded allocations due to slice pooling. An alternative would be to use copy-on-write (see #4600), where every time the Objects slice is changed a new slice is generated and it is never updated in place. This would have better performance when changes to container contents are infrequent, but has no real upper-bound on the amount of GC garbage that could be generated in the case where container contents are being frequently updated.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
