### PR TITLE
Fix possible deadlock and race condition around BaseWidget.Theme access

### DIFF
--- a/widget/accordion.go
+++ b/widget/accordion.go
@@ -234,10 +234,10 @@ func (r *accordionRenderer) Refresh() {
 }
 
 func (r *accordionRenderer) updateObjects() {
-	th := r.container.themeWithLock()
 	r.container.propertyLock.RLock()
 	defer r.container.propertyLock.RUnlock()
 
+	th := r.container.themeWithLock()
 	is := len(r.container.Items)
 	hs := len(r.headers)
 	ds := len(r.dividers)

--- a/widget/button.go
+++ b/widget/button.go
@@ -315,7 +315,7 @@ func (r *buttonRenderer) Refresh() {
 }
 
 // applyTheme updates this button to match the current theme
-// must be called with the button propertyLock held
+// must be called with the button propertyLock RLocked
 func (r *buttonRenderer) applyTheme() {
 	th := r.button.themeWithLock()
 	v := fyne.CurrentApp().Settings().ThemeVariant()
@@ -391,7 +391,7 @@ func (r *buttonRenderer) padding(th fyne.Theme) fyne.Size {
 	return fyne.NewSquareSize(th.Size(theme.SizeNameInnerPadding) * 2)
 }
 
-// must be called with r.button.propertyLock held
+// must be called with r.button.propertyLock RLocked
 func (r *buttonRenderer) updateIconAndText() {
 	if r.button.Icon != nil && r.button.Visible() {
 		icon := r.button.Icon

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -43,6 +43,7 @@ func (i *FileIcon) SetURI(uri fyne.URI) {
 	i.Refresh()
 }
 
+// must be called with i.propertyLock RLocked
 func (i *FileIcon) setURI(uri fyne.URI) {
 	if uri == nil {
 		i.resource = i.themeWithLock().Icon(theme.IconNameFile)
@@ -96,6 +97,7 @@ func (i *FileIcon) SetSelected(selected bool) {
 	i.Refresh()
 }
 
+// must be called with i.propertyLock RLocked
 func (i *FileIcon) lookupIcon(uri fyne.URI) fyne.Resource {
 	if icon, ok := uri.(fyne.URIWithIcon); ok {
 		return icon.Icon()

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -142,8 +142,8 @@ func (w *BaseWidget) Refresh() {
 //
 // Since: 2.5
 func (w *BaseWidget) Theme() fyne.Theme {
-	w.propertyLock.Lock()
-	defer w.propertyLock.Unlock()
+	w.propertyLock.RLock()
+	defer w.propertyLock.RUnlock()
 	return w.themeWithLock()
 }
 


### PR DESCRIPTION
### Description:

Addresses (but doesn't completely fix) #4902 

* Fixes a deadlock where main thread can be blocked trying to obtain lock for theme (switch to RLock for BaseWidget.Theme impl)
* Fixes a race condition where accordionRenderer called BaseWidget.themeWithLock without holding the lock

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.