### PR TITLE
Add a custom padded layout

### DIFF
--- a/layout/custompaddedlayout.go
+++ b/layout/custompaddedlayout.go
@@ -9,6 +9,8 @@ var _ fyne.Layout = (*CustomPaddedLayout)(nil)
 
 // CustomPaddedLayout is a layout similar to PaddedLayout, but uses
 // custom values for padding on each side, rather than the theme padding value.
+//
+// Since: 2.5
 type CustomPaddedLayout struct {
 	TopPadding    float32
 	BottomPadding float32

--- a/layout/custompaddedlayout.go
+++ b/layout/custompaddedlayout.go
@@ -1,0 +1,72 @@
+package layout
+
+import (
+	"fyne.io/fyne/v2"
+)
+
+// Declare conformity with Layout interface
+var _ fyne.Layout = (*CustomPaddedLayout)(nil)
+
+// CustomPaddedLayout is a layout similar to PaddedLayout, but uses
+// custom values for padding on each side, rather than the theme padding value.
+type CustomPaddedLayout struct {
+	TopPadding    float32
+	BottomPadding float32
+	LeftPadding   float32
+	RightPadding  float32
+}
+
+// NewCustomPaddedLayout creates a new CustomPaddedLayout instance
+// with the specified paddings.
+//
+// Since: 2.5
+func NewCustomPaddedLayout(padTop, padBottom, padLeft, padRight float32) fyne.Layout {
+	return CustomPaddedLayout{
+		TopPadding:    padTop,
+		BottomPadding: padBottom,
+		LeftPadding:   padLeft,
+		RightPadding:  padRight,
+	}
+}
+
+// NewSquareCustomPaddedLayout creates a new CustomPaddedLayout instance
+// with the same custom padding applied to all four sides.
+//
+// Since: 2.5
+func NewSquareCustomPaddedLayout(pad float32) fyne.Layout {
+	return CustomPaddedLayout{
+		TopPadding:    pad,
+		BottomPadding: pad,
+		LeftPadding:   pad,
+		RightPadding:  pad,
+	}
+}
+
+// Layout is called to pack all child objects into a specified size.
+// For PaddedLayout this sets all children to the full size passed minus padding all around.
+func (c CustomPaddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	pos := fyne.NewPos(c.LeftPadding, c.TopPadding)
+	siz := fyne.Size{
+		Width:  size.Width - c.LeftPadding - c.RightPadding,
+		Height: size.Height - c.TopPadding - c.BottomPadding,
+	}
+	for _, child := range objects {
+		child.Resize(siz)
+		child.Move(pos)
+	}
+}
+
+// MinSize finds the smallest size that satisfies all the child objects.
+// For PaddedLayout this is determined simply as the MinSize of the largest child plus padding all around.
+func (c CustomPaddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
+	for _, child := range objects {
+		if !child.Visible() {
+			continue
+		}
+
+		min = min.Max(child.MinSize())
+	}
+	min.Width += c.LeftPadding + c.RightPadding
+	min.Height += c.TopPadding + c.BottomPadding
+	return
+}

--- a/layout/custompaddedlayout.go
+++ b/layout/custompaddedlayout.go
@@ -31,19 +31,6 @@ func NewCustomPaddedLayout(padTop, padBottom, padLeft, padRight float32) fyne.La
 	}
 }
 
-// NewSquareCustomPaddedLayout creates a new CustomPaddedLayout instance
-// with the same custom padding applied to all four sides.
-//
-// Since: 2.5
-func NewSquareCustomPaddedLayout(pad float32) fyne.Layout {
-	return CustomPaddedLayout{
-		TopPadding:    pad,
-		BottomPadding: pad,
-		LeftPadding:   pad,
-		RightPadding:  pad,
-	}
-}
-
 // Layout is called to pack all child objects into a specified size.
 // For CustomPaddedLayout this sets all children to the full size passed minus the given paddings all around.
 func (c CustomPaddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {

--- a/layout/custompaddedlayout.go
+++ b/layout/custompaddedlayout.go
@@ -45,7 +45,7 @@ func NewSquareCustomPaddedLayout(pad float32) fyne.Layout {
 }
 
 // Layout is called to pack all child objects into a specified size.
-// For PaddedLayout this sets all children to the full size passed minus padding all around.
+// For CustomPaddedLayout this sets all children to the full size passed minus the given paddings all around.
 func (c CustomPaddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 	pos := fyne.NewPos(c.LeftPadding, c.TopPadding)
 	siz := fyne.Size{
@@ -59,7 +59,7 @@ func (c CustomPaddedLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) 
 }
 
 // MinSize finds the smallest size that satisfies all the child objects.
-// For PaddedLayout this is determined simply as the MinSize of the largest child plus padding all around.
+// For CustomPaddedLayout this is determined simply as the MinSize of the largest child plus the given paddings all around.
 func (c CustomPaddedLayout) MinSize(objects []fyne.CanvasObject) (min fyne.Size) {
 	for _, child := range objects {
 		if !child.Visible() {

--- a/layout/custompaddedlayout_test.go
+++ b/layout/custompaddedlayout_test.go
@@ -1,0 +1,38 @@
+package layout_test
+
+import (
+	"image/color"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomPaddedLayout(t *testing.T) {
+	size := fyne.NewSize(100, 100)
+
+	obj := canvas.NewRectangle(color.Black)
+	container := &fyne.Container{
+		Objects: []fyne.CanvasObject{obj},
+	}
+	container.Resize(size)
+
+	layout.NewCustomPaddedLayout(2, 3, 4, 5).Layout(container.Objects, size)
+
+	assert.Equal(t, obj.Size().Width, size.Width-4-5)
+	assert.Equal(t, obj.Size().Height, size.Height-2-3)
+}
+
+func TestCustomPaddedLayout_MinSize(t *testing.T) {
+	text := canvas.NewText("FooBar", color.Black)
+	minSize := text.MinSize()
+
+	container := container.NewWithoutLayout(text)
+	layoutMin := layout.NewCustomPaddedLayout(2, 3, 4, 5).MinSize(container.Objects)
+
+	assert.Equal(t, minSize.Width+4+5, layoutMin.Width)
+	assert.Equal(t, minSize.Height+2+3, layoutMin.Height)
+}


### PR DESCRIPTION
### Description:
This PR seeks to add a CustomPaddedLayout that behaves like PaddedLayout except allowing for a custom amount of padding applied to each side rather than the theme padding value.


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
