### PR TITLE
Make animation runner and Start zero-alloc

### DIFF
--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -11,10 +11,10 @@ import (
 type Runner struct {
 	// animationMutex synchronizes access to `animations` and `pendingAnimations`
 	// between the runner goroutine and calls to Start and Stop
-	animationMutex    sync.RWMutex
+	animationMutex sync.RWMutex
 
 	// animations is the list of animations that are being ticked in the current frame
-	animations        []*anim
+	animations []*anim
 
 	// pendingAnimations is animations that have been started but not yet picked up
 	// by the runner goroutine to be ticked each frame
@@ -25,7 +25,7 @@ type Runner struct {
 	// during a tick that are not completed, plus the pendingAnimations picked up at the end of the frame.
 	// At the end of a full frame of animations, the nextAnimations slice is swapped with
 	// the current `animations` slice which is then cleared out, while holding the mutex.
-	nextAnimations    []*anim
+	nextAnimations []*anim
 
 	runnerStarted bool
 }

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -23,7 +23,7 @@ type Runner struct {
 	// nextFrameAnimations is the list of animations that will be ticked in the next frame.
 	// It is accessed only by the runner goroutine and accumulates the continuing animations
 	// during a tick that are not completed, plus the pendingAnimations picked up at the end of the frame.
-	// At the end of a full frame of animations, the nextAnimations slice is swapped with
+	// At the end of a full frame of animations, the nextFrameAnimations slice is swapped with
 	// the current `animations` slice which is then cleared out, while holding the mutex.
 	nextFrameAnimations []*anim
 

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -9,10 +9,23 @@ import (
 
 // Runner is the main driver for animations package
 type Runner struct {
+	// animationMutex synchronizes access to `animations` and `pendingAnimations`
+	// between the runner goroutine and calls to Start and Stop
 	animationMutex    sync.RWMutex
+
+	// animations is the list of animations that are being ticked in the current frame
 	animations        []*anim
+
+	// pendingAnimations is animations that have been started but not yet picked up
+	// by the runner goroutine to be ticked each frame
 	pendingAnimations []*anim
-	nextAnimations    []*anim // used by runner goroutine only
+
+	// nextAnimations is the list of animations that will be ticked in the next frame.
+	// It is accessed only by the runner goroutine and accumulates the continuing animations
+	// during a tick that are not completed, plus the pendingAnimations picked up at the end of the frame.
+	// At the end of a full frame of animations, the nextAnimations slice is swapped with
+	// the current `animations` slice which is then cleared out, while holding the mutex.
+	nextAnimations    []*anim
 
 	runnerStarted bool
 }

--- a/internal/animation/runner_test.go
+++ b/internal/animation/runner_test.go
@@ -1,0 +1,26 @@
+package animation
+
+import (
+	"testing"
+	"time"
+
+	"fyne.io/fyne/v2"
+)
+
+func BenchmarkRunnerAllocs(b *testing.B) {
+	r := Runner{}
+	var fl float32
+	// setup some animations
+	for i := 0; i < 10; i++ {
+		r.pendingAnimations = append(r.pendingAnimations, newAnim(
+			fyne.NewAnimation(1000*time.Second, func(f float32) {
+				fl = f
+			})))
+	}
+	for n := 0; n < b.N; n++ {
+		r.runOneFrame()
+	}
+
+	b.ReportAllocs()
+	fl = fl + 1 // dummy use of variable
+}


### PR DESCRIPTION
### Description:

Fixes #4445

This is like the third try of fixing this but this way is the smallest diff and most logically similar to the preexisting code. The main change is to keep a new slice reference that can re-use the memory allocated for the animations slice that was previously discarded for garbage collection each tick.

Stopping an animation early is still not zero-alloc but it happens rare enough (relative to start and tick) that it shouldn't be a big issue, at least for now.

### Allocs benchmark:

== old code ==
goos: darwin
goarch: arm64
pkg: fyne.io/fyne/v2/internal/animation
BenchmarkRunnerAllocs-8      1843419           650.5 ns/op        80 B/op          1 allocs/op

we allocate once per frame (at 60fps in real-world) (new []*anim slice)

== new code ==

goos: darwin
goarch: arm64
pkg: fyne.io/fyne/v2/internal/animation
BenchmarkRunnerAllocs-8   	 1871389	       635.2 ns/op	       0 B/op	       0 allocs/op

We do not allocate at all on an individual frame of animations. We are also a tiny bit faster per frame, which is fairly negligible in the benchmark (allocating a slice *is* fast after all), but in real-world should mean less garbage and less GC triggers when it runs longer

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.