### PR TITLE
feat: Allow setting custom Layout paddings

### DIFF
--- a/cmd/fyne_demo/tutorials/welcome.go
+++ b/cmd/fyne_demo/tutorials/welcome.go
@@ -56,7 +56,7 @@ func welcomeScreen(_ fyne.Window) fyne.CanvasObject {
 	underlay := canvas.NewImageFromResource(data.FyneLogo)
 	bg := canvas.NewRectangle(bgColor)
 	underlayer := underLayout{}
-	slideBG := container.New(underlayer, underlay)
+	slideBG := container.New(&underlayer, underlay)
 	footerBG := canvas.NewRectangle(shadowColor)
 
 	listen := make(chan fyne.Settings)
@@ -81,10 +81,10 @@ func welcomeScreen(_ fyne.Window) fyne.CanvasObject {
 
 	bgClip := container.NewScroll(slideBG)
 	bgClip.Direction = container.ScrollNone
-	return container.NewStack(container.New(unpad{top: true}, bgClip, bg),
+	return container.NewStack(container.New(&unpad{top: true}, bgClip, bg),
 		container.NewBorder(nil,
 			container.NewStack(footerBG, footer), nil, nil,
-			container.New(unpad{top: true, bottom: true}, scroll)))
+			container.New(&unpad{top: true, bottom: true}, scroll)))
 }
 
 func withAlpha(c color.Color, alpha uint8) color.Color {
@@ -93,6 +93,8 @@ func withAlpha(c color.Color, alpha uint8) color.Color {
 }
 
 type underLayout struct {
+	layout.BaseLayout
+
 	offset float32
 }
 
@@ -107,21 +109,23 @@ func (u underLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
 }
 
 type unpad struct {
+	layout.BaseLayout
+
 	top, bottom bool
 }
 
 func (u unpad) Layout(objs []fyne.CanvasObject, s fyne.Size) {
-	pad := theme.Padding()
+	topPadding, bottomPadding, _, _ := u.GetPaddings()
 	var pos fyne.Position
 	if u.top {
-		pos = fyne.NewPos(0, -pad)
+		pos = fyne.NewPos(0, -topPadding)
 	}
 	size := s
 	if u.top {
-		size = size.AddWidthHeight(0, pad)
+		size = size.AddWidthHeight(0, topPadding)
 	}
 	if u.bottom {
-		size = size.AddWidthHeight(0, pad)
+		size = size.AddWidthHeight(0, bottomPadding)
 	}
 	for _, o := range objs {
 		o.Move(pos)

--- a/container/multiplewindows.go
+++ b/container/multiplewindows.go
@@ -3,6 +3,7 @@ package container
 import (
 	"fyne.io/fyne/v2"
 	intWidget "fyne.io/fyne/v2/internal/widget"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -92,6 +93,7 @@ func (m *MultipleWindows) setupChild(w *InnerWindow) {
 }
 
 type multiWinLayout struct {
+	layout.BaseLayout
 }
 
 func (m *multiWinLayout) Layout(objects []fyne.CanvasObject, _ fyne.Size) {

--- a/container_test.go
+++ b/container_test.go
@@ -181,6 +181,12 @@ func (c *customLayout) MinSize(objs []CanvasObject) Size {
 	return NewSize(10, float32(10*len(objs)))
 }
 
+func (c *customLayout) GetPaddings() (float32, float32, float32, float32) {
+	return 0, 0, 0, 0
+}
+
+func (c *customLayout) SetPaddingFn(paddingFn func() (float32, float32, float32, float32)) {}
+
 type dummyObject struct {
 	size   Size
 	pos    Position

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -197,6 +197,8 @@ func (renderer *themedBackgroundRenderer) Refresh() {
 // ===============================================================
 
 type dialogLayout struct {
+	layout.BaseLayout
+
 	d *dialog
 }
 

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -12,6 +12,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/lang"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/storage/repository"
 	"fyne.io/fyne/v2/theme"
@@ -911,10 +912,12 @@ func storageURI(a fyne.App) fyne.URI {
 // iconPaddingLayout adds padding to the left of a widget.Icon().
 // NOTE: It assumes that the slice only contains one item.
 type iconPaddingLayout struct {
+	layout.BaseLayout
 }
 
 func (i *iconPaddingLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	padding := theme.Padding() * 2
+	_, _, leftPadding, _ := i.GetPaddings()
+	padding := leftPadding * 2
 	objects[0].Move(fyne.NewPos(padding, 0))
 	objects[0].Resize(size.SubtractWidthHeight(padding, 0))
 }

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -567,6 +567,12 @@ func (l *recordingLayout) MinSize([]fyne.CanvasObject) fyne.Size {
 	return fyne.NewSize(6, 9)
 }
 
+func (l *recordingLayout) GetPaddings() (float32, float32, float32, float32) {
+	return 0, 0, 0, 0
+}
+
+func (l *recordingLayout) SetPaddingFn(paddingFn func() (float32, float32, float32, float32)) {}
+
 func (l *recordingLayout) popLayoutEvent() (e any) {
 	e, l.layoutEvents = pop(l.layoutEvents)
 	return

--- a/layout.go
+++ b/layout.go
@@ -8,4 +8,10 @@ type Layout interface {
 	// MinSize calculates the smallest size that will fit the listed
 	// CanvasObjects using this Layout algorithm.
 	MinSize(objects []CanvasObject) Size
+	// GetPaddings returns the top, bottom, left and right paddings used
+	// by this layout.
+	GetPaddings() (float32, float32, float32, float32)
+	// SetPaddingFn sets the function that will be called to get the
+	// padding values for this layout.
+	SetPaddingFn(fn func() (float32, float32, float32, float32))
 }

--- a/layout/baselayout.go
+++ b/layout/baselayout.go
@@ -1,0 +1,19 @@
+package layout
+
+import "fyne.io/fyne/v2/theme"
+
+type BaseLayout struct {
+	paddingFn func() (float32, float32, float32, float32)
+}
+
+func (b *BaseLayout) SetPaddingFn(fn func() (float32, float32, float32, float32)) {
+	b.paddingFn = fn
+}
+
+func (b *BaseLayout) GetPaddings() (float32, float32, float32, float32) {
+	if b.paddingFn == nil {
+		padding := theme.Padding()
+		return padding, padding, padding, padding
+	}
+	return b.paddingFn()
+}

--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -2,52 +2,58 @@ package layout
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 )
 
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*borderLayout)(nil)
 
 type borderLayout struct {
+	BaseLayout
+
 	top, bottom, left, right fyne.CanvasObject
 }
 
 // NewBorderLayout creates a new BorderLayout instance with top, bottom, left
 // and right objects set. All other items in the container will fill the centre
 // space
-func NewBorderLayout(top, bottom, left, right fyne.CanvasObject) fyne.Layout {
-	return &borderLayout{top, bottom, left, right}
+func NewBorderLayout(top, bottom, left, right fyne.CanvasObject, options ...LayoutOption) fyne.Layout {
+	l := &borderLayout{top: top, bottom: bottom, left: left, right: right}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }
 
 // Layout is called to pack all child objects into a specified size.
 // For BorderLayout this arranges the top, bottom, left and right widgets at
 // the sides and any remaining widgets are maximised in the middle space.
 func (b *borderLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	padding := theme.Padding()
+	topPadding, bottomPadding, leftPadding, rightPadding := b.GetPaddings()
+
 	var topSize, bottomSize, leftSize, rightSize fyne.Size
 	if b.top != nil && b.top.Visible() {
 		topHeight := b.top.MinSize().Height
 		b.top.Resize(fyne.NewSize(size.Width, topHeight))
 		b.top.Move(fyne.NewPos(0, 0))
-		topSize = fyne.NewSize(size.Width, topHeight+padding)
+		topSize = fyne.NewSize(size.Width, topHeight+topPadding)
 	}
 	if b.bottom != nil && b.bottom.Visible() {
 		bottomHeight := b.bottom.MinSize().Height
 		b.bottom.Resize(fyne.NewSize(size.Width, bottomHeight))
 		b.bottom.Move(fyne.NewPos(0, size.Height-bottomHeight))
-		bottomSize = fyne.NewSize(size.Width, bottomHeight+padding)
+		bottomSize = fyne.NewSize(size.Width, bottomHeight+bottomPadding)
 	}
 	if b.left != nil && b.left.Visible() {
 		leftWidth := b.left.MinSize().Width
 		b.left.Resize(fyne.NewSize(leftWidth, size.Height-topSize.Height-bottomSize.Height))
 		b.left.Move(fyne.NewPos(0, topSize.Height))
-		leftSize = fyne.NewSize(leftWidth+padding, size.Height-topSize.Height-bottomSize.Height)
+		leftSize = fyne.NewSize(leftWidth+leftPadding, size.Height-topSize.Height-bottomSize.Height)
 	}
 	if b.right != nil && b.right.Visible() {
 		rightWidth := b.right.MinSize().Width
 		b.right.Resize(fyne.NewSize(rightWidth, size.Height-topSize.Height-bottomSize.Height))
 		b.right.Move(fyne.NewPos(size.Width-rightWidth, topSize.Height))
-		rightSize = fyne.NewSize(rightWidth+padding, size.Height-topSize.Height-bottomSize.Height)
+		rightSize = fyne.NewSize(rightWidth+rightPadding, size.Height-topSize.Height-bottomSize.Height)
 	}
 
 	middleSize := fyne.NewSize(size.Width-leftSize.Width-rightSize.Width, size.Height-topSize.Height-bottomSize.Height)
@@ -80,28 +86,28 @@ func (b *borderLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 	}
 
-	padding := theme.Padding()
+	topPadding, bottomPadding, leftPadding, rightPadding := b.GetPaddings()
 
 	if b.left != nil && b.left.Visible() {
 		leftMin := b.left.MinSize()
 		minHeight := fyne.Max(minSize.Height, leftMin.Height)
-		minSize = fyne.NewSize(minSize.Width+leftMin.Width+padding, minHeight)
+		minSize = fyne.NewSize(minSize.Width+leftMin.Width+leftPadding, minHeight)
 	}
 	if b.right != nil && b.right.Visible() {
 		rightMin := b.right.MinSize()
 		minHeight := fyne.Max(minSize.Height, rightMin.Height)
-		minSize = fyne.NewSize(minSize.Width+rightMin.Width+padding, minHeight)
+		minSize = fyne.NewSize(minSize.Width+rightMin.Width+rightPadding, minHeight)
 	}
 
 	if b.top != nil && b.top.Visible() {
 		topMin := b.top.MinSize()
 		minWidth := fyne.Max(minSize.Width, topMin.Width)
-		minSize = fyne.NewSize(minWidth, minSize.Height+topMin.Height+padding)
+		minSize = fyne.NewSize(minWidth, minSize.Height+topMin.Height+topPadding)
 	}
 	if b.bottom != nil && b.bottom.Visible() {
 		bottomMin := b.bottom.MinSize()
 		minWidth := fyne.Max(minSize.Width, bottomMin.Width)
-		minSize = fyne.NewSize(minWidth, minSize.Height+bottomMin.Height+padding)
+		minSize = fyne.NewSize(minWidth, minSize.Height+bottomMin.Height+bottomPadding)
 	}
 
 	return minSize

--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -2,29 +2,38 @@ package layout
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 )
 
 // NewVBoxLayout returns a vertical box layout for stacking a number of child
 // canvas objects or widgets top to bottom. The objects are always displayed
 // at their vertical MinSize. Use a different layout if the objects are intended
 // to be larger then their vertical MinSize.
-func NewVBoxLayout() fyne.Layout {
-	return vBoxLayout{}
+func NewVBoxLayout(options ...LayoutOption) fyne.Layout {
+	l := &vBoxLayout{}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }
 
 // NewHBoxLayout returns a horizontal box layout for stacking a number of child
 // canvas objects or widgets left to right. The objects are always displayed
 // at their horizontal MinSize. Use a different layout if the objects are intended
 // to be larger then their horizontal MinSize.
-func NewHBoxLayout() fyne.Layout {
-	return hBoxLayout{}
+func NewHBoxLayout(options ...LayoutOption) fyne.Layout {
+	l := &hBoxLayout{}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }
 
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*vBoxLayout)(nil)
 
-type vBoxLayout struct{}
+type vBoxLayout struct {
+	BaseLayout
+}
 
 // Layout is called to pack all child objects into a specified size.
 // This will pack objects into a single column where each item
@@ -50,10 +59,10 @@ func (v vBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		total += child.MinSize().Height
 	}
 
-	padding := theme.Padding()
+	topPadding, _, _, _ := v.GetPaddings()
 
 	// Amount of space not taken up by visible objects and inter-object padding
-	extra := size.Height - total - (padding * float32(visibleObjects-1))
+	extra := size.Height - total - (topPadding * float32(visibleObjects-1))
 
 	// Spacers split extra space equally
 	spacerSize := float32(0)
@@ -74,7 +83,7 @@ func (v vBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		child.Move(fyne.NewPos(x, y))
 
 		height := child.MinSize().Height
-		y += padding + height
+		y += topPadding + height
 		child.Resize(fyne.NewSize(size.Width, height))
 	}
 }
@@ -85,7 +94,7 @@ func (v vBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 func (v vBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	minSize := fyne.NewSize(0, 0)
 	addPadding := false
-	padding := theme.Padding()
+	topPadding, _, _, _ := v.GetPaddings()
 	for _, child := range objects {
 		if !child.Visible() || isVerticalSpacer(child) {
 			continue
@@ -95,7 +104,7 @@ func (v vBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		minSize.Width = fyne.Max(childMin.Width, minSize.Width)
 		minSize.Height += childMin.Height
 		if addPadding {
-			minSize.Height += padding
+			minSize.Height += topPadding
 		}
 		addPadding = true
 	}
@@ -105,7 +114,9 @@ func (v vBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*hBoxLayout)(nil)
 
-type hBoxLayout struct{}
+type hBoxLayout struct {
+	BaseLayout
+}
 
 // Layout is called to pack all child objects into a specified size.
 // For a VBoxLayout this will pack objects into a single column where each item
@@ -131,10 +142,10 @@ func (g hBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		total += child.MinSize().Width
 	}
 
-	padding := theme.Padding()
+	_, _, leftPadding, _ := g.GetPaddings()
 
 	// Amount of space not taken up by visible objects and inter-object padding
-	extra := size.Width - total - (padding * float32(visibleObjects-1))
+	extra := size.Width - total - (leftPadding * float32(visibleObjects-1))
 
 	// Spacers split extra space equally
 	spacerSize := float32(0)
@@ -155,7 +166,7 @@ func (g hBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		child.Move(fyne.NewPos(x, y))
 
 		width := child.MinSize().Width
-		x += padding + width
+		x += leftPadding + width
 		child.Resize(fyne.NewSize(width, size.Height))
 	}
 }
@@ -166,7 +177,7 @@ func (g hBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 func (g hBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	minSize := fyne.NewSize(0, 0)
 	addPadding := false
-	padding := theme.Padding()
+	_, _, leftPadding, _ := g.GetPaddings()
 	for _, child := range objects {
 		if !child.Visible() || isHorizontalSpacer(child) {
 			continue
@@ -176,7 +187,7 @@ func (g hBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		minSize.Height = fyne.Max(childMin.Height, minSize.Height)
 		minSize.Width += childMin.Width
 		if addPadding {
-			minSize.Width += padding
+			minSize.Width += leftPadding
 		}
 		addPadding = true
 	}

--- a/layout/centerlayout.go
+++ b/layout/centerlayout.go
@@ -6,11 +6,16 @@ import "fyne.io/fyne/v2"
 var _ fyne.Layout = (*centerLayout)(nil)
 
 type centerLayout struct {
+	BaseLayout
 }
 
 // NewCenterLayout creates a new CenterLayout instance
-func NewCenterLayout() fyne.Layout {
-	return &centerLayout{}
+func NewCenterLayout(options ...LayoutOption) fyne.Layout {
+	l := &centerLayout{}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }
 
 // Layout is called to pack all child objects into a specified size.

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -13,6 +13,7 @@ var _ fyne.Layout = (*formLayout)(nil)
 
 // formLayout is two column grid where each row has a label and a widget.
 type formLayout struct {
+	BaseLayout
 }
 
 func (f *formLayout) countRows(objects []fyne.CanvasObject) int {
@@ -41,7 +42,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 		return table
 	}
 
-	padding := theme.Padding()
+	_, _, leftPadding, _ := f.GetPaddings()
 	innerPadding := theme.InnerPadding()
 	lowBound := 0
 	highBound := 2
@@ -74,7 +75,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 		row++
 	}
 
-	contentWidth := fyne.Max(contentCellMaxWidth, containerWidth-labelCellMaxWidth-padding)
+	contentWidth := fyne.Max(contentCellMaxWidth, containerWidth-labelCellMaxWidth-leftPadding)
 	for row := 0; row < rows; row++ {
 		table[row][0].Width = labelCellMaxWidth
 		table[row][1].Width = contentWidth
@@ -87,7 +88,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	table := f.tableCellsSize(objects, size.Width)
 
-	padding := theme.Padding()
+	topPadding, _, leftPadding, _ := f.GetPaddings()
 	innerPadding := theme.InnerPadding()
 
 	row := 0
@@ -97,7 +98,7 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 			continue
 		}
 		if row > 0 {
-			y += table[row-1][0].Height + padding
+			y += table[row-1][0].Height + topPadding
 		}
 
 		tableRow := table[row]
@@ -111,10 +112,10 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 		if i+1 < len(objects) {
 			if _, ok := objects[i+1].(*canvas.Text); ok {
-				objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width+innerPadding, y+innerPadding))
+				objects[i+1].Move(fyne.NewPos(leftPadding+tableRow[0].Width+innerPadding, y+innerPadding))
 				objects[i+1].Resize(fyne.NewSize(tableRow[1].Width-innerPadding*2, objects[i+1].MinSize().Height))
 			} else {
-				objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width, y))
+				objects[i+1].Move(fyne.NewPos(leftPadding+tableRow[0].Width, y))
 				objects[i+1].Resize(fyne.NewSize(tableRow[1].Width, tableRow[0].Height))
 			}
 		}
@@ -128,7 +129,7 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	table := f.tableCellsSize(objects, 0)
 
-	padding := theme.Padding()
+	topPadding, _, leftPadding, _ := f.GetPaddings()
 	minSize := fyne.NewSize(0, 0)
 
 	if len(table) == 0 {
@@ -136,11 +137,11 @@ func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	}
 
 	added := false
-	minSize.Width = table[0][0].Width + table[0][1].Width + padding
+	minSize.Width = table[0][0].Width + table[0][1].Width + leftPadding
 	for row := 0; row < len(table); row++ {
 		minSize.Height += table[row][0].Height
 		if added {
-			minSize.Height += padding
+			minSize.Height += topPadding
 		}
 		added = true
 	}
@@ -148,6 +149,10 @@ func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 }
 
 // NewFormLayout returns a new FormLayout instance
-func NewFormLayout() fyne.Layout {
-	return &formLayout{}
+func NewFormLayout(options ...LayoutOption) fyne.Layout {
+	l := &formLayout{}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }

--- a/layout/gridwraplayout.go
+++ b/layout/gridwraplayout.go
@@ -4,33 +4,37 @@ import (
 	"math"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 )
 
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*gridWrapLayout)(nil)
 
 type gridWrapLayout struct {
+	BaseLayout
 	CellSize fyne.Size
 	colCount int
 	rowCount int
 }
 
 // NewGridWrapLayout returns a new GridWrapLayout instance
-func NewGridWrapLayout(size fyne.Size) fyne.Layout {
-	return &gridWrapLayout{size, 1, 1}
+func NewGridWrapLayout(size fyne.Size, options ...LayoutOption) fyne.Layout {
+	l := &gridWrapLayout{CellSize: size, colCount: 1, rowCount: 1}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }
 
 // Layout is called to pack all child objects into a specified size.
 // For a GridWrapLayout this will attempt to lay all the child objects in a row
 // and wrap to a new row if the size is not large enough.
 func (g *gridWrapLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	padding := theme.Padding()
+	topPadding, _, leftPadding, _ := g.GetPaddings()
 	g.colCount = 1
 	g.rowCount = 0
 
 	if size.Width > g.CellSize.Width {
-		g.colCount = int(math.Floor(float64(size.Width+padding) / float64(g.CellSize.Width+padding)))
+		g.colCount = int(math.Floor(float64(size.Width+leftPadding) / float64(g.CellSize.Width+leftPadding)))
 	}
 
 	i, x, y := 0, float32(0), float32(0)
@@ -48,9 +52,9 @@ func (g *gridWrapLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 		if (i+1)%g.colCount == 0 {
 			x = 0
-			y += g.CellSize.Height + padding
+			y += g.CellSize.Height + topPadding
 		} else {
-			x += g.CellSize.Width + padding
+			x += g.CellSize.Width + leftPadding
 		}
 		i++
 	}
@@ -65,6 +69,7 @@ func (g *gridWrapLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	if rows < 1 {
 		rows = 1
 	}
+	topPadding, _, _, _ := g.GetPaddings()
 	return fyne.NewSize(g.CellSize.Width,
-		(g.CellSize.Height*float32(rows))+(float32(rows-1)*theme.Padding()))
+		(g.CellSize.Height*float32(rows))+(float32(rows-1)*topPadding))
 }

--- a/layout/option.go
+++ b/layout/option.go
@@ -1,0 +1,13 @@
+package layout
+
+import "fyne.io/fyne/v2"
+
+type LayoutOption func(fyne.Layout)
+
+// WithCustomPaddings is a LayoutOption that allows setting custom paddings for the layout.
+// It takes a function that returns the top, bottom, left, and right paddings.
+func WithCustomPaddings(fn func() (float32, float32, float32, float32)) LayoutOption {
+	return func(layout fyne.Layout) {
+		layout.SetPaddingFn(fn)
+	}
+}

--- a/layout/paddedlayout.go
+++ b/layout/paddedlayout.go
@@ -2,20 +2,23 @@ package layout
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 )
 
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*paddedLayout)(nil)
 
-type paddedLayout struct{}
+type paddedLayout struct {
+	BaseLayout
+}
 
 // Layout is called to pack all child objects into a specified size.
 // For PaddedLayout this sets all children to the full size passed minus padding all around.
 func (l paddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	padding := theme.Padding()
-	pos := fyne.NewSquareOffsetPos(padding)
-	siz := fyne.NewSize(size.Width-2*padding, size.Height-2*padding)
+	topPadding, bottomPadding, leftPadding, rightPadding := l.GetPaddings()
+	pos := fyne.NewPos(leftPadding, topPadding)
+	siz := fyne.NewSize(
+		size.Width-leftPadding-rightPadding,
+		size.Height-topPadding-bottomPadding)
 	for _, child := range objects {
 		child.Resize(siz)
 		child.Move(pos)
@@ -32,13 +35,18 @@ func (l paddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
 
 		min = min.Max(child.MinSize())
 	}
-	min = min.Add(fyne.NewSquareSize(2 * theme.Padding()))
+	topPadding, bottomPadding, leftPadding, rightPadding := l.GetPaddings()
+	min = min.Add(fyne.NewSize(leftPadding+rightPadding, topPadding+bottomPadding))
 	return
 }
 
 // NewPaddedLayout creates a new PaddedLayout instance
 //
 // Since: 1.4
-func NewPaddedLayout() fyne.Layout {
-	return paddedLayout{}
+func NewPaddedLayout(options ...LayoutOption) fyne.Layout {
+	l := &paddedLayout{}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }

--- a/layout/stacklayout.go
+++ b/layout/stacklayout.go
@@ -6,7 +6,9 @@ import "fyne.io/fyne/v2"
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*stackLayout)(nil)
 
-type stackLayout struct{}
+type stackLayout struct {
+	BaseLayout
+}
 
 // NewStackLayout returns a new StackLayout instance. Objects are stacked
 // on top of each other with later objects on top of those before.
@@ -14,8 +16,12 @@ type stackLayout struct{}
 // fill the available space even without a Stack.
 //
 // Since: 2.4
-func NewStackLayout() fyne.Layout {
-	return stackLayout{}
+func NewStackLayout(options ...LayoutOption) fyne.Layout {
+	l := &stackLayout{}
+	for _, option := range options {
+		option(l)
+	}
+	return l
 }
 
 // NewMaxLayout creates a new MaxLayout instance

--- a/widget/form.go
+++ b/widget/form.go
@@ -163,7 +163,7 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 	item.helperOutput = text
 	f.updateHelperText(item)
 	textContainer := &fyne.Container{Objects: []fyne.CanvasObject{text}}
-	return &fyne.Container{Layout: formItemLayout{form: f}, Objects: []fyne.CanvasObject{item.Widget, textContainer}}
+	return &fyne.Container{Layout: &formItemLayout{form: f}, Objects: []fyne.CanvasObject{item.Widget, textContainer}}
 }
 
 func (f *Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
@@ -383,6 +383,8 @@ func NewForm(items ...*FormItem) *Form {
 }
 
 type formItemLayout struct {
+	layout.BaseLayout
+
 	form *Form
 }
 

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal/widget"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -496,6 +497,8 @@ type gridItemAndID struct {
 }
 
 type gridWrapLayout struct {
+	layout.BaseLayout
+
 	list *GridWrap
 
 	itemPool   syncPool

--- a/widget/list.go
+++ b/widget/list.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal/widget"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -589,6 +590,8 @@ type listItemAndID struct {
 }
 
 type listLayout struct {
+	layout.BaseLayout
+
 	list       *List
 	separators []fyne.CanvasObject
 	children   []fyne.CanvasObject

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/scale"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -476,7 +477,7 @@ func newRichImage(u fyne.URI, align fyne.TextAlign) *richImage {
 }
 
 func (r *richImage) CreateRenderer() fyne.WidgetRenderer {
-	r.layout = &fyne.Container{Layout: &richImageLayout{r}, Objects: []fyne.CanvasObject{r.img}}
+	r.layout = &fyne.Container{Layout: &richImageLayout{r: r}, Objects: []fyne.CanvasObject{r.img}}
 	return NewSimpleRenderer(r.layout)
 }
 
@@ -503,6 +504,8 @@ func (r *richImage) setAlign(a fyne.TextAlign) {
 }
 
 type richImageLayout struct {
+	layout.BaseLayout
+
 	r *richImage
 }
 
@@ -525,6 +528,8 @@ func (r *richImageLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
 }
 
 type unpadTextWidgetLayout struct {
+	layout.BaseLayout
+
 	parent fyne.Widget
 }
 


### PR DESCRIPTION
### Description:

Introduce a `LayoutOption` concept, and allow setting custom paddings for a Layout. The `BaseLayout` struct implements the default paddings retrieval, to reduce the amount of changes required by project maintainers to comply with the new interface methods.

This change uses the Option pattern in case other customizations can be added to Layouts in the future, without changing the public API.

Main motivation for this change has been Supersonic needing to copy the entire Vbox/Hbox implementation, just to add custom paddings [1]. Also related to feature request #1031.

[1] https://github.com/dweymouth/supersonic/blob/02d4082f3dae4d1d54a4384489785a5984a7a7de/ui/layouts/hboxcustompadding.go

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.