### PR TITLE
Allow an About menu item in File to be used as special

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -120,6 +120,12 @@ func makeMenu(a fyne.App, w fyne.Window) *fyne.MainMenu {
 		w.Resize(fyne.NewSize(440, 520))
 		w.Show()
 	}
+	showAbout := func() {
+		w := a.NewWindow("About")
+		w.SetContent(widget.NewLabel("About Fyne Demo app..."))
+		w.Show()
+	}
+	aboutItem := fyne.NewMenuItem("About", showAbout)
 	settingsItem := fyne.NewMenuItem("Settings", openSettings)
 	settingsShortcut := &desktop.CustomShortcut{KeyName: fyne.KeyComma, Modifier: fyne.KeyModifierShortcutDefault}
 	settingsItem.Shortcut = settingsShortcut
@@ -170,6 +176,7 @@ func makeMenu(a fyne.App, w fyne.Window) *fyne.MainMenu {
 	if !device.IsMobile() && !device.IsBrowser() {
 		file.Items = append(file.Items, fyne.NewMenuItemSeparator(), settingsItem)
 	}
+	file.Items = append(file.Items, aboutItem)
 	main := fyne.NewMainMenu(
 		file,
 		fyne.NewMenu("Edit", cutItem, copyItem, pasteItem, fyne.NewMenuItemSeparator(), findItem),

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -139,11 +139,12 @@ func exceptionCallback(e *C.char) {
 
 func handleSpecialItems(w *window, menu *fyne.Menu, nextItemID int, addSeparator bool) (*fyne.Menu, int) {
 	for i, item := range menu.Items {
-		if item.Label == "Settings" || item.Label == "Settings…" || item.Label == "Preferences" || item.Label == "Preferences…" {
+		switch item.Label {
+		case "Settings", "Settings…", "Preferences", "Preferences…":
 			items := make([]*fyne.MenuItem, 0, len(menu.Items)-1)
 			items = append(items, menu.Items[:i]...)
 			items = append(items, menu.Items[i+1:]...)
-			menu, nextItemID = handleSpecialItems(w, fyne.NewMenu(menu.Label, items...), nextItemID, false)
+			menu.Items = items
 
 			insertNativeMenuItem(C.darwinAppMenu(), item, nextItemID, 1)
 			if addSeparator {
@@ -160,7 +161,29 @@ func handleSpecialItems(w *window, menu *fyne.Menu, nextItemID int, addSeparator
 				)
 			}
 			nextItemID = registerCallback(w, item, nextItemID)
-			break
+		case "About":
+			items := make([]*fyne.MenuItem, 0, len(menu.Items)-1)
+			items = append(items, menu.Items[:i]...)
+			if i < len(menu.Items)-1 {
+				items = append(items, menu.Items[i+1:]...)
+			}
+			menu.Items = items
+
+			insertNativeMenuItem(C.darwinAppMenu(), item, nextItemID, 1)
+			if addSeparator {
+				C.insertDarwinMenuItem(
+					C.darwinAppMenu(),
+					C.CString(""),
+					C.CString(""),
+					C.uint(0),
+					C.int(nextItemID),
+					C.int(1),
+					C.bool(true),
+					unsafe.Pointer(nil),
+					C.uint(0),
+				)
+			}
+			nextItemID = registerCallback(w, item, nextItemID)
 		}
 	}
 	return menu, nextItemID

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -138,13 +138,18 @@ func exceptionCallback(e *C.char) {
 }
 
 func handleSpecialItems(w *window, menu *fyne.Menu, nextItemID int, addSeparator bool) (*fyne.Menu, int) {
-	for i, item := range menu.Items {
+	menu = fyne.NewMenu(menu.Label, menu.Items...) // copy so we can manipulate
+	for i := 0; i < len(menu.Items); i++ {
+		item := menu.Items[i]
 		switch item.Label {
 		case "Settings", "Settings…", "Preferences", "Preferences…":
 			items := make([]*fyne.MenuItem, 0, len(menu.Items)-1)
 			items = append(items, menu.Items[:i]...)
-			items = append(items, menu.Items[i+1:]...)
+			if i < len(menu.Items)-1 {
+				items = append(items, menu.Items[i+1:]...)
+			}
 			menu.Items = items
+			i--
 
 			insertNativeMenuItem(C.darwinAppMenu(), item, nextItemID, 1)
 			if addSeparator {
@@ -168,6 +173,7 @@ func handleSpecialItems(w *window, menu *fyne.Menu, nextItemID int, addSeparator
 				items = append(items, menu.Items[i+1:]...)
 			}
 			menu.Items = items
+			i--
 
 			insertNativeMenuItem(C.darwinAppMenu(), item, nextItemID, 1)
 			if addSeparator {

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -142,41 +142,15 @@ func handleSpecialItems(w *window, menu *fyne.Menu, nextItemID int, addSeparator
 	for i := 0; i < len(menu.Items); i++ {
 		item := menu.Items[i]
 		switch item.Label {
-		case "Settings", "Settings…", "Preferences", "Preferences…":
+		case "About", "Settings", "Settings…", "Preferences", "Preferences…":
 			items := make([]*fyne.MenuItem, 0, len(menu.Items)-1)
 			items = append(items, menu.Items[:i]...)
-			if i < len(menu.Items)-1 {
-				items = append(items, menu.Items[i+1:]...)
-			}
-			menu.Items = items
+			items = append(items, menu.Items[i+1:]...)
+			menu, nextItemID = handleSpecialItems(w, fyne.NewMenu(menu.Label, items...), nextItemID, false)
 			i--
 
 			insertNativeMenuItem(C.darwinAppMenu(), item, nextItemID, 1)
-			if addSeparator {
-				C.insertDarwinMenuItem(
-					C.darwinAppMenu(),
-					C.CString(""),
-					C.CString(""),
-					C.uint(0),
-					C.int(nextItemID),
-					C.int(1),
-					C.bool(true),
-					unsafe.Pointer(nil),
-					C.uint(0),
-				)
-			}
-			nextItemID = registerCallback(w, item, nextItemID)
-		case "About":
-			items := make([]*fyne.MenuItem, 0, len(menu.Items)-1)
-			items = append(items, menu.Items[:i]...)
-			if i < len(menu.Items)-1 {
-				items = append(items, menu.Items[i+1:]...)
-			}
-			menu.Items = items
-			i--
-
-			insertNativeMenuItem(C.darwinAppMenu(), item, nextItemID, 1)
-			if addSeparator {
+			if addSeparator && item.Label != "About" {
 				C.insertDarwinMenuItem(
 					C.darwinAppMenu(),
 					C.CString(""),

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -109,10 +109,18 @@ const void* insertDarwinMenuItem(const void* m, const char* label, const char* k
         }
     }
 
-    if (index > -1) {
-        [menu insertItem:item atIndex:index];
+    if (strcmp(label, "About") == 0) {
+        item = [menu itemArray][0];
+        [item setAction:@selector(tapped:)];
+        [item setTarget:[FyneMenuHandler class]];
+        [item setTag:id+menuTagMin];
+        return item;
     } else {
-        [menu addItem:item];
+        if (index > -1) {
+            [menu insertItem:item atIndex:index];
+        } else {
+            [menu addItem:item];
+        }
     }
     [item release]; // retained by the menu
     return item;

--- a/internal/driver/glfw/menu_darwin.m
+++ b/internal/driver/glfw/menu_darwin.m
@@ -83,9 +83,17 @@ void handleException(const char* m, id e) {
     exceptionCallback([[NSString stringWithFormat:@"%s failed: %@", m, e] UTF8String]);
 }
 
-const void* insertDarwinMenuItem(const void* m, const char* label, const char* keyEquivalent, unsigned int keyEquivalentModifierMask, int id, int index, bool isSeparator, const void *imageData, unsigned int imageDataLength) {
+const void* insertDarwinMenuItem(const void* m, const char* label, const char* keyEquivalent, unsigned int keyEquivalentModifierMask, int nextId, int index, bool isSeparator, const void *imageData, unsigned int imageDataLength) {
     NSMenu* menu = (NSMenu*)m;
     NSMenuItem* item;
+
+    if (strcmp(label, "About") == 0) {
+        item = [menu itemArray][0];
+        [item setAction:@selector(tapped:)];
+        [item setTarget:[FyneMenuHandler class]];
+        [item setTag:nextId+menuTagMin];
+        return item;
+    }
 
     if (isSeparator) {
         item = [NSMenuItem separatorItem];
@@ -98,7 +106,7 @@ const void* insertDarwinMenuItem(const void* m, const char* label, const char* k
             [item setKeyEquivalentModifierMask: keyEquivalentModifierMask];
         }
         [item setTarget:[FyneMenuHandler class]];
-        [item setTag:id+menuTagMin];
+        [item setTag:nextId+menuTagMin];
         if (imageData) {
         char *x = (char *)imageData;
             NSData *data = [[NSData alloc] initWithBytes: imageData length: imageDataLength];
@@ -109,18 +117,10 @@ const void* insertDarwinMenuItem(const void* m, const char* label, const char* k
         }
     }
 
-    if (strcmp(label, "About") == 0) {
-        item = [menu itemArray][0];
-        [item setAction:@selector(tapped:)];
-        [item setTarget:[FyneMenuHandler class]];
-        [item setTag:id+menuTagMin];
-        return item;
+    if (index > -1) {
+        [menu insertItem:item atIndex:index];
     } else {
-        if (index > -1) {
-            [menu insertItem:item atIndex:index];
-        } else {
-            [menu addItem:item];
-        }
+        [menu addItem:item];
     }
     [item release]; // retained by the menu
     return item;

--- a/internal/driver/glfw/menu_darwin_test.go
+++ b/internal/driver/glfw/menu_darwin_test.go
@@ -3,6 +3,8 @@
 package glfw
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"unsafe"
 
@@ -40,7 +42,8 @@ func TestDarwinMenu(t *testing.T) {
 	itemRecent := fyne.NewMenuItem("Recent", nil)
 	itemFoo := fyne.NewMenuItem("Foo", func() { lastAction = "foo" })
 	itemRecent.ChildMenu = fyne.NewMenu("", itemFoo)
-	menuFile := fyne.NewMenu("File", itemNew, itemOpen, fyne.NewMenuItemSeparator(), itemRecent)
+	itemAbout := fyne.NewMenuItem("About", func() { lastAction = "about" })
+	menuFile := fyne.NewMenu("File", itemNew, itemOpen, fyne.NewMenuItemSeparator(), itemRecent, itemAbout)
 
 	itemHelp := fyne.NewMenuItem("Help", func() { lastAction = "Help!!!" })
 	itemHelp.Shortcut = &desktop.CustomShortcut{KeyName: fyne.KeyH, Modifier: fyne.KeyModifierControl}
@@ -70,7 +73,9 @@ func TestDarwinMenu(t *testing.T) {
 	assert.Equal(t, 5, testNSMenuNumberOfItems(mm), "two built-in + three custom")
 
 	m := testNSMenuItemSubmenu(testNSMenuItemAtIndex(mm, 0))
-	assert.Equal(t, "", testNSMenuTitle(m), "app menu doesn’t have a title")
+	assert.Equal(t, "", testNSMenuTitle(m), "app menu doesn't have a title")
+	assertNSMenuItem(t, "About "+filepath.Base(os.Args[0]), "", 0, m, 0)
+	assertLastAction("about")
 	assertNSMenuItemSeparator(m, 1)
 	assertNSMenuItem(t, "Preferences", "", 0, m, 2)
 	assertLastAction("prefs")

--- a/internal/driver/glfw/menu_darwin_test.go
+++ b/internal/driver/glfw/menu_darwin_test.go
@@ -40,7 +40,7 @@ func TestDarwinMenu(t *testing.T) {
 	itemRecent := fyne.NewMenuItem("Recent", nil)
 	itemFoo := fyne.NewMenuItem("Foo", func() { lastAction = "foo" })
 	itemRecent.ChildMenu = fyne.NewMenu("", itemFoo)
-	menuEdit := fyne.NewMenu("File", itemNew, itemOpen, fyne.NewMenuItemSeparator(), itemRecent)
+	menuFile := fyne.NewMenu("File", itemNew, itemOpen, fyne.NewMenuItemSeparator(), itemRecent)
 
 	itemHelp := fyne.NewMenuItem("Help", func() { lastAction = "Help!!!" })
 	itemHelp.Shortcut = &desktop.CustomShortcut{KeyName: fyne.KeyH, Modifier: fyne.KeyModifierControl}
@@ -59,7 +59,7 @@ func TestDarwinMenu(t *testing.T) {
 	itemMoreSetings := fyne.NewMenuItem("Settings…", func() { lastAction = "more settings" })
 	menuSettings := fyne.NewMenu("Settings", itemSettings, fyne.NewMenuItemSeparator(), itemMoreSetings)
 
-	mainMenu := fyne.NewMainMenu(menuEdit, menuHelp, menuMore, menuSettings)
+	mainMenu := fyne.NewMainMenu(menuFile, menuHelp, menuMore, menuSettings)
 	runOnMain(func() {
 		setupNativeMenu(w, mainMenu)
 	})


### PR DESCRIPTION
to replace the macOS about in the app menu

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
