### PR TITLE
Sync richtext parameters without allocations

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -70,8 +70,8 @@ type Entry struct {
 
 	dirty       bool
 	focused     bool
-	text        *RichText
-	placeholder *RichText
+	text        RichText
+	placeholder RichText
 	content     *entryContent
 	scroll      *widget.Scroll
 
@@ -1069,21 +1069,25 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 
 // placeholderProvider returns the placeholder text handler for this entry
 func (e *Entry) placeholderProvider() *RichText {
-	if e.placeholder != nil {
-		return e.placeholder
+	if len(e.placeholder.Segments) > 0 {
+		return &e.placeholder
 	}
+
+	e.placeholder.Scroll = widget.ScrollNone
+	e.placeholder.inset = fyne.NewSize(0, e.themeWithLock().Size(theme.SizeNameInputBorder))
 
 	style := RichTextStyleInline
 	style.ColorName = theme.ColorNamePlaceHolder
 	style.TextStyle = e.TextStyle
-	text := NewRichText(&TextSegment{
-		Style: style,
-		Text:  e.PlaceHolder,
-	})
-	text.ExtendBaseWidget(text)
-	text.inset = fyne.NewSize(0, e.themeWithLock().Size(theme.SizeNameInputBorder))
-	e.placeholder = text
-	return e.placeholder
+
+	e.placeholder.Segments = []RichTextSegment{
+		&TextSegment{
+			Style: style,
+			Text:  e.PlaceHolder,
+		},
+	}
+
+	return &e.placeholder
 }
 
 func (e *Entry) registerShortcut() {
@@ -1341,51 +1345,44 @@ func (e *Entry) syncSegments() {
 	if disabled {
 		colName = theme.ColorNameDisabled
 	}
-	e.textProvider().Wrapping = wrap
-	style := RichTextStyle{
-		Alignment: fyne.TextAlignLeading,
-		ColorName: colName,
-		TextStyle: e.TextStyle,
-	}
-	if e.Password {
-		style = RichTextStylePassword
-		style.ColorName = colName
-		style.TextStyle = e.TextStyle
-	}
-	e.textProvider().Segments = []RichTextSegment{&TextSegment{
-		Style: style,
-		Text:  e.Text,
-	}}
+
+	text := e.textProvider()
+	text.Wrapping = wrap
+
+	textSegment := text.Segments[0].(*TextSegment)
+	textSegment.Text = e.Text
+	textSegment.Style.ColorName = colName
+	textSegment.Style.concealed = e.Password
+	textSegment.Style.TextStyle = e.TextStyle
+
 	colName = theme.ColorNamePlaceHolder
 	if disabled {
 		colName = theme.ColorNameDisabled
 	}
-	e.placeholderProvider().Wrapping = wrap
-	e.placeholderProvider().Segments = []RichTextSegment{&TextSegment{
-		Style: RichTextStyle{
-			Alignment: fyne.TextAlignLeading,
-			ColorName: colName,
-			TextStyle: e.TextStyle,
-		},
-		Text: e.PlaceHolder,
-	}}
+
+	placeholder := e.placeholderProvider()
+	placeholder.Wrapping = wrap
+
+	textSegment = placeholder.Segments[0].(*TextSegment)
+	textSegment.Style.ColorName = colName
+	textSegment.Style.TextStyle = e.TextStyle
+	textSegment.Text = e.PlaceHolder
 }
 
 // textProvider returns the text handler for this entry
 func (e *Entry) textProvider() *RichText {
-	if e.text != nil {
-		return e.text
+	if len(e.text.Segments) > 0 {
+		return &e.text
 	}
 
 	if e.Text != "" {
 		e.dirty = true
 	}
 
-	text := NewRichTextWithText(e.Text)
-	text.ExtendBaseWidget(text)
-	text.inset = fyne.NewSize(0, e.themeWithLock().Size(theme.SizeNameInputBorder))
-	e.text = text
-	return e.text
+	e.text.Scroll = widget.ScrollNone
+	e.text.inset = fyne.NewSize(0, e.themeWithLock().Size(theme.SizeNameInputBorder))
+	e.text.Segments = []RichTextSegment{&TextSegment{Style: RichTextStyleInline, Text: e.Text}}
+	return &e.text
 }
 
 // textWrap calculates the wrapping that we should apply.

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -34,7 +35,7 @@ type Hyperlink struct {
 
 	textSize         fyne.Size // updated in syncSegments
 	focused, hovered bool
-	provider         *RichText
+	provider         RichText
 }
 
 // NewHyperlink creates a new hyperlink widget with the set text content
@@ -57,10 +58,7 @@ func NewHyperlinkWithStyle(text string, url *url.URL, alignment fyne.TextAlign, 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (hl *Hyperlink) CreateRenderer() fyne.WidgetRenderer {
 	hl.ExtendBaseWidget(hl)
-	hl.propertyLock.RLock()
-	hl.provider = NewRichTextWithText(hl.Text)
-	hl.propertyLock.RUnlock()
-	hl.provider.ExtendBaseWidget(hl.provider)
+	hl.provider.ExtendBaseWidget(&hl.provider)
 	hl.syncSegments()
 
 	th := hl.Theme()
@@ -71,7 +69,7 @@ func (hl *Hyperlink) CreateRenderer() fyne.WidgetRenderer {
 	focus.Hide()
 	under := canvas.NewRectangle(th.Color(theme.ColorNameHyperlink, v))
 	under.Hide()
-	return &hyperlinkRenderer{hl: hl, objects: []fyne.CanvasObject{hl.provider, focus, under}, focus: focus, under: under}
+	return &hyperlinkRenderer{hl: hl, objects: []fyne.CanvasObject{&hl.provider, focus, under}, focus: focus, under: under}
 }
 
 // Cursor returns the cursor type of this widget
@@ -143,11 +141,7 @@ func (hl *Hyperlink) isPosOverText(pos fyne.Position) bool {
 	th := hl.Theme()
 	innerPad := th.Size(theme.SizeNameInnerPadding)
 	pad := th.Size(theme.SizeNamePadding)
-	// If not rendered yet provider will be nil
-	lineCount := float32(1)
-	if hl.provider != nil {
-		lineCount = fyne.Max(lineCount, float32(len(hl.provider.rowBounds)))
-	}
+	lineCount := fyne.Max(1, float32(len(hl.provider.rowBounds)))
 
 	xpos := hl.focusXPos()
 	return pos.X >= xpos && pos.X <= xpos+hl.focusWidth() &&
@@ -158,19 +152,19 @@ func (hl *Hyperlink) isPosOverText(pos fyne.Position) bool {
 //
 // Implements: fyne.Widget
 func (hl *Hyperlink) Refresh() {
-	if hl.provider == nil { // not created until visible
-		return
+	if len(hl.provider.Segments) == 0 {
+		return // Not initialized yet.
 	}
-	hl.syncSegments()
 
+	hl.syncSegments()
 	hl.provider.Refresh()
 	hl.BaseWidget.Refresh()
 }
 
 // MinSize returns the smallest size this widget can shrink to
 func (hl *Hyperlink) MinSize() fyne.Size {
-	if hl.provider == nil {
-		hl.CreateRenderer()
+	if len(hl.provider.Segments) == 0 {
+		hl.syncSegments()
 	}
 
 	return hl.provider.MinSize()
@@ -180,8 +174,9 @@ func (hl *Hyperlink) MinSize() fyne.Size {
 // Note this should not be used if the widget is being managed by a Layout within a Container.
 func (hl *Hyperlink) Resize(size fyne.Size) {
 	hl.BaseWidget.Resize(size)
-	if hl.provider == nil { // not created until visible
-		return
+
+	if len(hl.provider.Segments) == 0 {
+		return // Not initialized yet.
 	}
 	hl.provider.Resize(size)
 }
@@ -191,8 +186,9 @@ func (hl *Hyperlink) SetText(text string) {
 	hl.propertyLock.Lock()
 	hl.Text = text
 	hl.propertyLock.Unlock()
-	if hl.provider == nil { // not created until visible
-		return
+
+	if len(hl.provider.Segments) == 0 {
+		return // Not initialized yet.
 	}
 	hl.syncSegments()
 	hl.provider.Refresh()
@@ -218,11 +214,6 @@ func (hl *Hyperlink) SetURLFromString(str string) error {
 
 // Tapped is called when a pointer tapped event is captured and triggers any change handler
 func (hl *Hyperlink) Tapped(e *fyne.PointEvent) {
-	// If not rendered yet (hl.provider == nil), register all taps
-	// in practice this probably only happens in our unit tests
-	if hl.provider != nil && !hl.isPosOverText(e.Position) {
-		return
-	}
 	hl.invokeAction()
 }
 
@@ -270,15 +261,28 @@ func (hl *Hyperlink) syncSegments() {
 
 	hl.provider.Wrapping = hl.Wrapping
 	hl.provider.Truncation = hl.Truncation
-	hl.provider.Segments = []RichTextSegment{&TextSegment{
-		Style: RichTextStyle{
-			Alignment: hl.Alignment,
-			ColorName: theme.ColorNameHyperlink,
-			Inline:    true,
-			TextStyle: hl.TextStyle,
-		},
-		Text: hl.Text,
-	}}
+
+	if len(hl.provider.Segments) == 0 {
+		hl.provider.Scroll = widget.ScrollNone
+		hl.provider.Segments = []RichTextSegment{
+			&TextSegment{
+				Style: RichTextStyle{
+					Alignment: hl.Alignment,
+					ColorName: theme.ColorNameHyperlink,
+					Inline:    true,
+					TextStyle: hl.TextStyle,
+				},
+				Text: hl.Text,
+			},
+		}
+		return
+	}
+
+	segment := hl.provider.Segments[0].(*TextSegment)
+	segment.Style.Alignment = hl.Alignment
+	segment.Style.TextStyle = hl.TextStyle
+	segment.Text = hl.Text
+
 	hl.textSize = fyne.MeasureText(hl.Text, th.Size(theme.SizeNameText), hl.TextStyle)
 }
 

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -55,7 +55,7 @@ func TestHyperlink_Alignment(t *testing.T) {
 	hyperlink := &Hyperlink{Text: "Test", Alignment: fyne.TextAlignTrailing}
 	hyperlink.CreateRenderer()
 
-	assert.Equal(t, fyne.TextAlignTrailing, richTextRenderTexts(hyperlink.provider)[0].Alignment)
+	assert.Equal(t, fyne.TextAlignTrailing, richTextRenderTexts(&hyperlink.provider)[0].Alignment)
 }
 
 func TestHyperlink_Hide(t *testing.T) {
@@ -135,7 +135,7 @@ func TestHyperlink_SetText(t *testing.T) {
 	hyperlink.SetText("New")
 
 	assert.Equal(t, "New", hyperlink.Text)
-	assert.Equal(t, "New", richTextRenderTexts(hyperlink.provider)[0].Text)
+	assert.Equal(t, "New", richTextRenderTexts(&hyperlink.provider)[0].Text)
 }
 
 func TestHyperlink_SetUrl(t *testing.T) {
@@ -183,17 +183,17 @@ func TestHyperlink_Truncate(t *testing.T) {
 	hyperlink.CreateRenderer()
 	hyperlink.Resize(fyne.NewSize(100, 20))
 
-	texts := richTextRenderTexts(hyperlink.provider)
+	texts := richTextRenderTexts(&hyperlink.provider)
 	assert.Equal(t, "TestingWithLongText", texts[0].Text)
 
 	hyperlink.Truncation = fyne.TextTruncateClip
 	hyperlink.Refresh()
-	texts = richTextRenderTexts(hyperlink.provider)
+	texts = richTextRenderTexts(&hyperlink.provider)
 	assert.Equal(t, "TestingWith", texts[0].Text)
 
 	hyperlink.Truncation = fyne.TextTruncateEllipsis
 	hyperlink.Refresh()
-	texts = richTextRenderTexts(hyperlink.provider)
+	texts = richTextRenderTexts(&hyperlink.provider)
 	assert.Equal(t, "TestingWi…", texts[0].Text)
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Rework of #4597 rebased on latest develop and with even more cleanups and less allocs.
Syncing parameters between the richtext segments no longer allocates a slice and a new style object.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
