### PR TITLE
Improve performance of content size calculation in List

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -365,15 +365,15 @@ func (l *List) contentMinSize() fyne.Size {
 	}
 
 	height := float32(0)
+	totalCustom := 0
 	templateHeight := l.itemMin.Height
-	for item := 0; item < items; item++ {
-		itemHeight, ok := l.itemHeights[item]
-		if ok {
+	for id, itemHeight := range l.itemHeights {
+		if id < items {
+			totalCustom++
 			height += itemHeight
-		} else {
-			height += templateHeight
 		}
 	}
+	height += float32(items-totalCustom) * templateHeight
 
 	return fyne.NewSize(l.itemMin.Width, height+separatorThickness*float32(items-1))
 }

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -672,3 +672,29 @@ func TestList_RefreshUpdatesAllItems(t *testing.T) {
 	list.Refresh()
 	assert.Equal(t, "0.0.", printOut)
 }
+
+var minSize fyne.Size
+
+func BenchmarkContentMinSize(b *testing.B) {
+	b.StopTimer()
+
+	l := NewList(
+		func() int { return 1000000 },
+		func() fyne.CanvasObject {
+			return NewLabel("Test")
+		},
+		func(id ListItemID, item fyne.CanvasObject) {
+			item.(*Label).SetText(fmt.Sprintf("%d", id))
+		},
+	)
+	l.SetItemHeight(10, 55)
+	l.SetItemHeight(12345, 2)
+
+	min := fyne.Size{}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		min = l.contentMinSize()
+	}
+
+	minSize = min
+}


### PR DESCRIPTION
### Description:
Makes calculating the content size in List O(n) in the number of custom-height items rather than the number of total items. Unsurprisingly, a huge performance improvement for long lists with only a few custom item heights (as is a common use case).

Fixes #3427 (for list)

### Checklist:

- [ ] Tests included. <- already covered by existing tests
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

Benchmark (before):

`goos: darwin
goarch: arm64
pkg: fyne.io/fyne/v2/widget`

`BenchmarkContentMinSize-8   	     198	   6114649 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	fyne.io/fyne/v2/widget	2.062s`

Benchmark (after):

`goos: darwin
goarch: arm64
pkg: fyne.io/fyne/v2/widget`

`BenchmarkContentMinSize-8   	19891040	        51.04 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	fyne.io/fyne/v2/widget	1.565s`
