### PR TITLE
Add option UseMobileLayout to force AppTab TabItem buttons to be stretched.

### DIFF
--- a/cmd/fyne_demo/tutorials/container.go
+++ b/cmd/fyne_demo/tutorials/container.go
@@ -32,6 +32,7 @@ func makeAppTabsTab(_ fyne.Window) fyne.CanvasObject {
 	for i := 4; i <= 12; i++ {
 		tabs.Append(container.NewTabItem(fmt.Sprintf("Tab %d", i), widget.NewLabel(fmt.Sprintf("Content of tab %d", i))))
 	}
+	tabs.UseMobileLayout()
 	locations := makeTabLocationSelect(tabs.SetTabLocation)
 	return container.NewBorder(locations, nil, nil, nil, tabs)
 }

--- a/cmd/fyne_tabs/FyneApp.toml
+++ b/cmd/fyne_tabs/FyneApp.toml
@@ -1,0 +1,4 @@
+[Details]
+  Icon = "../../theme/icons/fyne.png"
+  ID = "io.fyne.tabs"
+  Build = 1

--- a/cmd/fyne_tabs/main.go
+++ b/cmd/fyne_tabs/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+)
+
+func main() {
+
+	a := app.New()
+	a.Settings().SetTheme(NewThemeDark())
+	w := a.NewWindow("Fyne Tabs")
+
+	evenTabs := container.NewAppTabs(
+		container.NewTabItemWithIcon("", theme.HomeIcon(), widget.NewLabel("One!")),
+		container.NewTabItemWithIcon("", theme.SearchIcon(), widget.NewLabel("Two!")),
+	)
+	evenTabs.UseMobileLayout()
+	evenTabs.SetTabLocation(container.TabLocationBottom)
+
+	leftTabs := container.NewAppTabs(
+		container.NewTabItemWithIcon("", theme.HomeIcon(), widget.NewLabel("Three!")),
+		container.NewTabItemWithIcon("", theme.SearchIcon(), widget.NewLabel("Four!")),
+	)
+	leftTabs.SetTabLocation(container.TabLocationBottom)
+
+	tabs := container.NewAppTabs(
+		container.NewTabItem("Even", evenTabs),
+		container.NewTabItem("Left", leftTabs),
+	)
+	tabs.UseMobileLayout()
+	tabs.SetTabLocation(container.TabLocationTop)
+
+	w.SetContent(tabs)
+	w.Resize(fyne.NewSize(400, 700))
+	w.ShowAndRun()
+}

--- a/cmd/fyne_tabs/theme.go
+++ b/cmd/fyne_tabs/theme.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"image/color"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+type Theme struct {
+	fyne.Theme
+}
+
+func NewThemeDark() fyne.Theme {
+	return &Theme{
+		Theme: theme.DefaultTheme(),
+	}
+}
+
+func (t *Theme) Color(name fyne.ThemeColorName, _ fyne.ThemeVariant) color.Color {
+	return t.Theme.Color(name, theme.VariantDark)
+}
+
+func (t *Theme) Size(name fyne.ThemeSizeName) float32 {
+	// if name == theme.SizeNamePadding {
+	// 	return float32(10)
+	// }
+	if name == theme.SizeNameInlineIcon {
+		return float32(30)
+	}
+	if name == theme.SizeNameInnerPadding {
+		return float32(8)
+	}
+	if name == theme.SizeNameText {
+		return float32(30)
+	}
+	return t.Theme.Size(name)
+}

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -31,6 +31,8 @@ type AppTabs struct {
 	isTransitioning bool
 
 	popUpMenu *widget.PopUpMenu
+
+	useMobileLayout bool
 }
 
 // NewAppTabs creates a new tab container that allows the user to choose between different areas of an app.
@@ -41,6 +43,11 @@ func NewAppTabs(items ...*TabItem) *AppTabs {
 	tabs.BaseWidget.ExtendBaseWidget(tabs)
 	tabs.SetItems(items)
 	return tabs
+}
+
+// UseMobileLayout forces tab buttons to be spaced evenly along the tab bar's axis.
+func (t *AppTabs) UseMobileLayout() {
+	t.useMobileLayout = true
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
@@ -349,7 +356,7 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 	buttons := &fyne.Container{}
 
 	var iconPos buttonIconPosition
-	if fyne.CurrentDevice().IsMobile() {
+	if r.appTabs.useMobileLayout || fyne.CurrentDevice().IsMobile() {
 		cells := count
 		if cells == 0 {
 			cells = 1


### PR DESCRIPTION
### Description:
Add option UseMobileLayout to force AppTab TabItem buttons to be spaced evenly along the tab bar's axis instead of being aligned to the top and left. This option will give app developers the ability to have app tabs with a more refined look, if they choose, or if their needs are not met by the layout inferred for the given device. 

### Checklist:
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
