### PR TITLE
Use app ID from metadata where present in go build/run

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -112,7 +112,10 @@ func (a *fyneApp) newDefaultPreferences() *preferences {
 // New returns a new application instance with the default driver and no unique ID (unless specified in FyneApp.toml)
 func New() fyne.App {
 	if meta.ID == "" {
-		internal.LogHint("Applications should be created with a unique ID using app.NewWithID()")
+		checkLocalMetadata() // if no ID passed, check if it was in toml
+		if meta.ID == "" {
+			internal.LogHint("Applications should be created with a unique ID using app.NewWithID()")
+		}
 	}
 	return NewWithID(meta.ID)
 }


### PR DESCRIPTION
When `app.New()` was used with FyneApp.toml the `meta.ID` was not set when only using `go run` but was OK with `fyne package`

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
