### PR TITLE
Don't create the renderer in the constructor for infinite progressbar

### DIFF
--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -193,7 +193,7 @@ func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 // SetValue() is not defined for infinite progress bar
 // To stop the looping progress and set the progress bar to 100%, call ProgressBarInfinite.Stop()
 func NewProgressBarInfinite() *ProgressBarInfinite {
-	p := &ProgressBarInfinite{}
-	cache.Renderer(p).Layout(p.MinSize())
-	return p
+	bar := &ProgressBarInfinite{}
+	bar.ExtendBaseWidget(bar)
+	return bar
 }

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -32,6 +32,7 @@ func TestProgressBarInfinite_Creation(t *testing.T) {
 	assert.False(t, bar.Running())
 
 	win := test.NewWindow(bar)
+	defer win.Close()
 	win.Show()
 
 	// ticker should start automatically once the renderer is created
@@ -41,6 +42,7 @@ func TestProgressBarInfinite_Creation(t *testing.T) {
 func TestProgressBarInfinite_Destroy(t *testing.T) {
 	bar := NewProgressBarInfinite()
 	win := test.NewWindow(bar)
+	defer win.Close()
 	win.Show()
 
 	assert.True(t, cache.IsRendered(bar))
@@ -57,6 +59,7 @@ func TestProgressBarInfinite_Destroy(t *testing.T) {
 func TestProgressBarInfinite_Reshown(t *testing.T) {
 	bar := NewProgressBarInfinite()
 	win := test.NewWindow(bar)
+	defer win.Close()
 	win.Show()
 
 	assert.True(t, bar.Running())

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -27,12 +27,22 @@ func BenchmarkProgressbarInf(b *testing.B) {
 
 func TestProgressBarInfinite_Creation(t *testing.T) {
 	bar := NewProgressBarInfinite()
-	// ticker should start automatically
+
+	// ticker should be disabled until the widget is shown
+	assert.False(t, bar.Running())
+
+	win := test.NewWindow(bar)
+	win.Show()
+
+	// ticker should start automatically once the renderer is created
 	assert.True(t, bar.Running())
 }
 
 func TestProgressBarInfinite_Destroy(t *testing.T) {
 	bar := NewProgressBarInfinite()
+	win := test.NewWindow(bar)
+	win.Show()
+
 	assert.True(t, cache.IsRendered(bar))
 	assert.True(t, bar.Running())
 
@@ -46,6 +56,8 @@ func TestProgressBarInfinite_Destroy(t *testing.T) {
 
 func TestProgressBarInfinite_Reshown(t *testing.T) {
 	bar := NewProgressBarInfinite()
+	win := test.NewWindow(bar)
+	win.Show()
 
 	assert.True(t, bar.Running())
 	bar.Hide()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This fixes the infinite progress bar code to not create the renderer inside the constructor. The old behaviour was not only a potential performance and memory leak and just seems generally incorrect from a best practices standpoint.

The tests had to be modified to actually render the object so this is a change in behaviour but I would not call it breaking given that I consider the old behaviour a incorrect and a bug.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
