### PR TITLE
feat: support set nil for boundUntyped.Set()

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -117,8 +117,12 @@ func (b *boundUntyped) Set(val any) error {
 	if b.val.Interface() == val {
 		return nil
 	}
-
-	b.val.Set(reflect.ValueOf(val))
+	if val == nil {
+		zeroValue := reflect.Zero(b.val.Type())
+		b.val.Set(zeroValue)
+	} else {
+		b.val.Set(reflect.ValueOf(val))
+	}
 
 	b.trigger()
 	return nil

--- a/data/binding/binding_test.go
+++ b/data/binding/binding_test.go
@@ -61,3 +61,12 @@ func TestNewDataItemListener(t *testing.T) {
 	fn.DataChanged()
 	assert.True(t, called)
 }
+
+func TestBindAnyWithNil(t *testing.T) {
+	a := NewUntyped()
+	a.Set(nil)
+	b := 1
+	a.Set(b)
+	var tr any = nil
+	a.Set(tr)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
We should support setting nil for Untyped Binding. For the original code, when we pass nil for the Set function, it will call `b.val.Set(reflect.ValueOf(nil))` which will panic due to the lack of type information of nil. 

Fixes #4807

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
