### PR TITLE
Fix an issue where canvas.Text in form was not aligned

### DIFF
--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -110,8 +110,13 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		}
 
 		if i+1 < len(objects) {
-			objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width, y))
-			objects[i+1].Resize(fyne.NewSize(tableRow[1].Width, tableRow[0].Height))
+			if _, ok := objects[i+1].(*canvas.Text); ok {
+				objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width+innerPadding, y+innerPadding))
+				objects[i+1].Resize(fyne.NewSize(tableRow[1].Width-innerPadding*2, objects[i+1].MinSize().Height))
+			} else {
+				objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width, y))
+				objects[i+1].Resize(fyne.NewSize(tableRow[1].Width, tableRow[0].Height))
+			}
 		}
 		row++
 	}

--- a/layout/formlayout_test.go
+++ b/layout/formlayout_test.go
@@ -39,6 +39,20 @@ func TestFormLayout(t *testing.T) {
 	assert.Equal(t, fyne.NewSize(120, 80), content2.Size())
 }
 
+func TestFormLayout_Text(t *testing.T) {
+	size := fyne.NewSize(120, 50)
+	label := canvas.NewText("Label", color.Black)
+	content := canvas.NewText("Content", color.Black)
+
+	container := &fyne.Container{
+		Objects: []fyne.CanvasObject{label, content},
+	}
+	container.Resize(size)
+	layout.NewFormLayout().Layout(container.Objects, size)
+
+	assert.Equal(t, label.Size().Height, content.Size().Height)
+}
+
 func TestFormLayout_Hidden(t *testing.T) {
 	gridSize := fyne.NewSize(190+theme.Padding(), 125)
 

--- a/layout/formlayout_test.go
+++ b/layout/formlayout_test.go
@@ -16,14 +16,14 @@ import (
 func TestFormLayout(t *testing.T) {
 	gridSize := fyne.NewSize(125, 125)
 
-	label1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label1 := canvas.NewRectangle(color.Black)
 	label1.SetMinSize(fyne.NewSize(50, 50))
-	content1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content1 := canvas.NewRectangle(color.Black)
 	content1.SetMinSize(fyne.NewSize(100, 100))
 
-	label2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label2 := canvas.NewRectangle(color.Black)
 	label2.SetMinSize(fyne.NewSize(70, 30))
-	content2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content2 := canvas.NewRectangle(color.Black)
 	content2.SetMinSize(fyne.NewSize(120, 80))
 
 	container := &fyne.Container{
@@ -56,16 +56,16 @@ func TestFormLayout_Text(t *testing.T) {
 func TestFormLayout_Hidden(t *testing.T) {
 	gridSize := fyne.NewSize(190+theme.Padding(), 125)
 
-	label1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label1 := canvas.NewRectangle(color.Black)
 	label1.SetMinSize(fyne.NewSize(70, 50))
 	label1.Hide()
-	content1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content1 := canvas.NewRectangle(color.Black)
 	content1.SetMinSize(fyne.NewSize(120, 100))
 	content1.Hide()
 
-	label2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label2 := canvas.NewRectangle(color.Black)
 	label2.SetMinSize(fyne.NewSize(50, 30))
-	content2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content2 := canvas.NewRectangle(color.Black)
 	content2.SetMinSize(fyne.NewSize(100, 80))
 
 	container := &fyne.Container{
@@ -84,9 +84,9 @@ func TestFormLayout_Hidden(t *testing.T) {
 func TestFormLayout_StretchX(t *testing.T) {
 	wideSize := fyne.NewSize(150, 50)
 
-	label1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label1 := canvas.NewRectangle(color.Black)
 	label1.SetMinSize(fyne.NewSize(50, 50))
-	content1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content1 := canvas.NewRectangle(color.Black)
 	content1.SetMinSize(fyne.NewSize(50, 50))
 
 	container := &fyne.Container{
@@ -102,14 +102,14 @@ func TestFormLayout_StretchX(t *testing.T) {
 
 func TestFormLayout_MinSize(t *testing.T) {
 
-	label1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label1 := canvas.NewRectangle(color.Black)
 	label1.SetMinSize(fyne.NewSize(50, 50))
-	content1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content1 := canvas.NewRectangle(color.Black)
 	content1.SetMinSize(fyne.NewSize(100, 100))
 
-	label2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label2 := canvas.NewRectangle(color.Black)
 	label2.SetMinSize(fyne.NewSize(70, 30))
-	content2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content2 := canvas.NewRectangle(color.Black)
 	content2.SetMinSize(fyne.NewSize(120, 80))
 
 	container := &fyne.Container{
@@ -132,15 +132,15 @@ func TestFormLayout_MinSize(t *testing.T) {
 
 func TestFormLayout_MinSize_Hidden(t *testing.T) {
 
-	label1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label1 := canvas.NewRectangle(color.Black)
 	label1.SetMinSize(fyne.NewSize(50, 50))
-	content1 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content1 := canvas.NewRectangle(color.Black)
 	content1.SetMinSize(fyne.NewSize(100, 100))
 
-	label2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	label2 := canvas.NewRectangle(color.Black)
 	label2.SetMinSize(fyne.NewSize(70, 30))
 	label2.Hide()
-	content2 := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
+	content2 := canvas.NewRectangle(color.Black)
 	content2.SetMinSize(fyne.NewSize(120, 80))
 	content2.Hide()
 


### PR DESCRIPTION
As suggested in the issue the only sensible course is to add special case to content just like label.
It feels dirty, but we cannot remove the label special case, so this is all that makes sense.

Fixes #4665

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
