### PR TITLE
Add a cache for MinSize in BaseWidget

### DIFF
--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -14,6 +14,7 @@ type Base struct {
 	hidden   atomic.Bool
 	position async.Position
 	size     async.Size
+	minCache async.Size
 	impl     atomic.Pointer[fyne.Widget]
 }
 
@@ -63,6 +64,11 @@ func (w *Base) Move(pos fyne.Position) {
 
 // MinSize for the widget - it should never be resized below this value.
 func (w *Base) MinSize() fyne.Size {
+	minCache := w.minCache.Load()
+	if !minCache.IsZero() {
+		return minCache
+	}
+
 	impl := w.super()
 
 	r := cache.Renderer(impl)
@@ -112,8 +118,16 @@ func (w *Base) Refresh() {
 		return
 	}
 
+	w.minCache.Store(fyne.Size{})
 	render := cache.Renderer(impl)
 	render.Refresh()
+}
+
+// ResetMinSizeCache resets the cached MinSize for this widget.
+//
+// Since: 2.5.0
+func (w *Base) ResetMinSizeCache() {
+	w.minCache.Store(fyne.Size{})
 }
 
 // super will return the actual object that this represents.

--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -76,7 +76,9 @@ func (w *Base) MinSize() fyne.Size {
 		return fyne.NewSize(0, 0)
 	}
 
-	return r.MinSize()
+	minSize := r.MinSize()
+	w.minCache.Store(minSize)
+	return minSize
 }
 
 // Visible returns whether or not this widget should be visible.

--- a/widget/check.go
+++ b/widget/check.go
@@ -24,8 +24,6 @@ type Check struct {
 	hovered bool
 
 	binder basicBinder
-
-	minSize fyne.Size // cached for hover/tap position calculations
 }
 
 // NewCheck creates a new check widget with the set label and change handler
@@ -119,8 +117,9 @@ func (c *Check) MouseMoved(me *desktop.MouseEvent) {
 
 	// only hovered if cached minSize has not been initialized (test code)
 	// or the pointer is within the "active" area of the widget (its minSize)
-	c.hovered = c.minSize.IsZero() ||
-		(me.Position.X <= c.minSize.Width && me.Position.Y <= c.minSize.Height)
+	minSize := c.MinSize()
+	c.hovered = minSize.IsZero() ||
+		(me.Position.X <= minSize.Width && me.Position.Y <= minSize.Height)
 
 	if oldHovered != c.hovered {
 		c.Refresh()
@@ -132,8 +131,10 @@ func (c *Check) Tapped(pe *fyne.PointEvent) {
 	if c.Disabled() {
 		return
 	}
-	if !c.minSize.IsZero() &&
-		(pe.Position.X > c.minSize.Width || pe.Position.Y > c.minSize.Height) {
+
+	minSize := c.MinSize()
+	if !minSize.IsZero() &&
+		(pe.Position.X > minSize.Width || pe.Position.Y > minSize.Height) {
 		// tapped outside the active area of the widget
 		return
 	}
@@ -151,8 +152,7 @@ func (c *Check) Tapped(pe *fyne.PointEvent) {
 // MinSize returns the size that this widget should not shrink below
 func (c *Check) MinSize() fyne.Size {
 	c.ExtendBaseWidget(c)
-	c.minSize = c.BaseWidget.MinSize()
-	return c.minSize
+	return c.BaseWidget.MinSize()
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -96,7 +96,6 @@ type Entry struct {
 	ActionItem      fyne.CanvasObject `json:"-"`
 	binder          basicBinder
 	conversionError error
-	minCache        fyne.Size
 	multiLineRows   int // override global default number of visible lines
 
 	// undoStack stores the data necessary for undo/redo functionality
@@ -402,20 +401,8 @@ func (e *Entry) KeyUp(key *fyne.KeyEvent) {
 //
 // Implements: fyne.Widget
 func (e *Entry) MinSize() fyne.Size {
-	e.propertyLock.RLock()
-	cached := e.minCache
-	e.propertyLock.RUnlock()
-	if !cached.IsZero() {
-		return cached
-	}
-
 	e.ExtendBaseWidget(e)
-	min := e.BaseWidget.MinSize()
-
-	e.propertyLock.Lock()
-	e.minCache = min
-	e.propertyLock.Unlock()
-	return min
+	return e.BaseWidget.MinSize()
 }
 
 // MouseDown called on mouse click, this triggers a mouse click which can move the cursor,
@@ -478,14 +465,6 @@ func (e *Entry) Redo() {
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.propertyLock.Unlock()
 	e.Refresh()
-}
-
-func (e *Entry) Refresh() {
-	e.propertyLock.Lock()
-	e.minCache = fyne.Size{}
-	e.propertyLock.Unlock()
-
-	e.BaseWidget.Refresh()
 }
 
 // SelectedText returns the text currently selected in this Entry.

--- a/widget/select_entry.go
+++ b/widget/select_entry.go
@@ -55,7 +55,7 @@ func (e *SelectEntry) Disable() {
 // Implements: fyne.Widget
 func (e *SelectEntry) MinSize() fyne.Size {
 	e.ExtendBaseWidget(e)
-	return e.Entry.MinSize()
+	return e.BaseWidget.MinSize()
 }
 
 // Move changes the relative position of the select entry.

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -82,7 +82,9 @@ func (w *BaseWidget) MinSize() fyne.Size {
 		return fyne.Size{}
 	}
 
-	return r.MinSize()
+	minSize := r.MinSize()
+	w.minCache.Store(minSize)
+	return minSize
 }
 
 // Visible returns whether or not this widget should be visible.

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -16,6 +16,7 @@ import (
 // BaseWidget provides a helper that handles basic widget behaviours.
 type BaseWidget struct {
 	size     async.Size
+	minCache async.Size
 	position async.Position
 	Hidden   bool
 
@@ -69,6 +70,11 @@ func (w *BaseWidget) Move(pos fyne.Position) {
 
 // MinSize for the widget - it should never be resized below this value.
 func (w *BaseWidget) MinSize() fyne.Size {
+	minCache := w.minCache.Load()
+	if !minCache.IsZero() {
+		return minCache
+	}
+
 	impl := w.super()
 
 	r := cache.Renderer(impl)
@@ -123,6 +129,7 @@ func (w *BaseWidget) Refresh() {
 		return
 	}
 
+	w.minCache.Store(fyne.Size{})
 	w.propertyLock.Lock()
 	w.themeCache = nil
 	w.propertyLock.Unlock()
@@ -170,6 +177,8 @@ func (w *BaseWidget) SetFieldsAndRefresh(f func()) {
 	if impl == nil {
 		return
 	}
+
+	w.minCache.Store(fyne.Size{})
 	impl.Refresh()
 }
 

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -163,6 +163,13 @@ func (w *BaseWidget) themeWithLock() fyne.Theme {
 	return cached
 }
 
+// ResetMinSizeCache resets the cached MinSize for this widget.
+//
+// Since: 2.5.0
+func (w *BaseWidget) ResetMinSizeCache() {
+	w.minCache.Store(fyne.Size{})
+}
+
 // SetFieldsAndRefresh helps to make changes to a widget that should be followed by a refresh.
 // This method is a guaranteed thread-safe way of directly manipulating widget fields.
 // Widgets extending BaseWidget should use this in their setter functions.


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This attempts to cache MinSize values of widgets to provide for faster lookups by avoiding recalculations when nothing has changed. I think it feels quite a bit faster when just using fyne_demo. Placebo?  

Supersedes #4681

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
