### PR TITLE
RFC: Add caches to avoid recomputing MinSize multiple times

### DIFF
--- a/container.go
+++ b/container.go
@@ -10,8 +10,7 @@ var _ CanvasObject = (*Container)(nil)
 type Container struct {
 	size     Size     // The current size of the Container
 	position Position // The current position of the Container
-	minCache Size
-	Hidden   bool // Is this Container hidden
+	Hidden   bool     // Is this Container hidden
 
 	Layout  Layout // The Layout algorithm for arranging child CanvasObjects
 	lock    sync.Mutex
@@ -87,10 +86,6 @@ func (c *Container) Hide() {
 // MinSize calculates the minimum size of a Container.
 // This is delegated to the Layout, if specified, otherwise it will mimic MaxLayout.
 func (c *Container) MinSize() Size {
-	if !c.minCache.IsZero() {
-		return c.minCache
-	}
-
 	if c.Layout != nil {
 		return c.Layout.MinSize(c.Objects)
 	}
@@ -100,7 +95,6 @@ func (c *Container) MinSize() Size {
 		minSize = minSize.Max(child.MinSize())
 	}
 
-	c.minCache = minSize
 	return minSize
 }
 
@@ -117,8 +111,6 @@ func (c *Container) Position() Position {
 
 // Refresh causes this object to be redrawn in it's current state
 func (c *Container) Refresh() {
-	c.minCache = Size{}
-
 	c.layout()
 
 	for _, child := range c.Objects {

--- a/container.go
+++ b/container.go
@@ -117,6 +117,8 @@ func (c *Container) Position() Position {
 
 // Refresh causes this object to be redrawn in it's current state
 func (c *Container) Refresh() {
+	c.minCache = Size{}
+
 	c.layout()
 
 	for _, child := range c.Objects {
@@ -129,7 +131,6 @@ func (c *Container) Refresh() {
 		return
 	}
 	o.Refresh(c)
-	c.minCache = Size{}
 }
 
 // Remove updates the contents of this container to no longer include the specified object.

--- a/container.go
+++ b/container.go
@@ -1,8 +1,6 @@
 package fyne
 
-import (
-	"sync"
-)
+import "sync"
 
 // Declare conformity to CanvasObject
 var _ CanvasObject = (*Container)(nil)

--- a/container.go
+++ b/container.go
@@ -1,6 +1,8 @@
 package fyne
 
-import "sync"
+import (
+	"sync"
+)
 
 // Declare conformity to CanvasObject
 var _ CanvasObject = (*Container)(nil)
@@ -10,7 +12,8 @@ var _ CanvasObject = (*Container)(nil)
 type Container struct {
 	size     Size     // The current size of the Container
 	position Position // The current position of the Container
-	Hidden   bool     // Is this Container hidden
+	minCache Size
+	Hidden   bool // Is this Container hidden
 
 	Layout  Layout // The Layout algorithm for arranging child CanvasObjects
 	lock    sync.Mutex
@@ -86,6 +89,10 @@ func (c *Container) Hide() {
 // MinSize calculates the minimum size of a Container.
 // This is delegated to the Layout, if specified, otherwise it will mimic MaxLayout.
 func (c *Container) MinSize() Size {
+	if !c.minCache.IsZero() {
+		return c.minCache
+	}
+
 	if c.Layout != nil {
 		return c.Layout.MinSize(c.Objects)
 	}
@@ -95,6 +102,7 @@ func (c *Container) MinSize() Size {
 		minSize = minSize.Max(child.MinSize())
 	}
 
+	c.minCache = minSize
 	return minSize
 }
 
@@ -123,6 +131,7 @@ func (c *Container) Refresh() {
 		return
 	}
 	o.Refresh(c)
+	c.minCache = Size{}
 }
 
 // Remove updates the contents of this container to no longer include the specified object.

--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -120,9 +120,10 @@ func (w *Base) Refresh() {
 		return
 	}
 
+	w.minCache.Store(fyne.Size{})
+
 	render := cache.Renderer(impl)
 	render.Refresh()
-	w.minCache.Store(fyne.Size{})
 }
 
 // super will return the actual object that this represents.

--- a/widget/activity.go
+++ b/widget/activity.go
@@ -34,8 +34,7 @@ func NewActivity() *Activity {
 
 func (a *Activity) MinSize() fyne.Size {
 	a.ExtendBaseWidget(a)
-
-	return fyne.NewSquareSize(a.Theme().Size(theme.SizeNameInlineIcon))
+	return a.BaseWidget.MinSize()
 }
 
 // Start the activity indicator animation

--- a/widget/check.go
+++ b/widget/check.go
@@ -24,8 +24,6 @@ type Check struct {
 	hovered bool
 
 	binder basicBinder
-
-	minSize fyne.Size // cached for hover/tap position calculations
 }
 
 // NewCheck creates a new check widget with the set label and change handler
@@ -119,8 +117,9 @@ func (c *Check) MouseMoved(me *desktop.MouseEvent) {
 
 	// only hovered if cached minSize has not been initialized (test code)
 	// or the pointer is within the "active" area of the widget (its minSize)
-	c.hovered = c.minSize.IsZero() ||
-		(me.Position.X <= c.minSize.Width && me.Position.Y <= c.minSize.Height)
+	minSize := c.MinSize()
+	c.hovered = minSize.IsZero() ||
+		(me.Position.X <= minSize.Width && me.Position.Y <= minSize.Height)
 
 	if oldHovered != c.hovered {
 		c.Refresh()
@@ -132,8 +131,9 @@ func (c *Check) Tapped(pe *fyne.PointEvent) {
 	if c.Disabled() {
 		return
 	}
-	if !c.minSize.IsZero() &&
-		(pe.Position.X > c.minSize.Width || pe.Position.Y > c.minSize.Height) {
+	minSize := c.MinSize()
+	if !minSize.IsZero() &&
+		(pe.Position.X > minSize.Width || pe.Position.Y > minSize.Height) {
 		// tapped outside the active area of the widget
 		return
 	}
@@ -151,8 +151,7 @@ func (c *Check) Tapped(pe *fyne.PointEvent) {
 // MinSize returns the size that this widget should not shrink below
 func (c *Check) MinSize() fyne.Size {
 	c.ExtendBaseWidget(c)
-	c.minSize = c.BaseWidget.MinSize()
-	return c.minSize
+	return c.BaseWidget.MinSize()
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -409,16 +409,7 @@ func (e *Entry) MinSize() fyne.Size {
 	}
 
 	e.ExtendBaseWidget(e)
-
-	th := e.Theme()
-	iconSpace := th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameLineSpacing)
 	min := e.BaseWidget.MinSize()
-	if e.ActionItem != nil {
-		min = min.Add(fyne.NewSize(iconSpace, 0))
-	}
-	if e.Validator != nil {
-		min = min.Add(fyne.NewSize(iconSpace, 0))
-	}
 
 	e.propertyLock.Lock()
 	e.minCache = min
@@ -1679,25 +1670,39 @@ func (r *entryRenderer) MinSize() fyne.Size {
 	if rend := cache.Renderer(r.entry.content); rend != nil {
 		rend.(*entryContentRenderer).updateScrollDirections()
 	}
+
+	th := r.entry.Theme()
+	minSize := fyne.Size{}
+
 	if r.scroll.Direction == widget.ScrollNone {
-		return r.entry.content.MinSize().Add(fyne.NewSize(0, r.entry.Theme().Size(theme.SizeNameInputBorder)*2))
-	}
+		minSize = r.entry.content.MinSize().AddWidthHeight(0, th.Size(theme.SizeNameInputBorder)*2)
+	} else {
+		innerPadding := th.Size(theme.SizeNameInnerPadding)
+		textSize := th.Size(theme.SizeNameText)
+		charMin := r.entry.placeholderProvider().charMinSize(r.entry.Password, r.entry.TextStyle, textSize)
+		minSize = charMin.Add(fyne.NewSquareSize(innerPadding))
 
-	innerPadding := r.entry.Theme().Size(theme.SizeNameInnerPadding)
-	textSize := r.entry.Theme().Size(theme.SizeNameText)
-	charMin := r.entry.placeholderProvider().charMinSize(r.entry.Password, r.entry.TextStyle, textSize)
-	minSize := charMin.Add(fyne.NewSquareSize(innerPadding))
+		if r.entry.MultiLine {
+			count := r.entry.multiLineRows
+			if count <= 0 {
+				count = multiLineRows
+			}
 
-	if r.entry.MultiLine {
-		count := r.entry.multiLineRows
-		if count <= 0 {
-			count = multiLineRows
+			minSize.Height = charMin.Height*float32(count) + innerPadding
 		}
 
-		minSize.Height = charMin.Height*float32(count) + innerPadding
+		minSize = minSize.AddWidthHeight(innerPadding*2, innerPadding)
 	}
 
-	return minSize.Add(fyne.NewSize(innerPadding*2, innerPadding))
+	iconSpace := th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameLineSpacing)
+	if r.entry.ActionItem != nil {
+		minSize.Width += iconSpace
+	}
+	if r.entry.Validator != nil {
+		minSize.Width += iconSpace
+	}
+
+	return minSize
 }
 
 func (r *entryRenderer) Objects() []fyne.CanvasObject {

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -400,16 +400,8 @@ func (e *Entry) KeyUp(key *fyne.KeyEvent) {
 //
 // Implements: fyne.Widget
 func (e *Entry) MinSize() fyne.Size {
-	cached := e.GetMinSizeCache()
-	if !cached.IsZero() {
-		return cached
-	}
-
 	e.ExtendBaseWidget(e)
-	min := e.BaseWidget.MinSize()
-
-	e.SetMinSizeCache(min)
-	return min
+	return e.BaseWidget.MinSize()
 }
 
 // MouseDown called on mouse click, this triggers a mouse click which can move the cursor,

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -95,7 +95,6 @@ type Entry struct {
 	ActionItem      fyne.CanvasObject `json:"-"`
 	binder          basicBinder
 	conversionError error
-	minCache        fyne.Size
 	multiLineRows   int // override global default number of visible lines
 
 	// undoStack stores the data necessary for undo/redo functionality
@@ -401,9 +400,7 @@ func (e *Entry) KeyUp(key *fyne.KeyEvent) {
 //
 // Implements: fyne.Widget
 func (e *Entry) MinSize() fyne.Size {
-	e.propertyLock.RLock()
-	cached := e.minCache
-	e.propertyLock.RUnlock()
+	cached := e.GetMinSizeCache()
 	if !cached.IsZero() {
 		return cached
 	}
@@ -411,9 +408,7 @@ func (e *Entry) MinSize() fyne.Size {
 	e.ExtendBaseWidget(e)
 	min := e.BaseWidget.MinSize()
 
-	e.propertyLock.Lock()
-	e.minCache = min
-	e.propertyLock.Unlock()
+	e.SetMinSizeCache(min)
 	return min
 }
 
@@ -477,14 +472,6 @@ func (e *Entry) Redo() {
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.propertyLock.Unlock()
 	e.Refresh()
-}
-
-func (e *Entry) Refresh() {
-	e.propertyLock.Lock()
-	e.minCache = fyne.Size{}
-	e.propertyLock.Unlock()
-
-	e.BaseWidget.Refresh()
 }
 
 // SelectedText returns the text currently selected in this Entry.

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -454,7 +454,7 @@ func TestEntry_MinSize(t *testing.T) {
 	min = entry.MinSize()
 	entry.ActionItem = canvas.NewCircle(color.Black)
 	entry.Refresh()
-	assert.Equal(t, min.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0)), entry.MinSize())
+	assert.Equal(t, min.Add(fyne.NewSize(theme.IconInlineSize()+theme.LineSpacing(), 0)), entry.MinSize())
 }
 
 func TestEntryMultiline_MinSize(t *testing.T) {

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -112,7 +112,6 @@ func (l *GridWrap) FocusLost() {
 // MinSize returns the size that this widget should not shrink below.
 func (l *GridWrap) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
-
 	return l.BaseWidget.MinSize()
 }
 

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -188,6 +188,7 @@ func (hl *Hyperlink) SetText(text string) {
 		return // Not initialized yet.
 	}
 	hl.syncSegments()
+	hl.ResetMinSizeCache()
 	hl.provider.Refresh()
 }
 

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -163,11 +163,8 @@ func (hl *Hyperlink) Refresh() {
 
 // MinSize returns the smallest size this widget can shrink to
 func (hl *Hyperlink) MinSize() fyne.Size {
-	if len(hl.provider.Segments) == 0 {
-		hl.syncSegments()
-	}
-
-	return hl.provider.MinSize()
+	hl.ExtendBaseWidget(hl)
+	return hl.BaseWidget.MinSize()
 }
 
 // Resize sets a new size for the hyperlink.

--- a/widget/label.go
+++ b/widget/label.go
@@ -3,7 +3,6 @@ package widget
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/data/binding"
-	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -77,12 +76,8 @@ func (l *Label) CreateRenderer() fyne.WidgetRenderer {
 //
 // Implements: fyne.Widget
 func (l *Label) MinSize() fyne.Size {
-	if l.provider == nil {
-		l.ExtendBaseWidget(l)
-		cache.Renderer(l.super())
-	}
-
-	return l.provider.MinSize()
+	l.ExtendBaseWidget(l)
+	return l.BaseWidget.MinSize()
 }
 
 // Refresh triggers a redraw of the label.

--- a/widget/list.go
+++ b/widget/list.go
@@ -110,7 +110,6 @@ func (l *List) FocusLost() {
 // MinSize returns the size that this widget should not shrink below.
 func (l *List) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
-
 	return l.BaseWidget.MinSize()
 }
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -45,7 +45,6 @@ type RichText struct {
 
 	visualCache map[RichTextSegment][]fyne.CanvasObject
 	cacheLock   sync.Mutex
-	minCache    fyne.Size
 }
 
 // NewRichText returns a new RichText widget that renders the given text and segments.
@@ -89,19 +88,14 @@ func (t *RichText) CreateRenderer() fyne.WidgetRenderer {
 // MinSize calculates the minimum size of a rich text widget.
 // This is based on the contained text with a standard amount of padding added.
 func (t *RichText) MinSize() fyne.Size {
-	// we don't return the minCache here, as any internal segments could have caused it to change...
 	t.ExtendBaseWidget(t)
-
-	min := t.BaseWidget.MinSize()
-	t.minCache = min
-	return min
+	return t.BaseWidget.MinSize()
 }
 
 // Refresh triggers a redraw of the rich text.
 //
 // Implements: fyne.Widget
 func (t *RichText) Refresh() {
-	t.minCache = fyne.Size{}
 	t.updateRowBounds()
 
 	for _, s := range t.Segments {
@@ -123,10 +117,11 @@ func (t *RichText) Resize(size fyne.Size) {
 	}
 
 	t.size.Store(size)
+	minSize := t.MinSize()
 
 	t.propertyLock.RLock()
 	segments := t.Segments
-	skipResize := !t.minCache.IsZero() && size.Width >= t.minCache.Width && size.Height >= t.minCache.Height && t.Wrapping == fyne.TextWrapOff && t.Truncation == fyne.TextTruncateOff
+	skipResize := !minSize.IsZero() && size.Width >= minSize.Width && size.Height >= minSize.Height && t.Wrapping == fyne.TextWrapOff && t.Truncation == fyne.TextTruncateOff
 	t.propertyLock.RUnlock()
 
 	if skipResize {

--- a/widget/select_entry.go
+++ b/widget/select_entry.go
@@ -55,7 +55,7 @@ func (e *SelectEntry) Disable() {
 // Implements: fyne.Widget
 func (e *SelectEntry) MinSize() fyne.Size {
 	e.ExtendBaseWidget(e)
-	return e.Entry.MinSize()
+	return e.BaseWidget.MinSize()
 }
 
 // Move changes the relative position of the select entry.

--- a/widget/separator.go
+++ b/widget/separator.go
@@ -55,8 +55,7 @@ func (s *Separator) CreateRenderer() fyne.WidgetRenderer {
 // Implements: fyne.Widget
 func (s *Separator) MinSize() fyne.Size {
 	s.ExtendBaseWidget(s)
-	t := s.Theme().Size(theme.SizeNameSeparatorThickness)
-	return fyne.NewSize(t, t)
+	return s.BaseWidget.MinSize()
 }
 
 var _ fyne.WidgetRenderer = (*separatorRenderer)(nil)
@@ -68,8 +67,7 @@ type separatorRenderer struct {
 }
 
 func (r *separatorRenderer) MinSize() fyne.Size {
-	t := r.d.Theme().Size(theme.SizeNameSeparatorThickness)
-	return fyne.NewSize(t, t)
+	return fyne.NewSquareSize(r.d.Theme().Size(theme.SizeNameSeparatorThickness))
 }
 
 func (r *separatorRenderer) Refresh() {

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -75,13 +75,6 @@ func (w *BaseWidget) MinSize() fyne.Size {
 		return minCache
 	}
 
-	min := w.MinSizeFromRenderer()
-	w.minCache.Store(min)
-	return min
-}
-
-// MinSizeFromRenderer returns the MinSize has defined by this widget's renderer.
-func (w *BaseWidget) MinSizeFromRenderer() fyne.Size {
 	impl := w.super()
 
 	r := cache.Renderer(impl)
@@ -89,7 +82,9 @@ func (w *BaseWidget) MinSizeFromRenderer() fyne.Size {
 		return fyne.Size{}
 	}
 
-	return r.MinSize()
+	min := r.MinSize()
+	w.minCache.Store(min)
+	return min
 }
 
 // Visible returns whether or not this widget should be visible.
@@ -99,18 +94,6 @@ func (w *BaseWidget) Visible() bool {
 	defer w.propertyLock.RUnlock()
 
 	return !w.Hidden
-}
-
-// GetMinSizeCache returns the currently cached MinSize value.
-// This value is set to zero on calling Refresh().
-func (w *BaseWidget) GetMinSizeCache() fyne.Size {
-	return w.minCache.Load()
-}
-
-// SetMinSizeCache updates the internal cache for the MinSize.
-// This cached value will be used until the next Refresh.
-func (w *BaseWidget) SetMinSizeCache(cache fyne.Size) {
-	w.minCache.Store(cache)
 }
 
 // Show this widget so it becomes visible

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -75,7 +75,9 @@ func (w *BaseWidget) MinSize() fyne.Size {
 		return minCache
 	}
 
-	return w.MinSizeFromRenderer()
+	min := w.MinSizeFromRenderer()
+	w.minCache.Store(min)
+	return min
 }
 
 // MinSizeFromRenderer returns the MinSize has defined by this widget's renderer.

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -141,6 +141,11 @@ func (w *BaseWidget) Refresh() {
 	render.Refresh()
 }
 
+// ResetMinSizeCache resets the cached MinSize for this widget.
+func (w *BaseWidget) ResetMinSizeCache() {
+	w.minCache.Store(fyne.Size{})
+}
+
 // Theme returns a cached Theme instance for this widget (or its extending widget).
 // This will be the app theme in most cases, or a widget specific theme if it is inside a ThemeOverride container.
 //
@@ -181,6 +186,7 @@ func (w *BaseWidget) SetFieldsAndRefresh(f func()) {
 		return
 	}
 	impl.Refresh()
+	w.ResetMinSizeCache()
 }
 
 // super will return the actual object that this represents.


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is a request for comments about adding an automatic and built-in cache for MinSize values in BaseWidget and containers. This avoids having to recalculate the size by walking the entire tree of objects each time. It does incur a slight change of behaviours for widgets that overwrite the `MinSize()` method and use the size given from the BaseWidget to add or subtract to. I have updated all widgets to make sure that the renderer defines the needed MinSize and as such all widgets are updated to use the cache. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
