### PR TITLE
Improve logic for deciding if scrollbar should be large

### DIFF
--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -83,6 +83,10 @@ func (b *scrollBar) Cursor() desktop.Cursor {
 
 func (b *scrollBar) DragEnd() {
 	b.area.isDragged = false
+
+	if fyne.CurrentDevice().IsMobile() {
+		b.area.MouseOut()
+	}
 }
 
 func (b *scrollBar) Dragged(e *fyne.DragEvent) {

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -63,7 +63,6 @@ type scrollBar struct {
 	area            *scrollBarArea
 	draggedDistance float32
 	dragStart       float32
-	isDragged       bool
 	orientation     scrollBarOrientation
 }
 
@@ -83,12 +82,14 @@ func (b *scrollBar) Cursor() desktop.Cursor {
 }
 
 func (b *scrollBar) DragEnd() {
-	b.isDragged = false
+	b.area.isDragged = false
 }
 
 func (b *scrollBar) Dragged(e *fyne.DragEvent) {
-	if !b.isDragged {
-		b.isDragged = true
+	if !b.area.isDragged {
+		b.area.isDragged = true
+		b.area.MouseIn(nil)
+
 		switch b.orientation {
 		case scrollBarOrientationHorizontal:
 			b.dragStart = b.Position().X
@@ -186,6 +187,7 @@ var _ desktop.Hoverable = (*scrollBarArea)(nil)
 type scrollBarArea struct {
 	Base
 
+	isDragged   bool
 	isLarge     bool
 	scroll      *Scroll
 	orientation scrollBarOrientation
@@ -205,6 +207,10 @@ func (a *scrollBarArea) MouseMoved(*desktop.MouseEvent) {
 }
 
 func (a *scrollBarArea) MouseOut() {
+	if a.isDragged {
+		return
+	}
+
 	a.isLarge = false
 	a.scroll.Refresh()
 }

--- a/internal/widget/scroller_test.go
+++ b/internal/widget/scroller_test.go
@@ -781,3 +781,29 @@ func TestScrollBar_DraggedWithNonZeroStartPosition(t *testing.T) {
 	scrollBarVert.Dragged(&dragEvent)
 	assert.Equal(t, float32(350), scroll.Offset.Y)
 }
+
+func TestScrollBar_LargeHandleWhileInDrag(t *testing.T) {
+	rect := canvas.NewRectangle(color.Black)
+	rect.SetMinSize(fyne.NewSize(1000, 1000))
+	scroll := NewScroll(rect)
+	scroll.Resize(fyne.NewSize(200, 200))
+	scrollBarHoriz := cache.Renderer(cache.Renderer(scroll).(*scrollContainerRenderer).horizArea).(*scrollBarAreaRenderer).bar
+
+	// Make sure that hovering makes the bar large.
+	mouseEvent := &desktop.MouseEvent{}
+	assert.False(t, scrollBarHoriz.area.isLarge)
+	scrollBarHoriz.MouseIn(mouseEvent)
+	assert.True(t, scrollBarHoriz.area.isLarge)
+	scrollBarHoriz.MouseOut()
+	assert.False(t, scrollBarHoriz.area.isLarge)
+
+	// Make sure that the bar stays large when dragging, even if the mouse leaves the bar.
+	dragEvent := &fyne.DragEvent{Dragged: fyne.Delta{DX: 10}}
+	scrollBarHoriz.Dragged(dragEvent)
+	assert.True(t, scrollBarHoriz.area.isLarge)
+	scrollBarHoriz.MouseOut()
+	assert.True(t, scrollBarHoriz.area.isLarge)
+	scrollBarHoriz.DragEnd()
+	scrollBarHoriz.MouseOut()
+	assert.False(t, scrollBarHoriz.area.isLarge)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This fixes some weird behaviour where the scrollbar on desktop previously would go back to not being expanded if the mouse left the area of the bar while dragging it. It also fixes an issue where the scrollbar on mobile would stay small even when it is used to initiate a scroll.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

