### PR TITLE
Fix crashes on low memory iOS devices

### DIFF
--- a/internal/driver/mobile/app/android.go
+++ b/internal/driver/mobile/app/android.go
@@ -57,8 +57,6 @@ import (
 	"log"
 	"mime"
 	"os"
-	"runtime"
-	"runtime/debug"
 	"strings"
 	"time"
 	"unsafe"
@@ -278,8 +276,7 @@ func onConfigurationChanged(activity *C.ANativeActivity) {
 
 //export onLowMemory
 func onLowMemory(activity *C.ANativeActivity) {
-	runtime.GC()
-	debug.FreeOSMemory()
+	cleanCaches()
 }
 
 var (

--- a/internal/driver/mobile/app/darwin_ios.go
+++ b/internal/driver/mobile/app/darwin_ios.go
@@ -210,6 +210,11 @@ func lifecycleVisible() { theApp.sendLifecycle(lifecycle.StageVisible) }
 //export lifecycleFocused
 func lifecycleFocused() { theApp.sendLifecycle(lifecycle.StageFocused) }
 
+//export lifecycleMemoryWarning
+func lifecycleMemoryWarning() {
+	cleanCaches()
+}
+
 //export drawloop
 func drawloop() {
 	runtime.LockOSThread()

--- a/internal/driver/mobile/app/darwin_ios.m
+++ b/internal/driver/mobile/app/darwin_ios.m
@@ -70,6 +70,10 @@ static CGFloat keyboardHeight;
 	lifecycleDead();
 }
 
+- (void)applicationDidReceiveMemoryWarning:(UIApplication *)application {
+	lifecycleMemoryWarning();
+}
+
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray <NSURL *>*)urls {
     if ([urls count] == 0) {
         return;

--- a/internal/driver/mobile/app/mobile.go
+++ b/internal/driver/mobile/app/mobile.go
@@ -1,0 +1,15 @@
+//go:build ios || android
+
+package app
+
+import "C"
+import (
+	"runtime"
+	"runtime/debug"
+)
+
+// clean caches - called when the OS wants some memory back
+func cleanCaches() {
+	runtime.GC()
+	debug.FreeOSMemory()
+}


### PR DESCRIPTION
We were not responding to the OS requesting memory reclaimed. Now we are and the app is no longer killed.

Move the code to shared (not for simulator though).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. !? :)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

