### PR TITLE
Working around missing screen dimensions for Steam Deck

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -315,7 +315,7 @@ func (w *window) detectScale() float32 {
 	}
 
 	widthMm, heightMm := monitor.GetPhysicalSize()
-	if widthMm == 60 && heightMm == 60 { // some sort of failure - mostly on Steam Deck
+	if runtime.GOOS == "linux" && widthMm == 60 && heightMm == 60 { // some sort of failure - mostly on Steam Deck
 		return 1
 	}
 	widthPx := monitor.GetVideoMode().Width

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -307,15 +307,15 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 
 func (w *window) detectScale() float32 {
 	if build.IsWayland { // Wayland controls scale through content scaling
-		return 1.0
+		return 1
 	}
 	monitor := w.getMonitorForWindow()
 	if monitor == nil {
-		return 1.0
+		return 1
 	}
 
 	widthMm, heightMm := monitor.GetPhysicalSize()
-	if runtime.GOOS == "linux" && widthMm == 60 && heightMm == 60 { // some sort of failure - mostly on Steam Deck
+	if runtime.GOOS == "linux" && widthMm == 60 && heightMm == 60 { // Steam Deck incorrectly reports 6cm square!
 		return 1
 	}
 	widthPx := monitor.GetVideoMode().Width

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -314,7 +314,10 @@ func (w *window) detectScale() float32 {
 		return 1.0
 	}
 
-	widthMm, _ := monitor.GetPhysicalSize()
+	widthMm, heightMm := monitor.GetPhysicalSize()
+	if widthMm == 60 && heightMm == 60 { // some sort of failure - mostly on Steam Deck
+		return 1
+	}
 	widthPx := monitor.GetVideoMode().Width
 
 	return calculateDetectedScale(widthMm, widthPx)


### PR DESCRIPTION
And maybe more?

Fixes #4896

Results in this (not the right DPI, but not unexpected given how other software looks)

![Screenshot_20240709_095130](https://github.com/fyne-io/fyne/assets/294436/d0adb414-52ea-48cf-87dd-305c26e44d9d)


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
