### PR TITLE
Make the large scrollbar slightly narrower

### DIFF
--- a/theme/theme.go
+++ b/theme/theme.go
@@ -151,7 +151,7 @@ func (t *builtinTheme) Size(s fyne.ThemeSizeName) float32 {
 	case SizeNamePadding:
 		return 4
 	case SizeNameScrollBar:
-		return 16
+		return 12
 	case SizeNameScrollBarSmall:
 		return 3
 	case SizeNameText:


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

It was looking a bit too big previously and did not fit in well with the rest of the UI because of it. This makes it smaller, now four times as big as the small bar. We might want to make it smaller in the future but this seems like a step in the right direction.

#### Old size:

![image](https://github.com/fyne-io/fyne/assets/25466657/9ee38b16-0d1f-4e75-8bcc-f4aec68df1de)

#### New size:

![image](https://github.com/fyne-io/fyne/assets/25466657/b61f33ab-ba9a-4189-b010-f39cfefdb726)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
