### PR TITLE
Fix recognition of missing XDG user directories

### DIFF
--- a/dialog/file_xdg.go
+++ b/dialog/file_xdg.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/storage"
@@ -27,7 +28,7 @@ func getFavoriteLocation(homeURI fyne.URI, name, fallbackName string) (fyne.URI,
 	loc = loc[:len(loc)-1]
 	locURI := storage.NewFileURI(string(loc))
 
-	if locURI.String() == homeURI.String() {
+	if strings.TrimRight(locURI.String(), "/") == homeURI.String() {
 		fallback, _ := storage.Child(homeURI, fallbackName)
 		return fallback, fmt.Errorf("this computer does not define a %s folder", name)
 	}

--- a/dialog/file_xdg.go
+++ b/dialog/file_xdg.go
@@ -28,7 +28,7 @@ func getFavoriteLocation(homeURI fyne.URI, name, fallbackName string) (fyne.URI,
 	loc = loc[:len(loc)-1]
 	locURI := storage.NewFileURI(string(loc))
 
-	if strings.TrimRight(locURI.String(), "/") == homeURI.String() {
+	if strings.TrimRight(locURI.String(), "/") == strings.TrimRight(homeURI.String(), "/") {
 		fallback, _ := storage.Child(homeURI, fallbackName)
 		return fallback, fmt.Errorf("this computer does not define a %s folder", name)
 	}

--- a/dialog/file_xdg.go
+++ b/dialog/file_xdg.go
@@ -59,6 +59,9 @@ func getFavoriteLocations() (map[string]fyne.ListableURI, error) {
 	for _, favName := range favoriteNames {
 		var uri fyne.URI
 		uri, err = getFavoriteLocation(homeURI, arguments[favName], favName)
+		if err != nil {
+			continue
+		}
 
 		listURI, err1 := storage.ListerForURI(uri)
 		if err1 != nil {


### PR DESCRIPTION
### Description:
In `dialog/file_xdg.go` there was some code to check, if a user directory does not exist. This code did not work for me, because `locURI.String()` was, for example, `file:///home/richard/` when the "Videos" directory wasn't found. `homeUri.Strin()` was `file:///home/richard`.

I am not sure if `xdg-user-dir` always outputs the trailing slash, so I took a conservative approach and used `strings.TrimRight`.

I've added a second commit, which prevents the errors from `getFavoriteLocation` to be overwritten by errors from `storage.ListerForURI`.

### Checklist:
- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.