### PR TITLE
Fix memory leak in RichText when replacing segments

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -246,10 +246,10 @@ func makeNav(setTutorial func(tutorial tutorials.Tutorial), loadPrevious bool) f
 
 	themes := container.NewGridWithColumns(2,
 		widget.NewButton("Dark", func() {
-			a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantDark})
+			//a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantDark})
 		}),
 		widget.NewButton("Light", func() {
-			a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantLight})
+			//a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantLight})
 		}),
 	)
 

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -246,10 +246,10 @@ func makeNav(setTutorial func(tutorial tutorials.Tutorial), loadPrevious bool) f
 
 	themes := container.NewGridWithColumns(2,
 		widget.NewButton("Dark", func() {
-			//a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantDark})
+			a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantDark})
 		}),
 		widget.NewButton("Light", func() {
-			//a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantLight})
+			a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantLight})
 		}),
 	)
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -226,6 +226,9 @@ func (t *RichText) cachedSegmentVisual(seg RichTextSegment, offset int) fyne.Can
 }
 
 func (t *RichText) cleanVisualCache() {
+	if len(t.visualCache) <= len(t.Segments) {
+		return
+	}
 	var deletingSegs []RichTextSegment
 	for seg1 := range t.visualCache {
 		found := false

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -225,6 +225,26 @@ func (t *RichText) cachedSegmentVisual(seg RichTextSegment, offset int) fyne.Can
 	return vis
 }
 
+func (t *RichText) cleanVisualCache() {
+	var deletingSegs []RichTextSegment
+	for seg1 := range t.visualCache {
+		found := false
+		for _, seg2 := range t.Segments {
+			if seg1 == seg2 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// cached segment is not currently in t.Segments, clear it
+			deletingSegs = append(deletingSegs, seg1)
+		}
+	}
+	for _, seg := range deletingSegs {
+		delete(t.visualCache, seg)
+	}
+}
+
 // insertAt inserts the text at the specified position
 func (t *RichText) insertAt(pos int, runes string) {
 	index := 0
@@ -726,6 +746,8 @@ func (r *textRenderer) Refresh() {
 
 	r.Layout(r.obj.Size())
 	canvas.Refresh(r.obj.super())
+
+	r.obj.cleanVisualCache()
 }
 
 func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign, xPos, yPos, lineWidth float32) (float32, float32) {


### PR DESCRIPTION
### Description:
Clean out visualCache entries that are not currently needed on Refresh

Fixes #4723 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

