### PR TITLE
Double-click to select a file in FileOpen / FileSave dialogs

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -555,7 +555,8 @@ func (f *fileDialog) setView(view ViewLayout) {
 			parent := id == 0 && len(dir.Path()) < len(f.dir.Path())
 			_, isDir := dir.(fyne.ListableURI)
 			o.(*fileDialogItem).setLocation(dir, isDir || parent, parent, id)
-			o.(*fileDialogItem).setChooseAndOpenCallBack(choose, f.open.OnTapped)
+			o.(*fileDialogItem).choose = choose
+			o.(*fileDialogItem).open = f.open.OnTapped
 		}
 	}
 	// Acutally, during the real interaction, the choose won't be called.

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -554,12 +554,13 @@ func (f *fileDialog) setView(view ViewLayout) {
 		if dir, ok := f.getDataItem(id); ok {
 			parent := id == 0 && len(dir.Path()) < len(f.dir.Path())
 			_, isDir := dir.(fyne.ListableURI)
-			o.(*fileDialogItem).setLocation(dir, isDir || parent, parent, id)
+			o.(*fileDialogItem).setLocation(dir, isDir || parent, parent)
 			o.(*fileDialogItem).choose = choose
+			o.(*fileDialogItem).id = id
 			o.(*fileDialogItem).open = f.open.OnTapped
 		}
 	}
-	// Acutally, during the real interaction, the choose won't be called.
+	// Actually, during the real interaction, the OnSelected won't be called.
 	// It will be called only when we directly calls container.select(i)
 	if f.view == GridView {
 		grid := widget.NewGridWrap(count, template, update)

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -558,14 +558,17 @@ func (f *fileDialog) setView(view ViewLayout) {
 			o.(*fileDialogItem).setChooseAndOpenCallBack(choose, f.open.OnTapped)
 		}
 	}
-
+	// Acutally, during the real interaction, the choose won't be called.
+	// It will be called only when we directly calls container.select(i)
 	if f.view == GridView {
 		grid := widget.NewGridWrap(count, template, update)
+		grid.OnSelected = choose
 		f.files = grid
 		f.toggleViewButton.SetIcon(theme.ListIcon())
 		selectF = grid.Select
 	} else {
 		list := widget.NewList(count, template, update)
+		list.OnSelected = choose
 		f.files = list
 		f.toggleViewButton.SetIcon(theme.GridIcon())
 		selectF = list.Select

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/driver/desktop"
-	"fyne.io/fyne/v2/driver/mobile"
 	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -64,7 +62,8 @@ func (i *fileDialogItem) setLocation(l fyne.URI, dir, up bool, id int) {
 
 	i.Refresh()
 }
-func (i *fileDialogItem) tapped() {
+
+func (i *fileDialogItem) Tapped(*fyne.PointEvent) {
 	if i.choose != nil {
 		i.choose(i.id)
 	}
@@ -74,20 +73,6 @@ func (i *fileDialogItem) tapped() {
 		i.open()
 	}
 	i.lastClick = now
-}
-
-func (i *fileDialogItem) TouchDown(*mobile.TouchEvent) {}
-
-func (i *fileDialogItem) TouchUp(*mobile.TouchEvent) {
-	i.tapped()
-}
-
-func (i *fileDialogItem) TouchCancel(*mobile.TouchEvent) {}
-
-func (i *fileDialogItem) MouseDown(*desktop.MouseEvent) {}
-
-func (i *fileDialogItem) MouseUp(e *desktop.MouseEvent) {
-	i.tapped()
 }
 
 func (f *fileDialog) newFileItem(location fyne.URI, dir, up bool) *fileDialogItem {
@@ -110,6 +95,7 @@ func (f *fileDialog) newFileItem(location fyne.URI, dir, up bool) *fileDialogIte
 	item.ExtendBaseWidget(item)
 	return item
 }
+
 func (i *fileDialogItem) setChooseAndOpenCallBack(choose func(id int), open func()) {
 	i.choose = choose
 	i.open = open

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -96,11 +96,6 @@ func (f *fileDialog) newFileItem(location fyne.URI, dir, up bool) *fileDialogIte
 	return item
 }
 
-func (i *fileDialogItem) setChooseAndOpenCallBack(choose func(id int), open func()) {
-	i.choose = choose
-	i.open = open
-}
-
 type fileItemRenderer struct {
 	item         *fileDialogItem
 	fileTextSize float32

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -45,8 +45,7 @@ func (i *fileDialogItem) CreateRenderer() fyne.WidgetRenderer {
 	}
 }
 
-func (i *fileDialogItem) setLocation(l fyne.URI, dir, up bool, id int) {
-	i.id = id
+func (i *fileDialogItem) setLocation(l fyne.URI, dir, up bool) {
 	i.dir = dir
 	i.location = l
 	i.name = l.Name()

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -120,7 +120,7 @@ func TestFileItem_Wrap(t *testing.T) {
 	texts := test.WidgetRenderer(label).Objects()
 	assert.Equal(t, 1, len(texts))
 
-	item.setLocation(storage.NewFileURI("/path/to/averylongfilename.svg"), false, false, 0)
+	item.setLocation(storage.NewFileURI("/path/to/averylongfilename.svg"), false, false)
 	rich := test.WidgetRenderer(label).Objects()[0].(*widget.RichText)
 	texts = test.WidgetRenderer(rich).Objects()
 	assert.Equal(t, 2, len(texts))

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -120,7 +120,7 @@ func TestFileItem_Wrap(t *testing.T) {
 	texts := test.WidgetRenderer(label).Objects()
 	assert.Equal(t, 1, len(texts))
 
-	item.setLocation(storage.NewFileURI("/path/to/averylongfilename.svg"), false, false)
+	item.setLocation(storage.NewFileURI("/path/to/averylongfilename.svg"), false, false, 0)
 	rich := test.WidgetRenderer(label).Objects()[0].(*widget.RichText)
 	texts = test.WidgetRenderer(rich).Objects()
 	assert.Equal(t, 2, len(texts))


### PR DESCRIPTION
### Description:
Support Double-click to select a file in FileOpen / FileSave dialogs

Fixes #4676

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
