### PR TITLE
update documentation line indicating all List items must be same size

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -23,7 +23,8 @@ var _ fyne.Focusable = (*List)(nil)
 
 // List is a widget that pools list items for performance and
 // lays the items out in a vertical direction inside of a scroller.
-// List requires that all items are the same size.
+// By default List requires that all items are the same size, but specific
+// rows can have their heights set with SetItemHeight.
 //
 // Since: 1.4
 type List struct {

--- a/widget/list.go
+++ b/widget/list.go
@@ -23,7 +23,7 @@ var _ fyne.Focusable = (*List)(nil)
 
 // List is a widget that pools list items for performance and
 // lays the items out in a vertical direction inside of a scroller.
-// By default List requires that all items are the same size, but specific
+// By default, List requires that all items are the same size, but specific
 // rows can have their heights set with SetItemHeight.
 //
 // Since: 1.4


### PR DESCRIPTION
### Description:

Remove the line in the documentation that indicates that `widget.List` can only contain items of the same size.  This is no longer true since the introduction of `SetItemHeight` in 2.3

Addresses the confusion that led to #4777.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.