### PR TITLE
Bugfix finding closest supported language with app translations.

### DIFF
--- a/app/app_gl.go
+++ b/app/app_gl.go
@@ -4,13 +4,11 @@ package app
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/internal/driver/glfw"
 )
 
 // NewWithID returns a new app instance using the appropriate runtime driver.
 // The ID string should be globally unique to this app.
 func NewWithID(id string) fyne.App {
-	lang.SetLocalizer()
 	return newAppWithDriver(glfw.NewGLDriver(), id)
 }

--- a/app/app_gl.go
+++ b/app/app_gl.go
@@ -4,11 +4,13 @@ package app
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/internal/driver/glfw"
 )
 
 // NewWithID returns a new app instance using the appropriate runtime driver.
 // The ID string should be globally unique to this app.
 func NewWithID(id string) fyne.App {
+	lang.SetLocalizer()
 	return newAppWithDriver(glfw.NewGLDriver(), id)
 }

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -155,7 +155,10 @@ func AddTranslationsFS(fs embed.FS, dir string) (retErr error) {
 	return retErr
 }
 
-func setLocalizer() {
+func addLanguage(data []byte, name string) error {
+	f, err := bundle.ParseMessageFileBytes(data, name)
+	translated = append(translated, f.Tag)
+
 	// Find the closest translation from the user's locale list and set it up
 	all, err := locale.GetLocales()
 	if err != nil {
@@ -165,12 +168,7 @@ func setLocalizer() {
 	str := closestSupportedLocale(all).LanguageString()
 	setupLang(str)
 	localizer = i18n.NewLocalizer(bundle, str)
-}
 
-func addLanguage(data []byte, name string) error {
-	f, err := bundle.ParseMessageFileBytes(data, name)
-	translated = append(translated, f.Tag)
-	setLocalizer()
 	return err
 }
 

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -155,9 +155,22 @@ func AddTranslationsFS(fs embed.FS, dir string) (retErr error) {
 	return retErr
 }
 
+func setLocalizer() {
+	// Find the closest translation from the user's locale list and set it up
+	all, err := locale.GetLocales()
+	if err != nil {
+		fyne.LogError("Failed to load user locales", err)
+		all = []string{"en"}
+	}
+	str := closestSupportedLocale(all).LanguageString()
+	setupLang(str)
+	localizer = i18n.NewLocalizer(bundle, str)
+}
+
 func addLanguage(data []byte, name string) error {
 	f, err := bundle.ParseMessageFileBytes(data, name)
 	translated = append(translated, f.Tag)
+	setLocalizer()
 	return err
 }
 
@@ -169,18 +182,6 @@ func init() {
 	if err != nil {
 		fyne.LogError("Error occurred loading built-in translations", err)
 	}
-}
-
-func SetLocalizer() {
-	// Find the closest translation from the user's locale list and set it up
-	all, err := locale.GetLocales()
-	if err != nil {
-		fyne.LogError("Failed to load user locales", err)
-		all = []string{"en"}
-	}
-	str := closestSupportedLocale(all).LanguageString()
-	setupLang(str)
-	localizer = i18n.NewLocalizer(bundle, str)
 }
 
 func fallbackWithData(key, fallback string, data any) string {

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -169,7 +169,9 @@ func init() {
 	if err != nil {
 		fyne.LogError("Error occurred loading built-in translations", err)
 	}
+}
 
+func SetLocalizer() {
 	// Find the closest translation from the user's locale list and set it up
 	all, err := locale.GetLocales()
 	if err != nil {


### PR DESCRIPTION
### Description:
Finding the closest matching language only considers Fyne language files and Application language files are ignored.
This prevents it from using app translations other than these included in Fyne.

Fixes https://github.com/fyne-io/fyne/issues/5015

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
