### PR TITLE
fix: Make gradient resizing refresh and not use cached textures

### DIFF
--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -73,6 +73,16 @@ func (g *LinearGradient) Move(pos fyne.Position) {
 	repaint(g)
 }
 
+// Resize the gradient to a new size. Causes a refresh, as cached textures become invalid on resize.
+func (g *LinearGradient) Resize(size fyne.Size) {
+	if size == g.Size() {
+		return
+	}
+	g.baseObject.Resize(size)
+
+	g.Refresh()
+}
+
 // Refresh causes this gradient to be redrawn with its configured state.
 func (g *LinearGradient) Refresh() {
 	Refresh(g)
@@ -134,6 +144,16 @@ func (g *RadialGradient) Move(pos fyne.Position) {
 	g.baseObject.Move(pos)
 
 	repaint(g)
+}
+
+// Resize the gradient to a new size. Causes a refresh, as cached textures become invalid on resize.
+func (g *RadialGradient) Resize(size fyne.Size) {
+	if size == g.Size() {
+		return
+	}
+	g.baseObject.Resize(size)
+
+	g.Refresh()
 }
 
 // Refresh causes this gradient to be redrawn with its configured state.

--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -147,13 +147,14 @@ func (g *RadialGradient) Move(pos fyne.Position) {
 	repaint(g)
 }
 
-// Resize the gradient to a new size. Causes a refresh, as cached textures become invalid on resize.
+// Resize resizes the gradient to a new size.
 func (g *RadialGradient) Resize(size fyne.Size) {
 	if size == g.Size() {
 		return
 	}
 	g.baseObject.Resize(size)
 
+	// refresh needed to invalidate cached textures
 	g.Refresh()
 }
 

--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -73,13 +73,14 @@ func (g *LinearGradient) Move(pos fyne.Position) {
 	repaint(g)
 }
 
-// Resize the gradient to a new size. Causes a refresh, as cached textures become invalid on resize.
+// Resize resizes the gradient to a new size.
 func (g *LinearGradient) Resize(size fyne.Size) {
 	if size == g.Size() {
 		return
 	}
 	g.baseObject.Resize(size)
 
+	// refresh needed to invalidate cached textures
 	g.Refresh()
 }
 


### PR DESCRIPTION
### Description:

Avoid using cached textures for gradients, by refreshing the object on resize.

Fixes #4608.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.