### PR TITLE
Avoid time based debounce, code it in with parameters instead

### DIFF
--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -280,7 +280,7 @@ func TestEntry_EraseSelection(t *testing.T) {
 	keyPress(&fyne.KeyEvent{Name: fyne.KeyRight})
 
 	e.eraseSelection()
-	e.updateText(e.textProvider().String())
+	e.updateText(e.textProvider().String(), false)
 	assert.Equal(t, "Testing\nTeng\nTesting", e.Text)
 	a, b := e.selection()
 	assert.Equal(t, -1, a)

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -45,6 +45,21 @@ func TestEntry_Binding(t *testing.T) {
 	assert.Equal(t, "Typed", entry.Text)
 }
 
+func TestEntry_Binding_Bounce(t *testing.T) {
+	entry := widget.NewEntry()
+	entry.SetText("Init")
+	assert.Equal(t, "Init", entry.Text)
+	waitForBinding() // this time it is the de-echo before binding
+
+	str := binding.NewString()
+	entry.Bind(str)
+	str.Set("1")
+	time.Sleep(10 * time.Millisecond)
+	str.Set("2")
+	waitForBinding()
+	assert.Equal(t, "2", entry.Text)
+}
+
 func TestEntry_Binding_Replace(t *testing.T) {
 	entry := widget.NewEntry()
 	str := binding.NewString()


### PR DESCRIPTION
This feels like a more robust pattern - remember if your data source was binding before echoing the change back to your binding callback.

Fixes #4082, #4061

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

