### PR TITLE
Implement persistent storage for preferences on web

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -117,8 +117,8 @@ func New() fyne.App {
 }
 
 func makeStoreDocs(id string, s *store) *internal.Docs {
-	if id != "" {
-		err := os.MkdirAll(s.a.storageRoot(), 0755) // make the space before anyone can use it
+	if root := s.a.storageRoot(); root != "" && id != "" {
+		err := os.MkdirAll(root, 0755) // make the space before anyone can use it
 		if err != nil {
 			fyne.LogError("Failed to create app storage space", err)
 		}

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -29,7 +29,7 @@ var _ fyne.Preferences = (*preferences)(nil)
 // sentinel error to signal an empty preferences storage backend was loaded
 var errEmptyPreferencesStore = errors.New("empty preferences store")
 
-// returned from storageReader() - may be a file, browser local storage, etc
+// returned from storageWriter() - may be a file, browser local storage, etc
 type writeSyncCloser interface {
 	io.WriteCloser
 	Sync() error

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -96,7 +96,7 @@ func (p *preferences) load() {
 	if err == nil {
 		err = p.loadFromStorage(storage)
 	}
-	if err != nil {
+	if err != nil && err != errEmptyPreferencesStore {
 		fyne.LogError("Preferences load error:", err)
 	}
 }

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -2,8 +2,8 @@ package app
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
+	"errors"
+	"io"
 	"sync"
 	"time"
 
@@ -26,8 +26,17 @@ type preferences struct {
 // Declare conformity with Preferences interface
 var _ fyne.Preferences = (*preferences)(nil)
 
-// forceImmediateSave writes preferences to file immediately, ignoring the debouncing
-// logic in the change listener. Does nothing if preferences are not backed with a file.
+// sentinel error to signal an empty preferences storage backend was loaded
+var errEmptyPreferencesStore = errors.New("empty preferences store")
+
+// returned from storageReader() - may be a file, browser local storage, etc
+type writeSyncCloser interface {
+	io.WriteCloser
+	Sync() error
+}
+
+// forceImmediateSave writes preferences to storage immediately, ignoring the debouncing
+// logic in the change listener. Does nothing if preferences are not backed with a persistent store.
 func (p *preferences) forceImmediateSave() {
 	if !p.needsSaveBeforeExit {
 		return
@@ -54,37 +63,28 @@ func (p *preferences) resetSavedRecently() {
 }
 
 func (p *preferences) save() error {
-	return p.saveToFile(p.storagePath())
+	storage, err := p.storageWriter()
+	if err != nil {
+		return err
+	}
+	return p.saveToStorage(storage)
 }
 
-func (p *preferences) saveToFile(path string) error {
+func (p *preferences) saveToStorage(writer writeSyncCloser) error {
 	p.prefLock.Lock()
 	p.savedRecently = true
 	p.prefLock.Unlock()
 	defer p.resetSavedRecently()
-	err := os.MkdirAll(filepath.Dir(path), 0700)
-	if err != nil { // this is not an exists error according to docs
-		return err
-	}
 
-	file, err := os.Create(path)
-	if err != nil {
-		if !os.IsExist(err) {
-			return err
-		}
-		file, err = os.Open(path) // #nosec
-		if err != nil {
-			return err
-		}
-	}
-	defer file.Close()
-	encode := json.NewEncoder(file)
+	defer writer.Close()
+	encode := json.NewEncoder(writer)
 
+	var err error
 	p.InMemoryPreferences.ReadValues(func(values map[string]any) {
 		err = encode.Encode(&values)
 	})
 
-	err2 := file.Sync()
+	err2 := writer.Sync()
 	if err == nil {
 		err = err2
 	}
@@ -92,29 +92,22 @@ func (p *preferences) saveToFile(path string) error {
 }
 
 func (p *preferences) load() {
-	err := p.loadFromFile(p.storagePath())
+	storage, err := p.storageReader()
+	if err == nil {
+		err = p.loadFromStorage(storage)
+	}
 	if err != nil {
 		fyne.LogError("Preferences load error:", err)
 	}
 }
 
-func (p *preferences) loadFromFile(path string) (err error) {
-	file, err := os.Open(path) // #nosec
-	if err != nil {
-		if os.IsNotExist(err) {
-			if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-				return err
-			}
-			return nil
-		}
-		return err
-	}
+func (p *preferences) loadFromStorage(storage io.ReadCloser) (err error) {
 	defer func() {
-		if r := file.Close(); r != nil && err == nil {
+		if r := storage.Close(); r != nil && err == nil {
 			err = r
 		}
 	}()
-	decode := json.NewDecoder(file)
+	decode := json.NewDecoder(storage)
 
 	p.prefLock.Lock()
 	p.loadingInProgress = true
@@ -157,7 +150,7 @@ func newPreferences(app *fyneApp) *preferences {
 		}
 		p.prefLock.Unlock()
 
-		if shouldIgnoreChange { // callback after loading file, or too many updates in a row
+		if shouldIgnoreChange { // callback after loading from storage, or too many updates in a row
 			return
 		}
 

--- a/app/preferences_nonweb.go
+++ b/app/preferences_nonweb.go
@@ -1,0 +1,67 @@
+//go:build !wasm
+
+package app
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func (p *preferences) storageWriter() (writeSyncCloser, error) {
+	return p.storageWriterForPath(p.storagePath())
+}
+
+func (p *preferences) storageReader() (io.ReadCloser, error) {
+	return p.storageReaderForPath(p.storagePath())
+}
+
+func (p *preferences) storageWriterForPath(path string) (writeSyncCloser, error) {
+	err := os.MkdirAll(filepath.Dir(path), 0700)
+	if err != nil { // this is not an exists error according to docs
+		return nil, err
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		file, err = os.Open(path) // #nosec
+		if err != nil {
+			return nil, err
+		}
+	}
+	return file, nil
+}
+
+func (p *preferences) storageReaderForPath(path string) (io.ReadCloser, error) {
+	file, err := os.Open(path) // #nosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+				return nil, err
+			}
+			return nil, errEmptyPreferencesStore
+		}
+		return nil, err
+	}
+	return file, nil
+}
+
+// the following are only used in tests to save preferences to a tmp file
+
+func (p *preferences) saveToFile(path string) error {
+	file, err := p.storageWriterForPath(path)
+	if err != nil {
+		return err
+	}
+	return p.saveToStorage(file)
+}
+
+func (p *preferences) loadFromFile(path string) error {
+	file, err := p.storageReaderForPath(path)
+	if err != nil {
+		return err
+	}
+	return p.loadFromStorage(file)
+}

--- a/app/preferences_other.go
+++ b/app/preferences_other.go
@@ -1,4 +1,4 @@
-//go:build !ios && !android && !mobile
+//go:build !ios && !android && !mobile && !wasm
 
 package app
 

--- a/app/preferences_wasm.go
+++ b/app/preferences_wasm.go
@@ -1,0 +1,16 @@
+//go:build wasm
+
+package app
+
+import (
+	"errors"
+	"io"
+)
+
+func (p *preferences) storageReader() (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *preferences) storageWriter() (writeSyncCloser, error) {
+	return nil, errors.New("not implemented")
+}

--- a/app/preferences_wasm.go
+++ b/app/preferences_wasm.go
@@ -7,10 +7,18 @@ import (
 	"io"
 )
 
+func (a *fyneApp) storageRoot() string {
+	return "" // no storage root for web driver yet
+}
+
 func (p *preferences) storageReader() (io.ReadCloser, error) {
 	return nil, errors.New("not implemented")
 }
 
 func (p *preferences) storageWriter() (writeSyncCloser, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (p *preferences) watch() {
+	// no-op for web driver
 }

--- a/app/preferences_wasm.go
+++ b/app/preferences_wasm.go
@@ -3,22 +3,60 @@
 package app
 
 import (
-	"errors"
+	"bytes"
 	"io"
+	"strings"
+	"syscall/js"
 )
+
+const preferencesLocalStorageKey = "preferences.json"
 
 func (a *fyneApp) storageRoot() string {
 	return "" // no storage root for web driver yet
 }
 
 func (p *preferences) storageReader() (io.ReadCloser, error) {
-	return nil, errors.New("not implemented")
+	key := js.ValueOf(preferencesLocalStorageKey)
+	data := js.Global().Get("localStorage").Call("getItem", key).String()
+
+	if data == "" {
+		return nil, errEmptyPreferencesStore
+	}
+	return readerNopCloser{reader: strings.NewReader(data)}, nil
 }
 
 func (p *preferences) storageWriter() (writeSyncCloser, error) {
-	return nil, errors.New("not implemented")
+	return &localStorageWriter{key: preferencesLocalStorageKey}, nil
 }
 
 func (p *preferences) watch() {
 	// no-op for web driver
+}
+
+type readerNopCloser struct {
+	reader io.Reader
+}
+
+func (r readerNopCloser) Read(b []byte) (int, error) {
+	return r.reader.Read(b)
+}
+
+func (r readerNopCloser) Close() error {
+	return nil
+}
+
+type localStorageWriter struct {
+	bytes.Buffer
+	key string
+}
+
+func (s *localStorageWriter) Sync() error {
+	text := s.String()
+	s.Reset()
+	js.Global().Get("localStorage").Call("getItem", js.ValueOf(s.key), js.ValueOf(text))
+	return nil
+}
+
+func (s *localStorageWriter) Close() error {
+	return nil
 }

--- a/app/preferences_wasm.go
+++ b/app/preferences_wasm.go
@@ -9,7 +9,7 @@ import (
 	"syscall/js"
 )
 
-const preferencesLocalStorageKey = "preferences.json"
+const preferencesLocalStorageKey = "fyne-preferences.json"
 
 func (a *fyneApp) storageRoot() string {
 	return "" // no storage root for web driver yet

--- a/app/preferences_wasm.go
+++ b/app/preferences_wasm.go
@@ -17,12 +17,12 @@ func (a *fyneApp) storageRoot() string {
 
 func (p *preferences) storageReader() (io.ReadCloser, error) {
 	key := js.ValueOf(preferencesLocalStorageKey)
-	data := js.Global().Get("localStorage").Call("getItem", key).String()
-
-	if data == "" {
+	data := js.Global().Get("localStorage").Call("getItem", key)
+	if data.IsNull() || data.IsUndefined() {
 		return nil, errEmptyPreferencesStore
 	}
-	return readerNopCloser{reader: strings.NewReader(data)}, nil
+
+	return readerNopCloser{reader: strings.NewReader(data.String())}, nil
 }
 
 func (p *preferences) storageWriter() (writeSyncCloser, error) {
@@ -53,7 +53,7 @@ type localStorageWriter struct {
 func (s *localStorageWriter) Sync() error {
 	text := s.String()
 	s.Reset()
-	js.Global().Get("localStorage").Call("getItem", js.ValueOf(s.key), js.ValueOf(text))
+	js.Global().Get("localStorage").Call("setItem", js.ValueOf(s.key), js.ValueOf(text))
 	return nil
 }
 


### PR DESCRIPTION
Adds a persistent backend for the Preferences API for web, using browser local storage. The entire preferences map is saved as a single localStorage object, serialized in JSON under the key "preferences.json" (open to discussion if this key name should be different - user code can inadvertently access this using the `syscall/js` APIs themselves if they use the same key name).

This was done for maximum code sharing between platforms (only the "file-like storage object" is abstracted, the serialization/deserialization code is the same for all platforms), and also so that we don't need to worry about cleaning out individual user key-value pairs from local storage if we later add a Delete API to preferences - the whole preferences blob will just be updated.

Fixes #2734 

### Checklist:

- [ ] Tests included - test manually with wasm fyne_demo - note that it saves the active tutorial page across browser reloads
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
