### PR TITLE
Create tempdir in test using t.TempDir()

### DIFF
--- a/app/preferences_test.go
+++ b/app/preferences_test.go
@@ -72,8 +72,7 @@ func TestPreferences_Save_OverwriteFast(t *testing.T) {
 		val["key"] = "value"
 	})
 
-	path := filepath.Join(os.TempDir(), "fynePrefs2.json")
-	defer os.Remove(path)
+	path := filepath.Join(t.TempDir(), "fynePrefs2.json")
 	p.saveToFile(path)
 
 	p.WriteValues(func(val map[string]any) {

--- a/canvas/image_test.go
+++ b/canvas/image_test.go
@@ -43,6 +43,7 @@ func TestNewImageFromReader(t *testing.T) {
 	path := filepath.Join(filepath.Dir(pwd), "theme", "icons", "fyne.png")
 	read, err := os.Open(path)
 	assert.Nil(t, err)
+	defer read.Close()
 
 	img := canvas.NewImageFromReader(read, "fyne.png")
 	assert.NotNil(t, img)

--- a/internal/repository/file_test.go
+++ b/internal/repository/file_test.go
@@ -91,6 +91,7 @@ func TestFileRepositoryReader(t *testing.T) {
 	fooData, err := io.ReadAll(fooReader)
 	assert.Equal(t, []byte{}, fooData)
 	assert.Nil(t, err)
+	fooReader.Close()
 
 	// Make sure we can read the file with data.
 	barReader, err := storage.Reader(bar)
@@ -98,10 +99,12 @@ func TestFileRepositoryReader(t *testing.T) {
 	barData, err := io.ReadAll(barReader)
 	assert.Equal(t, []byte{1, 2, 3}, barData)
 	assert.Nil(t, err)
+	barReader.Close()
 
 	// Make sure we get an error if the file doesn't exist.
-	_, err = storage.Reader(baz)
+	bazReader, err := storage.Reader(baz)
 	assert.NotNil(t, err)
+	bazReader.Close()
 
 	// Also test that CanRead returns the expected results.
 	fooCanRead, err := storage.CanRead(foo)

--- a/internal/repository/file_test.go
+++ b/internal/repository/file_test.go
@@ -41,16 +41,12 @@ func TestFileRepositoryRegistration(t *testing.T) {
 }
 
 func TestFileRepositoryExists(t *testing.T) {
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	existsPath := path.Join(dir, "exists")
 	notExistsPath := path.Join(dir, "notExists")
 
-	err = os.WriteFile(existsPath, []byte{1, 2, 3, 4}, 0755)
+	err := os.WriteFile(existsPath, []byte{1, 2, 3, 4}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,18 +61,13 @@ func TestFileRepositoryExists(t *testing.T) {
 }
 
 func TestFileRepositoryReader(t *testing.T) {
-	// Set up a temporary directory.
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create some files to test with.
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
 	bazPath := path.Join(dir, "baz")
-	err = os.WriteFile(fooPath, []byte{}, 0755)
+	err := os.WriteFile(fooPath, []byte{}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,19 +118,14 @@ func TestFileRepositoryReader(t *testing.T) {
 }
 
 func TestFileRepositoryWriter(t *testing.T) {
-	// Set up a temporary directory.
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create some files to test with.
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
 	bazPath := path.Join(dir, "baz")
 	spamHamPath := path.Join(dir, "spam", "ham")
-	err = os.WriteFile(fooPath, []byte{}, 0755)
+	err := os.WriteFile(fooPath, []byte{}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,18 +233,13 @@ func TestFileRepositoryWriter(t *testing.T) {
 }
 
 func TestFileRepositoryCanWrite(t *testing.T) {
-	// Set up a temporary directory.
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create some files to test with.
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
 	bazPath := path.Join(dir, "baz")
-	err = os.WriteFile(fooPath, []byte{}, 0755)
+	err := os.WriteFile(fooPath, []byte{}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,17 +346,12 @@ func TestFileRepositoryChild(t *testing.T) {
 }
 
 func TestFileRepositoryCopy(t *testing.T) {
-	// Set up a temporary directory.
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create some files to test with.
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
-	err = os.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
+	err := os.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,17 +372,12 @@ func TestFileRepositoryCopy(t *testing.T) {
 }
 
 func TestFileRepositoryMove(t *testing.T) {
-	// Set up a temporary directory.
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create some files to test with.
 	fooPath := path.Join(dir, "foo")
 	barPath := path.Join(dir, "bar")
-	err = os.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
+	err := os.WriteFile(fooPath, []byte{1, 2, 3, 4, 5}, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,12 +400,7 @@ func TestFileRepositoryMove(t *testing.T) {
 }
 
 func TestFileRepositoryListing(t *testing.T) {
-	// Set up a temporary directory.
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create some files to tests with.
 	fooPath := path.Join(dir, "foo")
@@ -466,12 +432,7 @@ func TestFileRepositoryListing(t *testing.T) {
 }
 
 func TestFileRepositoryCreateListable(t *testing.T) {
-	// Set up a temporary directory.
-	dir, err := os.MkdirTemp("", "FyneInternalRepositoryFileTest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	f := NewFileRepository()
 	repository.Register("file", f)
@@ -482,7 +443,7 @@ func TestFileRepositoryCreateListable(t *testing.T) {
 	fooBar := storage.NewFileURI(fooBarPath)
 
 	// Creating a dir with no parent should fail
-	err = storage.CreateListable(fooBar)
+	err := storage.CreateListable(fooBar)
 	assert.NotNil(t, err)
 
 	// Creating foo should work though


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Go 1.18 introduced the .TempDir() method for automatically creating temporary directories in tests that then are removed automatically at the end of the tests. use that instead of the functions in the os package.

This change initially introduced errors that then turned out to be cases of actual bugs where we did not close file handles.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
