### PR TITLE
Add Desktop directory to file dialogs

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -860,6 +860,7 @@ func getFavoriteIcons() map[string]fyne.Resource {
 	if runtime.GOOS == "darwin" {
 		return map[string]fyne.Resource{
 			"Documents": theme.DocumentIcon(),
+			"Desktop":   theme.DesktopIcon(),
 			"Downloads": theme.DownloadIcon(),
 			"Music":     theme.MediaMusicIcon(),
 			"Pictures":  theme.MediaPhotoIcon(),
@@ -869,6 +870,7 @@ func getFavoriteIcons() map[string]fyne.Resource {
 
 	return map[string]fyne.Resource{
 		"Documents": theme.DocumentIcon(),
+		"Desktop":   theme.DesktopIcon(),
 		"Downloads": theme.DownloadIcon(),
 		"Music":     theme.MediaMusicIcon(),
 		"Pictures":  theme.MediaPhotoIcon(),
@@ -878,6 +880,7 @@ func getFavoriteIcons() map[string]fyne.Resource {
 
 func getFavoriteOrder() []string {
 	order := []string{
+		"Desktop",
 		"Documents",
 		"Downloads",
 		"Music",

--- a/dialog/file_xdg.go
+++ b/dialog/file_xdg.go
@@ -45,6 +45,7 @@ func getFavoriteLocations() (map[string]fyne.ListableURI, error) {
 
 	favoriteNames := getFavoriteOrder()
 	arguments := map[string]string{
+		"Desktop":   "DESKTOP",
 		"Documents": "DOCUMENTS",
 		"Downloads": "DOWNLOAD",
 		"Music":     "MUSIC",

--- a/test/markup_renderer.go
+++ b/test/markup_renderer.go
@@ -437,6 +437,7 @@ func knownResource(rsc fyne.Resource) string {
 		theme.ContentRemoveIcon():      "contentRemoveIcon",
 		theme.ContentUndoIcon():        "contentUndoIcon",
 		theme.DeleteIcon():             "deleteIcon",
+		theme.DesktopIcon():            "desktopIcon",
 		theme.DocumentCreateIcon():     "documentCreateIcon",
 		theme.DocumentIcon():           "documentIcon",
 		theme.DocumentPrintIcon():      "documentPrintIcon",

--- a/theme/bundled-icons.go
+++ b/theme/bundled-icons.go
@@ -430,6 +430,11 @@ var computerIconRes = &fyne.StaticResource{
 	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"black\" width=\"24px\" height=\"24px\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z\"/></svg>"),
 }
 
+var desktopIconRes = &fyne.StaticResource{
+	StaticName:    "desktop.svg",
+	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"black\" width=\"24px\" height=\"24px\"><path d=\"M21 2H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h7v2H8v2h8v-2h-2v-2h7c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H3V4h18v12z\"/></svg>\n"),
+}
+
 var storageIconRes = &fyne.StaticResource{
 	StaticName:    "storage.svg",
 	StaticContent: []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"black\" width=\"24px\" height=\"24px\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M2 20h20v-4H2v4zm2-3h2v2H4v-2zM2 4v4h20V4H2zm4 3H4V5h2v2zm-4 7h20v-4H2v4zm2-3h2v2H4v-2z\"/></svg>"),

--- a/theme/gen.go
+++ b/theme/gen.go
@@ -187,6 +187,7 @@ func main() {
 
 	bundleIcon("download", f)
 	bundleIcon("computer", f)
+	bundleIcon("desktop", f)
 	bundleIcon("storage", f)
 	bundleIcon("upload", f)
 

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -446,6 +446,11 @@ const (
 	// Since: 2.0
 	IconNameComputer fyne.ThemeIconName = "computer"
 
+	// IconNameDesktop is the name of theme lookup for desktop icon.
+	//
+	// Since: 2.5
+	IconNameDesktop fyne.ThemeIconName = "desktop"
+
 	// IconNameAccount is the name of theme lookup for account icon.
 	//
 	// Since: 2.1
@@ -590,6 +595,7 @@ var (
 
 		IconNameDownload: NewThemedResource(downloadIconRes),
 		IconNameComputer: NewThemedResource(computerIconRes),
+		IconNameDesktop:  NewThemedResource(desktopIconRes),
 		IconNameStorage:  NewThemedResource(storageIconRes),
 		IconNameUpload:   NewThemedResource(uploadIconRes),
 
@@ -1252,6 +1258,11 @@ func VolumeUpIcon() fyne.Resource {
 // ComputerIcon returns a resource containing the standard computer icon for the current theme
 func ComputerIcon() fyne.Resource {
 	return safeIconLookup(IconNameComputer)
+}
+
+// DesktopIcon returns a resource containing the standard desktop icon for the current theme
+func DesktopIcon() fyne.Resource {
+	return safeIconLookup(IconNameDesktop)
 }
 
 // DownloadIcon returns a resource containing the standard download icon for the current theme

--- a/theme/icons/desktop.svg
+++ b/theme/icons/desktop.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="24px" height="24px"><path d="M21 2H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h7v2H8v2h8v-2h-2v-2h7c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H3V4h18v12z"/></svg>


### PR DESCRIPTION
I believe that the "Desktop" directory is heavily used by many users. Thus I think it would be convenient, if it appeared in the favorites of file dialogs.

The changes are basically pure Cargo cult, but seem sensible to me and seem to work. Please correct me, if I've forgotten something.

I have not assigned an icon to this entry in the file dialogs, since the most common symbol seems to be a monitor and I couldn't find such a symbol in the `theme` package.