### PR TITLE
List optimization - handle SetItemHeight with default height as a special case

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -139,14 +139,22 @@ func (l *List) RefreshItem(id ListItemID) {
 func (l *List) SetItemHeight(id ListItemID, height float32) {
 	l.propertyLock.Lock()
 
-	if l.itemHeights == nil {
-		l.itemHeights = make(map[ListItemID]float32)
+	var refresh bool
+	if height == l.itemMin.Height {
+		// special case - unset custom item height for this item
+		if l.itemHeights != nil {
+			_, refresh = l.itemHeights[id]
+			delete(l.itemHeights, id)
+		}
+	} else {
+		if l.itemHeights == nil {
+			l.itemHeights = make(map[ListItemID]float32)
+		}
+		refresh = l.itemHeights[id] != height
+		l.itemHeights[id] = height
 	}
 
-	refresh := l.itemHeights[id] != height
-	l.itemHeights[id] = height
 	l.propertyLock.Unlock()
-
 	if refresh {
 		l.RefreshItem(id)
 	}

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -129,6 +129,10 @@ func TestList_SetItemHeight(t *testing.T) {
 	w := test.NewWindow(list)
 	w.Resize(fyne.NewSize(200, 200))
 	test.AssertImageMatches(t, "list/list_item_height.png", w.Canvas().Capture())
+
+	// special case of resetting item back to default height
+	list.SetItemHeight(2, 10)
+	assert.Equal(t, 0, len(list.itemHeights))
 }
 
 func TestList_SetItemHeight_InUpdate(t *testing.T) {


### PR DESCRIPTION
### Description:
Handles the case of SetItemHeight(h) where h is equal to the default item height specially. Instead of storing it in the itemHeights map, delete the entry in the map if it exists for the given item, since list operations are more efficient with fewer entries in the itemHeights map.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

