### PR TITLE
Fix system tray menu refresh race condition

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -51,6 +51,7 @@ type gLDriver struct {
 
 	trayStart, trayStop func()     // shut down the system tray, if used
 	systrayMenu         *fyne.Menu // cache the menu set so we know when to refresh
+	systrayLock         sync.Mutex
 }
 
 func toOSIcon(icon []byte) ([]byte, error) {

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -128,6 +128,9 @@ func itemForMenuItem(i *fyne.MenuItem, parent *systray.MenuItem) *systray.MenuIt
 }
 
 func (d *gLDriver) refreshSystray(m *fyne.Menu) {
+	d.systrayLock.Lock()
+	defer d.systrayLock.Unlock()
+
 	d.systrayMenu = m
 	systray.ResetMenu()
 	d.refreshSystrayMenu(m, nil)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
System tray menu refresh is not currently concurrent-safe. If `Refresh()` is called from a Goroutine, menu items can be duplicated. This PR adds a `systrayMutex` which is locked during `gLDriver.refreshSystray()`.

Fixes #4697

Screenshot of #4697 code snippet after fix:
<img width="116" alt="image" src="https://github.com/fyne-io/fyne/assets/7717888/79aedf80-a6a6-460f-915b-e6cbaafec10d">

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [x] Any breaking changes have a deprecation path or have been discussed.
- [x] Check for binary size increases when importing new modules.
