### PR TITLE
Cleanup how text providers are set up and synced

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -70,8 +70,8 @@ type Entry struct {
 
 	dirty       bool
 	focused     bool
-	text        *RichText
-	placeholder *RichText
+	text        RichText
+	placeholder RichText
 	content     *entryContent
 	scroll      *widget.Scroll
 
@@ -1055,21 +1055,17 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 
 // placeholderProvider returns the placeholder text handler for this entry
 func (e *Entry) placeholderProvider() *RichText {
-	if e.placeholder != nil {
-		return e.placeholder
+	if len(e.placeholder.Segments) != 0 {
+		return &e.placeholder
 	}
 
 	style := RichTextStyleInline
 	style.ColorName = theme.ColorNamePlaceHolder
 	style.TextStyle = e.TextStyle
-	text := NewRichText(&TextSegment{
-		Style: style,
-		Text:  e.PlaceHolder,
-	})
-	text.ExtendBaseWidget(text)
-	text.inset = fyne.NewSize(0, theme.InputBorderSize())
-	e.placeholder = text
-	return e.placeholder
+	e.placeholder.Segments = []RichTextSegment{&TextSegment{Style: style, Text: e.PlaceHolder}}
+	e.placeholder.Scroll = widget.ScrollNone
+	e.placeholder.inset = fyne.NewSize(0, theme.InputBorderSize())
+	return &e.placeholder
 }
 
 func (e *Entry) registerShortcut() {
@@ -1359,19 +1355,18 @@ func (e *Entry) syncSegments() {
 
 // textProvider returns the text handler for this entry
 func (e *Entry) textProvider() *RichText {
-	if e.text != nil {
-		return e.text
+	if len(e.text.Segments) != 0 {
+		return &e.text
 	}
 
 	if e.Text != "" {
 		e.dirty = true
 	}
 
-	text := NewRichTextWithText(e.Text)
-	text.ExtendBaseWidget(text)
-	text.inset = fyne.NewSize(0, theme.InputBorderSize())
-	e.text = text
-	return e.text
+	e.text.Scroll = widget.ScrollNone
+	e.text.Segments = []RichTextSegment{&TextSegment{Style: RichTextStyleInline, Text: e.Text}}
+	e.text.inset = fyne.NewSize(0, theme.InputBorderSize())
+	return &e.text
 }
 
 // textWrap calculates the wrapping that we should apply.

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -263,16 +264,25 @@ func (hl *Hyperlink) syncSegments() {
 
 	hl.provider.Wrapping = hl.Wrapping
 	hl.provider.Truncation = hl.Truncation
-	hl.provider.Segments = []RichTextSegment{&TextSegment{
-		Style: RichTextStyle{
-			Alignment: hl.Alignment,
-			ColorName: theme.ColorNameHyperlink,
-			Inline:    true,
-			TextStyle: hl.TextStyle,
-		},
-		Text: hl.Text,
-	}}
+
+	style := RichTextStyle{
+		Alignment: hl.Alignment,
+		ColorName: theme.ColorNameHyperlink,
+		Inline:    true,
+		TextStyle: hl.TextStyle,
+	}
+
 	hl.textSize = fyne.MeasureText(hl.Text, theme.TextSize(), hl.TextStyle)
+
+	if len(hl.provider.Segments) == 0 {
+		hl.provider.Scroll = widget.ScrollNone
+		hl.provider.Segments = []RichTextSegment{&TextSegment{Style: style, Text: hl.Text}}
+		return
+	}
+
+	segment := hl.provider.Segments[0].(*TextSegment)
+	segment.Style = style
+	segment.Text = hl.Text
 }
 
 var _ fyne.WidgetRenderer = (*hyperlinkRenderer)(nil)

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -55,7 +55,7 @@ func TestHyperlink_Alignment(t *testing.T) {
 	hyperlink := &Hyperlink{Text: "Test", Alignment: fyne.TextAlignTrailing}
 	hyperlink.CreateRenderer()
 
-	assert.Equal(t, fyne.TextAlignTrailing, richTextRenderTexts(hyperlink.provider)[0].Alignment)
+	assert.Equal(t, fyne.TextAlignTrailing, richTextRenderTexts(&hyperlink.provider)[0].Alignment)
 }
 
 func TestHyperlink_Hide(t *testing.T) {
@@ -135,7 +135,7 @@ func TestHyperlink_SetText(t *testing.T) {
 	hyperlink.SetText("New")
 
 	assert.Equal(t, "New", hyperlink.Text)
-	assert.Equal(t, "New", richTextRenderTexts(hyperlink.provider)[0].Text)
+	assert.Equal(t, "New", richTextRenderTexts(&hyperlink.provider)[0].Text)
 }
 
 func TestHyperlink_SetUrl(t *testing.T) {
@@ -183,17 +183,17 @@ func TestHyperlink_Truncate(t *testing.T) {
 	hyperlink.CreateRenderer()
 	hyperlink.Resize(fyne.NewSize(100, 20))
 
-	texts := richTextRenderTexts(hyperlink.provider)
+	texts := richTextRenderTexts(&hyperlink.provider)
 	assert.Equal(t, "TestingWithLongText", texts[0].Text)
 
 	hyperlink.Truncation = fyne.TextTruncateClip
 	hyperlink.Refresh()
-	texts = richTextRenderTexts(hyperlink.provider)
+	texts = richTextRenderTexts(&hyperlink.provider)
 	assert.Equal(t, "TestingWith", texts[0].Text)
 
 	hyperlink.Truncation = fyne.TextTruncateEllipsis
 	hyperlink.Refresh()
-	texts = richTextRenderTexts(hyperlink.provider)
+	texts = richTextRenderTexts(&hyperlink.provider)
 	assert.Equal(t, "TestingWi…", texts[0].Text)
 }
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -20,9 +20,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-const (
-	passwordChar = "•"
-)
+const passwordChar = "•"
 
 // RichText represents the base element for a rich text-based widget.
 //

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -384,8 +384,8 @@ func TestTextRenderer_ApplyTheme(t *testing.T) {
 func TestTextProvider_LineSizeToColumn(t *testing.T) {
 	label := NewLabel("Test")
 	label.CreateRenderer() // TODO make this a simple refresh call once it's in
-	provider := label.provider
 
+	provider := &label.provider
 	inPad := theme.InnerPadding()
 	textSize := theme.TextSize()
 	fullSize := provider.lineSizeToColumn(4, 0, textSize, inPad)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This cleans up a lot of code for setting up and syncing changes between widgets and their text providers. Text providers are created inline in the struct to not require an extra allocation plus nil checks, segments are synced without needing to allocate garbage in the form of new slices and some other cleanups are included. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
