### PR TITLE
move primary named color accessors to internal package

### DIFF
--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -12,6 +12,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	internalapp "fyne.io/fyne/v2/internal/app"
+	internaltheme "fyne.io/fyne/v2/internal/theme"
 	intWidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
@@ -185,7 +186,7 @@ func newPrimaryColorButton(name string, s *Settings) *primaryColorButton {
 }
 
 func (c *primaryColorButton) CreateRenderer() fyne.WidgetRenderer {
-	r := canvas.NewRectangle(theme.PrimaryColorNamed(c.name))
+	r := canvas.NewRectangle(internaltheme.PrimaryColorNamed(c.name))
 	r.CornerRadius = theme.SelectionRadiusSize()
 	r.StrokeWidth = 5
 
@@ -225,7 +226,7 @@ func (c *primaryColorButtonRenderer) Refresh() {
 	} else {
 		c.rect.StrokeColor = color.Transparent
 	}
-	c.rect.FillColor = theme.PrimaryColorNamed(c.c.name)
+	c.rect.FillColor = internaltheme.PrimaryColorNamed(c.c.name)
 	c.rect.CornerRadius = theme.SelectionRadiusSize()
 
 	c.rect.Refresh()
@@ -254,9 +255,9 @@ func (p *previewTheme) Color(n fyne.ThemeColorName, _ fyne.ThemeVariant) color.C
 
 	switch n {
 	case theme.ColorNamePrimary:
-		return theme.PrimaryColorNamed(p.s.fyneSettings.PrimaryColor)
+		return internaltheme.PrimaryColorNamed(p.s.fyneSettings.PrimaryColor)
 	case theme.ColorNameForegroundOnPrimary:
-		return theme.PrimaryForegroundColorNamed(p.s.fyneSettings.PrimaryColor)
+		return internaltheme.ForegroundOnPrimaryColorNamed(p.s.fyneSettings.PrimaryColor)
 	}
 
 	return p.t.Color(n, variant)

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,5 +1,7 @@
 package theme
 
+import "image/color"
+
 // Primary color names.
 const (
 	ColorBlue   = "blue"
@@ -11,3 +13,38 @@ const (
 	ColorRed    = "red"
 	ColorYellow = "yellow"
 )
+
+var (
+	colorLightPrimaryBlue   = color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
+	colorLightPrimaryBrown  = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
+	colorLightPrimaryGray   = color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
+	colorLightPrimaryGreen  = color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
+	colorLightPrimaryOrange = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
+	colorLightPrimaryPurple = color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
+	colorLightPrimaryRed    = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+	colorLightPrimaryYellow = color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
+)
+
+// PrimaryColorNamed returns a theme specific color value for a named primary color.
+func PrimaryColorNamed(name string) color.Color {
+	switch name {
+	case ColorRed:
+		return colorLightPrimaryRed
+	case ColorOrange:
+		return colorLightPrimaryOrange
+	case ColorYellow:
+		return colorLightPrimaryYellow
+	case ColorGreen:
+		return colorLightPrimaryGreen
+	case ColorPurple:
+		return colorLightPrimaryPurple
+	case ColorBrown:
+		return colorLightPrimaryBrown
+	case ColorGray:
+		return colorLightPrimaryGray
+	}
+
+	// We return the value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return colorLightPrimaryBlue
+}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,0 +1,13 @@
+package theme
+
+// Primary color names.
+const (
+	ColorBlue   = "blue"
+	ColorBrown  = "brown"
+	ColorGray   = "gray"
+	ColorGreen  = "green"
+	ColorOrange = "orange"
+	ColorPurple = "purple"
+	ColorRed    = "red"
+	ColorYellow = "yellow"
+)

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -15,15 +15,47 @@ const (
 )
 
 var (
-	colorLightPrimaryBlue   = color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
-	colorLightPrimaryBrown  = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
-	colorLightPrimaryGray   = color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
-	colorLightPrimaryGreen  = color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
-	colorLightPrimaryOrange = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
-	colorLightPrimaryPurple = color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
-	colorLightPrimaryRed    = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
-	colorLightPrimaryYellow = color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
+	colorLightOnPrimaryBlue   = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+	colorLightOnPrimaryBrown  = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+	colorLightOnPrimaryGray   = color.NRGBA{R: 0x17, G: 0x17, B: 0x18, A: 0xff}
+	colorLightOnPrimaryGreen  = color.NRGBA{R: 0x17, G: 0x17, B: 0x18, A: 0xff}
+	colorLightOnPrimaryOrange = color.NRGBA{R: 0x17, G: 0x17, B: 0x18, A: 0xff}
+	colorLightOnPrimaryPurple = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+	colorLightOnPrimaryRed    = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+	colorLightOnPrimaryYellow = color.NRGBA{R: 0x17, G: 0x17, B: 0x18, A: 0xff}
+	colorLightPrimaryBlue     = color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
+	colorLightPrimaryBrown    = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
+	colorLightPrimaryGray     = color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
+	colorLightPrimaryGreen    = color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
+	colorLightPrimaryOrange   = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
+	colorLightPrimaryPurple   = color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
+	colorLightPrimaryRed      = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+	colorLightPrimaryYellow   = color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
 )
+
+// ForegroundOnPrimaryColorNamed returns a theme specific color used for text and icons against the named primary color.
+func ForegroundOnPrimaryColorNamed(name string) color.Color {
+	switch name {
+	case ColorRed:
+		return colorLightOnPrimaryRed
+	case ColorOrange:
+		return colorLightOnPrimaryOrange
+	case ColorYellow:
+		return colorLightOnPrimaryYellow
+	case ColorGreen:
+		return colorLightOnPrimaryGreen
+	case ColorPurple:
+		return colorLightOnPrimaryPurple
+	case ColorBrown:
+		return colorLightOnPrimaryBrown
+	case ColorGray:
+		return colorLightOnPrimaryGray
+	}
+
+	// We return the “on” value for ColorBlue for every other value.
+	// There is no need to have it in the switch above.
+	return colorLightOnPrimaryBlue
+}
 
 // PrimaryColorNamed returns a theme specific color value for a named primary color.
 func PrimaryColorNamed(name string) color.Color {

--- a/theme/color.go
+++ b/theme/color.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 
 	"fyne.io/fyne/v2"
+	internaltheme "fyne.io/fyne/v2/internal/theme"
 )
 
 // Keep in mind to add new constants to the tests at theme/theme_test.go as well as test/theme_test.go.
@@ -11,35 +12,35 @@ const (
 	// ColorRed is the red primary color name.
 	//
 	// Since: 1.4
-	ColorRed = "red"
+	ColorRed = internaltheme.ColorRed
 	// ColorOrange is the orange primary color name.
 	//
 	// Since: 1.4
-	ColorOrange = "orange"
+	ColorOrange = internaltheme.ColorOrange
 	// ColorYellow is the yellow primary color name.
 	//
 	// Since: 1.4
-	ColorYellow = "yellow"
+	ColorYellow = internaltheme.ColorYellow
 	// ColorGreen is the green primary color name.
 	//
 	// Since: 1.4
-	ColorGreen = "green"
+	ColorGreen = internaltheme.ColorGreen
 	// ColorBlue is the blue primary color name.
 	//
 	// Since: 1.4
-	ColorBlue = "blue"
+	ColorBlue = internaltheme.ColorBlue
 	// ColorPurple is the purple primary color name.
 	//
 	// Since: 1.4
-	ColorPurple = "purple"
+	ColorPurple = internaltheme.ColorPurple
 	// ColorBrown is the brown primary color name.
 	//
 	// Since: 1.4
-	ColorBrown = "brown"
+	ColorBrown = internaltheme.ColorBrown
 	// ColorGray is the gray primary color name.
 	//
 	// Since: 1.4
-	ColorGray = "gray"
+	ColorGray = internaltheme.ColorGray
 
 	// ColorNameBackground is the name of theme lookup for background color.
 	//

--- a/theme/color.go
+++ b/theme/color.go
@@ -227,14 +227,6 @@ var (
 	colorLightOverlayBackground   = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
 	colorLightPlaceholder         = color.NRGBA{R: 0x88, G: 0x88, B: 0x88, A: 0xff}
 	colorLightPressed             = color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0x19}
-	colorLightPrimaryBlue         = color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
-	colorLightPrimaryBrown        = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
-	colorLightPrimaryGray         = color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
-	colorLightPrimaryGreen        = color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
-	colorLightPrimaryOrange       = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
-	colorLightPrimaryPurple       = color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
-	colorLightPrimaryRed          = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
-	colorLightPrimaryYellow       = color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
 	colorLightScrollBar           = color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0x99}
 	colorLightSelectionBlue       = color.NRGBA{R: 0x00, G: 0x6c, B: 0xff, A: 0x40}
 	colorLightSelectionBrown      = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f}
@@ -403,26 +395,7 @@ func PrimaryColor() color.Color {
 //
 // Since: 1.4
 func PrimaryColorNamed(name string) color.Color {
-	switch name {
-	case ColorRed:
-		return colorLightPrimaryRed
-	case ColorOrange:
-		return colorLightPrimaryOrange
-	case ColorYellow:
-		return colorLightPrimaryYellow
-	case ColorGreen:
-		return colorLightPrimaryGreen
-	case ColorPurple:
-		return colorLightPrimaryPurple
-	case ColorBrown:
-		return colorLightPrimaryBrown
-	case ColorGray:
-		return colorLightPrimaryGray
-	}
-
-	// We return the value for ColorBlue for every other value.
-	// There is no need to have it in the switch above.
-	return colorLightPrimaryBlue
+	return internaltheme.PrimaryColorNamed(name)
 }
 
 // PrimaryColorNames returns a list of the standard primary color options.

--- a/theme/color.go
+++ b/theme/color.go
@@ -341,13 +341,6 @@ func MenuBackgroundColor() color.Color {
 	return safeColorLookup(ColorNameMenuBackground, currentVariant())
 }
 
-// PrimaryForegroundColorNamed returns a theme specific color used for text and icons against the named primary color.
-//
-// Since: 2.5
-func PrimaryForegroundColorNamed(name string) color.Color {
-	return internaltheme.ForegroundOnPrimaryColorNamed(name)
-}
-
 // OverlayBackgroundColor returns the theme's background color for overlays like dialogs.
 //
 // Since: 2.3

--- a/theme/color.go
+++ b/theme/color.go
@@ -345,26 +345,7 @@ func MenuBackgroundColor() color.Color {
 //
 // Since: 2.5
 func PrimaryForegroundColorNamed(name string) color.Color {
-	switch name {
-	case ColorRed:
-		return colorLightBackground
-	case ColorOrange:
-		return colorDarkBackground
-	case ColorYellow:
-		return colorDarkBackground
-	case ColorGreen:
-		return colorDarkBackground
-	case ColorPurple:
-		return colorLightBackground
-	case ColorBrown:
-		return colorLightBackground
-	case ColorGray:
-		return colorDarkBackground
-	}
-
-	// We return the “on” value for ColorBlue for every other value.
-	// There is no need to have it in the switch above.
-	return colorLightBackground
+	return internaltheme.ForegroundOnPrimaryColorNamed(name)
 }
 
 // OverlayBackgroundColor returns the theme's background color for overlays like dialogs.

--- a/theme/color.go
+++ b/theme/color.go
@@ -206,6 +206,14 @@ var (
 	colorLightDisabled            = color.NRGBA{R: 0xe3, G: 0xe3, B: 0xe3, A: 0xff}
 	colorLightDisabledButton      = color.NRGBA{R: 0xf5, G: 0xf5, B: 0xf5, A: 0xff}
 	colorLightError               = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+	colorLightFocusBlue           = color.NRGBA{R: 0x00, G: 0x6c, B: 0xff, A: 0x2a}
+	colorLightFocusBrown          = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x7f}
+	colorLightFocusGray           = color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x7f}
+	colorLightFocusGreen          = color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x7f}
+	colorLightFocusOrange         = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f}
+	colorLightFocusPurple         = color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x7f}
+	colorLightFocusRed            = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f}
+	colorLightFocusYellow         = color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x7f}
 	colorLightForeground          = color.NRGBA{R: 0x56, G: 0x56, B: 0x56, A: 0xff}
 	colorLightForegroundOnError   = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
 	colorLightForegroundOnSuccess = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
@@ -218,7 +226,23 @@ var (
 	colorLightOverlayBackground   = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
 	colorLightPlaceholder         = color.NRGBA{R: 0x88, G: 0x88, B: 0x88, A: 0xff}
 	colorLightPressed             = color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0x19}
+	colorLightPrimaryBlue         = color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
+	colorLightPrimaryBrown        = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
+	colorLightPrimaryGray         = color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
+	colorLightPrimaryGreen        = color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
+	colorLightPrimaryOrange       = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
+	colorLightPrimaryPurple       = color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
+	colorLightPrimaryRed          = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+	colorLightPrimaryYellow       = color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
 	colorLightScrollBar           = color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0x99}
+	colorLightSelectionBlue       = color.NRGBA{R: 0x00, G: 0x6c, B: 0xff, A: 0x40}
+	colorLightSelectionBrown      = color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f}
+	colorLightSelectionGray       = color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x3f}
+	colorLightSelectionGreen      = color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x3f}
+	colorLightSelectionOrange     = color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x3f}
+	colorLightSelectionPurple     = color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x3f}
+	colorLightSelectionRed        = color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f}
+	colorLightSelectionYellow     = color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x3f}
 	colorLightSeparator           = color.NRGBA{R: 0xe3, G: 0xe3, B: 0xe3, A: 0xff}
 	colorLightShadow              = color.NRGBA{R: 0x00, G: 0x00, B: 0x00, A: 0x33}
 	colorLightSuccess             = color.NRGBA{R: 0x43, G: 0xf4, B: 0x36, A: 0xff}
@@ -380,24 +404,24 @@ func PrimaryColor() color.Color {
 func PrimaryColorNamed(name string) color.Color {
 	switch name {
 	case ColorRed:
-		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0xff}
+		return colorLightPrimaryRed
 	case ColorOrange:
-		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0xff}
+		return colorLightPrimaryOrange
 	case ColorYellow:
-		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0xff}
+		return colorLightPrimaryYellow
 	case ColorGreen:
-		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0xff}
+		return colorLightPrimaryGreen
 	case ColorPurple:
-		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0xff}
+		return colorLightPrimaryPurple
 	case ColorBrown:
-		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0xff}
+		return colorLightPrimaryBrown
 	case ColorGray:
-		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0xff}
+		return colorLightPrimaryGray
 	}
 
 	// We return the value for ColorBlue for every other value.
 	// There is no need to have it in the switch above.
-	return color.NRGBA{R: 0x29, G: 0x6f, B: 0xf6, A: 0xff}
+	return colorLightPrimaryBlue
 }
 
 // PrimaryColorNames returns a list of the standard primary color options.

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -8,6 +8,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/internal/cache"
+	internaltheme "fyne.io/fyne/v2/internal/theme"
 )
 
 // Keep in mind to add new constants to the tests at theme/theme_test.go as well as test/theme_test.go.
@@ -105,9 +106,9 @@ func (t *builtinTheme) Color(n fyne.ThemeColorName, v fyne.ThemeVariant) color.C
 
 	primary := fyne.CurrentApp().Settings().PrimaryColor()
 	if n == ColorNamePrimary || n == ColorNameHyperlink {
-		return PrimaryColorNamed(primary)
+		return internaltheme.PrimaryColorNamed(primary)
 	} else if n == ColorNameForegroundOnPrimary {
-		return PrimaryForegroundColorNamed(primary)
+		return internaltheme.ForegroundOnPrimaryColorNamed(primary)
 	} else if n == ColorNameFocus {
 		return focusColorNamed(primary)
 	} else if n == ColorNameSelection {

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -268,24 +268,24 @@ func darkPaletteColorNamed(name fyne.ThemeColorName) color.Color {
 func focusColorNamed(name string) color.NRGBA {
 	switch name {
 	case ColorRed:
-		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x7f}
+		return colorLightFocusRed
 	case ColorOrange:
-		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x7f}
+		return colorLightFocusOrange
 	case ColorYellow:
-		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x7f}
+		return colorLightFocusYellow
 	case ColorGreen:
-		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x7f}
+		return colorLightFocusGreen
 	case ColorPurple:
-		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x7f}
+		return colorLightFocusPurple
 	case ColorBrown:
-		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x7f}
+		return colorLightFocusBrown
 	case ColorGray:
-		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x7f}
+		return colorLightFocusGray
 	}
 
 	// We return the value for ColorBlue for every other value.
 	// There is no need to have it in the switch above.
-	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x2a}
+	return colorLightFocusBlue
 }
 
 func lightPaletteColorNamed(name fyne.ThemeColorName) color.Color {
@@ -354,24 +354,24 @@ func loadCustomFont(env, variant string, fallback fyne.Resource) fyne.Resource {
 func selectionColorNamed(name string) color.NRGBA {
 	switch name {
 	case ColorRed:
-		return color.NRGBA{R: 0xf4, G: 0x43, B: 0x36, A: 0x3f}
+		return colorLightSelectionRed
 	case ColorOrange:
-		return color.NRGBA{R: 0xff, G: 0x98, B: 0x00, A: 0x3f}
+		return colorLightSelectionOrange
 	case ColorYellow:
-		return color.NRGBA{R: 0xff, G: 0xeb, B: 0x3b, A: 0x3f}
+		return colorLightSelectionYellow
 	case ColorGreen:
-		return color.NRGBA{R: 0x8b, G: 0xc3, B: 0x4a, A: 0x3f}
+		return colorLightSelectionGreen
 	case ColorPurple:
-		return color.NRGBA{R: 0x9c, G: 0x27, B: 0xb0, A: 0x3f}
+		return colorLightSelectionPurple
 	case ColorBrown:
-		return color.NRGBA{R: 0x79, G: 0x55, B: 0x48, A: 0x3f}
+		return colorLightSelectionBrown
 	case ColorGray:
-		return color.NRGBA{R: 0x9e, G: 0x9e, B: 0x9e, A: 0x3f}
+		return colorLightSelectionGray
 	}
 
 	// We return the value for ColorBlue for every other value.
 	// There is no need to have it in the switch above.
-	return color.NRGBA{R: 0x00, G: 0x6C, B: 0xff, A: 0x40}
+	return colorLightSelectionBlue
 }
 
 func setupDefaultTheme() fyne.Theme {


### PR DESCRIPTION
### Description:

With the move of the accessors for named primary colors we achieve this:
- settings app is able to access the accessors
- the new accessor can be removed from the public package again (included)
- the old accessor can be deprecated in favour of `theme.Color()`

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
