### PR TITLE
Properly validate offset in GridWrap.ScrollToOffset

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -328,13 +328,13 @@ func (l *GridWrap) UnselectAll() {
 
 func (l *GridWrap) contentMinSize() fyne.Size {
 	padding := theme.Padding()
-	if lenF := l.Length; lenF != nil {
-		cols := l.ColumnCount()
-		rows := float32(math.Ceil(float64(lenF()) / float64(cols)))
-		return fyne.NewSize(l.itemMin.Width,
-			(l.itemMin.Height+padding)*rows-padding)
+	if l.Length == nil {
+		return fyne.NewSize(0, 0)
 	}
-	return fyne.NewSize(0, 0)
+	
+	cols := l.ColumnCount()
+	rows := float32(math.Ceil(float64(l.Length()) / float64(cols)))
+	return fyne.NewSize(l.itemMin.Width, (l.itemMin.Height+padding)*rows-padding)
 }
 
 // Declare conformity with WidgetRenderer interface.

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -215,8 +215,17 @@ func (l *GridWrap) ScrollToTop() {
 
 // ScrollToOffset scrolls the list to the given offset position
 func (l *GridWrap) ScrollToOffset(offset float32) {
+	if l.scroller == nil {
+		return
+	}
+	if offset < 0 {
+		offset = 0
+	} else if contentH := l.contentMinSize().Height; offset > contentH {
+		offset = contentH
+	}
 	l.scroller.Offset.Y = offset
 	l.offsetUpdated(l.scroller.Offset)
+	l.Refresh()
 }
 
 // TypedKey is called if a key event happens while this GridWrap is focused.
@@ -315,6 +324,17 @@ func (l *GridWrap) UnselectAll() {
 			f(id)
 		}
 	}
+}
+
+func (l *GridWrap) contentMinSize() fyne.Size {
+	padding := theme.Padding()
+	if lenF := l.Length; lenF != nil {
+		cols := l.getColCount()
+		rows := float32(math.Ceil(float64(lenF()) / float64(cols)))
+		return fyne.NewSize(l.itemMin.Width,
+			(l.itemMin.Height+padding)*rows-padding)
+	}
+	return fyne.NewSize(0, 0)
 }
 
 // Declare conformity with WidgetRenderer interface.
@@ -495,14 +515,7 @@ func (l *gridWrapLayout) Layout(_ []fyne.CanvasObject, _ fyne.Size) {
 }
 
 func (l *gridWrapLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
-	padding := theme.Padding()
-	if lenF := l.list.Length; lenF != nil {
-		cols := l.list.getColCount()
-		rows := float32(math.Ceil(float64(lenF()) / float64(cols)))
-		return fyne.NewSize(l.list.itemMin.Width,
-			(l.list.itemMin.Height+padding)*rows-padding)
-	}
-	return fyne.NewSize(0, 0)
+	return l.list.contentMinSize()
 }
 
 func (l *gridWrapLayout) getItem() *gridWrapItem {

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -329,7 +329,7 @@ func (l *GridWrap) UnselectAll() {
 func (l *GridWrap) contentMinSize() fyne.Size {
 	padding := theme.Padding()
 	if lenF := l.Length; lenF != nil {
-		cols := l.getColCount()
+		cols := l.ColumnCount()
 		rows := float32(math.Ceil(float64(lenF()) / float64(cols)))
 		return fyne.NewSize(l.itemMin.Width,
 			(l.itemMin.Height+padding)*rows-padding)

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -331,7 +331,7 @@ func (l *GridWrap) contentMinSize() fyne.Size {
 	if l.Length == nil {
 		return fyne.NewSize(0, 0)
 	}
-	
+
 	cols := l.ColumnCount()
 	rows := float32(math.Ceil(float64(l.Length()) / float64(cols)))
 	return fyne.NewSize(l.itemMin.Width, (l.itemMin.Height+padding)*rows-padding)

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -99,6 +99,19 @@ func TestGridWrap_ScrollTo(t *testing.T) {
 	assert.Equal(t, greatest, GridWrapItemID(999))
 }
 
+func TestGridWrap_ScrollToOffset(t *testing.T) {
+	g := createGridWrap(10)
+
+	g.ScrollToOffset(2)
+	assert.Equal(t, float32(2), g.GetScrollOffset())
+
+	g.ScrollToOffset(-20)
+	assert.Equal(t, float32(0), g.GetScrollOffset())
+
+	g.ScrollToOffset(10000)
+	assert.LessOrEqual(t, g.GetScrollOffset(), float32(50) /*upper bound on content height*/)
+}
+
 func TestGridWrap_ScrollToTop(t *testing.T) {
 	g := createGridWrap(1000)
 	g.ScrollTo(750)


### PR DESCRIPTION
### Description:
Ensures that ScrollToOffset cannot be used to scroll beyond the content size, even if the viewport (ie size of the widget itself) is larger than the content size. Also fixes a missed Refresh call in ScrollToOffset.

Fixes #4655 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
