### PR TITLE
Fix last row occasionally missing from list

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -411,11 +411,11 @@ func (l *listLayout) calculateVisibleRowHeights(itemHeight float32, length int) 
 			offY = 0
 		}
 
-		if maxRow > length {
-			maxRow = length
+		if maxRow > length-1 {
+			maxRow = length - 1
 		}
 
-		for i := 0; i < maxRow-minRow; i++ {
+		for i := 0; i <= maxRow-minRow; i++ {
 			l.visibleRowHeights = append(l.visibleRowHeights, itemHeight)
 		}
 		return


### PR DESCRIPTION
### Description:
The calculation calculates maxRow as the max row that could be visible, but then the rest of the code treated it as an exclusive bound (ie first row that *won't* be visible no matter what) instead of inclusive

Fixes #4909 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
