### PR TITLE
Fix ScrollToOffset when viewport is larger than content size

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -220,8 +220,13 @@ func (l *GridWrap) ScrollToOffset(offset float32) {
 	}
 	if offset < 0 {
 		offset = 0
-	} else if contentH := l.contentMinSize().Height; offset > contentH {
-		offset = contentH
+	}
+	contentHeight := l.contentMinSize().Height
+	if l.Size().Height >= contentHeight {
+		return // content fully visible - no need to scroll
+	}
+	if offset > contentHeight {
+		offset = contentHeight
 	}
 	l.scroller.Offset.Y = offset
 	l.offsetUpdated(l.scroller.Offset)

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -101,6 +101,7 @@ func TestGridWrap_ScrollTo(t *testing.T) {
 
 func TestGridWrap_ScrollToOffset(t *testing.T) {
 	g := createGridWrap(10)
+	g.Resize(fyne.NewSize(10, 10))
 
 	g.ScrollToOffset(2)
 	assert.Equal(t, float32(2), g.GetScrollOffset())
@@ -109,7 +110,12 @@ func TestGridWrap_ScrollToOffset(t *testing.T) {
 	assert.Equal(t, float32(0), g.GetScrollOffset())
 
 	g.ScrollToOffset(10000)
-	assert.LessOrEqual(t, g.GetScrollOffset(), float32(50) /*upper bound on content height*/)
+	assert.LessOrEqual(t, g.GetScrollOffset(), float32(500) /*upper bound on content height*/)
+
+	// GridWrap viewport is larger than content size
+	g.Resize(fyne.NewSize(50, 250))
+	g.ScrollToOffset(20)
+	assert.Equal(t, float32(0), g.GetScrollOffset()) // doesn't scroll
 }
 
 func TestGridWrap_ScrollToTop(t *testing.T) {

--- a/widget/list.go
+++ b/widget/list.go
@@ -266,8 +266,13 @@ func (l *List) ScrollToOffset(offset float32) {
 	}
 	if offset < 0 {
 		offset = 0
-	} else if h := l.contentMinSize().Height; offset > h {
-		offset = h
+	}
+	contentHeight := l.contentMinSize().Height
+	if l.Size().Height >= contentHeight {
+		return // content fully visible - no need to scroll
+	}
+	if offset > contentHeight {
+		offset = contentHeight
 	}
 	l.scroller.Offset.Y = offset
 	l.offsetUpdated(l.scroller.Offset)

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -242,6 +242,7 @@ func TestList_ScrollToTop(t *testing.T) {
 
 func TestList_ScrollOffset(t *testing.T) {
 	list := createList(10)
+	list.Resize(fyne.NewSize(20, 15))
 
 	offset := float32(25)
 	list.ScrollToOffset(25)
@@ -252,6 +253,11 @@ func TestList_ScrollOffset(t *testing.T) {
 
 	list.ScrollToOffset(1000)
 	assert.LessOrEqual(t, list.GetScrollOffset(), float32(500) /*upper bound on content height*/)
+
+	// list viewport is larger than content size
+	list.Resize(fyne.NewSize(100, 500))
+	list.ScrollToOffset(20)
+	assert.Equal(t, float32(0), list.GetScrollOffset()) // doesn't scroll
 }
 
 func TestList_Selection(t *testing.T) {


### PR DESCRIPTION
### Description:
There was a bug with the ScrollToOffset implementation in List where scrolling to a positive offset while the list viewport was larger than the content size (ie no scroll bar needed) would cause some items from the top of the list to disappear. This did *not* reproduce in the same visible way for GridWrap, but nonetheless I added the check there as well to be defensive.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.