### PR TITLE
fix accordion locking

### DIFF
--- a/widget/accordion.go
+++ b/widget/accordion.go
@@ -37,15 +37,11 @@ func (a *Accordion) Append(item *AccordionItem) {
 
 // Close collapses the item at the given index.
 func (a *Accordion) Close(index int) {
-	a.propertyLock.RLock()
-	numItems := len(a.Items)
-	a.propertyLock.RUnlock()
-
-	if index < 0 || index >= numItems {
+	a.propertyLock.Lock()
+	if index < 0 || index >= len(a.Items) {
+		a.propertyLock.Unlock()
 		return
 	}
-
-	a.propertyLock.Lock()
 	a.Items[index].Open = false
 	a.propertyLock.Unlock()
 
@@ -79,15 +75,13 @@ func (a *Accordion) MinSize() fyne.Size {
 
 // Open expands the item at the given index.
 func (a *Accordion) Open(index int) {
-	a.propertyLock.RLock()
-	numItems := len(a.Items)
-	a.propertyLock.RUnlock()
+	a.propertyLock.Lock()
 
-	if index < 0 || index >= numItems {
+	if index < 0 || index >= len(a.Items) {
+		a.propertyLock.Unlock()
 		return
 	}
 
-	a.propertyLock.Lock()
 	for i, ai := range a.Items {
 		if i == index {
 			ai.Open = true
@@ -134,15 +128,11 @@ func (a *Accordion) Remove(item *AccordionItem) {
 
 // RemoveIndex deletes the item at the given index from this Accordion.
 func (a *Accordion) RemoveIndex(index int) {
-	a.propertyLock.RLock()
-	numItems := len(a.Items)
-	a.propertyLock.RUnlock()
-
-	if index < 0 || index >= numItems {
+	a.propertyLock.Lock()
+	if index < 0 || index >= len(a.Items) {
+		a.propertyLock.Unlock()
 		return
 	}
-
-	a.propertyLock.Lock()
 	a.Items = append(a.Items[:index], a.Items[index+1:]...)
 	a.propertyLock.Unlock()
 


### PR DESCRIPTION
### Description:
There was a locking error in accordion where we would check the length of Items with a lock, then drop the lock, and later re-acquire it to do something that is dependent on length. The length could have changed during the interim so the lock needs to be held for the entire time.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
