### PR TITLE
Fix building with ios17.4

### DIFF
--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -529,6 +529,7 @@ var projPbxprojTmpl = template.Must(template.New("projPbxproj").Parse(`// !$*UTF
         PROVISIONING_PROFILE_SPECIFIER = "{{.Profile}}";
         SDKROOT = iphoneos;
         TARGETED_DEVICE_FAMILY = "1,2";
+        OS_ACTIVITY_MODE = "disable";
         VALIDATE_PRODUCT = YES;
         {{if not .BitcodeEnabled}}ENABLE_BITCODE = NO;{{end}}
       };

--- a/internal/driver/mobile/app/darwin_ios.m
+++ b/internal/driver/mobile/app/darwin_ios.m
@@ -48,7 +48,7 @@ struct utsname sysInfo;
 	updateConfig((int)size.width, (int)size.height, orientation);
 
 	UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-	center.delegate = self;
+	center.delegate = (id) self;
 
 	return YES;
 }
@@ -210,7 +210,7 @@ static void sendTouches(int change, NSSet* touches) {
 }
 
 -(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
-    keyboardTyped([string UTF8String]);
+    keyboardTyped((char *)[string UTF8String]);
     return NO;
 }
 
@@ -326,12 +326,12 @@ NSMutableArray *docTypesForMimeExts(char *mimes, char *exts) {
         NSString *mimeList = [NSString stringWithUTF8String:mimes];
 
         if ([mimeList isEqualToString:@"application/x-directory"]) {
-            [docTypes addObject:kUTTypeFolder];
+            [docTypes addObject:(NSString*)kUTTypeFolder];
         } else {
             NSArray *mimeItems = [mimeList componentsSeparatedByString:@"|"];
 
             for (NSString *mime in mimeItems)  {
-                CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mime, NULL);
+                NSString *UTI = (NSString *) UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (CFStringRef)mime, NULL);
 
                 [docTypes addObject:UTI];
             }
@@ -341,7 +341,7 @@ NSMutableArray *docTypesForMimeExts(char *mimes, char *exts) {
         NSArray *extItems = [extList componentsSeparatedByString:@"|"];
 
         for (NSString *ext in extItems)  {
-            CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, ext, NULL);
+            NSString *UTI = (NSString *) UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (CFStringRef)ext, NULL);
 
             [docTypes addObject:UTI];
         }
@@ -359,7 +359,7 @@ void showFileOpenPicker(char* mimes, char *exts) {
 
     UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc]
         initWithDocumentTypes:docTypes inMode:UIDocumentPickerModeOpen];
-    documentPicker.delegate = appDelegate;
+    documentPicker.delegate = (id) appDelegate;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [appDelegate.controller presentViewController:documentPicker animated:YES completion:nil];
@@ -380,7 +380,7 @@ void showFileSavePicker(char* mimes, char *exts) {
 
     UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc]
         initWithURL:temporaryFileURL inMode:UIDocumentPickerModeMoveToService];
-    documentPicker.delegate = appDelegate;
+    documentPicker.delegate = (id) appDelegate;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [appDelegate.controller presentViewController:documentPicker animated:YES completion:nil];

--- a/internal/driver/mobile/clipboard_ios.m
+++ b/internal/driver/mobile/clipboard_ios.m
@@ -12,5 +12,5 @@ void setClipboardContent(char *content) {
 char *getClipboardContent() {
     NSString *str = [[UIPasteboard generalPasteboard] string];
 
-    return [str UTF8String];
+    return (char *) [str UTF8String];
 }

--- a/internal/driver/mobile/folder_ios.m
+++ b/internal/driver/mobile/folder_ios.m
@@ -26,5 +26,5 @@ bool iosCreateListable(const char* urlCstr) {
 char* iosList(const char* url) {
     NSArray *children = listForURL(url);
 
-    return [[children componentsJoinedByString:@"|"] UTF8String];
+    return (char *) [[children componentsJoinedByString:@"|"] UTF8String];
 }

--- a/internal/driver/mobile/folder_ios.m
+++ b/internal/driver/mobile/folder_ios.m
@@ -9,7 +9,7 @@ NSArray *listForURL(const char* urlCstr) {
     NSString *urlStr = [NSString stringWithUTF8String:urlCstr];
     NSURL *url = [NSURL URLWithString:urlStr];
 
-    return [[NSFileManager defaultManager] contentsOfDirectoryAtURL:url includingPropertiesForKeys:nil options:nil error:nil];
+    return [[NSFileManager defaultManager] contentsOfDirectoryAtURL:url includingPropertiesForKeys:nil options:0 error:nil];
 }
 
 bool iosCanList(const char* url) {


### PR DESCRIPTION
Latest Xcode breaks the build due to escalation of warnings to errors.
This also fixes related errors found at the time.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
