### PR TITLE
Respect user-set button icon color for Medium importance buttons

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -337,9 +337,11 @@ func (r *buttonRenderer) applyTheme() {
 	r.label.Refresh()
 	if r.icon != nil && r.icon.Resource != nil {
 		icon := r.icon.Resource
-		if thRes, ok := icon.(fyne.ThemedResource); ok {
-			if thRes.ThemeColorName() != fgColorName {
-				icon = theme.NewColoredResource(icon, fgColorName)
+		if r.button.Importance != MediumImportance {
+			if thRes, ok := icon.(fyne.ThemedResource); ok {
+				if thRes.ThemeColorName() != fgColorName {
+					icon = theme.NewColoredResource(icon, fgColorName)
+				}
 			}
 		}
 		r.icon.Resource = cache.OverrideResourceTheme(icon, r.button)


### PR DESCRIPTION
### Description:

As part of the OnPrimary work, we had a regression in behavior where ThemedResource button icons with user-set color would be overridden to foreground. This PR reverts this behavior only for Medium importance, so as to lose as little functionality from the OnPrimary work as possible.

Fixes #4882 

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
