### PR TITLE
Fixes #4935; Show disabled app tabs as disabled in popup menu

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -338,7 +338,6 @@ func (r *appTabsRenderer) buildOverflowTabsButton() (overflow *widget.Button) {
 					r.appTabs.popUpMenu = nil
 				}
 			})
-			// Fixes #4935
 			if ti.Disabled() {
 				mi.Disabled = true
 			}

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -330,13 +330,19 @@ func (r *appTabsRenderer) buildOverflowTabsButton() (overflow *widget.Button) {
 			index := i // capture
 			// FIXME MenuItem doesn't support icons (#1752)
 			// FIXME MenuItem can't show if it is the currently selected tab (#1753)
-			items = append(items, fyne.NewMenuItem(r.appTabs.Items[i].Text, func() {
+			ti := r.appTabs.Items[i]
+			mi := fyne.NewMenuItem(ti.Text, func() {
 				r.appTabs.SelectIndex(index)
 				if r.appTabs.popUpMenu != nil {
 					r.appTabs.popUpMenu.Hide()
 					r.appTabs.popUpMenu = nil
 				}
-			}))
+			})
+			// Fixes #4935
+			if ti.Disabled() {
+				mi.Disabled = true
+			}
+			items = append(items, mi)
 		}
 
 		r.appTabs.popUpMenu = buildPopUpMenu(r.appTabs, overflow, items)

--- a/container/apptabs_desktop_test.go
+++ b/container/apptabs_desktop_test.go
@@ -307,3 +307,24 @@ func TestAppTabs_Tapped(t *testing.T) {
 	test.TapCanvas(c, fyne.NewPos(186, 10))
 	test.AssertRendersToMarkup(t, "apptabs/desktop/tapped_overflow_tabs.xml", c)
 }
+
+func TestAppTabs_TappedAndDisabled(t *testing.T) {
+	test.NewApp()
+	defer test.NewApp()
+
+	item1 := &container.TabItem{Text: "Test1", Content: widget.NewLabel("Text 1")}
+	item2 := &container.TabItem{Text: "Test2", Content: widget.NewLabel("Text 2")}
+	item3 := &container.TabItem{Text: "Test3", Content: widget.NewLabel("Text 3")}
+	tabs := container.NewAppTabs(item1, item2, item3)
+	tabs.DisableItem(item3)
+	w := test.NewWindow(tabs)
+	defer w.Close()
+	w.SetPadded(false)
+	w.Resize(fyne.NewSize(200, 100))
+	c := w.Canvas()
+
+	tabs.Append(&container.TabItem{Text: "Test4", Content: widget.NewLabel("Text 4")})
+
+	test.TapCanvas(c, fyne.NewPos(186, 10))
+	test.AssertRendersToMarkup(t, "apptabs/desktop/tapped_overflow_tabs_disabled.xml", c)
+}

--- a/container/testdata/apptabs/desktop/tapped_overflow_tabs_disabled.xml
+++ b/container/testdata/apptabs/desktop/tapped_overflow_tabs_disabled.xml
@@ -1,0 +1,57 @@
+<canvas size="200x100">
+	<content>
+		<widget size="200x100" type="*container.AppTabs">
+			<container size="200x36">
+				<container size="160x36">
+					<widget size="52x36" type="*container.tabButton">
+						<text alignment="center" bold color="primary" pos="8,8" size="36x20">Test1</text>
+					</widget>
+					<widget pos="56,0" size="52x36" type="*container.tabButton">
+						<text alignment="center" bold pos="8,8" size="36x20">Test2</text>
+					</widget>
+				</container>
+				<widget pos="164,0" size="36x36" type="*widget.Button">
+					<rectangle radius="4" size="36x36"/>
+					<rectangle size="36x36"/>
+					<image fillMode="contain" pos="8,8" rsc="more-horizontal.svg" size="iconInlineSize" themed="foreground"/>
+				</widget>
+			</container>
+			<rectangle fillColor="shadow" pos="0,36" size="200x4"/>
+			<rectangle fillColor="primary" pos="0,36" radius="4" size="52x4"/>
+			<widget pos="0,40" size="200x60" type="*widget.Label">
+				<widget size="200x60" type="*widget.RichText">
+					<text pos="8,8" size="38x19">Text 1</text>
+				</widget>
+			</widget>
+		</widget>
+	</content>
+	<overlay>
+		<widget pos="2,3" size="196x95" type="*widget.OverlayContainer">
+			<widget pos="145,20" size="50x74" type="*widget.PopUpMenu">
+				<widget size="50x74" type="*widget.Shadow">
+					<radialGradient centerOffset="0.5,0.5" pos="-4,-4" size="4x4" startColor="shadow"/>
+					<linearGradient endColor="shadow" pos="0,-4" size="50x4"/>
+					<radialGradient centerOffset="-0.5,0.5" pos="50,-4" size="4x4" startColor="shadow"/>
+					<linearGradient angle="270" pos="50,0" size="4x74" startColor="shadow"/>
+					<radialGradient centerOffset="-0.5,-0.5" pos="50,74" size="4x4" startColor="shadow"/>
+					<linearGradient pos="0,74" size="50x4" startColor="shadow"/>
+					<radialGradient centerOffset="0.5,-0.5" pos="-4,74" size="4x4" startColor="shadow"/>
+					<linearGradient angle="270" endColor="shadow" pos="-4,0" size="4x74"/>
+				</widget>
+				<widget size="50x74" type="*widget.Scroll">
+					<widget size="50x74" type="*widget.menuBox">
+						<rectangle fillColor="menuBackground" size="50x74"/>
+						<container size="50x74">
+							<widget size="50x35" type="*widget.menuItem">
+								<text color="disabled" pos="8,8" size="34x19">Test3</text>
+							</widget>
+							<widget pos="0,39" size="50x35" type="*widget.menuItem">
+								<text pos="8,8" size="34x19">Test4</text>
+							</widget>
+						</container>
+					</widget>
+				</widget>
+			</widget>
+		</widget>
+	</overlay>
+</canvas>


### PR DESCRIPTION
### Description:

When there is not enough space to draw all app tabs on screen, some are shown in a popup menu.

Currently disabled tabs are shown as normal menu items in the popup menu, which allows the user to select them.

This change disables menu items in the popup menu for any disabled tab, so they can no longer be selected by the user.

Fixes #4935 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

N/A