### PR TITLE
Introduce test.TempWidgetRenderer to destroy the renderer at end  of test

### DIFF
--- a/container/apptabs_extend_test.go
+++ b/container/apptabs_extend_test.go
@@ -30,31 +30,31 @@ func TestAppTabs_Extended_Tapped(t *testing.T) {
 		NewTabItem("Test2", widget.NewLabel("Test2")),
 	)
 	tabs.Resize(fyne.NewSize(150, 150)) // Ensure AppTabs is big enough to show both tab buttons
-	r := test.WidgetRenderer(tabs).(*appTabsRenderer)
+	r := test.TempWidgetRenderer(t, tabs).(*appTabsRenderer)
 
 	tab1 := r.bar.Objects[0].(*fyne.Container).Objects[0].(*tabButton)
 	tab2 := r.bar.Objects[0].(*fyne.Container).Objects[1].(*tabButton)
 	require.Equal(t, 0, tabs.SelectedIndex())
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
 
 	tab2.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 1, tabs.SelectedIndex())
-	require.Equal(t, theme.ForegroundColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab2).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.ForegroundColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab2).(*tabButtonRenderer).label.Color)
 	assert.False(t, tabs.Items[0].Content.Visible())
 	assert.True(t, tabs.Items[1].Content.Visible())
 
 	tab2.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 1, tabs.SelectedIndex())
-	require.Equal(t, theme.ForegroundColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab2).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.ForegroundColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab2).(*tabButtonRenderer).label.Color)
 	assert.False(t, tabs.Items[0].Content.Visible())
 	assert.True(t, tabs.Items[1].Content.Visible())
 
 	tab1.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 0, tabs.SelectedIndex())
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
-	require.Equal(t, theme.ForegroundColor(), test.WidgetRenderer(tab2).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.ForegroundColor(), test.TempWidgetRenderer(t, tab2).(*tabButtonRenderer).label.Color)
 	assert.True(t, tabs.Items[0].Content.Visible())
 	assert.False(t, tabs.Items[1].Content.Visible())
 }

--- a/container/apptabs_test.go
+++ b/container/apptabs_test.go
@@ -39,7 +39,7 @@ func TestAppTabs_Empty(t *testing.T) {
 	tabs = &AppTabs{}
 	assert.Equal(t, 0, len(tabs.Items))
 	assert.Nil(t, tabs.Selected())
-	assert.NotNil(t, test.WidgetRenderer(tabs)) // doesn't crash
+	assert.NotNil(t, test.TempWidgetRenderer(t, tabs)) // doesn't crash
 }
 
 func TestAppTabs_Hidden_AsChild(t *testing.T) {
@@ -183,7 +183,7 @@ func TestAppTabs_DisableIndex(t *testing.T) {
 
 func TestAppTabs_ShowAfterAdd(t *testing.T) {
 	tabs := NewAppTabs()
-	renderer := test.WidgetRenderer(tabs).(*appTabsRenderer)
+	renderer := test.TempWidgetRenderer(t, tabs).(*appTabsRenderer)
 
 	assert.True(t, renderer.indicator.Hidden)
 

--- a/container/doctabs_extend_test.go
+++ b/container/doctabs_extend_test.go
@@ -30,32 +30,32 @@ func TestDocTabs_Extended_Tapped(t *testing.T) {
 		NewTabItem("Test2", widget.NewLabel("Test2")),
 	)
 	tabs.Resize(fyne.NewSize(150, 150)) // Ensure DocTabs is big enough to show both tab buttons
-	r := test.WidgetRenderer(tabs).(*docTabsRenderer)
+	r := test.TempWidgetRenderer(t, tabs).(*docTabsRenderer)
 
 	buttons := r.bar.Objects[0].(*Scroll).Content.(*fyne.Container).Objects
 	tab1 := buttons[0].(*tabButton)
 	tab2 := buttons[1].(*tabButton)
 	require.Equal(t, 0, tabs.SelectedIndex())
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
 
 	tab2.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 1, tabs.SelectedIndex())
-	require.Equal(t, theme.ForegroundColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab2).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.ForegroundColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab2).(*tabButtonRenderer).label.Color)
 	assert.False(t, tabs.Items[0].Content.Visible())
 	assert.True(t, tabs.Items[1].Content.Visible())
 
 	tab2.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 1, tabs.SelectedIndex())
-	require.Equal(t, theme.ForegroundColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab2).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.ForegroundColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab2).(*tabButtonRenderer).label.Color)
 	assert.False(t, tabs.Items[0].Content.Visible())
 	assert.True(t, tabs.Items[1].Content.Visible())
 
 	tab1.Tapped(&fyne.PointEvent{})
 	assert.Equal(t, 0, tabs.SelectedIndex())
-	require.Equal(t, theme.PrimaryColor(), test.WidgetRenderer(tab1).(*tabButtonRenderer).label.Color)
-	require.Equal(t, theme.ForegroundColor(), test.WidgetRenderer(tab2).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.PrimaryColor(), test.TempWidgetRenderer(t, tab1).(*tabButtonRenderer).label.Color)
+	require.Equal(t, theme.ForegroundColor(), test.TempWidgetRenderer(t, tab2).(*tabButtonRenderer).label.Color)
 	assert.True(t, tabs.Items[0].Content.Visible())
 	assert.False(t, tabs.Items[1].Content.Visible())
 }

--- a/container/doctabs_test.go
+++ b/container/doctabs_test.go
@@ -40,7 +40,7 @@ func TestDocTabs_Empty(t *testing.T) {
 	tabs = &container.DocTabs{}
 	assert.Equal(t, 0, len(tabs.Items))
 	assert.Nil(t, tabs.Selected())
-	assert.NotNil(t, test.WidgetRenderer(tabs)) // doesn't crash
+	assert.NotNil(t, test.TempWidgetRenderer(t, tabs)) // doesn't crash
 }
 
 func TestDocTabs_Hidden_AsChild(t *testing.T) {

--- a/container/multiplewindows_test.go
+++ b/container/multiplewindows_test.go
@@ -20,7 +20,7 @@ func TestMultipleWindows_Add(t *testing.T) {
 func TestMultipleWindows_Drag(t *testing.T) {
 	w := NewInnerWindow("1", widget.NewLabel("Inside"))
 	m := NewMultipleWindows(w)
-	_ = test.WidgetRenderer(m) // initialise display
+	_ = test.TempWidgetRenderer(t, m) // initialise display
 	assert.Equal(t, 1, len(m.Windows))
 
 	assert.True(t, w.Position().IsZero())

--- a/container/split_test.go
+++ b/container/split_test.go
@@ -290,7 +290,7 @@ func TestSplitContainer_divider_drag(t *testing.T) {
 	t.Run("Horizontal", func(t *testing.T) {
 		split := NewHSplit(objA, objB)
 		split.Resize(fyne.NewSize(108, 108))
-		divider := test.WidgetRenderer(split).(*splitContainerRenderer).divider
+		divider := test.TempWidgetRenderer(t, split).(*splitContainerRenderer).divider
 		assert.Equal(t, 0.5, split.Offset)
 
 		divider.Dragged(&fyne.DragEvent{
@@ -324,7 +324,7 @@ func TestSplitContainer_divider_drag(t *testing.T) {
 	t.Run("Vertical", func(t *testing.T) {
 		split := NewVSplit(objA, objB)
 		split.Resize(fyne.NewSize(108, 108))
-		divider := test.WidgetRenderer(split).(*splitContainerRenderer).divider
+		divider := test.TempWidgetRenderer(t, split).(*splitContainerRenderer).divider
 		assert.Equal(t, 0.5, split.Offset)
 
 		divider.Dragged(&fyne.DragEvent{
@@ -366,7 +366,7 @@ func TestSplitContainer_divider_drag_StartOffsetLessThanMinSize(t *testing.T) {
 	t.Run("Horizontal", func(t *testing.T) {
 		split := NewHSplit(objA, objB)
 		split.Resize(fyne.NewSize(108, 108))
-		divider := test.WidgetRenderer(split).(*splitContainerRenderer).divider
+		divider := test.TempWidgetRenderer(t, split).(*splitContainerRenderer).divider
 		t.Run("Leading", func(t *testing.T) {
 			split.SetOffset(0.1)
 
@@ -391,7 +391,7 @@ func TestSplitContainer_divider_drag_StartOffsetLessThanMinSize(t *testing.T) {
 	t.Run("Vertical", func(t *testing.T) {
 		split := NewVSplit(objA, objB)
 		split.Resize(fyne.NewSize(108, 108))
-		divider := test.WidgetRenderer(split).(*splitContainerRenderer).divider
+		divider := test.TempWidgetRenderer(t, split).(*splitContainerRenderer).divider
 		t.Run("Leading", func(t *testing.T) {
 			split.SetOffset(0.1)
 

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -214,17 +214,17 @@ func TestShowFileOpen(t *testing.T) {
 	}
 
 	files := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[1].(*container.Scroll).Content.(*fyne.Container).Objects[0].(*widget.GridWrap)
-	objects := test.WidgetRenderer(files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects
+	objects := test.TempWidgetRenderer(t, files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects
 	assert.Greater(t, len(objects), 0)
 
-	fileName := test.WidgetRenderer(objects[0].(fyne.Widget)).Objects()[1].(*fileDialogItem).name
+	fileName := test.TempWidgetRenderer(t, objects[0].(fyne.Widget)).Objects()[1].(*fileDialogItem).name
 	assert.Equal(t, "(Parent)", fileName)
 	assert.True(t, open.Disabled())
 
 	var target *fileDialogItem
 	id := 0
 	for i, icon := range objects {
-		item := test.WidgetRenderer(icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
+		item := test.TempWidgetRenderer(t, icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
 		if item.dir == false {
 			target = item
 			id = i
@@ -283,12 +283,12 @@ func TestHiddenFiles(t *testing.T) {
 	assert.Equal(t, theme.SettingsIcon().Name(), optionsButton.Icon.Name())
 
 	files := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[1].(*container.Scroll).Content.(*fyne.Container).Objects[0].(*widget.GridWrap)
-	objects := test.WidgetRenderer(files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects
+	objects := test.TempWidgetRenderer(t, files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects
 	assert.Greater(t, len(objects), 0)
 
 	var target *fileDialogItem
 	for _, icon := range objects {
-		item := test.WidgetRenderer(icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
+		item := test.TempWidgetRenderer(t, icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
 		if item.name == ".hidden" {
 			target = item
 		}
@@ -299,7 +299,7 @@ func TestHiddenFiles(t *testing.T) {
 	d.dialog.refreshDir(d.dialog.dir)
 
 	for _, icon := range objects {
-		item := test.WidgetRenderer(icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
+		item := test.TempWidgetRenderer(t, icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
 		if item.name == ".hidden" {
 			target = item
 		}
@@ -330,17 +330,17 @@ func TestShowFileSave(t *testing.T) {
 	save := buttons.Objects[1].(*widget.Button)
 
 	files := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[1].(*container.Scroll).Content.(*fyne.Container).Objects[0].(*widget.GridWrap)
-	objects := test.WidgetRenderer(files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects
+	objects := test.TempWidgetRenderer(t, files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects
 	assert.Greater(t, len(objects), 0)
 
-	item := test.WidgetRenderer(objects[0].(fyne.Widget)).Objects()[1].(*fileDialogItem)
+	item := test.TempWidgetRenderer(t, objects[0].(fyne.Widget)).Objects()[1].(*fileDialogItem)
 	assert.Equal(t, "(Parent)", item.name)
 	assert.True(t, save.Disabled())
 
 	var target *fileDialogItem
 	id := -1
 	for i, icon := range objects {
-		item := test.WidgetRenderer(icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
+		item := test.TempWidgetRenderer(t, icon.(fyne.Widget)).Objects()[1].(*fileDialogItem)
 		if item.dir == false {
 			target = item
 			id = i

--- a/dialog/fileitem_test.go
+++ b/dialog/fileitem_test.go
@@ -115,14 +115,14 @@ func TestFileItem_Wrap(t *testing.T) {
 	_ = f.makeUI()
 	item := f.newFileItem(storage.NewFileURI("/path/to/filename.txt"), false, false)
 	item.Resize(item.MinSize())
-	label := test.WidgetRenderer(item).(*fileItemRenderer).text
+	label := test.TempWidgetRenderer(t, item).(*fileItemRenderer).text
 	assert.Equal(t, "filename", label.Text)
-	texts := test.WidgetRenderer(label).Objects()
+	texts := test.TempWidgetRenderer(t, label).Objects()
 	assert.Equal(t, 1, len(texts))
 
 	item.setLocation(storage.NewFileURI("/path/to/averylongfilename.svg"), false, false)
-	rich := test.WidgetRenderer(label).Objects()[0].(*widget.RichText)
-	texts = test.WidgetRenderer(rich).Objects()
+	rich := test.TempWidgetRenderer(t, label).Objects()[0].(*widget.RichText)
+	texts = test.TempWidgetRenderer(t, rich).Objects()
 	assert.Equal(t, 2, len(texts))
 	assert.Equal(t, "averylon", texts[0].(*canvas.Text).Text)
 }

--- a/dialog/folder_test.go
+++ b/dialog/folder_test.go
@@ -44,8 +44,8 @@ func TestShowFolderOpen(t *testing.T) {
 	files := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[1].(*container.Scroll).Content.(*fyne.Container).Objects[0].(*widget.GridWrap)
 	assert.Greater(t, len(d.dialog.data), 0)
 
-	item := test.WidgetRenderer(files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects[0]
-	fileName := test.WidgetRenderer(item.(fyne.Widget)).Objects()[1].(*fileDialogItem).name
+	item := test.TempWidgetRenderer(t, files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects[0]
+	fileName := test.TempWidgetRenderer(t, item.(fyne.Widget)).Objects()[1].(*fileDialogItem).name
 	assert.Equal(t, "(Parent)", fileName)
 	assert.False(t, open.Disabled())
 

--- a/test/test.go
+++ b/test/test.go
@@ -299,6 +299,14 @@ func ApplyTheme(t *testing.T, theme fyne.Theme) {
 	}
 }
 
+// TempWidgetRenderer allows test scripts to gain access to the current renderer for a widget.
+// This can be used for verifying correctness of rendered components for a widget in unit tests.
+// The widget renderer is automatically destroyed when the test ends.
+func TempWidgetRenderer(t *testing.T, wid fyne.Widget) fyne.WidgetRenderer {
+	t.Cleanup(func() { cache.DestroyRenderer(wid) })
+	return cache.Renderer(wid)
+}
+
 // WidgetRenderer allows test scripts to gain access to the current renderer for a widget.
 // This can be used for verifying correctness of rendered components for a widget in unit tests.
 func WidgetRenderer(wid fyne.Widget) fyne.WidgetRenderer {

--- a/test/test.go
+++ b/test/test.go
@@ -302,6 +302,8 @@ func ApplyTheme(t *testing.T, theme fyne.Theme) {
 // TempWidgetRenderer allows test scripts to gain access to the current renderer for a widget.
 // This can be used for verifying correctness of rendered components for a widget in unit tests.
 // The widget renderer is automatically destroyed when the test ends.
+//
+// Since: 2.5
 func TempWidgetRenderer(t *testing.T, wid fyne.Widget) fyne.WidgetRenderer {
 	t.Cleanup(func() { cache.DestroyRenderer(wid) })
 	return cache.Renderer(wid)

--- a/widget/accordion_internal_test.go
+++ b/widget/accordion_internal_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccordion_Toggle(t *testing.T) {
 	ai := NewAccordionItem("foo", NewLabel("foobar"))
 	ac := NewAccordion(ai)
-	ar := test.WidgetRenderer(ac).(*accordionRenderer)
+	ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 	aih := ar.headers[0]
 	assert.False(t, ai.Open)
 
@@ -35,7 +35,7 @@ func TestAccordionRenderer_Layout(t *testing.T) {
 	ac.Append(ai1)
 	ac.Append(ai2)
 
-	ar := test.WidgetRenderer(ac).(*accordionRenderer)
+	ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 	aih0 := ar.headers[0]
 	aih1 := ar.headers[1]
 	aih2 := ar.headers[2]
@@ -143,7 +143,7 @@ func TestAccordionRenderer_Layout(t *testing.T) {
 func TestAccordionRenderer_MinSize(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		ac := NewAccordion()
-		ar := test.WidgetRenderer(ac).(*accordionRenderer)
+		ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 		min := ar.MinSize()
 		assert.Equal(t, float32(0), min.Width)
 		assert.Equal(t, float32(0), min.Height)
@@ -154,7 +154,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			ac := NewAccordion()
 			ac.Append(ai)
 			ac.Open(0)
-			ar := test.WidgetRenderer(ac).(*accordionRenderer)
+			ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 			min := ar.MinSize()
 			aih := ar.headers[0].MinSize()
 			aid := ai.Detail.MinSize()
@@ -165,7 +165,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			ac := NewAccordion()
 			ac.Append(ai)
 			ac.Close(0)
-			ar := test.WidgetRenderer(ac).(*accordionRenderer)
+			ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 			min := ar.MinSize()
 			aih := ar.headers[0].MinSize()
 			assert.Equal(t, aih.Width, min.Width)
@@ -184,7 +184,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			ac.Open(0)
 			ac.Close(1)
 			ac.Close(2)
-			ar := test.WidgetRenderer(ac).(*accordionRenderer)
+			ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 			min := ar.MinSize()
 			aih0 := ar.headers[0].MinSize()
 			aih1 := ar.headers[1].MinSize()
@@ -209,7 +209,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			ac.Append(ai1)
 			ac.Append(ai2)
 			ac.OpenAll()
-			ar := test.WidgetRenderer(ac).(*accordionRenderer)
+			ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 			min := ar.MinSize()
 			aih0 := ar.headers[0].MinSize()
 			aih1 := ar.headers[1].MinSize()
@@ -242,7 +242,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			ac.Open(0)
 			ac.Open(1)
 			ac.Close(2)
-			ar := test.WidgetRenderer(ac).(*accordionRenderer)
+			ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 			min := ar.MinSize()
 			aih0 := ar.headers[0].MinSize()
 			aih1 := ar.headers[1].MinSize()
@@ -268,7 +268,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			ac.Append(ai1)
 			ac.Append(ai2)
 			ac.CloseAll()
-			ar := test.WidgetRenderer(ac).(*accordionRenderer)
+			ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 			min := ar.MinSize()
 			aih0 := ar.headers[0].MinSize()
 			aih1 := ar.headers[1].MinSize()
@@ -287,7 +287,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 
 func TestAccordionRenderer_AddRemove(t *testing.T) {
 	ac := NewAccordion()
-	ar := test.WidgetRenderer(ac).(*accordionRenderer)
+	ar := test.TempWidgetRenderer(t, ac).(*accordionRenderer)
 	ac.Append(NewAccordionItem("foo0", NewLabel("foobar0")))
 	ac.Append(NewAccordionItem("foo1", NewLabel("foobar1")))
 	ac.Append(NewAccordionItem("foo2", NewLabel("foobar2")))

--- a/widget/activity_internal_test.go
+++ b/widget/activity_internal_test.go
@@ -17,7 +17,7 @@ func TestActivity_Animation(t *testing.T) {
 	defer w.Close()
 	w.Resize(a.MinSize())
 
-	render := test.WidgetRenderer(a).(*activityRenderer)
+	render := test.TempWidgetRenderer(t, a).(*activityRenderer)
 	render.anim.Tick(0)
 	test.AssertImageMatches(t, "activity/animate_0.0.png", w.Canvas().Capture())
 

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestButton_Style(t *testing.T) {
 	button := NewButton("Test", nil)
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	render.applyTheme()
 	bg := render.background.FillColor
 
@@ -29,7 +29,7 @@ func TestButton_Style(t *testing.T) {
 
 func TestButton_DisabledColor(t *testing.T) {
 	button := NewButton("Test", nil)
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	render.applyTheme()
 	bg := render.background.FillColor
 	button.Importance = MediumImportance
@@ -43,7 +43,7 @@ func TestButton_DisabledColor(t *testing.T) {
 
 func TestButton_Hover_Math(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.HomeIcon(), func() {})
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	button.hovered = true
 	// unpremultiplied over operator:
 	// outA = srcA + dstA*(1-srcA)
@@ -82,7 +82,7 @@ func TestButton_Hover_Math(t *testing.T) {
 
 func TestButton_DisabledIcon(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
 
 	button.Disable()
@@ -94,7 +94,7 @@ func TestButton_DisabledIcon(t *testing.T) {
 
 func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
 
 	// assert we are using the disabled original icon
@@ -116,7 +116,7 @@ func TestButton_DisabledIconChangeUsingSetIcon(t *testing.T) {
 
 func TestButton_DisabledIconChangedDirectly(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	assert.Equal(t, render.icon.Resource.Name(), theme.CancelIcon().Name())
 
 	// assert we are using the disabled original icon
@@ -142,7 +142,7 @@ func TestButton_Focus(t *testing.T) {
 	button := NewButton("Test", func() {
 		tapped = true
 	})
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	render.applyTheme()
 	assert.Equal(t, theme.ButtonColor(), render.background.FillColor)
 
@@ -161,7 +161,7 @@ func TestButton_Focus(t *testing.T) {
 
 func TestButtonRenderer_Layout(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	render.Layout(render.MinSize())
 
 	assert.True(t, render.icon.Position().X < render.label.Position().X)
@@ -172,7 +172,7 @@ func TestButtonRenderer_Layout(t *testing.T) {
 func TestButtonRenderer_Layout_Stretch(t *testing.T) {
 	button := NewButtonWithIcon("Test", theme.CancelIcon(), nil)
 	button.Resize(button.MinSize().Add(fyne.NewSize(100, 100)))
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 
 	textHeight := render.label.MinSize().Height
 	minIconHeight := fyne.Max(theme.IconInlineSize(), textHeight)
@@ -186,7 +186,7 @@ func TestButtonRenderer_Layout_Stretch(t *testing.T) {
 
 func TestButtonRenderer_Layout_NoText(t *testing.T) {
 	button := NewButtonWithIcon("", theme.CancelIcon(), nil)
-	render := test.WidgetRenderer(button).(*buttonRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 
 	button.Resize(fyne.NewSize(100, 100))
 
@@ -196,8 +196,8 @@ func TestButtonRenderer_Layout_NoText(t *testing.T) {
 
 func TestButtonRenderer_ApplyTheme(t *testing.T) {
 	button := &Button{}
-	render := test.WidgetRenderer(button).(*buttonRenderer)
-	textRender := test.WidgetRenderer(render.label).(*textRenderer)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
+	textRender := test.TempWidgetRenderer(t, render.label).(*textRenderer)
 
 	textSize := textRender.Objects()[0].(*canvas.Text).TextSize
 	customTextSize := textSize
@@ -220,7 +220,7 @@ func TestButtonRenderer_TapAnimation(t *testing.T) {
 	w.Resize(fyne.NewSize(50, 50).Add(fyne.NewSize(20, 20)))
 	button.Resize(fyne.NewSize(50, 50))
 
-	render1 := test.WidgetRenderer(button).(*buttonRenderer)
+	render1 := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 	test.Tap(button)
 	button.tapAnim.Tick(0.5)
 	test.AssertImageMatches(t, "button/tap_animation.png", w.Canvas().Capture())
@@ -228,7 +228,7 @@ func TestButtonRenderer_TapAnimation(t *testing.T) {
 	cache.DestroyRenderer(button)
 	button.Refresh()
 
-	render2 := test.WidgetRenderer(button).(*buttonRenderer)
+	render2 := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 
 	assert.NotEqual(t, render1, render2)
 

--- a/widget/card_test.go
+++ b/widget/card_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCard_SetImage(t *testing.T) {
 	c := widget.NewCard("Title", "sub", widget.NewLabel("Content"))
-	r := test.WidgetRenderer(c)
+	r := test.TempWidgetRenderer(t, c)
 	assert.Equal(t, 4, len(r.Objects())) // the 3 above plus shadow
 
 	c.SetImage(canvas.NewImageFromResource(theme.ComputerIcon()))
@@ -24,7 +24,7 @@ func TestCard_SetImage(t *testing.T) {
 
 func TestCard_SetContent(t *testing.T) {
 	c := widget.NewCard("Title", "sub", widget.NewLabel("Content"))
-	r := test.WidgetRenderer(c)
+	r := test.TempWidgetRenderer(t, c)
 	assert.Equal(t, 4, len(r.Objects())) // the 3 above plus shadow
 
 	newContent := widget.NewLabel("New")

--- a/widget/check_internal_test.go
+++ b/widget/check_internal_test.go
@@ -45,7 +45,7 @@ func TestCheckUnChecked(t *testing.T) {
 func TestCheck_DisabledWhenChecked(t *testing.T) {
 	check := NewCheck("Hi", nil)
 	check.SetChecked(true)
-	render := test.WidgetRenderer(check).(*checkRenderer)
+	render := test.TempWidgetRenderer(t, check).(*checkRenderer)
 
 	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "primary_"))
 
@@ -55,7 +55,7 @@ func TestCheck_DisabledWhenChecked(t *testing.T) {
 
 func TestCheck_DisabledWhenUnchecked(t *testing.T) {
 	check := NewCheck("Hi", nil)
-	render := test.WidgetRenderer(check).(*checkRenderer)
+	render := test.TempWidgetRenderer(t, check).(*checkRenderer)
 	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "inputBorder_"))
 
 	check.Disable()
@@ -129,7 +129,7 @@ func TestCheck_Focused(t *testing.T) {
 	check := NewCheck("Test", func(on bool) {})
 	w := test.NewWindow(check)
 	defer w.Close()
-	render := test.WidgetRenderer(check).(*checkRenderer)
+	render := test.TempWidgetRenderer(t, check).(*checkRenderer)
 
 	assert.False(t, check.focused)
 	assert.Equal(t, color.Transparent, render.focusIndicator.FillColor)
@@ -168,7 +168,7 @@ func TestCheck_Hovered(t *testing.T) {
 	check := NewCheck("Test", func(on bool) {})
 	w := test.NewWindow(check)
 	defer w.Close()
-	render := test.WidgetRenderer(check).(*checkRenderer)
+	render := test.TempWidgetRenderer(t, check).(*checkRenderer)
 
 	check.SetChecked(true)
 	assert.False(t, check.hovered)
@@ -214,7 +214,7 @@ func TestCheck_HoveredOutsideActiveArea(t *testing.T) {
 	check := NewCheck("Test", func(on bool) {})
 	w := test.NewWindow(check)
 	defer w.Close()
-	render := test.WidgetRenderer(check).(*checkRenderer)
+	render := test.TempWidgetRenderer(t, check).(*checkRenderer)
 
 	check.SetChecked(true)
 	assert.False(t, check.hovered)
@@ -274,7 +274,7 @@ func TestCheck_Disabled(t *testing.T) {
 func TestCheckRenderer_ApplyTheme(t *testing.T) {
 	check := &Check{}
 	v := fyne.CurrentApp().Settings().ThemeVariant()
-	render := test.WidgetRenderer(check).(*checkRenderer)
+	render := test.TempWidgetRenderer(t, check).(*checkRenderer)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize

--- a/widget/entry_password_extend_test.go
+++ b/widget/entry_password_extend_test.go
@@ -22,19 +22,19 @@ func TestEntry_Password_Extended_CreateRenderer(t *testing.T) {
 	entry.ExtendBaseWidget(entry)
 	entry.Password = true
 	entry.Wrapping = fyne.TextWrap(fyne.TextTruncateClip)
-	assert.NotNil(t, test.WidgetRenderer(entry))
-	r := test.WidgetRenderer(entry).(*entryRenderer).scroll.Content.(*entryContent)
-	p := test.WidgetRenderer(r).(*entryContentRenderer).provider
+	assert.NotNil(t, test.TempWidgetRenderer(t, entry))
+	r := test.TempWidgetRenderer(t, entry).(*entryRenderer).scroll.Content.(*entryContent)
+	p := test.TempWidgetRenderer(t, r).(*entryContentRenderer).provider
 
 	w.SetContent(entry)
 
 	test.Type(entry, "Pass")
-	texts := test.WidgetRenderer(p).(*textRenderer).Objects()
+	texts := test.TempWidgetRenderer(t, p).(*textRenderer).Objects()
 	assert.Equal(t, passwordChar+passwordChar+passwordChar+passwordChar, texts[0].(*canvas.Text).Text)
 	assert.NotNil(t, entry.ActionItem)
 	test.Tap(entry.ActionItem.(*passwordRevealer))
 
-	texts = test.WidgetRenderer(p).(*textRenderer).Objects()
+	texts = test.TempWidgetRenderer(t, p).(*textRenderer).Objects()
 	assert.Equal(t, "Pass", texts[0].(*canvas.Text).Text)
 	assert.Equal(t, entry, w.Canvas().Focused())
 }

--- a/widget/entry_password_test.go
+++ b/widget/entry_password_test.go
@@ -14,12 +14,12 @@ import (
 func TestNewPasswordEntry(t *testing.T) {
 	p := widget.NewPasswordEntry()
 	p.Text = "visible"
-	r := test.WidgetRenderer(p)
+	r := test.TempWidgetRenderer(t, p)
 
 	cont := r.Objects()[2].(*container.Scroll).Content.(fyne.Widget)
-	r = test.WidgetRenderer(cont)
+	r = test.TempWidgetRenderer(t, cont)
 	rich := r.Objects()[1].(*widget.RichText)
-	r = test.WidgetRenderer(rich)
+	r = test.TempWidgetRenderer(t, rich)
 
 	assert.Equal(t, "•••••••", r.Objects()[0].(*canvas.Text).Text)
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1850,7 +1850,7 @@ func TestPasswordEntry_ActionItemSizeAndPlacement(t *testing.T) {
 	b := widget.NewButton("", func() {})
 	b.Icon = theme.CancelIcon()
 	e.ActionItem = b
-	test.WidgetRenderer(e).Layout(e.MinSize())
+	test.TempWidgetRenderer(t, e).Layout(e.MinSize())
 	assert.Equal(t, fyne.NewSize(theme.IconInlineSize(), theme.IconInlineSize()), b.Size())
 	assert.Equal(t, fyne.NewPos(e.MinSize().Width-2*theme.Padding()-b.Size().Width, 2*theme.Padding()), b.Position())
 }

--- a/widget/form_extend_test.go
+++ b/widget/form_extend_test.go
@@ -16,7 +16,7 @@ func TestForm_Extended_CreateRenderer(t *testing.T) {
 	form := &extendedForm{}
 	form.ExtendBaseWidget(form)
 	form.Items = []*FormItem{{Text: "test1", Widget: NewEntry()}}
-	assert.NotNil(t, test.WidgetRenderer(form))
+	assert.NotNil(t, test.TempWidgetRenderer(t, form))
 	assert.Equal(t, 2, len(form.itemGrid.Objects))
 
 	form.Append("test2", NewEntry())

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -25,7 +25,7 @@ func TestFormSize(t *testing.T) {
 
 func TestForm_CreateRenderer(t *testing.T) {
 	form := &Form{Items: []*FormItem{{Text: "test1", Widget: NewEntry()}}}
-	assert.NotNil(t, test.WidgetRenderer(form))
+	assert.NotNil(t, test.TempWidgetRenderer(t, form))
 	assert.Equal(t, 2, len(form.itemGrid.Objects))
 
 	form.Append("test2", NewEntry())
@@ -48,7 +48,7 @@ func TestForm_Append(t *testing.T) {
 func TestForm_Append_Items(t *testing.T) {
 	form := &Form{Items: []*FormItem{{Text: "test1", Widget: NewEntry()}}}
 	assert.Equal(t, 1, len(form.Items))
-	renderer := test.WidgetRenderer(form)
+	renderer := test.TempWidgetRenderer(t, form)
 
 	form.Items = append(form.Items, NewFormItem("test2", NewEntry()))
 	assert.True(t, len(form.Items) == 2)
@@ -117,7 +117,7 @@ func TestForm_ChangeText(t *testing.T) {
 	item := NewFormItem("Test", NewEntry())
 	form := NewForm(item)
 
-	renderer := test.WidgetRenderer(form)
+	renderer := test.TempWidgetRenderer(t, form)
 	c := renderer.Objects()[0].(*fyne.Container).Objects[0].(*fyne.Container)
 	assert.Equal(t, "Test", c.Objects[0].(*canvas.Text).Text)
 

--- a/widget/icon_internal_test.go
+++ b/widget/icon_internal_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewIcon(t *testing.T) {
 	icon := NewIcon(theme.ConfirmIcon())
-	render := test.WidgetRenderer(icon)
+	render := test.TempWidgetRenderer(t, icon)
 
 	assert.Equal(t, 1, len(render.Objects()))
 	obj := render.Objects()[0]
@@ -25,7 +25,7 @@ func TestNewIcon(t *testing.T) {
 
 func TestIcon_Nil(t *testing.T) {
 	icon := NewIcon(nil)
-	render := test.WidgetRenderer(icon)
+	render := test.TempWidgetRenderer(t, icon)
 
 	assert.Equal(t, 1, len(render.Objects()))
 	assert.Nil(t, render.Objects()[0].(*canvas.Image).Resource)
@@ -41,7 +41,7 @@ func TestIcon_MinSize(t *testing.T) {
 
 func TestIconRenderer_ApplyTheme(t *testing.T) {
 	icon := NewIcon(theme.CancelIcon())
-	render := test.WidgetRenderer(icon).(*iconRenderer)
+	render := test.TempWidgetRenderer(t, icon).(*iconRenderer)
 	visible := render.Objects()[0].Visible()
 
 	render.Refresh()

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -128,14 +128,14 @@ func TestText_MinSize_MultiLine(t *testing.T) {
 	textOneLine := NewLabel("Break")
 	min := textOneLine.MinSize()
 	textMultiLine := NewLabel("Bre\nak")
-	rich := test.WidgetRenderer(textMultiLine).Objects()[0].(*RichText)
+	rich := test.TempWidgetRenderer(t, textMultiLine).Objects()[0].(*RichText)
 	min2 := textMultiLine.MinSize()
 
 	assert.True(t, min2.Width < min.Width)
 	assert.True(t, min2.Height > min.Height)
 
 	yPos := float32(-1)
-	for _, text := range test.WidgetRenderer(rich).(*textRenderer).Objects() {
+	for _, text := range test.TempWidgetRenderer(t, rich).(*textRenderer).Objects() {
 		assert.True(t, text.Size().Height < min2.Height)
 		assert.True(t, text.Position().Y > yPos)
 		yPos = text.Position().Y
@@ -158,9 +158,9 @@ func TestText_MinSizeAdjustsWithContent(t *testing.T) {
 func TestLabel_ApplyTheme(t *testing.T) {
 	text := NewLabel("Line 1")
 	text.Hide()
-	rich := test.WidgetRenderer(text).Objects()[0].(*RichText)
+	rich := test.TempWidgetRenderer(t, text).Objects()[0].(*RichText)
 
-	render := test.WidgetRenderer(rich).(*textRenderer)
+	render := test.TempWidgetRenderer(t, rich).(*textRenderer)
 	assert.Equal(t, theme.ForegroundColor(), render.Objects()[0].(*canvas.Text).Color)
 	text.Show()
 	assert.Equal(t, theme.ForegroundColor(), render.Objects()[0].(*canvas.Text).Color)

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -28,7 +28,7 @@ func TestNewList(t *testing.T) {
 
 	assert.Equal(t, 1000, list.Length())
 	assert.GreaterOrEqual(t, list.MinSize().Width, template.MinSize().Width)
-	assert.Equal(t, list.MinSize(), template.MinSize().Max(test.WidgetRenderer(list).(*listRenderer).scroller.MinSize()))
+	assert.Equal(t, list.MinSize(), template.MinSize().Max(test.TempWidgetRenderer(t, list).(*listRenderer).scroller.MinSize()))
 	assert.Equal(t, float32(0), list.offsetY)
 }
 
@@ -51,7 +51,7 @@ func TestNewListWithData(t *testing.T) {
 
 	assert.Equal(t, 1000, list.Length())
 	assert.GreaterOrEqual(t, list.MinSize().Width, template.MinSize().Width)
-	assert.Equal(t, list.MinSize(), template.MinSize().Max(test.WidgetRenderer(list).(*listRenderer).scroller.MinSize()))
+	assert.Equal(t, list.MinSize(), template.MinSize().Max(test.TempWidgetRenderer(t, list).(*listRenderer).scroller.MinSize()))
 	assert.Equal(t, float32(0), list.offsetY)
 }
 
@@ -118,7 +118,7 @@ func TestList_SetItemHeight(t *testing.T) {
 		func(ListItemID, fyne.CanvasObject) {
 		})
 
-	lay := test.WidgetRenderer(list).(*listRenderer).layout
+	lay := test.TempWidgetRenderer(t, list).(*listRenderer).layout
 	assert.Equal(t, fyne.NewSize(32, 32), list.MinSize())
 	assert.Equal(t, fyne.NewSize(10, 10*5+(4*theme.Padding())), lay.MinSize())
 
@@ -166,7 +166,7 @@ func TestList_OffsetChange(t *testing.T) {
 
 	assert.Equal(t, float32(0), list.offsetY)
 
-	scroll := test.WidgetRenderer(list).(*listRenderer).scroller
+	scroll := test.TempWidgetRenderer(t, list).(*listRenderer).scroller
 	scroll.Scrolled(&fyne.ScrollEvent{Scrolled: fyne.NewDelta(0, -280)})
 
 	assert.NotEqual(t, 0, list.offsetY)

--- a/widget/progressbar_extend_test.go
+++ b/widget/progressbar_extend_test.go
@@ -22,7 +22,7 @@ func newExtendedProgressBar() *extendedProgressBar {
 func TestProgressBarRenderer_Extended_Layout(t *testing.T) {
 	bar := newExtendedProgressBar()
 	bar.Resize(fyne.NewSize(100, 100))
-	r := test.WidgetRenderer(bar).(*progressRenderer)
+	r := test.TempWidgetRenderer(t, bar).(*progressRenderer)
 
 	assert.Equal(t, 0.0, bar.Value)
 	assert.Equal(t, float32(0), r.bar.Size().Width)

--- a/widget/progressbar_test.go
+++ b/widget/progressbar_test.go
@@ -97,7 +97,7 @@ func TestProgressRenderer_Layout(t *testing.T) {
 	bar := NewProgressBar()
 	bar.Resize(fyne.NewSize(100, 10))
 
-	render := test.WidgetRenderer(bar).(*progressRenderer)
+	render := test.TempWidgetRenderer(t, bar).(*progressRenderer)
 	assert.Equal(t, float32(0), render.bar.Size().Width)
 
 	bar.SetValue(.5)
@@ -111,7 +111,7 @@ func TestProgressRenderer_Layout_Overflow(t *testing.T) {
 	bar := NewProgressBar()
 	bar.Resize(fyne.NewSize(100, 10))
 
-	render := test.WidgetRenderer(bar).(*progressRenderer)
+	render := test.TempWidgetRenderer(t, bar).(*progressRenderer)
 	bar.SetValue(1)
 	assert.Equal(t, bar.Size().Width, render.bar.Size().Width)
 
@@ -121,7 +121,7 @@ func TestProgressRenderer_Layout_Overflow(t *testing.T) {
 
 func TestProgressRenderer_ApplyTheme(t *testing.T) {
 	bar := NewProgressBar()
-	render := test.WidgetRenderer(bar).(*progressRenderer)
+	render := test.TempWidgetRenderer(t, bar).(*progressRenderer)
 
 	oldLabelColor := render.label.Color
 	render.Refresh()

--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -80,7 +80,7 @@ func TestInfiniteProgressRenderer_Layout(t *testing.T) {
 	width := float32(100.0)
 	bar.Resize(fyne.NewSize(width, 10))
 
-	render := test.WidgetRenderer(bar).(*infProgressRenderer)
+	render := test.TempWidgetRenderer(t, bar).(*infProgressRenderer)
 
 	render.updateBar(0.0)
 	// start at the smallest size

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -130,9 +130,9 @@ func TestRadioGroup_Extended_Hovered(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			radio := newextendedRadioGroup(tt.options, nil)
 			radio.Horizontal = tt.isHorizontal
-			item1 := test.WidgetRenderer(radio).Objects()[0].(*radioItem)
+			item1 := test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)
 			render1 := cache.Renderer(item1).(*radioItemRenderer)
-			render2 := cache.Renderer(test.WidgetRenderer(radio).Objects()[1].(*radioItem)).(*radioItemRenderer)
+			render2 := cache.Renderer(test.TempWidgetRenderer(t, radio).Objects()[1].(*radioItem)).(*radioItemRenderer)
 
 			assert.False(t, item1.hovered)
 			assert.Equal(t, color.Transparent, render1.focusIndicator.FillColor)
@@ -165,7 +165,7 @@ func TestRadioGroup_Extended_Hovered(t *testing.T) {
 
 func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 	radio := newextendedRadioGroup([]string{"Test"}, func(string) {})
-	render := cache.Renderer(test.WidgetRenderer(radio).Objects()[0].(*radioItem)).(*radioItemRenderer)
+	render := cache.Renderer(test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)).(*radioItemRenderer)
 
 	textSize := render.label.TextSize
 	customTextSize := textSize
@@ -179,7 +179,7 @@ func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 
 func extendedRadioGroupTestTapItem(t *testing.T, radio *extendedRadioGroup, item int) {
 	t.Helper()
-	renderer := test.WidgetRenderer(radio)
+	renderer := test.TempWidgetRenderer(t, radio)
 	radioItem := renderer.Objects()[item].(*radioItem)
 	radioItem.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
 }

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -95,26 +95,26 @@ func TestRadioGroup_Append(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi"}, nil)
 
 	assert.Equal(t, 1, len(radio.Options))
-	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 1, len(test.TempWidgetRenderer(t, radio).(*radioGroupRenderer).items))
 
 	radio.Options = append(radio.Options, "Another")
 	radio.Refresh()
 
 	assert.Equal(t, 2, len(radio.Options))
-	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 2, len(test.TempWidgetRenderer(t, radio).(*radioGroupRenderer).items))
 }
 
 func TestRadioGroup_Remove(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi", "Another"}, nil)
 
 	assert.Equal(t, 2, len(radio.Options))
-	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 2, len(test.TempWidgetRenderer(t, radio).(*radioGroupRenderer).items))
 
 	radio.Options = radio.Options[:1]
 	radio.Refresh()
 
 	assert.Equal(t, 1, len(radio.Options))
-	assert.Equal(t, 1, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 1, len(test.TempWidgetRenderer(t, radio).(*radioGroupRenderer).items))
 }
 
 func TestRadioGroup_SetSelected(t *testing.T) {
@@ -156,14 +156,14 @@ func TestRadioGroup_DuplicatedOptions(t *testing.T) {
 	radio := NewRadioGroup([]string{"Hi", "Hi", "Hi", "Another", "Another"}, nil)
 
 	assert.Equal(t, 5, len(radio.Options))
-	assert.Equal(t, 5, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 5, len(test.TempWidgetRenderer(t, radio).(*radioGroupRenderer).items))
 
 	radioGroupTestTapItem(t, radio, 1)
 	assert.Equal(t, "Hi", radio.Selected)
 	assert.Equal(t, 1, radio.selectedIndex())
-	item0 := test.WidgetRenderer(radio).Objects()[0].(*radioItem)
+	item0 := test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)
 	assert.Equal(t, false, item0.focused)
-	item1 := test.WidgetRenderer(radio).Objects()[0].(*radioItem)
+	item1 := test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)
 	assert.Equal(t, false, item1.focused)
 }
 
@@ -173,7 +173,7 @@ func TestRadioGroup_AppendDuplicate(t *testing.T) {
 	radio.Append("Hi")
 
 	assert.Equal(t, 2, len(radio.Options))
-	assert.Equal(t, 2, len(test.WidgetRenderer(radio).(*radioGroupRenderer).items))
+	assert.Equal(t, 2, len(test.TempWidgetRenderer(t, radio).(*radioGroupRenderer).items))
 }
 
 func TestRadioGroup_Disable(t *testing.T) {
@@ -235,7 +235,7 @@ func TestRadioGroup_Hovered(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			radio := NewRadioGroup(tt.options, nil)
 			radio.Horizontal = tt.isHorizontal
-			item1 := test.WidgetRenderer(radio).Objects()[0].(*radioItem)
+			item1 := test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)
 			render1 := radioGroupTestItemRenderer(t, radio, 0)
 			render2 := radioGroupTestItemRenderer(t, radio, 1)
 
@@ -311,12 +311,12 @@ func TestRadioGroupRenderer_ApplyTheme(t *testing.T) {
 
 func radioGroupTestTapItem(t *testing.T, radio *RadioGroup, item int) {
 	t.Helper()
-	renderer := test.WidgetRenderer(radio)
+	renderer := test.TempWidgetRenderer(t, radio)
 	radioItem := renderer.Objects()[item].(*radioItem)
 	radioItem.Tapped(&fyne.PointEvent{Position: fyne.NewPos(theme.Padding(), theme.Padding())})
 }
 
 func radioGroupTestItemRenderer(t *testing.T, radio *RadioGroup, item int) *radioItemRenderer {
 	t.Cleanup(func() { cache.DestroyRenderer(radio) })
-	return cache.Renderer(test.WidgetRenderer(radio).Objects()[item].(fyne.Widget)).(*radioItemRenderer)
+	return cache.Renderer(test.TempWidgetRenderer(t, radio).Objects()[item].(fyne.Widget)).(*radioItemRenderer)
 }

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -27,7 +27,7 @@ func BenchmarkRadioCreateRenderer(b *testing.B) {
 
 func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
 	item := newRadioItem("Hello", nil)
-	render := test.WidgetRenderer(item).(*radioItemRenderer)
+	render := test.TempWidgetRenderer(t, item).(*radioItemRenderer)
 	render.Layout(fyne.NewSize(200, 100))
 
 	focusIndicatorSize := theme.IconInlineSize() + 2*theme.Padding()

--- a/widget/richtext_objects_test.go
+++ b/widget/richtext_objects_test.go
@@ -15,7 +15,7 @@ import (
 func TestRichText_Image(t *testing.T) {
 	img := &ImageSegment{Title: "test", Source: storage.NewFileURI("./testdata/richtext/richtext_multiline.png")}
 	text := NewRichText(img)
-	texts := test.WidgetRenderer(text).Objects()
+	texts := test.TempWidgetRenderer(t, text).Objects()
 	drawn := texts[0].(*richImage).img
 
 	text.Resize(fyne.NewSize(200, 200))
@@ -37,10 +37,10 @@ func TestRichText_HyperLink(t *testing.T) {
 		&TextSegment{Text: "Text"},
 		&HyperlinkSegment{Text: "Link"},
 	}})
-	texts := test.WidgetRenderer(text).Objects()
+	texts := test.TempWidgetRenderer(t, text).Objects()
 	assert.Equal(t, "Text", texts[0].(*canvas.Text).Text)
-	richLink := test.WidgetRenderer(texts[1].(*fyne.Container).Objects[0].(*Hyperlink)).Objects()[0].(fyne.Widget)
-	linkText := test.WidgetRenderer(richLink).Objects()[0].(*canvas.Text)
+	richLink := test.TempWidgetRenderer(t, texts[1].(*fyne.Container).Objects[0].(*Hyperlink)).Objects()[0].(fyne.Widget)
+	linkText := test.TempWidgetRenderer(t, richLink).Objects()[0].(*canvas.Text)
 	assert.Equal(t, "Link", linkText.Text)
 
 	c := test.NewCanvas()
@@ -54,7 +54,7 @@ func TestRichText_List(t *testing.T) {
 	text := NewRichText(&ListSegment{Items: []RichTextSegment{
 		seg,
 	}})
-	texts := test.WidgetRenderer(text).Objects()
+	texts := test.TempWidgetRenderer(t, text).Objects()
 	assert.Equal(t, "•", strings.TrimSpace(texts[0].(*canvas.Text).Text))
 	assert.Equal(t, "Test", texts[1].(*canvas.Text).Text)
 }
@@ -64,7 +64,7 @@ func TestRichText_OrderedList(t *testing.T) {
 		&TextSegment{Text: "One"},
 		&TextSegment{Text: "Two"},
 	}})
-	texts := test.WidgetRenderer(text).Objects()
+	texts := test.TempWidgetRenderer(t, text).Objects()
 	assert.Equal(t, "1.", strings.TrimSpace(texts[0].(*canvas.Text).Text))
 	assert.Equal(t, "One", texts[1].(*canvas.Text).Text)
 	assert.Equal(t, "2.", strings.TrimSpace(texts[2].(*canvas.Text).Text))

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -49,7 +49,7 @@ func TestText_Alignment(t *testing.T) {
 	seg := trailingBoldErrorSegment()
 	seg.Text = "Test"
 	text := NewRichText(seg)
-	assert.Equal(t, fyne.TextAlignTrailing, test.WidgetRenderer(text).Objects()[0].(*canvas.Text).Alignment)
+	assert.Equal(t, fyne.TextAlignTrailing, test.TempWidgetRenderer(t, text).Objects()[0].(*canvas.Text).Alignment)
 }
 
 func TestText_Row(t *testing.T) {
@@ -136,8 +136,8 @@ func TestText_Scroll(t *testing.T) {
 	assert.Less(t, text4.MinSize().Width, text3.MinSize().Width)
 	assert.Equal(t, text4.MinSize().Height, text3.MinSize().Height)
 
-	content3 := test.WidgetRenderer(text3).Objects()[0].(*widget.Scroll).Content
-	content4 := test.WidgetRenderer(text4).Objects()[0].(*widget.Scroll).Content
+	content3 := test.TempWidgetRenderer(t, text3).Objects()[0].(*widget.Scroll).Content
+	content4 := test.TempWidgetRenderer(t, text4).Objects()[0].(*widget.Scroll).Content
 	assert.Less(t, content4.MinSize().Width, content3.MinSize().Width)
 	assert.Greater(t, content4.MinSize().Height, content3.MinSize().Height)
 }

--- a/widget/select_internal_test.go
+++ b/widget/select_internal_test.go
@@ -52,7 +52,7 @@ func TestSelectRenderer_TapAnimation(t *testing.T) {
 		path = "select/mobile/tap_animation.png"
 	}
 
-	render1 := test.WidgetRenderer(sel).(*selectRenderer)
+	render1 := test.TempWidgetRenderer(t, sel).(*selectRenderer)
 	test.Tap(sel)
 	sel.popUp.Hide()
 	sel.tapAnim.Tick(0.5)
@@ -61,7 +61,7 @@ func TestSelectRenderer_TapAnimation(t *testing.T) {
 	cache.DestroyRenderer(sel)
 	sel.Refresh()
 
-	render2 := test.WidgetRenderer(sel).(*selectRenderer)
+	render2 := test.TempWidgetRenderer(t, sel).(*selectRenderer)
 
 	assert.NotEqual(t, render1, render2)
 

--- a/widget/slider_test.go
+++ b/widget/slider_test.go
@@ -75,7 +75,7 @@ func TestSlider_HorizontalLayout(t *testing.T) {
 	slider := NewSlider(0, 1)
 	slider.Resize(fyne.NewSize(100, 10))
 
-	render := test.WidgetRenderer(slider).(*sliderRenderer)
+	render := test.TempWidgetRenderer(t, slider).(*sliderRenderer)
 	wSize := render.slider.Size()
 	tSize := render.track.Size()
 	aSize := render.active.Size()
@@ -118,7 +118,7 @@ func TestSlider_VerticalLayout(t *testing.T) {
 	slider.Orientation = Vertical
 	slider.Resize(fyne.NewSize(10, 100))
 
-	render := test.WidgetRenderer(slider).(*sliderRenderer)
+	render := test.TempWidgetRenderer(t, slider).(*sliderRenderer)
 	wSize := render.slider.Size()
 	tSize := render.track.Size()
 	aSize := render.active.Size()

--- a/widget/table_test.go
+++ b/widget/table_test.go
@@ -20,7 +20,7 @@ func TestTable_Empty(t *testing.T) {
 	table.Resize(fyne.NewSize(120, 120))
 
 	table.CreateRenderer()
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells))
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
 	cellRenderer.Refresh() // let's not crash :)
 }
 
@@ -39,7 +39,7 @@ func TestTable_Cache(t *testing.T) {
 	c.SetPadded(false)
 	c.Resize(fyne.NewSize(120, 148))
 
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells))
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
 	cellRenderer.Refresh()
 	assert.Equal(t, 6, len(cellRenderer.(*tableCellsRenderer).visible))
 	assert.Equal(t, "Cell 0, 0", cellRenderer.Objects()[0].(*Label).Text)
@@ -69,7 +69,7 @@ func TestTable_ChangeTheme(t *testing.T) {
 	table.CreateRenderer()
 
 	table.Resize(fyne.NewSize(50, 30))
-	content := test.WidgetRenderer(table.content.Content.(*tableCells)).(*tableCellsRenderer)
+	content := test.TempWidgetRenderer(t, table.content.Content.(*tableCells)).(*tableCellsRenderer)
 	w := test.NewWindow(table)
 	defer w.Close()
 	w.Resize(fyne.NewSize(180, 180))
@@ -78,7 +78,7 @@ func TestTable_ChangeTheme(t *testing.T) {
 	assert.Equal(t, NewLabel("placeholder").MinSize(), content.Objects()[0].(*Label).Size())
 
 	test.WithTestTheme(t, func() {
-		test.WidgetRenderer(table).Refresh()
+		test.TempWidgetRenderer(t, table).Refresh()
 		test.AssertImageMatches(t, "table/theme_changed.png", w.Canvas().Capture())
 	})
 	assert.Equal(t, NewLabel("placeholder").MinSize(), content.Objects()[0].(*Label).Size())
@@ -157,7 +157,7 @@ func TestTable_Headers(t *testing.T) {
 		})
 	table.Resize(fyne.NewSize(120, 120))
 
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells))
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
 	assert.Equal(t, "text", cellRenderer.(*tableCellsRenderer).Objects()[2].(*Label).Text)
 	assert.Equal(t, "text", cellRenderer.(*tableCellsRenderer).Objects()[5].(*Label).Text)
 	assert.True(t, areaContainsLabel(table.top.Content.(*fyne.Container).Objects, "A"))
@@ -197,7 +197,7 @@ func TestTable_Sticky(t *testing.T) {
 		})
 	table.Resize(fyne.NewSize(120, 120))
 
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells)).(*tableCellsRenderer)
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells)).(*tableCellsRenderer)
 	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 0,0"))
 	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 1,0"))
 	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 2,1"))
@@ -371,7 +371,7 @@ func TestTable_Refresh(t *testing.T) {
 		})
 	table.Resize(fyne.NewSize(120, 120))
 
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells))
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
 	assert.Equal(t, "placeholder", cellRenderer.(*tableCellsRenderer).Objects()[7].(*Label).Text)
 
 	displayText = "replaced"
@@ -737,7 +737,7 @@ func TestTable_SetColumnWidth(t *testing.T) {
 	table.Resize(fyne.NewSize(120, 120))
 	table.Select(TableCellID{1, 0})
 
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells))
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
 	cellRenderer.Refresh()
 	assert.Equal(t, 8, len(cellRenderer.(*tableCellsRenderer).visible))
 	assert.Equal(t, float32(32), cellRenderer.(*tableCellsRenderer).Objects()[0].Size().Width)
@@ -817,7 +817,7 @@ func TestTable_SetRowHeight(t *testing.T) {
 	table.Resize(fyne.NewSize(120, 120))
 	table.Select(TableCellID{0, 1})
 
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells))
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
 	cellRenderer.Refresh()
 	assert.Equal(t, 6, len(cellRenderer.(*tableCellsRenderer).visible))
 	assert.Equal(t, float32(48), cellRenderer.(*tableCellsRenderer).Objects()[0].Size().Height)
@@ -884,7 +884,7 @@ func TestTable_ShowVisible(t *testing.T) {
 		func(TableCellID, fyne.CanvasObject) {})
 	table.Resize(fyne.NewSize(120, 120))
 
-	cellRenderer := test.WidgetRenderer(table.content.Content.(*tableCells))
+	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
 	cellRenderer.Refresh()
 	assert.Equal(t, 8, len(cellRenderer.(*tableCellsRenderer).visible))
 }

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestNewTextGrid(t *testing.T) {
 	grid := NewTextGridFromString("A")
-	test.WidgetRenderer(grid).Refresh()
+	test.TempWidgetRenderer(t, grid).Refresh()
 
 	assert.Equal(t, 1, len(grid.Rows))
 	assert.Equal(t, 1, len(grid.Rows[0].Cells))
@@ -24,7 +24,7 @@ func TestNewTextGrid(t *testing.T) {
 func TestTextGrid_CreateRendererRows(t *testing.T) {
 	grid := NewTextGrid()
 	grid.Resize(fyne.NewSize(52, 22))
-	rend := test.WidgetRenderer(grid).(*textGridRenderer)
+	rend := test.TempWidgetRenderer(t, grid).(*textGridRenderer)
 	rend.Refresh()
 
 	assert.Equal(t, 12, len(rend.objects))
@@ -32,7 +32,7 @@ func TestTextGrid_CreateRendererRows(t *testing.T) {
 
 func TestTextGrid_Row(t *testing.T) {
 	grid := NewTextGridFromString("Ab\nC")
-	test.WidgetRenderer(grid).Refresh()
+	test.TempWidgetRenderer(t, grid).Refresh()
 
 	assert.NotNil(t, grid.Row(0))
 	assert.Equal(t, 2, len(grid.Row(0).Cells))
@@ -41,7 +41,7 @@ func TestTextGrid_Row(t *testing.T) {
 
 func TestTextGrid_Rows(t *testing.T) {
 	grid := NewTextGridFromString("Ab\nC")
-	test.WidgetRenderer(grid).Refresh()
+	test.TempWidgetRenderer(t, grid).Refresh()
 
 	assert.Equal(t, 2, len(grid.Rows))
 	assert.Equal(t, 2, len(grid.Rows[0].Cells))
@@ -49,7 +49,7 @@ func TestTextGrid_Rows(t *testing.T) {
 
 func TestTextGrid_RowText(t *testing.T) {
 	grid := NewTextGridFromString("Ab\nC")
-	test.WidgetRenderer(grid).Refresh()
+	test.TempWidgetRenderer(t, grid).Refresh()
 
 	assert.Equal(t, "Ab", grid.RowText(0))
 	assert.Equal(t, "C", grid.RowText(1))
@@ -140,7 +140,7 @@ func TestTextGridRenderer_Resize(t *testing.T) {
 	grid := NewTextGridFromString("1\n2")
 	grid.ShowLineNumbers = true
 
-	renderer := test.WidgetRenderer(grid)
+	renderer := test.TempWidgetRenderer(t, grid)
 	min := renderer.MinSize()
 
 	grid.Resize(fyne.NewSize(100, 250))
@@ -168,7 +168,7 @@ func TestTextGridRenderer_ShowLineNumbers(t *testing.T) {
 func TestTextGridRender_Size(t *testing.T) {
 	grid := NewTextGrid()
 	grid.Resize(fyne.NewSize(30, 42)) // causes refresh
-	rend := test.WidgetRenderer(grid).(*textGridRenderer)
+	rend := test.TempWidgetRenderer(t, grid).(*textGridRenderer)
 
 	assert.Equal(t, 3, rend.cols)
 	assert.Equal(t, 2, rend.rows)
@@ -222,7 +222,7 @@ func TestTextGridRender_TextColor(t *testing.T) {
 
 func assertGridContent(t *testing.T, g *TextGrid, expected string) {
 	lines := strings.Split(expected, "\n")
-	renderer := test.WidgetRenderer(g).(*textGridRenderer)
+	renderer := test.TempWidgetRenderer(t, g).(*textGridRenderer)
 
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes
@@ -236,7 +236,7 @@ func assertGridContent(t *testing.T, g *TextGrid, expected string) {
 
 func assertGridStyle(t *testing.T, g *TextGrid, expected string, expectedStyles map[string]TextGridStyle) {
 	lines := strings.Split(expected, "\n")
-	renderer := test.WidgetRenderer(g).(*textGridRenderer)
+	renderer := test.TempWidgetRenderer(t, g).(*textGridRenderer)
 
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes

--- a/widget/toolbar_test.go
+++ b/widget/toolbar_test.go
@@ -45,7 +45,7 @@ func TestToolbar_Replace(t *testing.T) {
 	icon := theme.ContentCutIcon()
 	toolbar := NewToolbar(NewToolbarAction(icon, func() {}))
 	assert.Equal(t, 1, len(toolbar.Items))
-	render := test.WidgetRenderer(toolbar)
+	render := test.TempWidgetRenderer(t, toolbar)
 	assert.Equal(t, icon.Name(), render.Objects()[0].(*Button).Icon.Name())
 
 	toolbar.Items[0] = NewToolbarAction(theme.HelpIcon(), func() {})

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -881,7 +881,7 @@ func TestTree_RefreshItem(t *testing.T) {
 	c := test.NewWindow(tree)
 	c.Resize(fyne.NewSize(100, 100))
 
-	r := test.WidgetRenderer(tree.scroller.Content.(*treeContent)).(*treeContentRenderer)
+	r := test.TempWidgetRenderer(t, tree.scroller.Content.(*treeContent)).(*treeContentRenderer)
 
 	assert.Equal(t, "Leaf", r.leaves["foobar1"].content.(*Label).Text)
 
@@ -899,13 +899,13 @@ func TestTreeNodeRenderer_BackgroundColor(t *testing.T) {
 	tree.OpenAllBranches()
 	t.Run("Branch", func(t *testing.T) {
 		a := getBranch(t, tree, "A")
-		ar := test.WidgetRenderer(a).(*treeNodeRenderer)
+		ar := test.TempWidgetRenderer(t, a).(*treeNodeRenderer)
 		assert.Equal(t, theme.HoverColor(), ar.background.FillColor)
 		assert.False(t, ar.background.Visible())
 	})
 	t.Run("Leaf", func(t *testing.T) {
 		b := getLeaf(t, tree, "B")
-		br := test.WidgetRenderer(b).(*treeNodeRenderer)
+		br := test.TempWidgetRenderer(t, b).(*treeNodeRenderer)
 		assert.Equal(t, theme.HoverColor(), br.background.FillColor)
 		assert.False(t, br.background.Visible())
 	})
@@ -919,7 +919,7 @@ func TestTreeNodeRenderer_BackgroundColor_Hovered(t *testing.T) {
 	tree.OpenAllBranches()
 	t.Run("Branch", func(t *testing.T) {
 		a := getBranch(t, tree, "A")
-		ar := test.WidgetRenderer(a).(*treeNodeRenderer)
+		ar := test.TempWidgetRenderer(t, a).(*treeNodeRenderer)
 		a.MouseIn(&desktop.MouseEvent{})
 		assert.Equal(t, theme.HoverColor(), ar.background.FillColor)
 		assert.True(t, ar.background.Visible())
@@ -929,7 +929,7 @@ func TestTreeNodeRenderer_BackgroundColor_Hovered(t *testing.T) {
 	})
 	t.Run("Leaf", func(t *testing.T) {
 		b := getLeaf(t, tree, "B")
-		br := test.WidgetRenderer(b).(*treeNodeRenderer)
+		br := test.TempWidgetRenderer(t, b).(*treeNodeRenderer)
 		b.MouseIn(&desktop.MouseEvent{})
 		assert.Equal(t, theme.HoverColor(), br.background.FillColor)
 		assert.True(t, br.background.Visible())


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This allows us to fix many cases where the tests created and looked up widget renderers that would stay alive until the old window was destroyed. This mostly matters for all of the tests that just interacted with unrendered widgets.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
