### PR TITLE
Mimic desktop behaviour for FileSave/FileOpen dialogs: focus and submitting by keyboard

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -649,11 +648,8 @@ func showFile(file *FileDialog) *fileDialog {
 	d.setLocation(file.effectiveStartingDir())
 	d.win.Show()
 	if file.save {
-		// Focus on the filename Entry as soon as the dialog is shown
-		go func() {
-			time.Sleep(25 * time.Millisecond)
-			file.dialog.win.Canvas.Focus(file.dialog.fileName.(*widget.Entry))
-		}()
+		// Focus on the fileName Entry as soon as the dialog is shown
+		d.win.Canvas.Focus(d.fileName.(*widget.Entry))
 	}
 	return d
 }

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -648,7 +648,6 @@ func showFile(file *FileDialog) *fileDialog {
 	d.setLocation(file.effectiveStartingDir())
 	d.win.Show()
 	if file.save {
-		// Focus on the fileName Entry as soon as the dialog is shown
 		d.win.Canvas.Focus(d.fileName.(*widget.Entry))
 	}
 	return d

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -101,6 +101,9 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 			}
 		}
 		saveName.SetPlaceHolder(lang.L("Enter filename"))
+		saveName.OnSubmitted = func(s string) {
+			f.open.OnTapped()
+		}
 		f.fileName = saveName
 	} else {
 		f.fileName = widget.NewLabel("")

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -647,6 +648,13 @@ func showFile(file *FileDialog) *fileDialog {
 
 	d.setLocation(file.effectiveStartingDir())
 	d.win.Show()
+	if file.save {
+		// Focus on the filename Entry as soon as the dialog is shown
+		go func() {
+			time.Sleep(25 * time.Millisecond)
+			file.dialog.win.Canvas.Focus(file.dialog.fileName.(*widget.Entry))
+		}()
+	}
 	return d
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Two commits, each introducing one change:

1. Submitting (clicking ENTER) while in the fileName Entry the SaveDialog submits the form (clicks the Save button)
2. When the Save / Open file dialog is shown, the fileName entry is focused immediately

This mimics the native behaviour on desktop environments (at least Windows & Linux, can't test on OSX).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

