### PR TITLE
Fix OS theme variant detection for Linux XDG

### DIFF
--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rymdport/portal/notification"
 	"github.com/rymdport/portal/openuri"
 	portalSettings "github.com/rymdport/portal/settings"
-	"github.com/rymdport/portal/settings/appearance"
 
 	"fyne.io/fyne/v2"
 	internalapp "fyne.io/fyne/v2/internal/app"
@@ -37,15 +36,38 @@ func (a *fyneApp) OpenURL(url *url.URL) error {
 
 // fetch color variant from dbus portal desktop settings.
 func findFreedesktopColorScheme() fyne.ThemeVariant {
-	colourScheme, err := appearance.GetColorScheme()
+	dbusConn, err := dbus.SessionBus()
 	if err != nil {
+		fyne.LogError("Unable to connect to session D-Bus", err)
 		return theme.VariantDark
 	}
 
-	switch colourScheme {
-	case appearance.Light:
+	dbusObj := dbusConn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+	call := dbusObj.Call(
+		"org.freedesktop.portal.Settings.Read",
+		dbus.FlagNoAutoStart,
+		"org.freedesktop.appearance",
+		"color-scheme",
+	)
+	if call.Err != nil {
+		// many desktops don't have this exported yet
+		return theme.VariantDark
+	}
+
+	var value uint8
+	if err = call.Store(&value); err != nil {
+		fyne.LogError("failed to read theme variant from D-Bus", err)
+		return theme.VariantDark
+	}
+
+	// See: https://github.com/flatpak/xdg-desktop-portal/blob/1.16.0/data/org.freedesktop.impl.portal.Settings.xml#L32-L46
+	// 0: No preference
+	// 1: Prefer dark appearance
+	// 2: Prefer light appearance
+	switch value {
+	case 2:
 		return theme.VariantLight
-	case appearance.Dark:
+	case 1:
 		return theme.VariantDark
 	default:
 		// Default to light theme to support Gnome's default see https://github.com/fyne-io/fyne/pull/3561
@@ -119,6 +141,8 @@ func watchTheme() {
 	go func() {
 		// with portal this may not be immediate, so we update a cache instead
 		internalapp.CurrentVariant.Store(uint64(findFreedesktopColorScheme()))
+		// ensure initial variant setting is applied at startup
+		fyne.CurrentApp().Settings().(*settings).setupTheme()
 
 		portalSettings.OnSignalSettingChanged(func(changed portalSettings.Changed) {
 			if changed.Namespace == "org.freedesktop.appearance" && changed.Key == "color-scheme" {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

The theme variant detection from rymdport/portal appears to be broken - until the issue can be resolved there we can switch back to the working XDG variant detection code from 2.4.x. Also fix a missed setupTheme() call to get the app to theme correctly to the detected variant at startup.

Fixes #5029 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
