### PR TITLE
Fix: Set indicator not hidden if there is any item selected

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -396,6 +396,7 @@ func (r *appTabsRenderer) updateIndicator(animate bool) {
 		r.indicator.Hide()
 		return
 	}
+	r.indicator.Show()
 
 	var selectedPos fyne.Position
 	var selectedSize fyne.Size

--- a/container/apptabs_test.go
+++ b/container/apptabs_test.go
@@ -184,6 +184,7 @@ func TestAppTabs_DisableIndex(t *testing.T) {
 func TestAppTabs_ShowAfterAdd(t *testing.T) {
 	tabs := NewAppTabs()
 	renderer := test.WidgetRenderer(tabs).(*appTabsRenderer)
+
 	assert.True(t, renderer.indicator.Hidden)
 
 	tabs.Append(NewTabItem("test", widget.NewLabel("Test")))

--- a/container/apptabs_test.go
+++ b/container/apptabs_test.go
@@ -1,10 +1,9 @@
-package container_test
+package container
 
 import (
 	"testing"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -13,23 +12,23 @@ import (
 )
 
 func TestAppTabs_Selected(t *testing.T) {
-	tab1 := &container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
-	tab2 := &container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
-	tabs := container.NewAppTabs(tab1, tab2)
+	tab1 := &TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
+	tab2 := &TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
+	tabs := NewAppTabs(tab1, tab2)
 
 	assert.Equal(t, 2, len(tabs.Items))
 	assert.Equal(t, tab1, tabs.Selected())
 }
 
 func TestAppTabs_SelectedIndex(t *testing.T) {
-	tabs := container.NewAppTabs(&container.TabItem{Text: "Test", Content: widget.NewLabel("Test")})
+	tabs := NewAppTabs(&TabItem{Text: "Test", Content: widget.NewLabel("Test")})
 
 	assert.Equal(t, 1, len(tabs.Items))
 	assert.Equal(t, 0, tabs.SelectedIndex())
 }
 
 func TestAppTabs_Empty(t *testing.T) {
-	tabs := container.NewAppTabs()
+	tabs := NewAppTabs()
 	assert.Equal(t, 0, len(tabs.Items))
 	assert.Equal(t, -1, tabs.SelectedIndex())
 	assert.Nil(t, tabs.Selected())
@@ -37,7 +36,7 @@ func TestAppTabs_Empty(t *testing.T) {
 	assert.Equal(t, float32(0), min.Width)
 	assert.Equal(t, theme.Padding(), min.Height)
 
-	tabs = &container.AppTabs{}
+	tabs = &AppTabs{}
 	assert.Equal(t, 0, len(tabs.Items))
 	assert.Nil(t, tabs.Selected())
 	assert.NotNil(t, test.WidgetRenderer(tabs)) // doesn't crash
@@ -46,9 +45,9 @@ func TestAppTabs_Empty(t *testing.T) {
 func TestAppTabs_Hidden_AsChild(t *testing.T) {
 	c1 := widget.NewLabel("Tab 1 content")
 	c2 := widget.NewLabel("Tab 2 content\nTab 2 content\nTab 2 content")
-	ti1 := container.NewTabItem("Tab 1", c1)
-	ti2 := container.NewTabItem("Tab 2", c2)
-	tabs := container.NewAppTabs(ti1, ti2)
+	ti1 := NewTabItem("Tab 1", c1)
+	ti2 := NewTabItem("Tab 2", c2)
+	tabs := NewAppTabs(ti1, ti2)
 	tabs.Refresh()
 
 	assert.True(t, c1.Visible())
@@ -60,7 +59,7 @@ func TestAppTabs_Hidden_AsChild(t *testing.T) {
 }
 
 func TestAppTabs_Resize_Empty(t *testing.T) {
-	tabs := container.NewAppTabs()
+	tabs := NewAppTabs()
 	tabs.Resize(fyne.NewSize(10, 10))
 	size := tabs.Size()
 	assert.Equal(t, float32(10), size.Height)
@@ -68,19 +67,19 @@ func TestAppTabs_Resize_Empty(t *testing.T) {
 }
 
 func TestAppTabs_Select(t *testing.T) {
-	tab1 := &container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
-	tab2 := &container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
-	tabs := container.NewAppTabs(tab1, tab2)
+	tab1 := &TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
+	tab2 := &TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
+	tabs := NewAppTabs(tab1, tab2)
 
 	assert.Equal(t, 2, len(tabs.Items))
 	assert.Equal(t, tab1, tabs.Selected())
 
-	var selectedTab *container.TabItem
-	tabs.OnSelected = func(tab *container.TabItem) {
+	var selectedTab *TabItem
+	tabs.OnSelected = func(tab *TabItem) {
 		selectedTab = tab
 	}
-	var unselectedTab *container.TabItem
-	tabs.OnUnselected = func(tab *container.TabItem) {
+	var unselectedTab *TabItem
+	tabs.OnUnselected = func(tab *TabItem) {
 		unselectedTab = tab
 	}
 	tabs.Select(tab2)
@@ -88,29 +87,29 @@ func TestAppTabs_Select(t *testing.T) {
 	assert.Equal(t, tab2, selectedTab)
 	assert.Equal(t, tab1, unselectedTab)
 
-	tabs.OnSelected = func(tab *container.TabItem) {
+	tabs.OnSelected = func(tab *TabItem) {
 		assert.Fail(t, "unexpected tab selected")
 	}
-	tabs.OnUnselected = func(tab *container.TabItem) {
+	tabs.OnUnselected = func(tab *TabItem) {
 		assert.Fail(t, "unexpected tab unselected")
 	}
-	tabs.Select(container.NewTabItem("Test3", widget.NewLabel("Test3")))
+	tabs.Select(NewTabItem("Test3", widget.NewLabel("Test3")))
 	assert.Equal(t, tab2, tabs.Selected())
 }
 
 func TestAppTabs_SelectIndex(t *testing.T) {
-	tabs := container.NewAppTabs(&container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")},
-		&container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")})
+	tabs := NewAppTabs(&TabItem{Text: "Test1", Content: widget.NewLabel("Test1")},
+		&TabItem{Text: "Test2", Content: widget.NewLabel("Test2")})
 
 	assert.Equal(t, 2, len(tabs.Items))
 	assert.Equal(t, 0, tabs.SelectedIndex())
 
-	var selectedTab *container.TabItem
-	tabs.OnSelected = func(tab *container.TabItem) {
+	var selectedTab *TabItem
+	tabs.OnSelected = func(tab *TabItem) {
 		selectedTab = tab
 	}
-	var unselectedTab *container.TabItem
-	tabs.OnUnselected = func(tab *container.TabItem) {
+	var unselectedTab *TabItem
+	tabs.OnUnselected = func(tab *TabItem) {
 		unselectedTab = tab
 	}
 	tabs.SelectIndex(1)
@@ -120,8 +119,8 @@ func TestAppTabs_SelectIndex(t *testing.T) {
 }
 
 func TestAppTabs_RemoveIndex(t *testing.T) {
-	tabs := container.NewAppTabs(&container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")},
-		&container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")})
+	tabs := NewAppTabs(&TabItem{Text: "Test1", Content: widget.NewLabel("Test1")},
+		&TabItem{Text: "Test2", Content: widget.NewLabel("Test2")})
 
 	tabs.SelectIndex(1)
 	tabs.RemoveIndex(1)
@@ -133,9 +132,9 @@ func TestAppTabs_RemoveIndex(t *testing.T) {
 }
 
 func TestAppTabs_EnableItem(t *testing.T) {
-	tab1 := &container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
-	tab2 := &container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
-	tabs := container.NewAppTabs(tab1, tab2)
+	tab1 := &TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
+	tab2 := &TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
+	tabs := NewAppTabs(tab1, tab2)
 	tabs.DisableItem(tab1)
 
 	assert.True(t, tab1.Disabled())
@@ -145,9 +144,9 @@ func TestAppTabs_EnableItem(t *testing.T) {
 }
 
 func TestAppTabs_EnableIndex(t *testing.T) {
-	tab1 := &container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
-	tab2 := &container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
-	tabs := container.NewAppTabs(tab1, tab2)
+	tab1 := &TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
+	tab2 := &TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
+	tabs := NewAppTabs(tab1, tab2)
 	tabs.DisableItem(tab1)
 
 	assert.True(t, tab1.Disabled())
@@ -157,9 +156,9 @@ func TestAppTabs_EnableIndex(t *testing.T) {
 }
 
 func TestAppTabs_DisableItem(t *testing.T) {
-	tab1 := &container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
-	tab2 := &container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
-	tabs := container.NewAppTabs(tab1, tab2)
+	tab1 := &TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
+	tab2 := &TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
+	tabs := NewAppTabs(tab1, tab2)
 
 	assert.False(t, tab1.Disabled())
 
@@ -170,9 +169,9 @@ func TestAppTabs_DisableItem(t *testing.T) {
 }
 
 func TestAppTabs_DisableIndex(t *testing.T) {
-	tab1 := &container.TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
-	tab2 := &container.TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
-	tabs := container.NewAppTabs(tab1, tab2)
+	tab1 := &TabItem{Text: "Test1", Content: widget.NewLabel("Test1")}
+	tab2 := &TabItem{Text: "Test2", Content: widget.NewLabel("Test2")}
+	tabs := NewAppTabs(tab1, tab2)
 
 	assert.False(t, tab1.Disabled())
 
@@ -180,4 +179,14 @@ func TestAppTabs_DisableIndex(t *testing.T) {
 	assert.True(t, tab1.Disabled())
 
 	assert.Equal(t, 1, tabs.SelectedIndex())
+}
+
+func TestAppTabs_ShowAfterAdd(t *testing.T) {
+	tabs := NewAppTabs()
+	renderer := test.WidgetRenderer(tabs).(*appTabsRenderer)
+	assert.True(t, renderer.indicator.Hidden)
+
+	tabs.Append(NewTabItem("test", widget.NewLabel("Test")))
+
+	assert.False(t, renderer.indicator.Hidden)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Add call of `indicator.Show` in `updateIndicator` to make sure the indicator will be visiable after we add something into the AppTabs as it used to be empty.
Fixes #4809

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
