### PR TITLE
Fix SetOnClosed for FileDialog

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -736,13 +736,13 @@ func (f *FileDialog) SetLocation(u fyne.ListableURI) {
 // SetOnClosed sets a callback function that is called when
 // the dialog is closed.
 func (f *FileDialog) SetOnClosed(closed func()) {
-	if f.dialog == nil {
-		return
-	}
 	// If there is already a callback set, remember it and call both.
 	originalCallback := f.onClosedCallback
 
 	f.onClosedCallback = func(response bool) {
+		if f.dialog == nil {
+			return
+		}
 		closed()
 		if originalCallback != nil {
 			originalCallback(response)

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -671,3 +671,13 @@ func TestCreateNewFolderInDir(t *testing.T) {
 	folderNameInputCreate := folderNameInputUI.Objects[3].(*fyne.Container).Objects[1].(*widget.Button)
 	assert.Equal(t, theme.ConfirmIcon(), folderNameInputCreate.Icon)
 }
+
+func TestSetOnClosedBeforeShow(t *testing.T) {
+	win := test.NewWindow(widget.NewLabel("Content"))
+	d := NewFileSave(func(fyne.URIWriteCloser, error) {}, win)
+	onClosedCalled := false
+	d.SetOnClosed(func() { onClosedCalled = true })
+	d.Show()
+	d.Hide()
+	assert.True(t, onClosedCalled)
+}


### PR DESCRIPTION
### Description:
`SetOnClose` did not work if called before `Show` for file dialogs.

Fixes #4651 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
