### PR TITLE
Correctly handle URIs like c: on Windows

### DIFF
--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -170,6 +172,11 @@ func (r *FileRepository) Parent(u fyne.URI) (fyne.URI, error) {
 
 	// trim the scheme
 	s = strings.TrimPrefix(s, fileSchemePrefix)
+
+	// Only for Windows: If the path is a drive root, no parent is possible
+	if runtime.GOOS == "windows" && regexp.MustCompile(`(?i)^/[a-z]:$`).MatchString(s) {
+		return nil, repository.ErrURIRoot
+	}
 
 	// Completely empty URI with just a scheme
 	if s == "" {

--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"errors"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -22,6 +23,10 @@ func NewFileURI(path string) fyne.URI {
 	// or NT style paths, with / or \, but when we reconstruct
 	// the URI, we want to have / only.
 	if runtime.GOOS == "windows" {
+		// Make sure that Windows paths (eg "c:\") also correctly start with a "/"
+		if regexp.MustCompile(`(?i)^[a-z]:`).MatchString(path) {
+			path = "/" + path
+		}
 		// seems that sometimes we end up with
 		// double-backslashes
 		path = filepath.ToSlash(path)

--- a/storage/uri_test.go
+++ b/storage/uri_test.go
@@ -114,7 +114,7 @@ func TestURI_Scheme(t *testing.T) {
 func TestURI_Name(t *testing.T) {
 	assert.Equal(t, "text.txt", storage.NewURI("file:///text.txt").Name())
 	assert.Equal(t, "library.a", storage.NewURI("file:///library.a").Name())
-	assert.Equal(t, "directory", storage.NewURI("file://C:/directory/").Name())
+	assert.Equal(t, "directory", storage.NewURI("file:///C:/directory/").Name())
 	assert.Equal(t, "image.JPEG", storage.NewFileURI("C:/image.JPEG").Name())
 }
 
@@ -130,9 +130,9 @@ func TestURI_Parent(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "file:///foo/bar/", parent.String())
 
-	parent, err = storage.Parent(storage.NewURI("file://C:/foo/bar/baz/"))
+	parent, err = storage.Parent(storage.NewURI("file:///C:/foo/bar/baz/"))
 	assert.Nil(t, err)
-	assert.Equal(t, "file://C:/foo/bar/", parent.String())
+	assert.Equal(t, "file:///C:/foo/bar/", parent.String())
 
 	// TODO hook in an http/https handler
 	//parent, err = storage.Parent(storage.NewURI("http://foo/bar/baz/"))
@@ -156,14 +156,17 @@ func TestURI_Parent(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// Only the Windows version of filepath will know how to handle
 		// backslashes.
-		uri := storage.NewURI("file://C:\\foo\\bar\\baz\\")
-		assert.Equal(t, "file://C:/foo/bar/baz/", uri.String())
+		uri := storage.NewURI("file:///C:\\foo\\bar\\baz\\")
+		assert.Equal(t, "file:///C:/foo/bar/baz/", uri.String())
 		uri = storage.NewFileURI("C:\\foo\\bar\\baz\\")
-		assert.Equal(t, "file://C:/foo/bar/baz/", uri.String())
+		assert.Equal(t, "file:///C:/foo/bar/baz/", uri.String())
+		// This is the legacy format but we still accept it
+		uri = storage.NewURI("file://C:\\foo\\bar\\baz\\")
+		assert.Equal(t, "file:///C:/foo/bar/baz/", uri.String())
 
 		parent, err = storage.Parent(uri)
 		assert.Nil(t, err)
-		assert.Equal(t, "file://C:/foo/bar/", parent.String())
+		assert.Equal(t, "file:///C:/foo/bar/", parent.String())
 	}
 
 	_, err = storage.Parent(storage.NewURI("file:///"))
@@ -176,20 +179,15 @@ func TestURI_Parent(t *testing.T) {
 
 		// This should cause an error, since this is a Windows-style
 		// path and thus we can't get the parent of a drive letter.
-		_, err = storage.Parent(storage.NewURI("file://C:/"))
+		_, err = storage.Parent(storage.NewURI("file:///C:/"))
 		assert.Equal(t, repository.ErrURIRoot, err)
 	}
-
-	// Windows supports UNIX-style paths. /C:/ is also a valid path.
-	parent, err = storage.Parent(storage.NewURI("file:///C:/"))
-	assert.Nil(t, err)
-	assert.Equal(t, "file:///", parent.String())
 }
 
 func TestURI_Extension(t *testing.T) {
 	assert.Equal(t, ".txt", storage.NewURI("file:///text.txt").Extension())
-	assert.Equal(t, ".JPEG", storage.NewURI("file://C:/image.JPEG").Extension())
-	assert.Equal(t, "", storage.NewURI("file://C:/directory/").Extension())
+	assert.Equal(t, ".JPEG", storage.NewURI("file:///C:/image.JPEG").Extension())
+	assert.Equal(t, "", storage.NewURI("file:///C:/directory/").Extension())
 	assert.Equal(t, ".a", storage.NewFileURI("/library.a").Extension())
 }
 
@@ -203,11 +201,11 @@ func TestURI_Child(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// Only the Windows version of filepath will know how to handle
 		// backslashes.
-		uri := storage.NewURI("file://C:\\foo\\bar\\")
-		assert.Equal(t, "file://C:/foo/bar/", uri.String())
+		uri := storage.NewURI("file:///C:\\foo\\bar\\")
+		assert.Equal(t, "file:///C:/foo/bar/", uri.String())
 
 		p, _ = storage.Child(uri, "baz")
-		assert.Equal(t, "file://C:/foo/bar/baz", p.String())
+		assert.Equal(t, "file:///C:/foo/bar/baz", p.String())
 	}
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
This change makes sure that file URIs on Windows with drive letters are handled correctly.
It kind of is a breaking change but old formats (`storage.NewURI("file://C:\\foo\\bar\\baz\\")`) are still accepted but converted to the new format.

Fixes #4605

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [ ] Any breaking changes have a deprecation path or have been discussed.
