### PR TITLE
Various improvements to the progress bar renderer

### DIFF
--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -7,7 +7,6 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
-	"fyne.io/fyne/v2/internal/cache"
 	col "fyne.io/fyne/v2/internal/color"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -177,10 +176,9 @@ func (p *ProgressBar) Unbind() {
 // The default Min is 0 and Max is 1, Values set should be between those numbers.
 // The display will convert this to a percentage.
 func NewProgressBar() *ProgressBar {
-	p := &ProgressBar{Min: 0, Max: 1}
-
-	cache.Renderer(p).Layout(p.MinSize())
-	return p
+	bar := &ProgressBar{Min: 0, Max: 1}
+	bar.ExtendBaseWidget(bar)
+	return bar
 }
 
 // NewProgressBarWithData returns a progress bar connected with the specified data source.
@@ -189,7 +187,6 @@ func NewProgressBar() *ProgressBar {
 func NewProgressBarWithData(data binding.Float) *ProgressBar {
 	p := NewProgressBar()
 	p.Bind(data)
-
 	return p
 }
 

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -25,15 +25,14 @@ type progressRenderer struct {
 func (p *progressRenderer) MinSize() fyne.Size {
 	th := p.progress.Theme()
 
-	var tsize fyne.Size
-	if text := p.progress.TextFormatter; text != nil {
-		tsize = fyne.MeasureText(text(), p.label.TextSize, p.label.TextStyle)
-	} else {
-		tsize = fyne.MeasureText("100%", p.label.TextSize, p.label.TextStyle)
+	text := "100%"
+	if format := p.progress.TextFormatter; format != nil {
+		text = format()
 	}
 
 	padding := th.Size(theme.SizeNameInnerPadding) * 2
-	return fyne.NewSize(tsize.Width+padding, tsize.Height+padding)
+	size := fyne.MeasureText(text, p.label.TextSize, p.label.TextStyle)
+	return size.AddWidthHeight(padding, padding)
 }
 
 func (p *progressRenderer) updateBar() {

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -52,6 +52,10 @@ func (p *progressRenderer) layoutBar(size fyne.Size) {
 func (p *progressRenderer) updateBar() {
 	p.layoutBar(p.progress.Size())
 
+	// Don't draw rectangles when they can't be seen.
+	p.background.Hidden = p.ratio == 1.0
+	p.bar.Hidden = p.ratio == 0.0
+
 	if text := p.progress.TextFormatter; text != nil {
 		p.label.Text = text()
 	} else {

--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -12,7 +12,7 @@ import (
 
 var globalProgressRenderer fyne.WidgetRenderer
 
-func BenchmarkProgressbar(b *testing.B) {
+func BenchmarkProgressbarCreateRenderer(b *testing.B) {
 	var renderer fyne.WidgetRenderer
 	widget := &ProgressBar{}
 	b.ReportAllocs()
@@ -23,6 +23,17 @@ func BenchmarkProgressbar(b *testing.B) {
 
 	// Avoid having the value optimized out by the compiler.
 	globalProgressRenderer = renderer
+}
+
+func BenchmarkProgressBarLayout(b *testing.B) {
+	b.ReportAllocs() // We should see zero allocations.
+
+	bar := &ProgressBar{}
+	renderer := bar.CreateRenderer()
+
+	for i := 0; i < b.N; i++ {
+		renderer.Layout(fyne.NewSize(100, 100))
+	}
 }
 
 func TestNewProgressBarWithData(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This rewrites part of the renderer for the progress bar to be more efficient and smarter.
The following changes have been implemented:
- Refactor MinSize to use less duplicated code.
- Keep ratio calculations in float64 to avoid potential rounding errors.
- Don't allocate and set text when doing a layout (i.e. perform part of a refresh). Keep that path fast by using stored ratio.
- Don't render the background under the progress indicator when at 100% progress.
- Keep the progress indicator hidden until progress goes above 0%.

Other related changes:
- The constructor now extends the base widget correctly instead of going through the cached renderer and then forcing a layout step before being rendered.

### Benchmarks:

This change makes the layout call roughly 3.8x faster. If a complex text formatter is set, the gain might be bigger.
```
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
BenchmarkProgressBarLayoutBefore-8   	29877590	        38.35 ns/op	       2 B/op	       1 allocs/op
BenchmarkProgressBarLayoutAfter-8   	100000000	        10.18 ns/op	       0 B/op	       0 allocs/op
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
