### PR TITLE
Add IME support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [fyne-io, andydotxyz, toaster, Jacalz, changkun, dweymouth]
+github: [fyne-io, andydotxyz, toaster, Jacalz, changkun, dweymouth, lucor]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 This file lists the main changes with each version of the Fyne toolkit.
 More detailed release notes can be found on the [releases page](https://github.com/fyne-io/fyne/releases). 
 
-<<<<<<< HEAD
 ## 2.4.3 - 23 December 2023
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 * Failure with fyne release -os android/arm (#4174)
 * Android GoBack with forcefully close the app even if the keyboard is up (#4257)
 * *BSD systems using the wrong (and slow) window resize
-* Optimisations to reduce memory allocations in List, GridWrap and mime type handling
+* Optimisations to reduce memory allocations in List, GridWrap, driver and mime type handling
 * Reduce calls to C and repeated size checks in painter and driver code
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file lists the main changes with each version of the Fyne toolkit.
 More detailed release notes can be found on the [releases page](https://github.com/fyne-io/fyne/releases). 
 
-## 2.4.3 - 22 December 2023
+## 2.4.3 - 23 December 2023
 
 ### Fixed
 

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -75,6 +75,14 @@ type Focusable interface {
 	TypedKey(*KeyEvent)
 }
 
+// Preeditable describes any CanvasObject that can respond to IME inputs.
+// Originally, it should be a method of Focusable, but only a few widgets need PreeditChanged,
+// and adding a method to Focusable will have a big impact on others, so defined as a new interface.
+type Preeditable interface {
+	// PreeditChanged is a hook called by window with IME is on and typed multi-byte characters inputed
+	PreeditChanged(preedit string)
+}
+
 // Scrollable describes any CanvasObject that can also be scrolled.
 // This is mostly used to implement the widget.ScrollContainer.
 type Scrollable interface {

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -75,12 +75,16 @@ type Focusable interface {
 	TypedKey(*KeyEvent)
 }
 
+type CursorPositionChangedCallback func(pos Position)
+
 // Preeditable describes any CanvasObject that can respond to IME inputs.
 // Originally, it should be a method of Focusable, but only a few widgets need PreeditChanged,
 // and adding a method to Focusable will have a big impact on others, so defined as a new interface.
 type Preeditable interface {
 	// PreeditChanged is a hook called by window with IME is on and typed multi-byte characters inputed
 	PreeditChanged(preedit string)
+
+	ReceiveCursorPositionChangedCallback(callback CursorPositionChangedCallback)
 }
 
 // Scrollable describes any CanvasObject that can also be scrolled.

--- a/canvasobject.go
+++ b/canvasobject.go
@@ -75,7 +75,7 @@ type Focusable interface {
 	TypedKey(*KeyEvent)
 }
 
-type CursorPositionChangedCallback func(pos Position)
+type CursorPositionChangedCallback func(pos Position, size Size)
 
 // Preeditable describes any CanvasObject that can respond to IME inputs.
 // Originally, it should be a method of Focusable, but only a few widgets need PreeditChanged,

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -191,6 +191,15 @@ func (c *Canvas) Focused() fyne.Focusable {
 	return mgr.Focused()
 }
 
+// Preeditable return the current preeditable object only when focused
+func (c *Canvas) Preeditable() fyne.Preeditable {
+	focused := c.Focused()
+	if focused == nil {
+		return nil
+	}
+	return focused.(fyne.Preeditable)
+}
+
 // FocusGained signals to the manager that its content got focus.
 // Valid only on Desktop.
 func (c *Canvas) FocusGained() {

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -197,7 +197,10 @@ func (c *Canvas) Preeditable() fyne.Preeditable {
 	if focused == nil {
 		return nil
 	}
-	return focused.(fyne.Preeditable)
+	if preeditable, ok := focused.(fyne.Preeditable); ok {
+		return preeditable
+	}
+	return nil
 }
 
 // FocusGained signals to the manager that its content got focus.

--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -11,8 +11,11 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
+const GLFW_X11_ONTHESPOT glfw.Hint = 0x00052002
+
 func (d *gLDriver) initGLFW() {
 	initOnce.Do(func() {
+		glfw.InitHint(GLFW_X11_ONTHESPOT, 1) // enable IME callbacks, hint must be set before Init()
 		err := glfw.Init()
 		if err != nil {
 			fyne.LogError("failed to initialise GLFW", err)

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -805,6 +805,14 @@ func (w *window) processCharInput(char rune) {
 	}
 }
 
+// preedit defines the character with modifiers callback
+// witch is called when character input on IME
+func (w *window) processPreedit(preedit string) {
+	if preeditable := w.canvas.Preeditable(); preeditable != nil {
+		w.QueueEvent(func() { preeditable.PreeditChanged(preedit) })
+	}
+}
+
 func (w *window) processFocused(focus bool) {
 	if focus {
 		if curWindow == nil {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -685,10 +685,11 @@ func (w *window) imeStatus(_ *glfw.Window) {
 	fmt.Println("ime status ", counterIme)
 	counterIme++
 	if preeditable := w.canvas.Preeditable(); preeditable != nil {
+		// This callback function is called by the focused widget and tells the system the exact canvas coordinates
+		// of the text cursor on the window. The system will display an IME Candidate Window with those coordinates
 		preeditable.ReceiveCursorPositionChangedCallback(func(pos fyne.Position) {
-			monitor := w.getMonitorForWindow()
-			xscale, yscale := monitor.GetContentScale()
-			w.viewport.SetPreeditCursorRectangle(int(pos.X*xscale), int(pos.Y*yscale), 100, 100)
+			canvasScale := w.canvas.scale
+			w.viewport.SetPreeditCursorRectangle(int(pos.X*canvasScale), int(pos.Y*canvasScale), 100, 100)
 		})
 	}
 }
@@ -815,6 +816,7 @@ func (w *window) create() {
 		win.SetKeyCallback(w.keyPressed)
 		win.SetCharCallback(w.charInput)
 		win.SetFocusCallback(w.focused)
+		win.SetInputMode(glfw.ImeOwnerDraw, glfw.False)
 
 		w.canvas.detectedScale = w.detectScale()
 		w.canvas.scale = w.calculatedScale()

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -11,7 +11,6 @@ import (
 	_ "image/png" // for the icon
 	"runtime"
 	"sync"
-	"unsafe"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -685,6 +684,13 @@ var counterIme int
 func (w *window) imeStatus(_ *glfw.Window) {
 	fmt.Println("ime status ", counterIme)
 	counterIme++
+	if preeditable := w.canvas.Preeditable(); preeditable != nil {
+		preeditable.ReceiveCursorPositionChangedCallback(func(pos fyne.Position) {
+			monitor := w.getMonitorForWindow()
+			xscale, yscale := monitor.GetContentScale()
+			w.viewport.SetPreeditCursorRectangle(int(pos.X*xscale), int(pos.Y*yscale), 100, 100)
+		})
+	}
 }
 
 func (w *window) preedit(
@@ -700,15 +706,17 @@ func (w *window) preedit(
 }
 
 func (w *window) preeditCandidate(
-	_ *glfw.Window,
+	glwin *glfw.Window,
 	candidatesCount int,
 	selectedIndex int,
 	pageStart int,
 	pageSize int,
 ) {
 	fmt.Println("preeditCandidate", "candidatesCount", candidatesCount, "selectedIndex", selectedIndex, "pageStart", pageStart, "pageSize", pageSize)
-	candidates := glfw.GetPreeditCandidate(unsafe.Pointer(w))
-	fmt.Println("candidates", candidates)
+	candidate := glwin.GetPreeditCandidate(selectedIndex)
+	if candidate != nil {
+		fmt.Println("candidates", *candidate)
+	}
 }
 
 func (w *window) focused(_ *glfw.Window, focused bool) {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -682,14 +682,13 @@ var counterIme int
 
 // IME
 func (w *window) imeStatus(_ *glfw.Window) {
-	fmt.Println("ime status ", counterIme)
 	counterIme++
 	if preeditable := w.canvas.Preeditable(); preeditable != nil {
 		// This callback function is called by the focused widget and tells the system the exact canvas coordinates
 		// of the text cursor on the window. The system will display an IME Candidate Window with those coordinates
-		preeditable.ReceiveCursorPositionChangedCallback(func(pos fyne.Position) {
+		preeditable.ReceiveCursorPositionChangedCallback(func(pos fyne.Position, size fyne.Size) {
 			canvasScale := w.canvas.scale
-			w.viewport.SetPreeditCursorRectangle(int(pos.X*canvasScale), int(pos.Y*canvasScale), 100, 100)
+			w.viewport.SetPreeditCursorRectangle(int(pos.X*canvasScale), int(pos.Y*canvasScale), 100, int(size.Height))
 		})
 	}
 }
@@ -713,7 +712,6 @@ func (w *window) preeditCandidate(
 	pageStart int,
 	pageSize int,
 ) {
-	fmt.Println("preeditCandidate", "candidatesCount", candidatesCount, "selectedIndex", selectedIndex, "pageStart", pageStart, "pageSize", pageSize)
 	candidate := glwin.GetPreeditCandidate(selectedIndex)
 	if candidate != nil {
 		fmt.Println("candidates", *candidate)

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -689,6 +689,7 @@ func (w *window) imeStatus(_ *glfw.Window) {
 		preeditable.ReceiveCursorPositionChangedCallback(func(pos fyne.Position, size fyne.Size) {
 			canvasScale := w.canvas.scale
 			w.viewport.SetPreeditCursorRectangle(int(pos.X*canvasScale), int(pos.Y*canvasScale), 100, int(size.Height))
+			w.viewport.UpdatePreeditCursorRectangle()
 		})
 	}
 }

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -6,6 +6,7 @@ package glfw
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"image"
 	_ "image/png" // for the icon
 	"runtime"
@@ -677,6 +678,32 @@ func (w *window) charInput(viewport *glfw.Window, char rune) {
 	w.processCharInput(char)
 }
 
+var counterIme int
+
+// IME
+func (w *window) imeStatus(_ *glfw.Window) {
+	fmt.Println("ime status ", counterIme)
+	counterIme++
+}
+func (w *window) preedit(
+	_ *glfw.Window,
+	preeditCount int,
+	preeditString string,
+	blockCount int,
+	blockSizes string,
+	focusedBlock int,
+	caret int,
+) {
+	fmt.Println(
+		"preedit preeditCount", preeditCount,
+		"preeditString", preeditString,
+		"blockCount", blockCount,
+		"focusedBlock", focusedBlock,
+		"caret", caret,
+	)
+	w.processPreedit(preeditString)
+}
+
 func (w *window) focused(_ *glfw.Window, focused bool) {
 	w.processFocused(focused)
 }
@@ -765,6 +792,8 @@ func (w *window) create() {
 		win.SetRefreshCallback(w.refresh)
 		win.SetContentScaleCallback(w.scaled)
 		win.SetCursorPosCallback(w.mouseMoved)
+		win.SetPreeditCallback(w.preedit)
+		win.SetImeStatusCallback(w.imeStatus)
 		win.SetMouseButtonCallback(w.mouseClicked)
 		win.SetScrollCallback(w.mouseScrolled)
 		win.SetKeyCallback(w.keyPressed)

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -11,6 +11,7 @@ import (
 	_ "image/png" // for the icon
 	"runtime"
 	"sync"
+	"unsafe"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -685,6 +686,7 @@ func (w *window) imeStatus(_ *glfw.Window) {
 	fmt.Println("ime status ", counterIme)
 	counterIme++
 }
+
 func (w *window) preedit(
 	_ *glfw.Window,
 	preeditCount int,
@@ -694,14 +696,19 @@ func (w *window) preedit(
 	focusedBlock int,
 	caret int,
 ) {
-	fmt.Println(
-		"preedit preeditCount", preeditCount,
-		"preeditString", preeditString,
-		"blockCount", blockCount,
-		"focusedBlock", focusedBlock,
-		"caret", caret,
-	)
 	w.processPreedit(preeditString)
+}
+
+func (w *window) preeditCandidate(
+	_ *glfw.Window,
+	candidatesCount int,
+	selectedIndex int,
+	pageStart int,
+	pageSize int,
+) {
+	fmt.Println("preeditCandidate", "candidatesCount", candidatesCount, "selectedIndex", selectedIndex, "pageStart", pageStart, "pageSize", pageSize)
+	candidates := glfw.GetPreeditCandidate(unsafe.Pointer(w))
+	fmt.Println("candidates", candidates)
 }
 
 func (w *window) focused(_ *glfw.Window, focused bool) {
@@ -794,6 +801,7 @@ func (w *window) create() {
 		win.SetCursorPosCallback(w.mouseMoved)
 		win.SetPreeditCallback(w.preedit)
 		win.SetImeStatusCallback(w.imeStatus)
+		win.SetPreeditCandidateCallback(w.preeditCandidate)
 		win.SetMouseButtonCallback(w.mouseClicked)
 		win.SetScrollCallback(w.mouseScrolled)
 		win.SetKeyCallback(w.keyPressed)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -830,10 +830,17 @@ func (e *Entry) ReceiveCursorPositionChangedCallback(callback fyne.CursorPositio
 
 	//e.propertyLock.Lock()
 	e.onCursorPositionChanged = callback
-	d := fyne.CurrentApp().Driver()
-	pos := d.AbsolutePositionForObject(e.cursorAnim.cursor)
-	e.onCursorPositionChanged(pos)
+	e.preeditCursorPositionChanged()
 	//e.propertyLock.Unlock()
+}
+
+// preeditCursorPositionChanged notifies window that preedit cursor has moved
+func (e *Entry) preeditCursorPositionChanged() {
+	if e.onCursorPositionChanged != nil {
+		d := fyne.CurrentApp().Driver()
+		pos := d.AbsolutePositionForObject(e.cursorAnim.cursor)
+		e.onCursorPositionChanged(pos)
+	}
 }
 
 // TypedShortcut implements the Shortcutable interface
@@ -1783,6 +1790,7 @@ func (r *entryContentRenderer) Refresh() {
 	}
 	r.moveCursor()
 	preedit.position.X = r.cursor.Position().X
+	r.content.entry.preeditCursorPositionChanged()
 
 	for _, selection := range selections {
 		selection.(*canvas.Rectangle).Hidden = !r.content.entry.focused


### PR DESCRIPTION
### Description:
As everyone knows, fyne does not currently support IME. This is fundamentally caused by the fact that glfw does not support IME, and cannot be resolved by fyne's efforts alone. So I solved this problem by adding a hack to both go-gl/glfw and fyne. Please check it on your PC.


Fixes #618

## Supported environments

- supported
  - Windows
  - Mac
  - Linux(X11, Wayland)
- not supported
  - Android
  - iOS


## How to try this

```bash
git clone https://github.com/kanryu/fyne
git clone https://github.com/kanryu/glfw
cd fyne
go mod edit -replace github.com/go-gl/glfw/v3.3/glfw=../glfw/v3.4/glfw
go run cmd/fyne_demo/main.go
```

https://github.com/fyne-io/fyne/assets/759165/89c858dc-beaf-4b19-948f-77baee4aa2a6


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
