### PR TITLE
Add ScrollToOffset/GetScrollOffset APIs for List

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -261,10 +261,17 @@ func (l *List) ScrollToTop() {
 //
 // Since: 2.5
 func (l *List) ScrollToOffset(offset float32) {
-	if l.scroller != nil {
-		l.scroller.Offset.Y = offset
-		l.offsetUpdated(l.scroller.Offset)
+	if l.scroller == nil {
+		return
 	}
+	if offset < 0 {
+		offset = 0
+	} else if h := l.contentMinSize().Height; offset > h {
+		offset = h
+	}
+	l.scroller.Offset.Y = offset
+	l.offsetUpdated(l.scroller.Offset)
+	l.Refresh()
 }
 
 // GetScrollOffset returns the current scroll offset position
@@ -336,6 +343,36 @@ func (l *List) UnselectAll() {
 			f(id)
 		}
 	}
+}
+
+func (l *List) contentMinSize() fyne.Size {
+	l.propertyLock.Lock()
+	defer l.propertyLock.Unlock()
+	items := 0
+	if f := l.Length; f == nil {
+		return fyne.NewSize(0, 0)
+	} else {
+		items = f()
+	}
+
+	separatorThickness := theme.Padding()
+	if l.itemHeights == nil || len(l.itemHeights) == 0 {
+		return fyne.NewSize(l.itemMin.Width,
+			(l.itemMin.Height+separatorThickness)*float32(items)-separatorThickness)
+	}
+
+	height := float32(0)
+	templateHeight := l.itemMin.Height
+	for item := 0; item < items; item++ {
+		itemHeight, ok := l.itemHeights[item]
+		if ok {
+			height += itemHeight
+		} else {
+			height += templateHeight
+		}
+	}
+
+	return fyne.NewSize(l.itemMin.Width, height+separatorThickness*float32(items-1))
 }
 
 // fills l.visibleRowHeights and also returns offY and minRow
@@ -575,33 +612,7 @@ func (l *listLayout) Layout([]fyne.CanvasObject, fyne.Size) {
 }
 
 func (l *listLayout) MinSize([]fyne.CanvasObject) fyne.Size {
-	l.list.propertyLock.Lock()
-	defer l.list.propertyLock.Unlock()
-	items := 0
-	if f := l.list.Length; f == nil {
-		return fyne.NewSize(0, 0)
-	} else {
-		items = f()
-	}
-
-	separatorThickness := theme.Padding()
-	if l.list.itemHeights == nil || len(l.list.itemHeights) == 0 {
-		return fyne.NewSize(l.list.itemMin.Width,
-			(l.list.itemMin.Height+separatorThickness)*float32(items)-separatorThickness)
-	}
-
-	height := float32(0)
-	templateHeight := l.list.itemMin.Height
-	for item := 0; item < items; item++ {
-		itemHeight, ok := l.list.itemHeights[item]
-		if ok {
-			height += itemHeight
-		} else {
-			height += templateHeight
-		}
-	}
-
-	return fyne.NewSize(l.list.itemMin.Width, height+separatorThickness*float32(items-1))
+	return l.list.contentMinSize()
 }
 
 func (l *listLayout) getItem() *listItem {

--- a/widget/list.go
+++ b/widget/list.go
@@ -348,12 +348,10 @@ func (l *List) UnselectAll() {
 func (l *List) contentMinSize() fyne.Size {
 	l.propertyLock.Lock()
 	defer l.propertyLock.Unlock()
-	items := 0
-	if f := l.Length; f == nil {
+	if l.Length == nil  {
 		return fyne.NewSize(0, 0)
-	} else {
-		items = f()
 	}
+	items := l.Length()
 
 	separatorThickness := theme.Padding()
 	if l.itemHeights == nil || len(l.itemHeights) == 0 {

--- a/widget/list.go
+++ b/widget/list.go
@@ -257,6 +257,23 @@ func (l *List) ScrollToTop() {
 	l.Refresh()
 }
 
+// ScrollToOffset scrolls the list to the given offset position.
+//
+// Since: 2.5
+func (l *List) ScrollToOffset(offset float32) {
+	if l.scroller != nil {
+		l.scroller.Offset.Y = offset
+		l.offsetUpdated(l.scroller.Offset)
+	}
+}
+
+// GetScrollOffset returns the current scroll offset position
+//
+// Since: 2.5
+func (l *List) GetScrollOffset() float32 {
+	return l.offsetY
+}
+
 // TypedKey is called if a key event happens while this List is focused.
 //
 // Implements: fyne.Focusable

--- a/widget/list.go
+++ b/widget/list.go
@@ -348,7 +348,7 @@ func (l *List) UnselectAll() {
 func (l *List) contentMinSize() fyne.Size {
 	l.propertyLock.Lock()
 	defer l.propertyLock.Unlock()
-	if l.Length == nil  {
+	if l.Length == nil {
 		return fyne.NewSize(0, 0)
 	}
 	items := l.Length()

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -240,6 +240,16 @@ func TestList_ScrollToTop(t *testing.T) {
 	assert.Equal(t, offset, list.scroller.Offset.Y)
 }
 
+func TestList_ScrollOffset(t *testing.T) {
+	list := createList(1000)
+
+	offset := float32(25)
+	list.ScrollToOffset(25)
+	assert.Equal(t, offset, list.offsetY)
+	assert.Equal(t, offset, list.scroller.Offset.Y)
+	assert.Equal(t, offset, list.GetScrollOffset())
+}
+
 func TestList_Selection(t *testing.T) {
 	list := createList(1000)
 	children := list.scroller.Content.(*fyne.Container).Layout.(*listLayout).children

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -241,13 +241,17 @@ func TestList_ScrollToTop(t *testing.T) {
 }
 
 func TestList_ScrollOffset(t *testing.T) {
-	list := createList(1000)
+	list := createList(10)
 
 	offset := float32(25)
 	list.ScrollToOffset(25)
-	assert.Equal(t, offset, list.offsetY)
-	assert.Equal(t, offset, list.scroller.Offset.Y)
 	assert.Equal(t, offset, list.GetScrollOffset())
+
+	list.ScrollToOffset(-2)
+	assert.Equal(t, float32(0), list.GetScrollOffset())
+
+	list.ScrollToOffset(1000)
+	assert.LessOrEqual(t, list.GetScrollOffset(), float32(500) /*upper bound on content height*/)
 }
 
 func TestList_Selection(t *testing.T) {


### PR DESCRIPTION
### Description:
These APIs already exist on GridWrap and are useful for two things: 
- saving the state of a list view and re-creating it with a new widget that is scrolled to the same position (eg in apps that have "pages" and can navigate back/forward
- implementing keyboard scrolling when nothing is focused (ie key events hit the window canvas) for apps that have just one list view as their main UI element

Fixes #3544 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
