### PR TITLE
Fix undo/redo for multi byte runes

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -790,7 +791,7 @@ func (e *Entry) Undo() {
 	}
 	pos := modify.Position
 	if modify.Delete {
-		pos += len([]rune(modify.Text))
+		pos += utf8.RuneCountInString(modify.Text)
 	}
 	e.propertyLock.Lock()
 	e.updateText(newText, false)
@@ -2313,7 +2314,7 @@ func (i *entryModifyAction) add(s string) string {
 // Deletes Text
 func (i *entryModifyAction) sub(s string) string {
 	runes := []rune(s)
-	return string(runes[:i.Position]) + string(runes[i.Position+len([]rune(i.Text)):])
+	return string(runes[:i.Position]) + string(runes[i.Position+utf8.RuneCountInString(i.Text):])
 }
 
 func (i *entryModifyAction) TryMerge(other entryMergeableUndoAction) bool {
@@ -2342,13 +2343,13 @@ func (i *entryModifyAction) TryMerge(other entryMergeableUndoAction) bool {
 		}
 
 		if i.Delete {
-			if i.Position == other.Position+len([]rune(other.Text)) {
+			if i.Position == other.Position+utf8.RuneCountInString(other.Text) {
 				i.Position = other.Position
 				i.Text = other.Text + i.Text
 				return true
 			}
 		} else {
-			if i.Position+len([]rune(i.Text)) == other.Position {
+			if i.Position+utf8.RuneCountInString(i.Text) == other.Position {
 				i.Text += other.Text
 				return true
 			}

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -702,8 +702,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 
 		e.propertyLock.Lock()
 		pos := e.cursorTextPos()
-		deletedText := e.Text[pos-1 : pos]
-		provider.deleteFromTo(pos-1, pos)
+		deletedText := provider.deleteFromTo(pos-1, pos)
 		e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos - 1)
 		e.undoStack.MergeOrAdd(&entryModifyAction{
 			Delete:   true,
@@ -718,8 +717,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 		}
 
 		e.propertyLock.Lock()
-		deletedText := e.Text[pos : pos+1]
-		provider.deleteFromTo(pos, pos+1)
+		deletedText := provider.deleteFromTo(pos, pos+1)
 		e.undoStack.MergeOrAdd(&entryModifyAction{
 			Delete:   true,
 			Position: pos,
@@ -792,7 +790,7 @@ func (e *Entry) Undo() {
 	}
 	pos := modify.Position
 	if modify.Delete {
-		pos += len(modify.Text)
+		pos += len([]rune(modify.Text))
 	}
 	e.propertyLock.Lock()
 	e.updateText(newText, false)
@@ -2308,12 +2306,14 @@ func (i *entryModifyAction) Redo(s string) string {
 
 // Inserts Text
 func (i *entryModifyAction) add(s string) string {
-	return s[:i.Position] + i.Text + s[i.Position:]
+	runes := []rune(s)
+	return string(runes[:i.Position]) + i.Text + string(runes[i.Position:])
 }
 
 // Deletes Text
 func (i *entryModifyAction) sub(s string) string {
-	return s[:i.Position] + s[i.Position+len(i.Text):]
+	runes := []rune(s)
+	return string(runes[:i.Position]) + string(runes[i.Position+len([]rune(i.Text)):])
 }
 
 func (i *entryModifyAction) TryMerge(other entryMergeableUndoAction) bool {
@@ -2342,13 +2342,13 @@ func (i *entryModifyAction) TryMerge(other entryMergeableUndoAction) bool {
 		}
 
 		if i.Delete {
-			if i.Position == other.Position+len(other.Text) {
+			if i.Position == other.Position+len([]rune(other.Text)) {
 				i.Position = other.Position
 				i.Text = other.Text + i.Text
 				return true
 			}
 		} else {
-			if i.Position+len(i.Text) == other.Position {
+			if i.Position+len([]rune(i.Text)) == other.Position {
 				i.Text += other.Text
 				return true
 			}

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -556,6 +556,7 @@ func (e *Entry) Append(text string) {
 	content := provider.String()
 	changed := e.updateText(content, false)
 	cb := e.OnChanged
+	e.undoStack.Clear()
 	e.propertyLock.Unlock()
 
 	if changed {

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1984,7 +1984,84 @@ func TestEntry_CarriageReturn(t *testing.T) {
 	test.AssertImageMatches(t, "entry/carriage_return_text.png", w.Canvas().Capture())
 }
 
-func TestEntry_UndoRedo(t *testing.T) {
+func TestEntry_UndoRedo_TypeRune(t *testing.T) {
+	entry := widget.NewEntry()
+
+	// Check undo when there is nothing to undo
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "", entry.Text)
+
+	for _, r := range "aaa ààà bbb" {
+		entry.TypedRune(r)
+	}
+
+	assert.Equal(t, "aaa ààà bbb", entry.Text)
+
+	// Check redo when there is nothing to redo
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "aaa ààà bbb", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "aaa ààà", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "aaa", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "", entry.Text)
+
+	// Check undo when there is nothing to undo
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "aaa", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "aaa ààà", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "aaa ààà bbb", entry.Text)
+
+	// Check redo when there is nothing to redo
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "aaa ààà bbb", entry.Text)
+}
+
+func TestEntry_UndoRedo_Delete(t *testing.T) {
+	entry := widget.NewEntry()
+
+	// Check Undo when there is nothing to undo
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "", entry.Text)
+
+	for _, r := range "àbcdéf" {
+		entry.TypedRune(r)
+	}
+	assert.Equal(t, "àbcdéf", entry.Text)
+
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyLeft})
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyLeft})
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyBackspace})
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyBackspace})
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDelete})
+
+	assert.Equal(t, "àbf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "àbéf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "àbcdéf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "àbéf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "àbf", entry.Text)
+}
+
+func TestEntry_UndoRedoImage(t *testing.T) {
 	e, window := setupImageTest(t, true)
 	window.Resize(fyne.NewSize(128, 128))
 	c := window.Canvas()

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1991,21 +1991,21 @@ func TestEntry_UndoRedo_TypeRune(t *testing.T) {
 	entry.TypedShortcut(&fyne.ShortcutUndo{})
 	assert.Equal(t, "", entry.Text)
 
-	for _, r := range "aaa ààà bbb" {
+	for _, r := range "abc éàè 123" {
 		entry.TypedRune(r)
 	}
 
-	assert.Equal(t, "aaa ààà bbb", entry.Text)
+	assert.Equal(t, "abc éàè 123", entry.Text)
 
 	// Check redo when there is nothing to redo
 	entry.TypedShortcut(&fyne.ShortcutRedo{})
-	assert.Equal(t, "aaa ààà bbb", entry.Text)
+	assert.Equal(t, "abc éàè 123", entry.Text)
 
 	entry.TypedShortcut(&fyne.ShortcutUndo{})
-	assert.Equal(t, "aaa ààà", entry.Text)
+	assert.Equal(t, "abc éàè", entry.Text)
 
 	entry.TypedShortcut(&fyne.ShortcutUndo{})
-	assert.Equal(t, "aaa", entry.Text)
+	assert.Equal(t, "abc", entry.Text)
 
 	entry.TypedShortcut(&fyne.ShortcutUndo{})
 	assert.Equal(t, "", entry.Text)
@@ -2015,17 +2015,17 @@ func TestEntry_UndoRedo_TypeRune(t *testing.T) {
 	assert.Equal(t, "", entry.Text)
 
 	entry.TypedShortcut(&fyne.ShortcutRedo{})
-	assert.Equal(t, "aaa", entry.Text)
+	assert.Equal(t, "abc", entry.Text)
 
 	entry.TypedShortcut(&fyne.ShortcutRedo{})
-	assert.Equal(t, "aaa ààà", entry.Text)
+	assert.Equal(t, "abc éàè", entry.Text)
 
 	entry.TypedShortcut(&fyne.ShortcutRedo{})
-	assert.Equal(t, "aaa ààà bbb", entry.Text)
+	assert.Equal(t, "abc éàè 123", entry.Text)
 
 	// Check redo when there is nothing to redo
 	entry.TypedShortcut(&fyne.ShortcutRedo{})
-	assert.Equal(t, "aaa ààà bbb", entry.Text)
+	assert.Equal(t, "abc éàè 123", entry.Text)
 }
 
 func TestEntry_UndoRedo_Delete(t *testing.T) {
@@ -2059,6 +2059,29 @@ func TestEntry_UndoRedo_Delete(t *testing.T) {
 
 	entry.TypedShortcut(&fyne.ShortcutRedo{})
 	assert.Equal(t, "àbf", entry.Text)
+}
+
+func TestEntry_UndoRedo_Replace(t *testing.T) {
+	entry := widget.NewEntry()
+
+	entry.SetText("àbcdéf")
+	typeKeys(entry, fyne.KeyRight, fyne.KeyRight, keyShiftLeftDown, fyne.KeyRight, fyne.KeyRight, keyShiftLeftUp)
+	assert.Equal(t, "cd", entry.SelectedText())
+
+	entry.TypedRune('z')
+	assert.Equal(t, "àbzéf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "àbéf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "àbcdéf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "àbéf", entry.Text)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "àbzéf", entry.Text)
 }
 
 func TestEntry_UndoRedoImage(t *testing.T) {

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -160,9 +160,13 @@ func (t *RichText) charMinSize(concealed bool, style fyne.TextStyle, textSize fl
 }
 
 // deleteFromTo removes the text between the specified positions
-func (t *RichText) deleteFromTo(lowBound int, highBound int) string {
+func (t *RichText) deleteFromTo(lowBound int, highBound int) []rune {
+	if lowBound >= highBound {
+		return []rune{}
+	}
+
 	start := 0
-	var ret []rune
+	ret := make([]rune, 0, highBound-lowBound)
 	deleting := false
 	var segs []RichTextSegment
 	for i, seg := range t.Segments {
@@ -181,10 +185,8 @@ func (t *RichText) deleteFromTo(lowBound int, highBound int) string {
 
 		startOff := int(math.Max(float64(lowBound-start), 0))
 		endOff := int(math.Min(float64(end), float64(highBound))) - start
-		deleted := make([]rune, endOff-startOff)
 		r := ([]rune)(seg.(*TextSegment).Text)
-		copy(deleted, r[startOff:endOff])
-		ret = append(ret, deleted...)
+		ret = append(ret, r[startOff:endOff]...)
 		r2 := append(r[:startOff], r[endOff:]...)
 		seg.(*TextSegment).Text = string(r2)
 		segs = append(segs, seg)
@@ -200,7 +202,7 @@ func (t *RichText) deleteFromTo(lowBound int, highBound int) string {
 	}
 	t.Segments = segs
 	t.Refresh()
-	return string(ret)
+	return ret
 }
 
 // cachedSegmentVisual returns a cached segment visual representation.
@@ -251,7 +253,7 @@ func (t *RichText) cleanVisualCache() {
 }
 
 // insertAt inserts the text at the specified position
-func (t *RichText) insertAt(pos int, runes string) {
+func (t *RichText) insertAt(pos int, runes []rune) {
 	index := 0
 	start := 0
 	var into *TextSegment
@@ -276,7 +278,7 @@ func (t *RichText) insertAt(pos int, runes string) {
 	if pos > len(r) { // safety in case position is out of bounds for the segment
 		pos = len(r)
 	}
-	r2 := append(r[:pos], append([]rune(runes), r[pos:]...)...)
+	r2 := append(r[:pos], append(runes, r[pos:]...)...)
 	into.Text = string(r2)
 	t.Segments[index] = into
 }

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -178,7 +178,7 @@ func TestText_InsertAt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			text := NewRichTextWithText(tt.fields.buffer)
-			text.insertAt(tt.args.pos, tt.args.runes)
+			text.insertAt(tt.args.pos, []rune(tt.args.runes))
 			assert.Equal(t, tt.wantBuffer, text.String())
 		})
 	}
@@ -186,11 +186,11 @@ func TestText_InsertAt(t *testing.T) {
 
 func TestText_Insert(t *testing.T) {
 	text := NewRichTextWithText("")
-	text.insertAt(0, "a")
+	text.insertAt(0, []rune("a"))
 	assert.Equal(t, "a", text.String())
-	text.insertAt(1, "\n")
+	text.insertAt(1, []rune("\n"))
 	assert.Equal(t, "a\n", text.String())
-	text.insertAt(2, "b")
+	text.insertAt(2, []rune("b"))
 	assert.Equal(t, "a\nb", text.String())
 }
 
@@ -244,7 +244,7 @@ func TestText_DeleteFromTo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			text := NewRichTextWithText(tt.fields.buffer)
 			got := text.deleteFromTo(tt.args.lowBound, tt.args.highBound)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, string(got))
 			assert.Equal(t, tt.wantBuffer, text.String())
 		})
 	}
@@ -332,7 +332,7 @@ func TestText_DeleteFromTo_Segments(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			text := NewRichText(tt.segments...)
 			got := text.deleteFromTo(tt.args.lowBound, tt.args.highBound)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, string(got))
 			for _, s := range tt.wantSegments {
 				if txt, ok := s.(*TextSegment); ok {
 					txt.parent = text


### PR DESCRIPTION
### Description:
The position in entry is the index in a rune slice. But the implementation of the undo/redo use it as an index in a string. This works for runes that are 1 byte long. But It was broken for longer runes.

I fixed the implementation of undo/redo to index a rune slices instead of the string directly

Fixes #5001

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

