### PR TITLE
Update portal to v0.2.2 and implement various code improvements

### DIFF
--- a/dialog/file_xdg_flatpak.go
+++ b/dialog/file_xdg_flatpak.go
@@ -3,8 +3,6 @@
 package dialog
 
 import (
-	"fmt"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/storage"
 	"github.com/rymdport/portal/filechooser"
@@ -13,13 +11,12 @@ import (
 func fileOpenOSOverride(d *FileDialog) bool {
 	go func() {
 		folderCallback, folder := d.callback.(func(fyne.ListableURI, error))
-		options := &filechooser.OpenOptions{
-			Modal:       true,
+		options := &filechooser.OpenFileOptions{
 			Directory:   folder,
 			AcceptLabel: d.confirmText,
 		}
 		if d.startingLocation != nil {
-			options.Location = d.startingLocation.Path()
+			options.CurrentFolder = d.startingLocation.Path()
 		}
 
 		parentWindowHandle := d.parent.(interface{ GetWindowHandle() string }).GetWindowHandle()
@@ -70,17 +67,15 @@ func fileOpenOSOverride(d *FileDialog) bool {
 
 func fileSaveOSOverride(d *FileDialog) bool {
 	go func() {
-		options := &filechooser.SaveSingleOptions{
-			Modal:       true,
+		options := &filechooser.SaveFileOptions{
 			AcceptLabel: d.confirmText,
-			FileName:    d.initialFileName,
+			CurrentName: d.initialFileName,
 		}
 		if d.startingLocation != nil {
-			options.Location = d.startingLocation.Path()
+			options.CurrentFolder = d.startingLocation.Path()
 		}
 
 		parentWindowHandle := d.parent.(interface{ GetWindowHandle() string }).GetWindowHandle()
-		fmt.Println(parentWindowHandle)
 
 		callback := d.callback.(func(fyne.URIWriteCloser, error))
 		uris, err := filechooser.SaveFile(parentWindowHandle, "Open File", options)

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nicksnyder/go-i18n/v2 v2.4.0
-	github.com/rymdport/portal v0.1.0
+	github.com/rymdport/portal v0.2.0
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nicksnyder/go-i18n/v2 v2.4.0
-	github.com/rymdport/portal v0.2.0
+	github.com/rymdport/portal v0.2.1
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nicksnyder/go-i18n/v2 v2.4.0
-	github.com/rymdport/portal v0.2.1
+	github.com/rymdport/portal v0.2.2
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/rymdport/portal v0.2.1 h1:tL+yD1pHrsoEYmm3BzPCU1UAG9xDhvphbPs/M8uaStg=
-github.com/rymdport/portal v0.2.1/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
+github.com/rymdport/portal v0.2.2 h1:P2Q/4k673zxdFAsbD8EESZ7psfuO6/4jNu6EDrDICkM=
+github.com/rymdport/portal v0.2.2/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/rymdport/portal v0.1.0 h1:VTnOQ7rMgka5ZUJEjw+lTXVoA/Z8K7qhtm0d9jXfK38=
-github.com/rymdport/portal v0.1.0/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
+github.com/rymdport/portal v0.2.0 h1:YzhOFH10u2KCOPEWiPL7FGgHxN6w01Z/WqVgjwE0Hck=
+github.com/rymdport/portal v0.2.0/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/rymdport/portal v0.2.0 h1:YzhOFH10u2KCOPEWiPL7FGgHxN6w01Z/WqVgjwE0Hck=
-github.com/rymdport/portal v0.2.0/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
+github.com/rymdport/portal v0.2.1 h1:tL+yD1pHrsoEYmm3BzPCU1UAG9xDhvphbPs/M8uaStg=
+github.com/rymdport/portal v0.2.1/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This removes some dead code, fixes a possible race condition when adding notifications and contains and improved watcher for settings changes. The latter is likely a performance improvement when changing theme because the old one would match both the internal Gnome key (old implementation) and the FreeDesktop standard key and thus refreshing the window twice.

See https://github.com/rymdport/portal/releases/tag/v0.2.0 for release notes.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

