### PR TITLE
Add IntToFloat (and FloatToInt) in bindings

### DIFF
--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -649,11 +649,9 @@ type intToFloat struct {
 	from Int
 }
 
-// IntToFloat creates a binding that connects a Int data item to a Float.
-// Changes to the String will be parsed and pushed to the Float if the parse was successful, and setting
-// the Float update the Int binding.
+// IntToFloat creates a binding that connects an Int data item to a Float.
 //
-// Since: 2.0
+// Since: 2.5
 func IntToFloat(val Int) Float {
 	v := &intToFloat{from: val}
 	val.AddListener(v)
@@ -699,11 +697,9 @@ type intFromFloat struct {
 	from Float
 }
 
-// FloatToInt creates a binding that connects a Float data item to a String.
-// Changes to the Float will be pushed to the String and setting the string will parse and set the
-// Float if the parse was successful.
+// FloatToInt creates a binding that connects a Float data item to an Int.
 //
-// Since: 2.0
+// Since: 2.5
 func FloatToInt(v Float) Int {
 	i := &intFromFloat{from: v}
 	v.AddListener(i)

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -393,8 +393,11 @@ func (s *stringToBool) Set(val bool) error {
 	}
 
 	old, err := s.from.Get()
-	if str == old {
+	if err != nil {
 		return err
+	}
+	if str == old {
+		return nil
 	}
 
 	if err = s.from.Set(str); err != nil {
@@ -635,4 +638,85 @@ func (s *stringToURI) DataChanged() {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	s.trigger()
+}
+type floatToInt struct {
+	base
+
+	from Float
+}
+func (s *floatToInt) Get() (int, error) {
+	val, err := s.from.Get()
+	if err != nil {
+		return 0.0, err
+	}
+	return int(val), nil
+}
+
+func (s *floatToInt) Set(val int) error {
+	f := float64(val)
+	old, err := s.from.Get()
+	if err != nil {
+		return err
+	}
+	if old == f {
+		return nil
+	}
+	if err = s.from.Set(f); err != nil {
+		return err
+	}
+
+	s.DataChanged()
+	return nil
+}
+
+func (s *floatToInt) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	s.trigger()
+}
+// FloatToInt creates a binding that connects a Float data item to an Int.
+// The conversion is just doing a type cast.
+func FloatToInt(val Float) Int {
+	return &floatToInt{from: val}
+}
+
+type intToFloat struct {
+	base
+
+	from Int
+}
+func (s *intToFloat) Get() (float64, error) {
+	val, err := s.from.Get()
+	if err != nil {
+		return 0, err
+	}
+	return float64(val), nil
+}
+
+func (s *intToFloat) Set(val float64) error {
+	i := int(val)
+	old, err := s.from.Get()
+	if err != nil {
+		return err
+	}
+	if old == i {
+		return nil
+	}
+	if err = s.from.Set(i); err != nil {
+		return err
+	}
+
+	s.DataChanged()
+	return nil
+}
+
+func (s *intToFloat) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	s.trigger()
+}
+// IntToFloat creates a binding that connects a Int data item to an Float.
+// The conversion is just doing a type cast.
+func IntToFloat(val Int) Float {
+	return &intToFloat{from: val}
 }

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -12,6 +12,7 @@ import (
 func internalFloatToInt(val float64) (int, error) {
 	return int(val), nil
 }
+
 func internalIntToFloat(val int) (float64, error) {
 	return float64(val), nil
 }
@@ -185,6 +186,103 @@ func (s *stringFromFloat) Set(str string) error {
 }
 
 func (s *stringFromFloat) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	s.trigger()
+}
+
+type intToFloat struct {
+	base
+	from Int
+}
+
+// IntToFloat creates a binding that connects an Int data item to a Float.
+//
+// Since: 2.5
+func IntToFloat(val Int) Float {
+	v := &intToFloat{from: val}
+	val.AddListener(v)
+	return v
+}
+
+func (s *intToFloat) Get() (float64, error) {
+	val, err := s.from.Get()
+	if err != nil {
+		return 0.0, err
+	}
+	return internalIntToFloat(val)
+}
+
+func (s *intToFloat) Set(val float64) error {
+	i, err := internalFloatToInt(val)
+	if err != nil {
+		return err
+	}
+	old, err := s.from.Get()
+	if i == old {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err = s.from.Set(i); err != nil {
+		return err
+	}
+
+	s.DataChanged()
+	return nil
+}
+
+func (s *intToFloat) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	s.trigger()
+}
+
+type intFromFloat struct {
+	base
+	from Float
+}
+
+// FloatToInt creates a binding that connects a Float data item to an Int.
+//
+// Since: 2.5
+func FloatToInt(v Float) Int {
+	i := &intFromFloat{from: v}
+	v.AddListener(i)
+	return i
+}
+
+func (s *intFromFloat) Get() (int, error) {
+	val, err := s.from.Get()
+	if err != nil {
+		return 0, err
+	}
+	return internalFloatToInt(val)
+}
+
+func (s *intFromFloat) Set(v int) error {
+	val, err := internalIntToFloat(v)
+	if err != nil {
+		return err
+	}
+
+	old, err := s.from.Get()
+	if err != nil {
+		return err
+	}
+	if val == old {
+		return nil
+	}
+	if err = s.from.Set(val); err != nil {
+		return err
+	}
+
+	s.DataChanged()
+	return nil
+}
+
+func (s *intFromFloat) DataChanged() {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	s.trigger()
@@ -639,103 +737,6 @@ func (s *stringToURI) Set(val fyne.URI) error {
 }
 
 func (s *stringToURI) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	s.trigger()
-}
-
-type intToFloat struct {
-	base
-	from Int
-}
-
-// IntToFloat creates a binding that connects an Int data item to a Float.
-//
-// Since: 2.5
-func IntToFloat(val Int) Float {
-	v := &intToFloat{from: val}
-	val.AddListener(v)
-	return v
-}
-
-func (s *intToFloat) Get() (float64, error) {
-	val, err := s.from.Get()
-	if err != nil {
-		return 0.0, err
-	}
-	return internalIntToFloat(val)
-}
-
-func (s *intToFloat) Set(val float64) error {
-	i, err := internalFloatToInt(val)
-	if err != nil {
-		return err
-	}
-	old, err := s.from.Get()
-	if i == old {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if err = s.from.Set(i); err != nil {
-		return err
-	}
-
-	s.DataChanged()
-	return nil
-}
-
-func (s *intToFloat) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	s.trigger()
-}
-
-type intFromFloat struct {
-	base
-	from Float
-}
-
-// FloatToInt creates a binding that connects a Float data item to an Int.
-//
-// Since: 2.5
-func FloatToInt(v Float) Int {
-	i := &intFromFloat{from: v}
-	v.AddListener(i)
-	return i
-}
-
-func (s *intFromFloat) Get() (int, error) {
-	val, err := s.from.Get()
-	if err != nil {
-		return 0, err
-	}
-	return internalFloatToInt(val)
-}
-
-func (s *intFromFloat) Set(v int) error {
-	val, err := internalIntToFloat(v)
-	if err != nil {
-		return err
-	}
-
-	old, err := s.from.Get()
-	if err != nil {
-		return err
-	}
-	if val == old {
-		return nil
-	}
-	if err = s.from.Set(val); err != nil {
-		return err
-	}
-
-	s.DataChanged()
-	return nil
-}
-
-func (s *intFromFloat) DataChanged() {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	s.trigger()

--- a/data/binding/convert_test.go
+++ b/data/binding/convert_test.go
@@ -363,3 +363,43 @@ func TestURIToString(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "file:///tmp/test.txt", v2.String())
 }
+
+func TestFloatToInt(t *testing.T) {
+	f := NewFloat()
+	i := FloatToInt(f)
+	v, err := i.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, v)
+
+	err = f.Set(0.3)
+	assert.Nil(t, err)
+	v, err = i.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, v)
+
+	err = i.Set(5)
+	assert.Nil(t, err)
+	v2, err := f.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, 5.0, v2)
+}
+
+func TestIntToFloat(t *testing.T) {
+	i := NewInt()
+	f := IntToFloat(i)
+	v, err := f.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, 0.0, v)
+
+	err = i.Set(3)
+	assert.Nil(t, err)
+	v, err = f.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, 3.0, v)
+
+	err = f.Set(5)
+	assert.Nil(t, err)
+	v2, err := i.Get()
+	assert.Nil(t, err)
+	assert.Equal(t, 5, v2)
+}

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -278,7 +278,7 @@ type intFrom{{ .Name }} struct {
 
 // {{ .Name }}ToInt creates a binding that connects a {{ .Name }} data item to an Int.
 //
-// Since: {{ .Since }}
+// Since: 2.5
 func {{ .Name }}ToInt(v {{ .Name }}) Int {
 	i := &intFrom{{ .Name }}{from: v}
 	v.AddListener(i)
@@ -328,7 +328,7 @@ type intTo{{ .Name }} struct {
 
 // IntTo{{ .Name }} creates a binding that connects an Int data item to a {{ .Name }}.
 //
-// Since: {{ .Since }}
+// Since: 2.5
 func IntTo{{ .Name }}(val Int) {{ .Name }} {
 	v := &intTo{{ .Name }}{from: val}
 	val.AddListener(v)
@@ -1197,6 +1197,12 @@ import (
 		if b.Format != "" || b.ToString != "" {
 			writeFile(convertFile, toString, b)
 		}
+		if b.FromInt != "" {
+			writeFile(convertFile, fromInt, b)
+		}
+		if b.ToInt != "" {
+			writeFile(convertFile, toInt, b)
+		}
 	}
 	// add StringTo... at the bottom of the convertFile for correct ordering
 	for _, b := range binds {
@@ -1206,24 +1212,6 @@ import (
 
 		if b.Format != "" || b.FromString != "" {
 			writeFile(convertFile, fromString, b)
-		}
-	}
-	for _, b := range binds {
-		if b.Since == "" {
-			b.Since = "2.5"
-		}
-
-		if b.FromInt != "" {
-			writeFile(convertFile, fromInt, b)
-		}
-	}
-	for _, b := range binds {
-		if b.Since == "" {
-			b.Since = "2.5"
-		}
-
-		if b.ToInt != "" {
-			writeFile(convertFile, toInt, b)
 		}
 	}
 }

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -276,9 +276,7 @@ type intFrom{{ .Name }} struct {
 	from {{ .Name }}
 }
 
-// {{ .Name }}ToInt creates a binding that connects a {{ .Name }} data item to a String.
-// Changes to the {{ .Name }} will be pushed to the String and setting the string will parse and set the
-// {{ .Name }} if the parse was successful.
+// {{ .Name }}ToInt creates a binding that connects a {{ .Name }} data item to an Int.
 //
 // Since: {{ .Since }}
 func {{ .Name }}ToInt(v {{ .Name }}) Int {
@@ -328,9 +326,7 @@ type intTo{{ .Name }} struct {
 	from Int
 }
 
-// IntTo{{ .Name }} creates a binding that connects a Int data item to a {{ .Name }}.
-// Changes to the String will be parsed and pushed to the {{ .Name }} if the parse was successful, and setting
-// the {{ .Name }} update the Int binding.
+// IntTo{{ .Name }} creates a binding that connects an Int data item to a {{ .Name }}.
 //
 // Since: {{ .Since }}
 func IntTo{{ .Name }}(val Int) {{ .Name }} {
@@ -1118,6 +1114,7 @@ import (
 func internalFloatToInt(val float64) (int, error) {
 	return int(val), nil
 }
+
 func internalIntToFloat(val int) (float64, error) {
 	return float64(val), nil
 }
@@ -1211,11 +1208,9 @@ import (
 			writeFile(convertFile, fromString, b)
 		}
 	}
-	// add IntTo
-
 	for _, b := range binds {
 		if b.Since == "" {
-			b.Since = "2.0"
+			b.Since = "2.5"
 		}
 
 		if b.FromInt != "" {
@@ -1224,7 +1219,7 @@ import (
 	}
 	for _, b := range binds {
 		if b.Since == "" {
-			b.Since = "2.0"
+			b.Since = "2.5"
 		}
 
 		if b.ToInt != "" {

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -270,7 +270,109 @@ func (s *stringFrom{{ .Name }}) DataChanged() {
 	s.trigger()
 }
 `
+const toIntTemplate = `
+type intFrom{{ .Name }} struct {
+	base
+	from {{ .Name }}
+}
 
+// {{ .Name }}ToInt creates a binding that connects a {{ .Name }} data item to a String.
+// Changes to the {{ .Name }} will be pushed to the String and setting the string will parse and set the
+// {{ .Name }} if the parse was successful.
+//
+// Since: {{ .Since }}
+func {{ .Name }}ToInt(v {{ .Name }}) Int {
+	i := &intFrom{{ .Name }}{from: v}
+	v.AddListener(i)
+	return i
+}
+
+func (s *intFrom{{ .Name }}) Get() (int, error) {
+	val, err := s.from.Get()
+	if err != nil {
+		return 0, err
+	}
+	return {{ .ToInt }}(val)
+}
+
+func (s *intFrom{{ .Name }}) Set(v int) error {
+	val, err := {{ .FromInt }}(v)
+	if err != nil {
+		return err
+	}
+
+	old, err := s.from.Get()
+	if err != nil {
+		return err
+	}
+	if val == old {
+		return nil
+	}
+	if err = s.from.Set(val); err != nil {
+		return err
+	}
+
+	s.DataChanged()
+	return nil
+}
+
+func (s *intFrom{{ .Name }}) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	s.trigger()
+}
+`
+const fromIntTemplate = `
+type intTo{{ .Name }} struct {
+	base
+	from Int
+}
+
+// IntTo{{ .Name }} creates a binding that connects a Int data item to a {{ .Name }}.
+// Changes to the String will be parsed and pushed to the {{ .Name }} if the parse was successful, and setting
+// the {{ .Name }} update the Int binding.
+//
+// Since: {{ .Since }}
+func IntTo{{ .Name }}(val Int) {{ .Name }} {
+	v := &intTo{{ .Name }}{from: val}
+	val.AddListener(v)
+	return v
+}
+
+func (s *intTo{{ .Name }}) Get() ({{ .Type }}, error) {
+	val, err := s.from.Get()
+	if err != nil {
+		return {{ .Default }}, err
+	}
+	return {{ .FromInt }}(val)
+}
+
+func (s *intTo{{ .Name }}) Set(val {{ .Type }}) error {
+	i, err := {{ .ToInt }}(val)
+	if err != nil {
+		return err
+	}
+	old, err := s.from.Get()
+	if i == old {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err = s.from.Set(i); err != nil {
+		return err
+	}
+
+	s.DataChanged()
+	return nil
+}
+
+func (s *intTo{{ .Name }}) DataChanged() {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	s.trigger()
+}
+`
 const fromStringTemplate = `
 type stringTo{{ .Name }} struct {
 	base
@@ -961,6 +1063,7 @@ type bindValues struct {
 	SupportsPreferences  bool
 	FromString, ToString string // function names...
 	Comparator           string // comparator function name
+	FromInt, ToInt       string // function names...
 }
 
 func newFile(name string) (*os.File, error) {
@@ -1011,6 +1114,13 @@ import (
 
 	"fyne.io/fyne/v2"
 )
+
+func internalFloatToInt(val float64) (int, error) {
+	return int(val), nil
+}
+func internalIntToFloat(val int) (float64, error) {
+	return float64(val), nil
+}
 `)
 	prefFile, err := newFile("preference")
 	if err != nil {
@@ -1055,6 +1165,8 @@ import (
 
 	item := template.Must(template.New("item").Parse(itemBindTemplate))
 	fromString := template.Must(template.New("fromString").Parse(fromStringTemplate))
+	fromInt := template.Must(template.New("fromInt").Parse(fromIntTemplate))
+	toInt := template.Must(template.New("toInt").Parse(toIntTemplate))
 	toString := template.Must(template.New("toString").Parse(toStringTemplate))
 	preference := template.Must(template.New("preference").Parse(prefTemplate))
 	list := template.Must(template.New("list").Parse(listBindTemplate))
@@ -1062,7 +1174,7 @@ import (
 	binds := []bindValues{
 		{Name: "Bool", Type: "bool", Default: "false", Format: "%t", SupportsPreferences: true},
 		{Name: "Bytes", Type: "[]byte", Default: "nil", Since: "2.2", Comparator: "bytes.Equal"},
-		{Name: "Float", Type: "float64", Default: "0.0", Format: "%f", SupportsPreferences: true},
+		{Name: "Float", Type: "float64", Default: "0.0", Format: "%f", SupportsPreferences: true, ToInt: "internalFloatToInt", FromInt: "internalIntToFloat"},
 		{Name: "Int", Type: "int", Default: "0", Format: "%d", SupportsPreferences: true},
 		{Name: "Rune", Type: "rune", Default: "rune(0)"},
 		{Name: "String", Type: "string", Default: "\"\"", SupportsPreferences: true},
@@ -1097,6 +1209,26 @@ import (
 
 		if b.Format != "" || b.FromString != "" {
 			writeFile(convertFile, fromString, b)
+		}
+	}
+	// add IntTo
+
+	for _, b := range binds {
+		if b.Since == "" {
+			b.Since = "2.0"
+		}
+
+		if b.FromInt != "" {
+			writeFile(convertFile, fromInt, b)
+		}
+	}
+	for _, b := range binds {
+		if b.Since == "" {
+			b.Since = "2.0"
+		}
+
+		if b.ToInt != "" {
+			writeFile(convertFile, toInt, b)
 		}
 	}
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #4666
The behavior is as same as the Golang native type cast.
### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

According to #4666, it can be used in the situation below:
```go
boundTeaPotCount := binding.NewInt()

slider := widget.NewSliderWithData(0, 130, binding.IntToFloat(boundTeaPotCount))
label := widget.NewLabelWithData(binding.IntToString(boundTeaPotCount))
```

