### PR TITLE
Try to decrease allocations in form layout

### DIFF
--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -75,11 +75,6 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 	}
 
 	contentCellMaxWidth = fyne.Max(contentCellMaxWidth, containerWidth-labelCellMaxWidth-padding)
-	for row := 0; row < rows; row++ {
-		table[row][0].Width = labelCellMaxWidth
-		table[row][1].Width = contentCellMaxWidth
-	}
-
 	return labelCellMaxWidth, contentCellMaxWidth, table
 }
 
@@ -111,10 +106,10 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 		if i+1 < len(objects) {
 			if _, ok := objects[i+1].(*canvas.Text); ok {
-				objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width+innerPadding, y+innerPadding))
+				objects[i+1].Move(fyne.NewPos(padding+labelWidth+innerPadding, y+innerPadding))
 				objects[i+1].Resize(fyne.NewSize(contentWidth-innerPadding*2, objects[i+1].MinSize().Height))
 			} else {
-				objects[i+1].Move(fyne.NewPos(padding+tableRow[0].Width, y))
+				objects[i+1].Move(fyne.NewPos(padding+labelWidth, y))
 				objects[i+1].Resize(fyne.NewSize(contentWidth, tableRow[0].Height))
 			}
 		}

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -116,21 +116,18 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 // the sum of all column children combined with padding between each.
 func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	labelWidth, contentWidth, heights := f.tableCellsSize(objects, 0)
-
-	minSize := fyne.NewSize(0, 0)
 	if len(heights) == 0 {
-		return minSize
+		return fyne.Size{}
 	}
 
 	padding := theme.Padding()
-	added := false
-	minSize.Width = labelWidth + contentWidth + padding
+	minSize := fyne.Size{
+		Width:  labelWidth + contentWidth + padding,
+		Height: padding * float32(len(heights)-1),
+	}
+
 	for row := 0; row < len(heights); row++ {
 		minSize.Height += heights[row]
-		if added {
-			minSize.Height += padding
-		}
-		added = true
 	}
 	return minSize
 }

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -28,12 +28,14 @@ func (f *formLayout) countRows(objects []fyne.CanvasObject) int {
 	return count
 }
 
-// tableCellsSize defines the size for all the cells of the form table.
-// The height of each row will be set as the max value between the label and content cell heights.
-// The width of the label column will be set as the max width value between all the label cells.
-// The width of the content column will be set as the max width value between all the content cells
-// or the remaining space of the bounding containerWidth, if it is larger.
-func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth float32) (float32, float32, []float32) {
+// calculateTableSizes calculates the size of all of the cells in the table.
+// It returns the width of the left column (labels), the width of the right column (content)
+// as well as a slice with the height of each row. The height of each row will be set as the max
+// size of the label and content cell heights for that row. The width of the label column will
+// be set as the max width of all the label cells. The width of the content column will be set as
+// the max width of all the content cells or the remaining space of the bounding containerWidth,
+// if it is larger.
+func (f *formLayout) calculateTableSizes(objects []fyne.CanvasObject, containerWidth float32) (float32, float32, []float32) {
 	rows := f.countRows(objects)
 	heights := make([]float32, rows)
 
@@ -74,7 +76,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 
 // Layout is called to pack all child objects into a table format with two columns.
 func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
-	labelWidth, contentWidth, heights := f.tableCellsSize(objects, size.Width)
+	labelWidth, contentWidth, heights := f.calculateTableSizes(objects, size.Width)
 
 	padding := theme.Padding()
 	innerPadding := theme.InnerPadding()
@@ -120,7 +122,7 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 // For a FormLayout this is the width of the widest label and content items and the height is
 // the sum of all column children combined with padding between each.
 func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
-	labelWidth, contentWidth, heights := f.tableCellsSize(objects, 0)
+	labelWidth, contentWidth, heights := f.calculateTableSizes(objects, 0)
 	if len(heights) == 0 {
 		return fyne.Size{}
 	}
@@ -131,9 +133,10 @@ func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		Height: padding * float32(len(heights)-1),
 	}
 
-	for row := 0; row < len(heights); row++ {
-		minSize.Height += heights[row]
+	for _, height := range heights {
+		minSize.Height += height
 	}
+
 	return minSize
 }
 

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -41,7 +41,6 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 		return 0, 0, heights
 	}
 
-	padding := theme.Padding()
 	innerPadding := theme.InnerPadding()
 	lowBound := 0
 	highBound := 2
@@ -69,7 +68,7 @@ func (f *formLayout) tableCellsSize(objects []fyne.CanvasObject, containerWidth 
 		row++
 	}
 
-	contentCellMaxWidth = fyne.Max(contentCellMaxWidth, containerWidth-labelCellMaxWidth-padding)
+	contentCellMaxWidth = fyne.Max(contentCellMaxWidth, containerWidth-labelCellMaxWidth-theme.Padding())
 	return labelCellMaxWidth, contentCellMaxWidth, heights
 }
 
@@ -90,22 +89,28 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 			y += heights[row-1] + padding
 		}
 
+		pos := fyne.NewPos(0, y)
+		size := fyne.NewSize(labelWidth, heights[row])
 		if _, ok := objects[i].(*canvas.Text); ok {
-			objects[i].Move(fyne.NewPos(innerPadding, y+innerPadding))
-			objects[i].Resize(fyne.NewSize(labelWidth-innerPadding*2, objects[i].MinSize().Height))
-		} else {
-			objects[i].Move(fyne.NewPos(0, y))
-			objects[i].Resize(fyne.NewSize(labelWidth, heights[row]))
+			pos = pos.AddXY(innerPadding, innerPadding)
+			size.Width -= innerPadding * 2
+			size.Height = objects[i].MinSize().Height
 		}
 
+		objects[i].Move(pos)
+		objects[i].Resize(size)
+
 		if i+1 < len(objects) {
+			pos = fyne.NewPos(padding+labelWidth, y)
+			size = fyne.NewSize(contentWidth, heights[row])
 			if _, ok := objects[i+1].(*canvas.Text); ok {
-				objects[i+1].Move(fyne.NewPos(padding+labelWidth+innerPadding, y+innerPadding))
-				objects[i+1].Resize(fyne.NewSize(contentWidth-innerPadding*2, objects[i+1].MinSize().Height))
-			} else {
-				objects[i+1].Move(fyne.NewPos(padding+labelWidth, y))
-				objects[i+1].Resize(fyne.NewSize(contentWidth, heights[row]))
+				pos = pos.AddXY(innerPadding, innerPadding)
+				size.Width -= innerPadding * 2
+				size.Height = objects[i+1].MinSize().Height
 			}
+
+			objects[i+1].Move(pos)
+			objects[i+1].Resize(size)
 		}
 		row++
 	}

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -128,13 +128,12 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 func (f *formLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	labelWidth, contentWidth, table := f.tableCellsSize(objects, 0)
 
-	padding := theme.Padding()
 	minSize := fyne.NewSize(0, 0)
-
 	if len(table) == 0 {
 		return minSize
 	}
 
+	padding := theme.Padding()
 	added := false
 	minSize.Width = labelWidth + contentWidth + padding
 	for row := 0; row < len(table); row++ {

--- a/layout/formlayout_test.go
+++ b/layout/formlayout_test.go
@@ -13,6 +13,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var minSize fyne.Size
+
+func BenchmarkFormLayout(b *testing.B) {
+	b.StopTimer()
+
+	min := fyne.Size{}
+	form := layout.NewFormLayout()
+	label1 := canvas.NewRectangle(color.Black)
+	content1 := canvas.NewRectangle(color.Black)
+	label2 := canvas.NewRectangle(color.Black)
+	content2 := canvas.NewRectangle(color.Black)
+
+	objects := []fyne.CanvasObject{label1, content1, label2, content2}
+
+	b.StartTimer()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		min = form.MinSize(objects)
+	}
+
+	minSize = min
+}
+
 func TestFormLayout(t *testing.T) {
 	gridSize := fyne.NewSize(125, 125)
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This PR does some refactoring to remove unnecessary code and allocate only as much as we need.
The code is cleaner, tidier and does allocate 75% less memory but we are still allocating in the fast path so this is not a final solution but a step in the right direction. Performance wise, it is only ever so slightly faster. 

```
BenchmarkFormMinSizeBefore-8   	 6294230	       188.3 ns/op	      32 B/op	       1 allocs/op
BenchmarkFormMinSizeAfter-8   	 6604521	       175.1 ns/op	       8 B/op	       1 allocs/op

BenchmarkFormLayoutBefore-8   	 3236059	       363.9 ns/op	      32 B/op	       1 allocs/op
BenchmarkFormLayoutAfter-8   	 3091474	       350.5 ns/op	       8 B/op	       1 allocs/op
```

For #4821 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
