### PR TITLE
Queue dropped callbacks to our event thread

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -156,7 +156,9 @@ func (w *window) SetOnDropped(dropped func(pos fyne.Position, items []fyne.URI))
 				uris[i] = storage.NewFileURI(name)
 			}
 
-			dropped(w.mousePos, uris)
+			w.QueueEvent(func() {
+				dropped(w.mousePos, uris)
+			})
 		})
 	})
 }


### PR DESCRIPTION
This is one of those things we will have to clarify when we finalise the new threading model - calling back on the right queue ;).

Fixes #4624

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
