### PR TITLE
Rework activity widget to not talk directly with renderer

### DIFF
--- a/widget/activity.go
+++ b/widget/activity.go
@@ -42,7 +42,6 @@ func (a *Activity) Start() {
 		return // already started
 	}
 
-
 	a.Refresh()
 }
 
@@ -82,9 +81,9 @@ type activityRenderer struct {
 	dots   []fyne.CanvasObject
 	parent *Activity
 
-	bound  fyne.Size
-	maxCol color.NRGBA
-	maxRad float32
+	bound      fyne.Size
+	maxCol     color.NRGBA
+	maxRad     float32
 	wasStarted bool
 }
 

--- a/widget/activity.go
+++ b/widget/activity.go
@@ -7,7 +7,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
-	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -43,9 +42,8 @@ func (a *Activity) Start() {
 		return // already started
 	}
 
-	if r, ok := cache.Renderer(a.super()).(*activityRenderer); ok {
-		r.start()
-	}
+
+	a.Refresh()
 }
 
 // Stop the activity indicator animation
@@ -54,9 +52,7 @@ func (a *Activity) Stop() {
 		return // already stopped
 	}
 
-	if r, ok := cache.Renderer(a.super()).(*activityRenderer); ok {
-		r.stop()
-	}
+	a.Refresh()
 }
 
 func (a *Activity) CreateRenderer() fyne.WidgetRenderer {
@@ -89,9 +85,11 @@ type activityRenderer struct {
 	bound  fyne.Size
 	maxCol color.NRGBA
 	maxRad float32
+	wasStarted bool
 }
 
 func (a *activityRenderer) Destroy() {
+	a.parent.started.Store(false)
 	a.stop()
 }
 
@@ -109,6 +107,17 @@ func (a *activityRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (a *activityRenderer) Refresh() {
+	started := a.parent.started.Load()
+	if started {
+		if !a.wasStarted {
+			a.start()
+		}
+		return
+	} else if a.wasStarted {
+		a.stop()
+		return
+	}
+
 	a.updateColor()
 }
 
@@ -152,10 +161,12 @@ func (a *activityRenderer) scaleDot(dot *canvas.Circle, off float32) {
 }
 
 func (a *activityRenderer) start() {
+	a.wasStarted = true
 	a.anim.Start()
 }
 
 func (a *activityRenderer) stop() {
+	a.wasStarted = false
 	a.anim.Stop()
 }
 

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -71,6 +71,7 @@ func (p *infProgressRenderer) Refresh() {
 		return // we refresh from the goroutine
 	} else if p.wasRunning {
 		p.stop()
+		return
 	}
 
 	th := p.progress.Theme()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Similar to recent changes to progress bar infinite, this applies the same change to Activity.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
