### PR TITLE
Don't use fmt.Errorf without formatting

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -431,7 +431,7 @@ func (f *fileDialog) setLocation(dir fyne.URI) error {
 		f.files.Unselect(f.selectedID)
 	}
 	if dir == nil {
-		return fmt.Errorf("failed to open nil directory")
+		return errors.New("failed to open nil directory")
 	}
 	list, err := storage.ListerForURI(dir)
 	if err != nil {

--- a/internal/driver/mobile/app/shiny.go
+++ b/internal/driver/mobile/app/shiny.go
@@ -6,12 +6,10 @@
 
 package app
 
-import (
-	"fmt"
-)
+import "log"
 
 func main(f func(a App)) {
-	fmt.Errorf("Running mobile simulation mode does not currently work on Windows.")
+	log.Fatalln("Running mobile simulation mode does not currently work on Windows.")
 }
 
 func GoBack() {

--- a/internal/driver/mobile/folder.go
+++ b/internal/driver/mobile/folder.go
@@ -1,7 +1,7 @@
 package mobile
 
 import (
-	"fmt"
+	"errors"
 
 	"fyne.io/fyne/v2"
 )
@@ -16,7 +16,7 @@ func (l *lister) List() ([]fyne.URI, error) {
 
 func listerForURI(uri fyne.URI) (fyne.ListableURI, error) {
 	if !canListURI(uri) {
-		return nil, fmt.Errorf("specified URI is not listable")
+		return nil, errors.New("specified URI is not listable")
 	}
 
 	return &lister{uri}, nil

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -1,6 +1,7 @@
 package gl
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"image/draw"
@@ -37,7 +38,7 @@ func (p *painter) getTexture(object fyne.CanvasObject, creator func(canvasObject
 		cache.SetTexture(object, texture, p.canvas)
 	}
 	if !cache.IsValid(texture) {
-		return noTexture, fmt.Errorf("no texture available")
+		return noTexture, errors.New("no texture available")
 	}
 	return Texture(texture), nil
 }

--- a/test/testfile.go
+++ b/test/testfile.go
@@ -11,6 +11,8 @@ import (
 	"fyne.io/fyne/v2/storage"
 )
 
+var errUnsupportedURLProtocol = errors.New("unsupported URL protocol")
+
 type file struct {
 	*os.File
 	path string
@@ -45,7 +47,7 @@ func (f *file) URI() fyne.URI {
 
 func openFile(uri fyne.URI, create bool) (*file, error) {
 	if uri.Scheme() != "file" {
-		return nil, errors.New("unsupported URL protocol")
+		return nil, errUnsupportedURLProtocol
 	}
 
 	path := uri.Path()
@@ -68,7 +70,7 @@ func (d *testDriver) FileWriterForURI(uri fyne.URI) (fyne.URIWriteCloser, error)
 
 func (d *testDriver) ListerForURI(uri fyne.URI) (fyne.ListableURI, error) {
 	if uri.Scheme() != "file" {
-		return nil, errors.New("unsupported URL protocol")
+		return nil, errUnsupportedURLProtocol
 	}
 
 	path := uri.String()[len(uri.Scheme())+3 : len(uri.String())]
@@ -86,7 +88,7 @@ func (d *testDriver) ListerForURI(uri fyne.URI) (fyne.ListableURI, error) {
 
 func (d *directory) List() ([]fyne.URI, error) {
 	if d.Scheme() != "file" {
-		return nil, fmt.Errorf("unsupported URL protocol")
+		return nil, errUnsupportedURLProtocol
 	}
 
 	path := d.String()[len(d.Scheme())+3 : len(d.String())]


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Just a minor change to avoid the overhead of `fmt.Errorf` when we aren't formatting. Also fixes a bug when running the mobile simulator on Windows where someone seemed to think that it printed an error to the terminal.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

