### PR TITLE
Avoid internal packages when starting and stopping infinite progress bar

### DIFF
--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -470,6 +470,10 @@ func startProgress() {
 }
 
 func stopProgress() {
+	if infProgress == nil {
+		return
+	}
+
 	if !infProgress.Running() {
 		return
 	}

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -146,16 +146,30 @@ func (p *ProgressBarInfinite) Hide() {
 
 // Start the infinite progress bar animation
 func (p *ProgressBarInfinite) Start() {
-	p.SetFieldsAndRefresh(func() {
-		p.running = true
-	})
+	p.propertyLock.Lock()
+	if p.running {
+		p.propertyLock.Unlock()
+		return
+	}
+
+	p.running = true
+	p.propertyLock.Unlock()
+
+	p.BaseWidget.Refresh()
 }
 
 // Stop the infinite progress bar animation
 func (p *ProgressBarInfinite) Stop() {
-	p.SetFieldsAndRefresh(func() {
-		p.running = false
-	})
+	p.propertyLock.Lock()
+	if !p.running {
+		p.propertyLock.Unlock()
+		return
+	}
+
+	p.running = false
+	p.propertyLock.Unlock()
+
+	p.BaseWidget.Refresh()
 }
 
 // Running returns the current state of the infinite progress animation


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This refactors the code to use a better mechanism for triggering start and stop in the renderer. The code now used Refresh() to indicate a state change to the renderer; this is a lot more consistent with other widgets.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

