### PR TITLE
Un-export setFieldsAndRefresh

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -243,7 +243,7 @@ func (e *Entry) DoubleTapped(p *fyne.PointEvent) {
 		return
 	}
 
-	e.SetFieldsAndRefresh(func() {
+	e.setFieldsAndRefresh(func() {
 		if !e.selectKeyDown {
 			e.selectRow = e.CursorRow
 			e.selectColumn = start
@@ -316,7 +316,7 @@ func (e *Entry) ExtendBaseWidget(wid fyne.Widget) {
 //
 // Implements: fyne.Focusable
 func (e *Entry) FocusGained() {
-	e.SetFieldsAndRefresh(func() {
+	e.setFieldsAndRefresh(func() {
 		e.dirty = true
 		e.focused = true
 	})
@@ -329,7 +329,7 @@ func (e *Entry) FocusGained() {
 //
 // Implements: fyne.Focusable
 func (e *Entry) FocusLost() {
-	e.SetFieldsAndRefresh(func() {
+	e.setFieldsAndRefresh(func() {
 		e.focused = false
 		e.selectKeyDown = false
 	})
@@ -1145,7 +1145,7 @@ func (e *Entry) registerShortcut() {
 			return
 		}
 
-		e.SetFieldsAndRefresh(func() {
+		e.setFieldsAndRefresh(func() {
 			if s.(*desktop.CustomShortcut).KeyName == fyne.KeyLeft {
 				if e.CursorColumn == 0 {
 					if e.CursorRow > 0 {
@@ -1246,7 +1246,7 @@ func (e *Entry) selectAll() {
 	if e.textProvider().len() == 0 {
 		return
 	}
-	e.SetFieldsAndRefresh(func() {
+	e.setFieldsAndRefresh(func() {
 		e.selectRow = 0
 		e.selectColumn = 0
 
@@ -1294,7 +1294,7 @@ func (e *Entry) selectingKeyHandler(key *fyne.KeyEvent) bool {
 	case fyne.KeyReturn, fyne.KeyEnter:
 		if e.MultiLine {
 			// clear the selection -- return unhandled to add the newline
-			e.SetFieldsAndRefresh(e.eraseSelectionAndUpdate)
+			e.setFieldsAndRefresh(e.eraseSelectionAndUpdate)
 		}
 		return false
 	}
@@ -1594,6 +1594,18 @@ func (e *Entry) selectCurrentRow() {
 	e.Refresh()
 }
 
+func (e *Entry) setFieldsAndRefresh(f func()) {
+	e.propertyLock.Lock()
+	f()
+	e.propertyLock.Unlock()
+
+	impl := e.super()
+	if impl == nil {
+		return
+	}
+	impl.Refresh()
+}
+
 var _ fyne.WidgetRenderer = (*entryRenderer)(nil)
 
 type entryRenderer struct {
@@ -1685,7 +1697,7 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 	resizedTextPos := r.entry.textPosFromRowCol(r.entry.CursorRow, r.entry.CursorColumn)
 	r.entry.propertyLock.Unlock()
 	if textPos != resizedTextPos {
-		r.entry.SetFieldsAndRefresh(func() {
+		r.entry.setFieldsAndRefresh(func() {
 			r.entry.CursorRow, r.entry.CursorColumn = r.entry.rowColFromTextPos(textPos)
 
 			if r.entry.selecting {

--- a/widget/entry_password.go
+++ b/widget/entry_password.go
@@ -45,7 +45,7 @@ func (r *passwordRevealer) Tapped(*fyne.PointEvent) {
 		return
 	}
 
-	r.entry.SetFieldsAndRefresh(func() {
+	r.entry.setFieldsAndRefresh(func() {
 		r.entry.Password = !r.entry.Password
 	})
 	fyne.CurrentApp().Driver().CanvasForObject(r).Focus(r.entry.super().(fyne.Focusable))

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -94,9 +94,15 @@ func (w *BaseWidget) Show() {
 		return
 	}
 
-	w.SetFieldsAndRefresh(func() {
-		w.Hidden = false
-	})
+	w.propertyLock.Lock()
+	w.Hidden = false
+	w.propertyLock.Unlock()
+
+	impl := w.super()
+	if impl == nil {
+		return
+	}
+	impl.Refresh()
 }
 
 // Hide this widget so it is no longer visible
@@ -154,23 +160,6 @@ func (w *BaseWidget) themeWithLock() fyne.Theme {
 	}
 
 	return cached
-}
-
-// SetFieldsAndRefresh helps to make changes to a widget that should be followed by a refresh.
-// This method is a guaranteed thread-safe way of directly manipulating widget fields.
-// Widgets extending BaseWidget should use this in their setter functions.
-//
-// Since: 2.5
-func (w *BaseWidget) SetFieldsAndRefresh(f func()) {
-	w.propertyLock.Lock()
-	f()
-	w.propertyLock.Unlock()
-
-	impl := w.super()
-	if impl == nil {
-		return
-	}
-	impl.Refresh()
 }
 
 // super will return the actual object that this represents.


### PR DESCRIPTION
### Description:

As discussed in Slack, it doesn't make sense to add SetFieldsAndRefresh as a public API in 2.5, when it will be superseded in 2.6 by fyne.RunOnMain (naming tbd)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
