### PR TITLE
Add support for the default icon in Windows notifications

### DIFF
--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -19,13 +19,13 @@ import (
 
 const notificationTemplate = `$title = "%s"
 $content = "%s"
-
+$iconPath = "file:///%s"
 [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null
-$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastImageAndText02)
 $toastXml = [xml] $template.GetXml()
 $toastXml.GetElementsByTagName("text")[0].AppendChild($toastXml.CreateTextNode($title)) > $null
 $toastXml.GetElementsByTagName("text")[1].AppendChild($toastXml.CreateTextNode($content)) > $null
-
+$toastXml.GetElementsByTagName("image")[0].SetAttribute("src", $iconPath) > $null
 $xml = New-Object Windows.Data.Xml.Dom.XmlDocument
 $xml.LoadXml($toastXml.OuterXml)
 $toast = [Windows.UI.Notifications.ToastNotification]::new($xml)
@@ -71,12 +71,13 @@ var scriptNum = 0
 func (a *fyneApp) SendNotification(n *fyne.Notification) {
 	title := escapeNotificationString(n.Title)
 	content := escapeNotificationString(n.Content)
+	iconFilePath := a.CachedIconPath()
 	appID := a.UniqueID()
 	if appID == "" || strings.Index(appID, "missing-id") == 0 {
 		appID = a.Metadata().Name
 	}
 
-	script := fmt.Sprintf(notificationTemplate, title, content, appID)
+	script := fmt.Sprintf(notificationTemplate, title, content, iconFilePath, appID)
 	go runScript("notify", script)
 }
 

--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -71,7 +71,7 @@ var scriptNum = 0
 func (a *fyneApp) SendNotification(n *fyne.Notification) {
 	title := escapeNotificationString(n.Title)
 	content := escapeNotificationString(n.Content)
-	iconFilePath := a.CachedIconPath()
+	iconFilePath := a.cachedIconPath()
 	appID := a.UniqueID()
 	if appID == "" || strings.Index(appID, "missing-id") == 0 {
 		appID = a.Metadata().Name

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -71,7 +71,7 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 		return
 	}
 
-	appIcon := a.CachedIconPath()
+	appIcon := a.cachedIconPath()
 	timeout := int32(0) // we don't support this yet
 
 	obj := conn.Object("org.freedesktop.Notifications", "/org/freedesktop/Notifications")

--- a/app/icon_cache_file.go
+++ b/app/icon_cache_file.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"fyne.io/fyne/v2"
+)
+
+var once sync.Once
+
+func (a *fyneApp) CachedIconPath() string {
+	if a.Icon() == nil {
+		return ""
+	}
+
+	dirPath := filepath.Join(rootCacheDir(), a.UniqueID())
+	filePath := filepath.Join(dirPath, "icon.png")
+	once.Do(func() {
+		err := a.saveIconToCache(dirPath, filePath)
+		if err != nil {
+			filePath = ""
+		}
+	})
+
+	return filePath
+}
+
+func rootCacheDir() string {
+	desktopCache, _ := os.UserCacheDir()
+	return filepath.Join(desktopCache, "fyne")
+}
+
+func (a *fyneApp) saveIconToCache(dirPath, filePath string) error {
+	err := os.MkdirAll(dirPath, 0700)
+	if err != nil {
+		fyne.LogError("Unable to create application cache directory", err)
+		return err
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		fyne.LogError("Unable to create icon file", err)
+		return err
+	}
+
+	defer file.Close()
+
+	if icon := a.Icon(); icon != nil {
+		_, err = file.Write(icon.Content())
+		if err != nil {
+			fyne.LogError("Unable to write icon contents", err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/app/icon_cache_file.go
+++ b/app/icon_cache_file.go
@@ -10,7 +10,7 @@ import (
 
 var once sync.Once
 
-func (a *fyneApp) CachedIconPath() string {
+func (a *fyneApp) cachedIconPath() string {
 	if a.Icon() == nil {
 		return ""
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #2592
(now based on develop branch 🙂)

Adds support for the default icon in Windows notifications by changing the ToastTemplateType from ToastText02 to ToastImageAndText02 and adding the app's default icon. Also, since Windows ToastNotificationManager requests a path for the icon, we write the icon file in the temporary folder.

Example:

![319294268-43faee05-ea36-43cd-a94b-2087d158b7ad](https://github.com/fyne-io/fyne/assets/25851559/f29e30b0-d781-4c00-91fa-3ba5bb31ec62)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.