### PR TITLE
Make sure the release flag is always passed down

### DIFF
--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -375,6 +375,7 @@ func (p *Packager) validate() (err error) {
 	os.Chdir(p.srcDir)
 
 	p.appData.CustomMetadata = p.customMetadata.m
+	p.appData.Release = p.release
 
 	data, err := metadata.LoadStandard(p.srcDir)
 	if err == nil {
@@ -383,7 +384,6 @@ func (p *Packager) validate() (err error) {
 			data.Details.Icon = util.MakePathRelativeTo(p.srcDir, data.Details.Icon)
 		}
 
-		p.appData.Release = p.release
 		p.appData.mergeMetadata(data)
 		p.linuxAndBSDMetadata = data.LinuxAndBSD
 	}

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -188,13 +188,13 @@ func (r *Releaser) PrintHelp(indent string) {
 //
 // Deprecated: A better version will be exposed in the future.
 func (r *Releaser) Run(params []string) {
+	r.Packager.distribution = true
+	r.Packager.release = true
+
 	if err := r.validate(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		return
 	}
-
-	r.Packager.distribution = true
-	r.Packager.release = true
 
 	if err := r.beforePackage(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
@@ -207,12 +207,12 @@ func (r *Releaser) Run(params []string) {
 }
 
 func (r *Releaser) releaseAction(_ *cli.Context) error {
+	r.Packager.distribution = true
+	r.Packager.release = true
+
 	if err := r.validate(); err != nil {
 		return err
 	}
-
-	r.Packager.distribution = true
-	r.Packager.release = true
 
 	if err := r.beforePackage(); err != nil {
 		return err


### PR DESCRIPTION
Fixes #4711 which was somehow Linux specific

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
