### PR TITLE
Fix double refresh in entry and unnecessary string buffer allocs

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1050,7 +1050,12 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 	if e.selecting {
 		e.SetFieldsAndRefresh(e.eraseSelection)
 	}
+
 	text := clipboard.Content()
+	if text == "" {
+		return // Nothing to paste into the text content.
+	}
+
 	if !e.MultiLine {
 		// format clipboard content to be compatible with single line entry
 		text = strings.Replace(text, "\n", " ", -1)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -481,8 +481,8 @@ func (e *Entry) Redo() {
 	if !modify.Delete {
 		pos += len(modify.Text)
 	}
-	e.updateTextAndRefresh(newText, false)
 	e.propertyLock.Lock()
+	e.updateText(newText, false)
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.propertyLock.Unlock()
 	e.Refresh()
@@ -510,7 +510,7 @@ func (e *Entry) SelectedText() string {
 	if start == stop {
 		return ""
 	}
-	r := ([]rune)(e.textProvider().String())
+	r := ([]rune)(e.Text)
 	return string(r[start:stop])
 }
 
@@ -802,8 +802,8 @@ func (e *Entry) Undo() {
 	if modify.Delete {
 		pos += len(modify.Text)
 	}
-	e.updateTextAndRefresh(newText, false)
 	e.propertyLock.Lock()
+	e.updateText(newText, false)
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.propertyLock.Unlock()
 	e.Refresh()
@@ -1065,10 +1065,10 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 		Position: pos,
 		Text:     text,
 	})
+	e.updateText(provider.String(), false)
+	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos + len(runes))
 	e.propertyLock.Unlock()
 
-	e.updateTextAndRefresh(provider.String(), false)
-	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos + len(runes))
 	e.Refresh() // placing the cursor (and refreshing) happens last
 }
 

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -280,7 +280,7 @@ func TestEntry_EraseSelection(t *testing.T) {
 	keyPress(&fyne.KeyEvent{Name: fyne.KeyRight})
 
 	_ = e.Theme()
-	e.eraseSelection()
+	e.eraseSelectionAndUpdate()
 	e.updateText(e.textProvider().String(), false)
 	assert.Equal(t, "Testing\nTeng\nTesting", e.Text)
 	a, b := e.selection()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is a reimplementation of the excellent work done by #4465 but without the strange test failures. I have not managed to figure out why they were failing but I managed to get these ones to not do so. I also fixed up a few cases where erasing selection was allocating the string buffer twice and a few extra refreshes being removed compared to the other PR.

We need to take care in the future to not refresh twice and not to run `provider.String()` as often given that it does allocate a string buffer every time. I believe that this should remove all cases of duplicated calls to these APIs. It would be nice to get this into v2.4.5 as it does speed things up nicely.

Replaces #4465
Fixes #4397 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
