### PR TITLE
Update portal dialogs to use native window API

### DIFF
--- a/dialog/file_xdg_flatpak.go
+++ b/dialog/file_xdg_flatpak.go
@@ -64,13 +64,7 @@ func fileOpenOSOverride(d *FileDialog) bool {
 			options.CurrentFolder = d.startingLocation.Path()
 		}
 
-		parentWindowHandle := ""
-		if !build.IsWayland {
-			d.parent.(driver.NativeWindow).RunNative(func(context any) {
-				handle := context.(*driver.X11WindowContext).WindowHandle
-				parentWindowHandle = x11WindowHandleToString(handle)
-			})
-		}
+		parentWindowHandle := windowHandleForPortal(d.parent)
 
 		if folder {
 			openFolder(parentWindowHandle, folderCallback, options)
@@ -93,13 +87,7 @@ func fileSaveOSOverride(d *FileDialog) bool {
 			options.CurrentFolder = d.startingLocation.Path()
 		}
 
-		parentWindowHandle := ""
-		if !build.IsWayland {
-			d.parent.(driver.NativeWindow).RunNative(func(context any) {
-				handle := context.(driver.X11WindowContext).WindowHandle
-				parentWindowHandle = x11WindowHandleToString(handle)
-			})
-		}
+		parentWindowHandle := windowHandleForPortal(d.parent)
 
 		callback := d.callback.(func(fyne.URIWriteCloser, error))
 		uris, err := filechooser.SaveFile(parentWindowHandle, "Open File", options)
@@ -124,7 +112,19 @@ func fileSaveOSOverride(d *FileDialog) bool {
 	return true
 }
 
-// TODO: We need to get the Wayland handle from the xdg_foreign protocol and convert to string on the form "wayland:{id}".
 func x11WindowHandleToString(handle uintptr) string {
 	return "x11:" + strconv.FormatUint(uint64(handle), 16)
+}
+
+func windowHandleForPortal(window fyne.Window) string {
+	parentWindowHandle := ""
+	if !build.IsWayland {
+		window.(driver.NativeWindow).RunNative(func(context any) {
+			handle := context.(driver.X11WindowContext).WindowHandle
+			parentWindowHandle = x11WindowHandleToString(handle)
+		})
+	}
+
+	// TODO: We need to get the Wayland handle from the xdg_foreign protocol and convert to string on the form "wayland:{id}".
+	return parentWindowHandle
 }

--- a/internal/driver/glfw/window_notxdg.go
+++ b/internal/driver/glfw/window_notxdg.go
@@ -21,8 +21,3 @@ func (w *window) platformResize(canvasSize fyne.Size) {
 		})
 	}
 }
-
-// GetWindowHandle returns the window handle. Only implemented for X11 currently.
-func (w *window) GetWindowHandle() string {
-	return ""
-}

--- a/internal/driver/glfw/window_wayland.go
+++ b/internal/driver/glfw/window_wayland.go
@@ -8,11 +8,6 @@ import (
 	"fyne.io/fyne/v2/driver"
 )
 
-// GetWindowHandle returns the window handle. Only implemented for X11 currently.
-func (w *window) GetWindowHandle() string {
-	return "" // TODO: Find a way to get the Wayland handle for xdg_foreign protocol. Return "wayland:{id}".
-}
-
 // assert we are implementing driver.NativeWindow
 var _ driver.NativeWindow = (*window)(nil)
 

--- a/internal/driver/glfw/window_x11.go
+++ b/internal/driver/glfw/window_x11.go
@@ -2,17 +2,7 @@
 
 package glfw
 
-import (
-	"strconv"
-
-	"fyne.io/fyne/v2/driver"
-)
-
-// GetWindowHandle returns the window handle. Only implemented for X11 currently.
-func (w *window) GetWindowHandle() string {
-	xid := uint(w.viewport.GetX11Window())
-	return "x11:" + strconv.FormatUint(uint64(xid), 16)
-}
+import "fyne.io/fyne/v2/driver"
 
 // assert we are implementing driver.NativeWindow
 var _ driver.NativeWindow = (*window)(nil)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Look up the window handle using the new native window API instead of using custom methods on the window.
These nice new APIs really do help make the code cleaner. Now I only have to get the xdg_foreign protocol hooked up so I can get the same support on the Wayland side.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
