### PR TITLE
Add custom padded box layouts

### DIFF
--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -10,7 +10,9 @@ import (
 // at their vertical MinSize. Use a different layout if the objects are intended
 // to be larger then their vertical MinSize.
 func NewVBoxLayout() fyne.Layout {
-	return vBoxLayout{}
+	return vBoxLayout{
+		paddingFunc: theme.Padding,
+	}
 }
 
 // NewHBoxLayout returns a horizontal box layout for stacking a number of child
@@ -18,13 +20,37 @@ func NewVBoxLayout() fyne.Layout {
 // at their horizontal MinSize. Use a different layout if the objects are intended
 // to be larger then their horizontal MinSize.
 func NewHBoxLayout() fyne.Layout {
-	return hBoxLayout{}
+	return hBoxLayout{
+		paddingFunc: theme.Padding,
+	}
+}
+
+// NewCustomPaddedHBoxLayout returns a layout similar to HBoxLayout that uses a custom
+// amount of padding in between objects instead of the theme.Padding value.
+//
+// Since: 2.5
+func NewCustomPaddedHBoxLayout(padding float32) fyne.Layout {
+	return hBoxLayout{
+		paddingFunc: func() float32 { return padding },
+	}
+}
+
+// NewCustomPaddedVBoxLayout returns a layout similar to VBoxLayout that uses a custom
+// amount of padding in between objects instead of the theme.Padding value.
+//
+// Since: 2.5
+func NewCustomPaddedVBoxLayout(padding float32) fyne.Layout {
+	return vBoxLayout{
+		paddingFunc: func() float32 { return padding },
+	}
 }
 
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*vBoxLayout)(nil)
 
-type vBoxLayout struct{}
+type vBoxLayout struct {
+	paddingFunc func() float32
+}
 
 // Layout is called to pack all child objects into a specified size.
 // This will pack objects into a single column where each item
@@ -50,7 +76,7 @@ func (v vBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		total += child.MinSize().Height
 	}
 
-	padding := theme.Padding()
+	padding := v.paddingFunc()
 
 	// Amount of space not taken up by visible objects and inter-object padding
 	extra := size.Height - total - (padding * float32(visibleObjects-1))
@@ -85,7 +111,7 @@ func (v vBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 func (v vBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	minSize := fyne.NewSize(0, 0)
 	addPadding := false
-	padding := theme.Padding()
+	padding := v.paddingFunc()
 	for _, child := range objects {
 		if !child.Visible() || isVerticalSpacer(child) {
 			continue
@@ -105,7 +131,9 @@ func (v vBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*hBoxLayout)(nil)
 
-type hBoxLayout struct{}
+type hBoxLayout struct {
+	paddingFunc func() float32
+}
 
 // Layout is called to pack all child objects into a specified size.
 // For a VBoxLayout this will pack objects into a single column where each item
@@ -131,7 +159,7 @@ func (g hBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		total += child.MinSize().Width
 	}
 
-	padding := theme.Padding()
+	padding := g.paddingFunc()
 
 	// Amount of space not taken up by visible objects and inter-object padding
 	extra := size.Width - total - (padding * float32(visibleObjects-1))
@@ -166,7 +194,7 @@ func (g hBoxLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 func (g hBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	minSize := fyne.NewSize(0, 0)
 	addPadding := false
-	padding := theme.Padding()
+	padding := g.paddingFunc()
 	for _, child := range objects {
 		if !child.Visible() || isHorizontalSpacer(child) {
 			continue

--- a/layout/boxlayout_test.go
+++ b/layout/boxlayout_test.go
@@ -41,6 +41,28 @@ func TestHBoxLayout_Simple(t *testing.T) {
 	assert.Equal(t, cell3Pos, obj3.Position())
 }
 
+func TestCustomPaddedHBoxLayout_Simple(t *testing.T) {
+	cellSize := fyne.NewSize(50, 50)
+
+	obj1 := NewMinSizeRect(cellSize)
+	obj2 := NewMinSizeRect(cellSize)
+	obj3 := NewMinSizeRect(cellSize)
+
+	padding := float32(15)
+	container := container.New(layout.NewCustomPaddedHBoxLayout(padding), obj1, obj2, obj3)
+
+	// We are not in a window. Resize the container to a default size.
+	container.Resize(container.MinSize())
+
+	assert.Equal(t, container.MinSize(), fyne.NewSize(150+padding*2, 50))
+
+	assert.Equal(t, obj1.Size(), cellSize)
+	cell2Pos := fyne.NewPos(50+padding, 0)
+	assert.Equal(t, cell2Pos, obj2.Position())
+	cell3Pos := fyne.NewPos(100+padding*2, 0)
+	assert.Equal(t, cell3Pos, obj3.Position())
+}
+
 func TestHBoxLayout_HiddenItem(t *testing.T) {
 	cellSize := fyne.NewSize(50, 50)
 
@@ -158,6 +180,28 @@ func TestVBoxLayout_Simple(t *testing.T) {
 	cell2Pos := fyne.NewPos(0, 50+theme.Padding())
 	assert.Equal(t, cell2Pos, obj2.Position())
 	cell3Pos := fyne.NewPos(0, 100+theme.Padding()*2)
+	assert.Equal(t, cell3Pos, obj3.Position())
+}
+
+func TestCustomPaddedVBoxLayout_Simple(t *testing.T) {
+	cellSize := fyne.NewSize(50, 50)
+
+	obj1 := NewMinSizeRect(cellSize)
+	obj2 := NewMinSizeRect(cellSize)
+	obj3 := NewMinSizeRect(cellSize)
+
+	padding := float32(15)
+	container := container.New(layout.NewCustomPaddedVBoxLayout(padding), obj1, obj2, obj3)
+
+	// We are not in a window. Resize the container to a default size.
+	container.Resize(container.MinSize())
+
+	assert.Equal(t, container.MinSize(), fyne.NewSize(50, 150+padding*2))
+
+	assert.Equal(t, obj1.Size(), cellSize)
+	cell2Pos := fyne.NewPos(0, 50+padding)
+	assert.Equal(t, cell2Pos, obj2.Position())
+	cell3Pos := fyne.NewPos(0, 100+padding*2)
 	assert.Equal(t, cell3Pos, obj3.Position())
 }
 


### PR DESCRIPTION
### Description:
Add custom padded HBox and VBox layouts that use a specified amount of padding between objects instead of theme.Padding

Fixes #1031 (orig. closed as won't fix)

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
