### PR TITLE
Register http and https in test driver like the main app

### DIFF
--- a/canvas/image_test.go
+++ b/canvas/image_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2/canvas"
-	intRepo "fyne.io/fyne/v2/internal/repository"
 	"fyne.io/fyne/v2/storage"
-	"fyne.io/fyne/v2/storage/repository"
+	_ "fyne.io/fyne/v2/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,9 +77,6 @@ func TestNewImageFromURI_File(t *testing.T) {
 }
 
 func TestNewImageFromURI_HTTP(t *testing.T) {
-	h := intRepo.NewHTTPRepository()
-	repository.Register("http", h)
-
 	pwd, _ := os.Getwd()
 	path := filepath.Join(filepath.Dir(pwd), "theme", "icons", "fyne.png")
 	f, _ := os.ReadFile(path)
@@ -96,6 +92,7 @@ func TestNewImageFromURI_HTTP(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	// http is mounted in Fyne test handlers by default
 	url, _ := storage.ParseURI(ts.URL)
 	img := canvas.NewImageFromURI(url)
 	assert.NotNil(t, img)

--- a/test/testdriver.go
+++ b/test/testdriver.go
@@ -33,6 +33,10 @@ func NewDriver() fyne.Driver {
 	drv := &testDriver{windowsMutex: sync.RWMutex{}}
 	repository.Register("file", intRepo.NewFileRepository())
 
+	httpHandler := intRepo.NewHTTPRepository()
+	repository.Register("http", httpHandler)
+	repository.Register("https", httpHandler)
+
 	// make a single dummy window for rendering tests
 	drv.CreateWindow("")
 


### PR DESCRIPTION
Fixes #4863

Also requires the import in test case:
 `import _ "fyne.io/fyne/v2/test"`

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
