### PR TITLE
Don't crash when a widget tries to get theme info before app start

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -56,6 +56,8 @@ func (s *settings) PrimaryColor() string {
 
 // OverrideTheme allows the settings app to temporarily preview different theme details.
 // Please make sure that you remember the original settings and call this again to revert the change.
+//
+// Deprecated: Use container.NewThemeOverride to change the appearance of part of your application.
 func (s *settings) OverrideTheme(theme fyne.Theme, name string) {
 	s.propertyLock.Lock()
 	defer s.propertyLock.Unlock()
@@ -64,6 +66,10 @@ func (s *settings) OverrideTheme(theme fyne.Theme, name string) {
 }
 
 func (s *settings) Theme() fyne.Theme {
+	if s == nil {
+		fyne.LogError("Attempt to access current Fyne theme when no app is started", nil)
+		return nil
+	}
 	s.propertyLock.RLock()
 	defer s.propertyLock.RUnlock()
 	return s.theme


### PR DESCRIPTION
Fixes #4781

Whilst there I made a deprecation note that the landed ThemeOverride replaces old overriding code.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- this is not part of our API promise, just not crashing when misused before app start
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

