### PR TITLE
Fix a few unused parameter warnings

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -107,7 +107,7 @@ func renderNode(source []byte, n ast.Node, blockquote bool) ([]RichTextSegment, 
 			// These empty text elements indicate single line breaks after non-text elements in goldmark.
 			return []RichTextSegment{&TextSegment{Style: RichTextStyleInline, Text: " "}}, nil
 		}
-		text = suffixSpaceIfAppropriate(text, source, n)
+		text = suffixSpaceIfAppropriate(text, n)
 		if blockquote {
 			return []RichTextSegment{&TextSegment{Style: RichTextStyleBlockquote, Text: text}}, nil
 		}
@@ -125,7 +125,7 @@ func renderNode(source []byte, n ast.Node, blockquote bool) ([]RichTextSegment, 
 	return nil, nil
 }
 
-func suffixSpaceIfAppropriate(text string, source []byte, n ast.Node) string {
+func suffixSpaceIfAppropriate(text string, n ast.Node) string {
 	next := n.NextSibling()
 	if next != nil && next.Type() == ast.TypeInline && !strings.HasSuffix(text, " ") {
 		return text + " "

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -317,5 +317,6 @@ func radioGroupTestTapItem(t *testing.T, radio *RadioGroup, item int) {
 }
 
 func radioGroupTestItemRenderer(t *testing.T, radio *RadioGroup, item int) *radioItemRenderer {
+	t.Cleanup(func() { cache.DestroyRenderer(radio) })
 	return cache.Renderer(test.WidgetRenderer(radio).Objects()[item].(fyne.Widget)).(*radioItemRenderer)
 }

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -989,7 +989,7 @@ func newBranch(tree *Tree, content fyne.CanvasObject) (b *branch) {
 
 func (b *branch) update(uid string, depth int) {
 	b.treeNode.update(uid, depth)
-	b.icon.(*branchIcon).update(uid, depth)
+	b.icon.(*branchIcon).update(uid)
 }
 
 var _ fyne.Tappable = (*branchIcon)(nil)
@@ -1021,7 +1021,7 @@ func (i *branchIcon) Tapped(*fyne.PointEvent) {
 	i.tree.ToggleBranch(i.uid)
 }
 
-func (i *branchIcon) update(uid string, depth int) {
+func (i *branchIcon) update(uid string) {
 	i.uid = uid
 	i.Refresh()
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

My editor was complaining about these. A few of these was just a case of removing parameters or making them named `_` but I also make sure to destroy the renderer after we look it up in a test (destroying renderers in tests is likely something we want to do more).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
