### PR TITLE
Add HideSeparators option to collection widgets

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -36,6 +36,11 @@ type List struct {
 	OnSelected   func(id ListItemID)                         `json:"-"`
 	OnUnselected func(id ListItemID)                         `json:"-"`
 
+	// HideSeparators hides the separators between list rows
+	//
+	// Since: 2.5
+	HideSeparators bool
+
 	currentFocus  ListItemID
 	focused       bool
 	scroller      *widget.Scroll
@@ -772,6 +777,10 @@ func (l *listLayout) updateList(newOnly bool) {
 }
 
 func (l *listLayout) updateSeparators() {
+	if l.list.HideSeparators {
+		l.separators = nil
+		return
+	}
 	if lenChildren := len(l.children); lenChildren > 1 {
 		if lenSep := len(l.separators); lenSep > lenChildren {
 			l.separators = l.separators[:lenChildren]

--- a/widget/table.go
+++ b/widget/table.go
@@ -82,6 +82,11 @@ type Table struct {
 	// Since: 2.4
 	StickyColumnCount int
 
+	// HideSeparators hides the separator lines between the table cells
+	//
+	// Since: 2.5
+	HideSeparators bool
+
 	currentFocus              TableCellID
 	focused                   bool
 	selectedCell, hoveredCell *TableCellID
@@ -1043,6 +1048,11 @@ func (t *tableRenderer) Layout(s fyne.Size) {
 	t.t.corner.Resize(fyne.NewSize(off.X, off.Y))
 
 	t.t.dividerLayer.Resize(s)
+	if t.t.HideSeparators {
+		t.t.dividerLayer.Hide()
+	} else {
+		t.t.dividerLayer.Show()
+	}
 }
 
 func (t *tableRenderer) MinSize() fyne.Size {

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -30,6 +30,11 @@ type Tree struct {
 	BaseWidget
 	Root TreeNodeID
 
+	// HideSeparators hides the separators between tree nodes
+	//
+	// Since: 2.5
+	HideSeparators bool
+
 	ChildUIDs      func(uid TreeNodeID) (c []TreeNodeID)                     `json:"-"` // Return a sorted slice of Children TreeNodeIDs for the given Node TreeNodeID
 	CreateNode     func(branch bool) (o fyne.CanvasObject)                   `json:"-"` // Return a CanvasObject that can represent a Branch (if branch is true), or a Leaf (if branch is false)
 	IsBranch       func(uid TreeNodeID) (ok bool)                            `json:"-"` // Return true if the given TreeNodeID represents a Branch
@@ -624,6 +629,7 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 	separatorThickness := theme.SeparatorThicknessSize()
 	separatorSize := fyne.NewSize(width, separatorThickness)
 	separatorOff := (pad + separatorThickness) / 2
+	hideSeparators := r.treeContent.tree.HideSeparators
 	y := float32(0)
 	// walkAll open branches and obtain nodes to render in scroller's viewport
 	r.treeContent.tree.walkAll(func(uid, _ string, isBranch bool, depth int) {
@@ -654,10 +660,11 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 		} else {
 			// Node is in viewport
 
-			if addSeparator {
+			if addSeparator && !hideSeparators {
 				var separator fyne.CanvasObject
 				if separatorCount < len(r.separators) {
 					separator = r.separators[separatorCount]
+					separator.Show() // it may previously have been hidden
 				} else {
 					separator = NewSeparator()
 					r.separators = append(r.separators, separator)
@@ -702,6 +709,10 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 		y += m.Height
 	})
 
+	if hideSeparators {
+		// start below iteration from 0 to hide all separators
+		separatorCount = 0
+	}
 	// Hide any separators that haven't been reused
 	for ; separatorCount < len(r.separators); separatorCount++ {
 		r.separators[separatorCount].Hide()


### PR DESCRIPTION
### Description:

Adds a `HideSeparators bool` property to List, Tree, and Table (GridWrap does not have separators) to toggle whether the separator lines between elements are shown.

Fixes #3756 

### Checklist:

- [ ] Tests included. <- tested by building a toggle checkbox into the List tab of fyne_demo locally
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.

