### PR TITLE
widget: Move some minsize calculations to the renderer

### DIFF
--- a/widget/activity.go
+++ b/widget/activity.go
@@ -34,8 +34,7 @@ func NewActivity() *Activity {
 
 func (a *Activity) MinSize() fyne.Size {
 	a.ExtendBaseWidget(a)
-
-	return fyne.NewSquareSize(a.Theme().Size(theme.SizeNameInlineIcon))
+	return a.BaseWidget.MinSize()
 }
 
 // Start the activity indicator animation

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -409,16 +409,7 @@ func (e *Entry) MinSize() fyne.Size {
 	}
 
 	e.ExtendBaseWidget(e)
-
-	th := e.Theme()
-	iconSpace := th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameLineSpacing)
 	min := e.BaseWidget.MinSize()
-	if e.ActionItem != nil {
-		min = min.Add(fyne.NewSize(iconSpace, 0))
-	}
-	if e.Validator != nil {
-		min = min.Add(fyne.NewSize(iconSpace, 0))
-	}
 
 	e.propertyLock.Lock()
 	e.minCache = min
@@ -1679,25 +1670,39 @@ func (r *entryRenderer) MinSize() fyne.Size {
 	if rend := cache.Renderer(r.entry.content); rend != nil {
 		rend.(*entryContentRenderer).updateScrollDirections()
 	}
+
+	th := r.entry.Theme()
+	minSize := fyne.Size{}
+
 	if r.scroll.Direction == widget.ScrollNone {
-		return r.entry.content.MinSize().Add(fyne.NewSize(0, r.entry.Theme().Size(theme.SizeNameInputBorder)*2))
-	}
+		minSize = r.entry.content.MinSize().AddWidthHeight(0, th.Size(theme.SizeNameInputBorder)*2)
+	} else {
+		innerPadding := th.Size(theme.SizeNameInnerPadding)
+		textSize := th.Size(theme.SizeNameText)
+		charMin := r.entry.placeholderProvider().charMinSize(r.entry.Password, r.entry.TextStyle, textSize)
+		minSize = charMin.Add(fyne.NewSquareSize(innerPadding))
 
-	innerPadding := r.entry.Theme().Size(theme.SizeNameInnerPadding)
-	textSize := r.entry.Theme().Size(theme.SizeNameText)
-	charMin := r.entry.placeholderProvider().charMinSize(r.entry.Password, r.entry.TextStyle, textSize)
-	minSize := charMin.Add(fyne.NewSquareSize(innerPadding))
+		if r.entry.MultiLine {
+			count := r.entry.multiLineRows
+			if count <= 0 {
+				count = multiLineRows
+			}
 
-	if r.entry.MultiLine {
-		count := r.entry.multiLineRows
-		if count <= 0 {
-			count = multiLineRows
+			minSize.Height = charMin.Height*float32(count) + innerPadding
 		}
 
-		minSize.Height = charMin.Height*float32(count) + innerPadding
+		minSize = minSize.AddWidthHeight(innerPadding*2, innerPadding)
 	}
 
-	return minSize.Add(fyne.NewSize(innerPadding*2, innerPadding))
+	iconSpace := th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameLineSpacing)
+	if r.entry.ActionItem != nil {
+		minSize.Width += iconSpace
+	}
+	if r.entry.Validator != nil {
+		minSize.Width += iconSpace
+	}
+
+	return minSize
 }
 
 func (r *entryRenderer) Objects() []fyne.CanvasObject {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -454,7 +454,7 @@ func TestEntry_MinSize(t *testing.T) {
 	min = entry.MinSize()
 	entry.ActionItem = canvas.NewCircle(color.Black)
 	entry.Refresh()
-	assert.Equal(t, min.Add(fyne.NewSize(theme.IconInlineSize()+theme.Padding(), 0)), entry.MinSize())
+	assert.Equal(t, min.Add(fyne.NewSize(theme.IconInlineSize()+theme.LineSpacing(), 0)), entry.MinSize())
 }
 
 func TestEntryMultiline_MinSize(t *testing.T) {

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -112,7 +112,6 @@ func (l *GridWrap) FocusLost() {
 // MinSize returns the size that this widget should not shrink below.
 func (l *GridWrap) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
-
 	return l.BaseWidget.MinSize()
 }
 

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -163,11 +163,8 @@ func (hl *Hyperlink) Refresh() {
 
 // MinSize returns the smallest size this widget can shrink to
 func (hl *Hyperlink) MinSize() fyne.Size {
-	if len(hl.provider.Segments) == 0 {
-		hl.syncSegments()
-	}
-
-	return hl.provider.MinSize()
+	hl.ExtendBaseWidget(hl)
+	return hl.BaseWidget.MinSize()
 }
 
 // Resize sets a new size for the hyperlink.

--- a/widget/label.go
+++ b/widget/label.go
@@ -3,7 +3,6 @@ package widget
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/data/binding"
-	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -77,12 +76,8 @@ func (l *Label) CreateRenderer() fyne.WidgetRenderer {
 //
 // Implements: fyne.Widget
 func (l *Label) MinSize() fyne.Size {
-	if l.provider == nil {
-		l.ExtendBaseWidget(l)
-		cache.Renderer(l.super())
-	}
-
-	return l.provider.MinSize()
+	l.ExtendBaseWidget(l)
+	return l.BaseWidget.MinSize()
 }
 
 // Refresh triggers a redraw of the label.

--- a/widget/list.go
+++ b/widget/list.go
@@ -110,7 +110,6 @@ func (l *List) FocusLost() {
 // MinSize returns the size that this widget should not shrink below.
 func (l *List) MinSize() fyne.Size {
 	l.ExtendBaseWidget(l)
-
 	return l.BaseWidget.MinSize()
 }
 

--- a/widget/separator.go
+++ b/widget/separator.go
@@ -55,8 +55,7 @@ func (s *Separator) CreateRenderer() fyne.WidgetRenderer {
 // Implements: fyne.Widget
 func (s *Separator) MinSize() fyne.Size {
 	s.ExtendBaseWidget(s)
-	t := s.Theme().Size(theme.SizeNameSeparatorThickness)
-	return fyne.NewSize(t, t)
+	return s.BaseWidget.MinSize()
 }
 
 var _ fyne.WidgetRenderer = (*separatorRenderer)(nil)
@@ -68,8 +67,7 @@ type separatorRenderer struct {
 }
 
 func (r *separatorRenderer) MinSize() fyne.Size {
-	t := r.d.Theme().Size(theme.SizeNameSeparatorThickness)
-	return fyne.NewSize(t, t)
+	return fyne.NewSquareSize(r.d.Theme().Size(theme.SizeNameSeparatorThickness))
 }
 
 func (r *separatorRenderer) Refresh() {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Part of https://github.com/fyne-io/fyne/pull/4681 ripped out into a separate PR.
Moving calculations of the MinSize into the renderer allows us to clean up some of the code
because `BaseWidget.MinSize()` will create the renderer if it does not exists and as such do any setup necessary.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
