### PR TITLE
fix wrong theme dependencies

### DIFF
--- a/cmd/fyne_demo/tutorials/animation.go
+++ b/cmd/fyne_demo/tutorials/animation.go
@@ -21,11 +21,14 @@ func makeAnimationCanvas() fyne.CanvasObject {
 	rect := canvas.NewRectangle(color.Black)
 	rect.Resize(fyne.NewSize(410, 140))
 
-	a := canvas.NewColorRGBAAnimation(theme.PrimaryColorNamed(theme.ColorBlue), theme.PrimaryColorNamed(theme.ColorGreen),
+	a := canvas.NewColorRGBAAnimation(
+		color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xaa},
+		color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xaa},
 		time.Second*3, func(c color.Color) {
 			rect.FillColor = c
 			canvas.Refresh(rect)
-		})
+		},
+	)
 	a.RepeatCount = fyne.AnimationRepeatForever
 	a.AutoReverse = true
 	a.Start()

--- a/dialog/color_picker.go
+++ b/dialog/color_picker.go
@@ -12,29 +12,36 @@ import (
 
 // newColorBasicPicker returns a component for selecting basic colors.
 func newColorBasicPicker(callback func(color.Color)) fyne.CanvasObject {
-	return newColorButtonBox([]color.Color{
-		theme.PrimaryColorNamed(theme.ColorRed),
-		theme.PrimaryColorNamed(theme.ColorOrange),
-		theme.PrimaryColorNamed(theme.ColorYellow),
-		theme.PrimaryColorNamed(theme.ColorGreen),
-		theme.PrimaryColorNamed(theme.ColorBlue),
-		theme.PrimaryColorNamed(theme.ColorPurple),
-		theme.PrimaryColorNamed(theme.ColorBrown),
-		// theme.PrimaryColorNamed(theme.ColorGray),
-	}, theme.ColorChromaticIcon(), callback)
+	return newColorButtonBox(
+		stringsToColors(
+			"#f44336", // red
+			"#ff9800", // orange
+			"#ffeb3b", // yellow
+			"#8bc34a", // green
+			"#296ff6", // blue
+			"#9c27b0", // purple
+			"#795548", // brown
+		),
+		theme.ColorChromaticIcon(),
+		callback,
+	)
 }
 
 // newColorGreyscalePicker returns a component for selecting greyscale colors.
 func newColorGreyscalePicker(callback func(color.Color)) fyne.CanvasObject {
-	return newColorButtonBox(stringsToColors([]string{
-		"#ffffff",
-		"#cccccc",
-		"#aaaaaa",
-		"#808080",
-		"#555555",
-		"#333333",
-		"#000000",
-	}...), theme.ColorAchromaticIcon(), callback)
+	return newColorButtonBox(
+		stringsToColors(
+			"#ffffff",
+			"#cccccc",
+			"#aaaaaa",
+			"#808080",
+			"#555555",
+			"#333333",
+			"#000000",
+		),
+		theme.ColorAchromaticIcon(),
+		callback,
+	)
 }
 
 // newColorRecentPicker returns a component for selecting recent colors.


### PR DESCRIPTION
### Description:

This PR removes dependencies from theme colors which were wrong:
- The simple color picker’s colors should not be theme dependent.
- The demo animation should not depend on the theme.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
