### PR TITLE
Don't insert tab character in Entry when Shift+Tab typed

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -729,6 +729,11 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	case fyne.KeyReturn, fyne.KeyEnter:
 		e.typedKeyReturn(provider, multiLine)
 	case fyne.KeyTab:
+		if dd, ok := fyne.CurrentApp().Driver().(desktop.Driver); ok {
+			if dd.CurrentKeyModifiers()&fyne.KeyModifierShift != 0 {
+				return // don't insert a tab when Shift+Tab typed
+			}
+		}
 		e.TypedRune('\t')
 	case fyne.KeyUp:
 		e.typedKeyUp(provider)

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -729,12 +729,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	case fyne.KeyReturn, fyne.KeyEnter:
 		e.typedKeyReturn(provider, multiLine)
 	case fyne.KeyTab:
-		if dd, ok := fyne.CurrentApp().Driver().(desktop.Driver); ok {
-			if dd.CurrentKeyModifiers()&fyne.KeyModifierShift != 0 {
-				return // don't insert a tab when Shift+Tab typed
-			}
-		}
-		e.TypedRune('\t')
+		e.typedKeyTab()
 	case fyne.KeyUp:
 		e.typedKeyUp(provider)
 	case fyne.KeyDown:
@@ -880,6 +875,15 @@ func (e *Entry) typedKeyEnd(provider *RichText) {
 		e.CursorColumn = provider.len()
 	}
 	e.propertyLock.Unlock()
+}
+
+func (e *Entry) typedKeyTab() {
+	if dd, ok := fyne.CurrentApp().Driver().(desktop.Driver); ok {
+		if dd.CurrentKeyModifiers()&fyne.KeyModifierShift != 0 {
+			return // don't insert a tab when Shift+Tab typed
+		}
+	}
+	e.TypedRune('\t')
 }
 
 // TypedRune receives text input events when the Entry widget is focused.


### PR DESCRIPTION
### Description:

Fixes #4837 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
