### PR TITLE
Fix regression of hyperlink tap rejection if outside text area

### DIFF
--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -211,6 +211,9 @@ func (hl *Hyperlink) SetURLFromString(str string) error {
 
 // Tapped is called when a pointer tapped event is captured and triggers any change handler
 func (hl *Hyperlink) Tapped(e *fyne.PointEvent) {
+	if len(hl.provider.Segments) != 0 && !hl.isPosOverText(e.Position) {
+		return // tapped outside text area
+	}
 	hl.invokeAction()
 }
 

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -111,7 +111,7 @@ func TestHyperlink_TappedOutsideTextBoundary(t *testing.T) {
 	}
 	link.syncSegments()
 	link.Tapped(&fyne.PointEvent{
-		Position: fyne.NewPos(2, 50 /*past text boundary*/),
+		Position: fyne.NewPos(50 /*past text boundary*/, 2),
 	})
 	assert.Equal(t, 0, tapped)
 }

--- a/widget/hyperlink_test.go
+++ b/widget/hyperlink_test.go
@@ -103,6 +103,19 @@ func TestHyperlink_OnTapped(t *testing.T) {
 	assert.Equal(t, 1, tapped)
 }
 
+func TestHyperlink_TappedOutsideTextBoundary(t *testing.T) {
+	tapped := 0
+	link := &Hyperlink{Text: "Test"}
+	link.OnTapped = func() {
+		tapped++
+	}
+	link.syncSegments()
+	link.Tapped(&fyne.PointEvent{
+		Position: fyne.NewPos(2, 50 /*past text boundary*/),
+	})
+	assert.Equal(t, 0, tapped)
+}
+
 func TestHyperlink_KeyboardOnTapped(t *testing.T) {
 	tapped := 0
 	link := &Hyperlink{Text: "Test"}


### PR DESCRIPTION
### Description:
Fix a regression on develop of Hyperlink behavior

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

