### PR TITLE
Rework markdown parser to fix #4613

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -27,196 +27,179 @@ func (t *RichText) ParseMarkdown(content string) {
 	t.Refresh()
 }
 
-type markdownRenderer struct {
-	blockquote  bool
-	heading     bool
-	nextSeg     RichTextSegment
-	parentStack [][]RichTextSegment
-	segs        []RichTextSegment
-}
+type markdownRenderer []RichTextSegment
 
 func (m *markdownRenderer) AddOptions(...renderer.Option) {}
 
 func (m *markdownRenderer) Render(_ io.Writer, source []byte, n ast.Node) error {
-	m.nextSeg = &TextSegment{}
-	err := ast.Walk(n, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			if n.Kind().String() == "Heading" {
-				m.segs = append(m.segs, m.nextSeg)
-				m.heading = false
-			}
-			return ast.WalkContinue, m.handleExitNode(n)
-		}
-
-		switch n.Kind().String() {
-		case "List":
-			// prepare a new child level
-			m.parentStack = append(m.parentStack, m.segs)
-			m.segs = nil
-		case "ListItem":
-			// prepare a new item level
-			m.parentStack = append(m.parentStack, m.segs)
-			m.segs = nil
-		case "Heading":
-			m.heading = true
-			switch n.(*ast.Heading).Level {
-			case 1:
-				m.nextSeg = &TextSegment{
-					Style: RichTextStyleHeading,
-				}
-			case 2:
-				m.nextSeg = &TextSegment{
-					Style: RichTextStyleSubHeading,
-				}
-			default:
-				m.nextSeg = &TextSegment{
-					Style: RichTextStyleParagraph,
-				}
-				m.nextSeg.(*TextSegment).Style.TextStyle.Bold = true
-			}
-		case "HorizontalRule", "ThematicBreak":
-			m.segs = append(m.segs, &SeparatorSegment{})
-		case "Link":
-			m.nextSeg = makeLink(n.(*ast.Link))
-		case "Paragraph":
-			m.nextSeg = &TextSegment{
-				Style: RichTextStyleInline, // we make it a paragraph at the end if there are no more elements
-			}
-			if m.blockquote {
-				m.nextSeg.(*TextSegment).Style = RichTextStyleBlockquote
-			}
-		case "CodeSpan":
-			m.nextSeg = &TextSegment{
-				Style: RichTextStyleCodeInline,
-			}
-		case "CodeBlock", "FencedCodeBlock":
-			var data []byte
-			lines := n.Lines()
-			for i := 0; i < lines.Len(); i++ {
-				line := lines.At(i)
-				data = append(data, line.Value(source)...)
-			}
-			if len(data) == 0 {
-				return ast.WalkContinue, nil
-			}
-			if data[len(data)-1] == '\n' {
-				data = data[:len(data)-1]
-			}
-			m.segs = append(m.segs, &TextSegment{
-				Style: RichTextStyleCodeBlock,
-				Text:  string(data),
-			})
-		case "Emph", "Emphasis":
-			switch n.(*ast.Emphasis).Level {
-			case 2:
-				m.nextSeg = &TextSegment{
-					Style: RichTextStyleStrong,
-				}
-			default:
-				m.nextSeg = &TextSegment{
-					Style: RichTextStyleEmphasis,
-				}
-			}
-		case "Strong":
-			m.nextSeg = &TextSegment{
-				Style: RichTextStyleStrong,
-			}
-		case "Text":
-			ret := addTextToSegment(string(n.Text(source)), m.nextSeg, n)
-			if ret != 0 {
-				return ret, nil
-			}
-
-			_, isImage := m.nextSeg.(*ImageSegment)
-			if !m.heading && !isImage {
-				m.segs = append(m.segs, m.nextSeg)
-			}
-		case "Blockquote":
-			m.blockquote = true
-		case "Image":
-			m.nextSeg = makeImage(n.(*ast.Image)) // remember this for applying title
-			m.segs = append(m.segs, m.nextSeg)
-		}
-
-		return ast.WalkContinue, nil
-	})
+	segs, err := renderNode(source, n, false, true)
+	*m = segs
 	return err
 }
 
-func (m *markdownRenderer) handleExitNode(n ast.Node) error {
-	if n.Kind().String() == "Blockquote" {
-		m.blockquote = false
-	} else if n.Kind().String() == "List" {
-		listSegs := m.segs
-		m.segs = m.parentStack[len(m.parentStack)-1]
-		m.parentStack = m.parentStack[:len(m.parentStack)-1]
-		marker := n.(*ast.List).Marker
-		m.segs = append(m.segs, &ListSegment{Items: listSegs, Ordered: marker != '*' && marker != '-' && marker != '+'})
-	} else if n.Kind().String() == "ListItem" {
-		itemSegs := m.segs
-		m.segs = m.parentStack[len(m.parentStack)-1]
-		m.parentStack = m.parentStack[:len(m.parentStack)-1]
-		m.segs = append(m.segs, &ParagraphSegment{Texts: itemSegs})
-	} else if !m.blockquote && !m.heading {
-		if len(m.segs) > 0 {
-			if text, ok := m.segs[len(m.segs)-1].(*TextSegment); ok && n.Kind().String() == "Paragraph" {
-				text.Style.Inline = false
+func renderNode(source []byte, n ast.Node, blockquote, firstSegInParagraph bool) ([]RichTextSegment, error) {
+	switch t := n.(type) {
+	case *ast.Document:
+		return renderChildren(source, n, blockquote, true)
+	case *ast.Paragraph:
+		children, err := renderChildren(source, n, blockquote, true)
+		if !blockquote {
+			linebreak := &TextSegment{Style: RichTextStyleParagraph}
+			children = append(children, linebreak)
+		}
+		return children, err
+	case *ast.List:
+		items, err := renderChildren(source, n, blockquote, firstSegInParagraph)
+		return []RichTextSegment{
+			&ListSegment{Items: items, Ordered: t.Marker != '*' && t.Marker != '-' && t.Marker != '+'},
+		}, err
+	case *ast.ListItem:
+		texts, err := renderChildren(source, n, blockquote, firstSegInParagraph)
+		return []RichTextSegment{&ParagraphSegment{Texts: texts}}, err
+	case *ast.TextBlock:
+		return renderChildren(source, n, blockquote, true)
+	case *ast.Heading:
+		text := forceIntoHeadingText(source, n)
+		switch t.Level {
+		case 1:
+			return []RichTextSegment{&TextSegment{Style: RichTextStyleHeading, Text: text}}, nil
+		case 2:
+			return []RichTextSegment{&TextSegment{Style: RichTextStyleSubHeading, Text: text}}, nil
+		default:
+			textSegment := TextSegment{Style: RichTextStyleParagraph, Text: text}
+			textSegment.Style.TextStyle.Bold = true
+			return []RichTextSegment{&textSegment}, nil
+		}
+	case *ast.ThematicBreak:
+		return []RichTextSegment{&SeparatorSegment{}}, nil
+	case *ast.Link:
+		link, _ := url.Parse(string(t.Destination))
+		text := forceIntoText(source, n)
+		text = prefixSpaceIfAppropriate(text, source, n, firstSegInParagraph)
+		firstSegInParagraph = false
+		return []RichTextSegment{&HyperlinkSegment{Alignment: fyne.TextAlignLeading, Text: text, URL: link}}, nil
+	case *ast.CodeSpan:
+		text := forceIntoText(source, n)
+		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeInline, Text: text}}, nil
+	case *ast.CodeBlock, *ast.FencedCodeBlock:
+		var data []byte
+		lines := n.Lines()
+		for i := 0; i < lines.Len(); i++ {
+			line := lines.At(i)
+			data = append(data, line.Value(source)...)
+		}
+		if len(data) == 0 {
+			return nil, nil
+		}
+		if data[len(data)-1] == '\n' {
+			data = data[:len(data)-1]
+		}
+		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeBlock, Text: string(data)}}, nil
+	case *ast.Emphasis:
+		text := string(forceIntoText(source, n))
+		text = prefixSpaceIfAppropriate(text, source, n, firstSegInParagraph)
+		firstSegInParagraph = false
+		switch t.Level {
+		case 2:
+			return []RichTextSegment{&TextSegment{Style: RichTextStyleStrong, Text: text}}, nil
+		default:
+			return []RichTextSegment{&TextSegment{Style: RichTextStyleEmphasis, Text: text}}, nil
+		}
+	case *ast.Text:
+		text := string(t.Text(source))
+		if text == "" {
+			// These empty text elements indicate single line breaks after non-text elements in goldmark.
+			return []RichTextSegment{&TextSegment{Style: RichTextStyleInline, Text: " "}}, nil
+		}
+		text = prefixSpaceIfAppropriate(text, source, n, firstSegInParagraph)
+		firstSegInParagraph = false
+		if blockquote {
+			return []RichTextSegment{&TextSegment{Style: RichTextStyleBlockquote, Text: text}}, nil
+		}
+		return []RichTextSegment{&TextSegment{Style: RichTextStyleInline, Text: text}}, nil
+	case *ast.Blockquote:
+		return renderChildren(source, n, true, firstSegInParagraph)
+	case *ast.Image:
+		dest := string(t.Destination)
+		u, err := storage.ParseURI(dest)
+		if err != nil {
+			u = storage.NewFileURI(dest)
+		}
+		return []RichTextSegment{&ImageSegment{Source: u, Title: string(t.Title), Alignment: fyne.TextAlignCenter}}, nil
+	}
+	return nil, nil
+}
+
+func prefixSpaceIfAppropriate(text string, source []byte, n ast.Node, firstSegInParagraph bool) string {
+	// No space should be added before the first segment in a paragraph.
+	//
+	// Also, if the previous sibling was not Text (it was Emphasis or
+	// Link), goldmark already indicates whether a space should be added by
+	// emitting an empty Text. This is already handled in renderNode.
+	if !firstSegInParagraph && n.PreviousSibling() != nil {
+		if t, ok := n.PreviousSibling().(*ast.Text); ok {
+			prevText := string(t.Text(source))
+			if prevText == "" {
+				// A spacer was already added in renderNode for this node.
+				return text
+			} else if strings.HasSuffix(prevText, " ") {
+				// There was no linebreak and the previous text contains the space.
+				return text
+			}
+			return " " + text
+		}
+	}
+	return text
+}
+
+func renderChildren(source []byte, n ast.Node, blockquote, firstSegInParagraph bool) ([]RichTextSegment, error) {
+	children := make([]RichTextSegment, 0, n.ChildCount())
+	for childCount, child := n.ChildCount(), n.FirstChild(); childCount > 0; childCount-- {
+		segs, err := renderNode(source, child, blockquote, firstSegInParagraph)
+		firstSegInParagraph = false
+		if err != nil {
+			return children, err
+		}
+		children = append(children, segs...)
+		child = child.NextSibling()
+	}
+	return children, nil
+}
+
+func forceIntoText(source []byte, n ast.Node) string {
+	texts := make([]string, 0)
+	ast.Walk(n, func(n2 ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			switch t := n2.(type) {
+			case *ast.Text:
+				texts = append(texts, string(t.Text(source)))
 			}
 		}
-		m.nextSeg = &TextSegment{
-			Style: RichTextStyleInline,
-		}
-	}
-	return nil
+		return ast.WalkContinue, nil
+	})
+	return strings.Join(texts, " ")
 }
 
-func addTextToSegment(text string, s RichTextSegment, node ast.Node) ast.WalkStatus {
-	trimmed := strings.ReplaceAll(text, "\n", " ") // newline inside paragraph is not newline
-	if trimmed == "" {
-		return ast.WalkContinue
-	}
-	if t, ok := s.(*TextSegment); ok {
-		next := node.(*ast.Text).NextSibling()
-		if next != nil {
-			if nextText, ok := next.(*ast.Text); ok {
-				if nextText.Segment.Start > node.(*ast.Text).Segment.Stop { // detect presence of a trailing newline
-					trimmed = trimmed + " "
-				}
+func forceIntoHeadingText(source []byte, n ast.Node) string {
+	var text strings.Builder
+	ast.Walk(n, func(n2 ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			switch t := n2.(type) {
+			case *ast.Text:
+				text.Write(t.Text(source))
 			}
 		}
-
-		t.Text = t.Text + trimmed
-	}
-	if link, ok := s.(*HyperlinkSegment); ok {
-		link.Text = link.Text + trimmed
-	}
-	return 0
-}
-
-func makeImage(n *ast.Image) *ImageSegment {
-	dest := string(n.Destination)
-	u, err := storage.ParseURI(dest)
-	if err != nil {
-		u = storage.NewFileURI(dest)
-	}
-	return &ImageSegment{Source: u, Title: string(n.Title), Alignment: fyne.TextAlignCenter}
-}
-
-func makeLink(n *ast.Link) *HyperlinkSegment {
-	link, _ := url.Parse(string(n.Destination))
-	return &HyperlinkSegment{fyne.TextAlignLeading, "", link, nil}
+		return ast.WalkContinue, nil
+	})
+	return text.String()
 }
 
 func parseMarkdown(content string) []RichTextSegment {
-	r := &markdownRenderer{}
-	if content == "" {
-		return r.segs
-	}
-
-	md := goldmark.New(goldmark.WithRenderer(r))
+	r := markdownRenderer{}
+	md := goldmark.New(goldmark.WithRenderer(&r))
 	err := md.Convert([]byte(content), nil)
 	if err != nil {
 		fyne.LogError("Failed to parse markdown", err)
 	}
-	return r.segs
+	return r
 }

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -225,3 +225,22 @@ func TestRichTextMarkdown_Separator(t *testing.T) {
 		t.Error("Segment should be a separator")
 	}
 }
+
+func BenchmarkMarkdownParsing(b *testing.B) {
+	md := `# Test heading
+This is some test markdown. It contains some different markdown
+elements in an effort to put a realistic load onto the parser.
+
+> Here is a quote.
+> It streches over two lines and contains some ` + "`inline code`" + `.
+
+Moreover, we've got a list:
+- foo
+- bar
+- baz
+`
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		NewRichTextFromMarkdown(md)
+	}
+}

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -165,13 +165,13 @@ func TestRichTextMarkdown_Lines(t *testing.T) {
 
 	assert.Equal(t, 3, len(r.Segments))
 	if text, ok := r.Segments[0].(*TextSegment); ok {
-		assert.Equal(t, "line1", text.Text)
+		assert.Equal(t, "line1 ", text.Text)
 		assert.True(t, text.Inline())
 	} else {
 		t.Error("Segment should be Text")
 	}
 	if text, ok := r.Segments[1].(*TextSegment); ok {
-		assert.Equal(t, " line2", text.Text)
+		assert.Equal(t, "line2", text.Text)
 	} else {
 		t.Error("Segment should be Text")
 	}

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -11,8 +11,8 @@ import (
 func TestRichTextMarkdown_Blockquote(t *testing.T) {
 	r := NewRichTextFromMarkdown("p1\n\n> quote\n\np2")
 
-	assert.Equal(t, 3, len(r.Segments))
-	if text, ok := r.Segments[1].(*TextSegment); ok {
+	assert.Equal(t, 5, len(r.Segments))
+	if text, ok := r.Segments[2].(*TextSegment); ok {
 		assert.Equal(t, "quote", text.Text)
 		assert.Equal(t, RichTextStyleBlockquote, text.Style)
 	} else {
@@ -23,7 +23,7 @@ func TestRichTextMarkdown_Blockquote(t *testing.T) {
 func TestRichTextMarkdown_Code(t *testing.T) {
 	r := NewRichTextFromMarkdown("a `code` inline")
 
-	assert.Equal(t, 3, len(r.Segments))
+	assert.Equal(t, 4, len(r.Segments))
 	if text, ok := r.Segments[1].(*TextSegment); ok {
 		assert.Equal(t, "code", text.Text)
 		assert.Equal(t, RichTextStyleCodeInline, text.Style)
@@ -44,10 +44,10 @@ func TestRichTextMarkdown_Code(t *testing.T) {
 func TestRichTextMarkdown_Code_Incomplete(t *testing.T) {
 	r := NewRichTextFromMarkdown("` ")
 
-	assert.Equal(t, 1, len(r.Segments))
+	assert.Equal(t, 2, len(r.Segments))
 	if text, ok := r.Segments[0].(*TextSegment); ok {
 		assert.Equal(t, "`", text.Text)
-		assert.Equal(t, RichTextStyleParagraph, text.Style)
+		assert.Equal(t, RichTextStyleInline, text.Style)
 	} else {
 		t.Error("Segment should be Text")
 	}
@@ -62,7 +62,7 @@ func TestRichTextMarkdown_Code_Incomplete(t *testing.T) {
 func TestRichTextMarkdown_Emphasis(t *testing.T) {
 	r := NewRichTextFromMarkdown("*a*")
 
-	assert.Equal(t, 1, len(r.Segments))
+	assert.Equal(t, 2, len(r.Segments))
 	if text, ok := r.Segments[0].(*TextSegment); ok {
 		assert.Equal(t, "a", text.Text)
 		assert.True(t, text.Style.TextStyle.Italic)
@@ -72,7 +72,7 @@ func TestRichTextMarkdown_Emphasis(t *testing.T) {
 
 	r.ParseMarkdown("**b**.")
 
-	assert.Equal(t, 2, len(r.Segments))
+	assert.Equal(t, 3, len(r.Segments))
 	if text, ok := r.Segments[0].(*TextSegment); ok {
 		assert.Equal(t, "b", text.Text)
 		assert.True(t, text.Style.TextStyle.Bold)
@@ -131,7 +131,7 @@ func TestRichTextMarkdown_Heading_Blank(t *testing.T) {
 func TestRichTextMarkdown_Hyperlink(t *testing.T) {
 	r := NewRichTextFromMarkdown("[title](https://fyne.io/)")
 
-	assert.Equal(t, 1, len(r.Segments))
+	assert.Equal(t, 2, len(r.Segments))
 	if link, ok := r.Segments[0].(*HyperlinkSegment); ok {
 		assert.Equal(t, "title", link.Text)
 		assert.Equal(t, "fyne.io", link.URL.Host)
@@ -143,7 +143,7 @@ func TestRichTextMarkdown_Hyperlink(t *testing.T) {
 func TestRichTextMarkdown_Image(t *testing.T) {
 	r := NewRichTextFromMarkdown("![title](../../theme/icons/fyne.png)")
 
-	assert.Equal(t, 1, len(r.Segments))
+	assert.Equal(t, 2, len(r.Segments))
 	if img, ok := r.Segments[0].(*ImageSegment); ok {
 		assert.Equal(t, storage.NewFileURI("../../theme/icons/fyne.png"), img.Source)
 	} else {
@@ -152,7 +152,7 @@ func TestRichTextMarkdown_Image(t *testing.T) {
 
 	r = NewRichTextFromMarkdown("![](../../theme/icons/fyne.png)")
 
-	assert.Equal(t, 1, len(r.Segments))
+	assert.Equal(t, 2, len(r.Segments))
 	if img, ok := r.Segments[0].(*ImageSegment); ok {
 		assert.Equal(t, storage.NewFileURI("../../theme/icons/fyne.png"), img.Source)
 	} else {
@@ -163,29 +163,29 @@ func TestRichTextMarkdown_Image(t *testing.T) {
 func TestRichTextMarkdown_Lines(t *testing.T) {
 	r := NewRichTextFromMarkdown("line1\nline2\n") // a single newline is not a new paragraph
 
-	assert.Equal(t, 2, len(r.Segments))
+	assert.Equal(t, 3, len(r.Segments))
 	if text, ok := r.Segments[0].(*TextSegment); ok {
-		assert.Equal(t, "line1 ", text.Text)
+		assert.Equal(t, "line1", text.Text)
 		assert.True(t, text.Inline())
 	} else {
 		t.Error("Segment should be Text")
 	}
 	if text, ok := r.Segments[1].(*TextSegment); ok {
-		assert.Equal(t, "line2", text.Text)
+		assert.Equal(t, " line2", text.Text)
 	} else {
 		t.Error("Segment should be Text")
 	}
 
 	r.ParseMarkdown("line1\n\nline2\n")
 
-	assert.Equal(t, 2, len(r.Segments))
+	assert.Equal(t, 4, len(r.Segments))
 	if text, ok := r.Segments[0].(*TextSegment); ok {
 		assert.Equal(t, "line1", text.Text)
-		assert.False(t, text.Inline())
+		assert.True(t, text.Inline())
 	} else {
 		t.Error("Segment should be Text")
 	}
-	if text, ok := r.Segments[1].(*TextSegment); ok {
+	if text, ok := r.Segments[2].(*TextSegment); ok {
 		assert.Equal(t, "line2", text.Text)
 	} else {
 		t.Error("Segment should be Text")

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -226,6 +226,31 @@ func TestRichTextMarkdown_Separator(t *testing.T) {
 	}
 }
 
+func TestRichTextMarkdown_NewlinesAroundEmphasis(t *testing.T) {
+	r := NewRichTextFromMarkdown("foo\n*bar*\nbaz")
+	assert.Equal(t, "foo bar baz", r.String())
+}
+
+func TestRichTextMarkdown_NewlinesAroundStrong(t *testing.T) {
+	r := NewRichTextFromMarkdown("foo\n**bar**\nbaz")
+	assert.Equal(t, "foo bar baz", r.String())
+}
+
+func TestRichTextMarkdown_NewlinesAroundHyperlink(t *testing.T) {
+	r := NewRichTextFromMarkdown("foo\n[bar](https://fyne.io/)\nbaz")
+	assert.Equal(t, "foo bar baz", r.String())
+}
+
+func TestRichTextMarkdown_SpacesAroundHyperlink(t *testing.T) {
+	r := NewRichTextFromMarkdown("foo [bar](https://fyne.io/) baz")
+	assert.Equal(t, "foo bar baz", r.String())
+}
+
+func TestRichTextMarkdown_NewlineInHyperlink(t *testing.T) {
+	r := NewRichTextFromMarkdown("[foo\nbar](https://fyne.io/)")
+	assert.Equal(t, "foo bar", r.String())
+}
+
 func BenchmarkMarkdownParsing(b *testing.B) {
 	md := `# Test heading
 This is some test markdown. It contains some different markdown

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -226,6 +226,18 @@ func TestRichTextMarkdown_Separator(t *testing.T) {
 	}
 }
 
+func TestRichTextMarkdown_Paragraph(t *testing.T) {
+	r := NewRichTextFromMarkdown("foo")
+
+	assert.Equal(t, 2, len(r.Segments))
+	if text, ok := r.Segments[1].(*TextSegment); ok {
+		assert.Equal(t, "", text.Text)
+		assert.Equal(t, RichTextStyleParagraph, text.Style)
+	} else {
+		t.Error("Last segment of paragraph should be empty text")
+	}
+}
+
 func TestRichTextMarkdown_NewlinesAroundEmphasis(t *testing.T) {
 	r := NewRichTextFromMarkdown("foo\n*bar*\nbaz")
 	assert.Equal(t, "foo bar baz", r.String())


### PR DESCRIPTION
### Description:
First of all: Sorry for the huge diff, without any previous conversation. I had an idea for a rework, but before suggesting it, I wanted to see if the idea would even work. Before I knew it, I fell into a rabbit hole and now here I am with this PR.

Inspired by #4613, I read through `markdown.go` and investigated goldmark a little bit (here's a tool to visualize goldmark's ASTs: [goldmarkvis](https://github.com/codesoap/goldmarkvis)). I got an understanding of where spaces should be added, but couldn't find an easy way to incorporate my newfound knowledge into the existing design. I felt like it would be easier, if the AST were rendered with recursive code.

I went ahead and tried it out. With this approach, I was able to fix all the problems mentioned in #4613 (including the "split link"). As a side effect, the code also got a little more compact and slightly more readable (but that's highly subjective, of course).

I have also added a benchmark, which shows a slight decline of performance with the new implementation, but it's not too bad and I would assume that performance would have decreased anyway, no matter how #4613 would have been fixed:
- Before: `BenchmarkMarkdownParsing-4  8527  135023 ns/op  34864 B/op  306 allocs/op`
- After: `BenchmarkMarkdownParsing-4  7798  149466 ns/op  35920 B/op  328 allocs/op`

Since the new implementation adds leading spaces instead of trailing ones, and also adds new segments for some spaces and the end of paragraphs, I had to adapt the existing tests slightly.

Fixes #4613 

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.