### PR TITLE
Fix Typos: it's -> its

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1327,7 +1327,7 @@ The import path is now `fyne.io/fyne/v2` when you are ready to make the update.
 * Don't add a button bar to a form if it has no buttons
 * Moved driver/gl package to internal/driver/gl
 * Clicking/Tapping in an entry will position the cursor
-* A container with no layout will not change the position or size of it's content
+* A container with no layout will not change the position or size of its content
 * Update the fyne_demo app to reflect the expanding feature set
 
 ### Fixed

--- a/cmd/fyne/internal/mobile/README.txt
+++ b/cmd/fyne/internal/mobile/README.txt
@@ -1,6 +1,6 @@
 This directory is a partial clone of the golang.org/x/mobile/cmd/gomobile package.
 It also includes the golang.org/x/mobile/internal/bindata as a subpackage.
 
-The full project, it's license and command line tools can be found at https://github.com/golang/mobile
+The full project, its license and command line tools can be found at https://github.com/golang/mobile
 
 This package is for the purpose of removing a runtime dependency and will be removed in due course.

--- a/cmd/fyne/internal/mobile/binres/binres.go
+++ b/cmd/fyne/internal/mobile/binres/binres.go
@@ -686,7 +686,7 @@ func addAttributeNamespace(attr xml.Attr, nattr *Attribute, tbl *Table, pool *Po
 				return fmt.Errorf("invalid bool value %q", attr.Value)
 			}
 		case DataIntDec, DataFloat, DataFraction:
-			// TODO DataFraction needs it's own case statement. minSdkVersion identifies as DataFraction
+			// TODO DataFraction needs its own case statement. minSdkVersion identifies as DataFraction
 			// but has accepted input in the past such as android:minSdkVersion="L"
 			// Other use-cases for DataFraction are currently unknown as applicable to manifest generation
 			// but this provides minimum support for writing out minSdkVersion="15" correctly.
@@ -851,7 +851,7 @@ func (bx *XML) kind(t ResType) (unmarshaler, error) {
 	}
 }
 
-// MarshalBinary formats the XML in memory to it's text appearance
+// MarshalBinary formats the XML in memory to its text appearance
 func (bx *XML) MarshalBinary() ([]byte, error) {
 	bx.typ = ResXML
 	bx.headerByteSize = 8

--- a/cmd/fyne/internal/mobile/doc.go
+++ b/cmd/fyne/internal/mobile/doc.go
@@ -6,7 +6,7 @@
 Package mobile is a partial clone of the golang.org/x/mobile/cmd/gomobile package.
 It also includes the golang.org/x/mobile/internal/bindata as a subpackage.
 
-The full project, it's license and command line tools can be found at https://github.com/golang/mobile
+The full project, its license and command line tools can be found at https://github.com/golang/mobile
 
 This package is for the purpose of removing a runtime dependency and will be removed in due course.
 */

--- a/cmd/fyne_demo/tutorials/data.go
+++ b/cmd/fyne_demo/tutorials/data.go
@@ -61,7 +61,7 @@ var (
 			makeSplitTab,
 		},
 		"scroll": {"Scroll",
-			"A container that provides scrolling for it's content.",
+			"A container that provides scrolling for its content.",
 			makeScrollTab,
 		},
 		"innerwindow": {"InnerWindow",

--- a/container.go
+++ b/container.go
@@ -109,7 +109,7 @@ func (c *Container) Position() Position {
 	return c.position
 }
 
-// Refresh causes this object to be redrawn in it's current state
+// Refresh causes this object to be redrawn in its current state
 func (c *Container) Refresh() {
 	c.layout()
 

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -245,7 +245,7 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 			f.breadcrumbScroll, f.filesScroll,
 		),
 	)
-	body.SetOffset(0) // Set the minimum offset so that the favoritesList takes only it's minimal width
+	body.SetOffset(0) // Set the minimum offset so that the favoritesList takes only its minimal width
 
 	return container.NewBorder(header, footer, nil, nil, body)
 }

--- a/internal/clip.go
+++ b/internal/clip.go
@@ -28,7 +28,7 @@ func (c *ClipStack) Length() int {
 }
 
 // Push a new clip onto this stack at position and size specified.
-// The returned clip item is the result of calculating the intersection of the requested clip and it's parent.
+// The returned clip item is the result of calculating the intersection of the requested clip and its parent.
 func (c *ClipStack) Push(p fyne.Position, s fyne.Size) *ClipItem {
 	outer := c.Top()
 	inner := outer.Intersect(p, s)

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -53,7 +53,7 @@ func (w *window) screenSize(canvasSize fyne.Size) (int, int) {
 }
 
 func (w *window) Resize(size fyne.Size) {
-	// we cannot perform this until window is prepared as we don't know it's scale!
+	// we cannot perform this until window is prepared as we don't know its scale!
 	bigEnough := size.Max(w.canvas.canvasSize(w.canvas.Content().MinSize()))
 	w.runOnMainWhenCreated(func() {
 		w.viewLock.Lock()

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -183,7 +183,7 @@ func (r *FileRepository) Parent(u fyne.URI) (fyne.URI, error) {
 		parent += "/"
 	}
 
-	// only root is it's own parent
+	// only root is its own parent
 	if filepath.Clean(parent) == filepath.Clean(s) {
 		return nil, repository.ErrURIRoot
 	}

--- a/internal/repository/memory.go
+++ b/internal/repository/memory.go
@@ -39,7 +39,7 @@ type nodeReaderWriter struct {
 // "virtual repository". In future, we may consider moving this into the public
 // API.
 //
-// Because of it's design, this repository has several quirks:
+// Because of its design, this repository has several quirks:
 //
 // * The Parent() of a path that exists does not necessarily exist
 //

--- a/storage/repository/generic.go
+++ b/storage/repository/generic.go
@@ -23,7 +23,7 @@ func splitNonEmpty(str, sep string) []string {
 // HierarchicalRepository.Parent(). It will create a parent URI based on
 // IETF RFC3986.
 //
-// In short, the URI is separated into it's component parts, the path component
+// In short, the URI is separated into its component parts, the path component
 // is split along instances of '/', and the trailing element is removed. The
 // result is concatenated and parsed as a new URI.
 //
@@ -63,13 +63,13 @@ func GenericParent(u fyne.URI) (fyne.URI, error) {
 
 	// NOTE: we specifically want to use ParseURI, rather than &uri{},
 	// since the repository for the URI we just created might be a
-	// CustomURIRepository that implements it's own ParseURI.
+	// CustomURIRepository that implements its own ParseURI.
 	return ParseURI(newURI)
 }
 
 // GenericChild can be used as a common-case implementation of
 // HierarchicalRepository.Child(). It will create a child URI by separating the
-// URI into it's component parts as described in IETF RFC 3986, then appending
+// URI into its component parts as described in IETF RFC 3986, then appending
 // "/" + component to the path, then concatenating the result and parsing it as
 // a new URI.
 //
@@ -97,7 +97,7 @@ func GenericChild(u fyne.URI, component string) (fyne.URI, error) {
 
 	// NOTE: we specifically want to use ParseURI, rather than &uri{},
 	// since the repository for the URI we just created might be a
-	// CustomURIRepository that implements it's own ParseURI.
+	// CustomURIRepository that implements its own ParseURI.
 	return ParseURI(newURI)
 }
 

--- a/storage/uri.go
+++ b/storage/uri.go
@@ -494,7 +494,7 @@ func List(u fyne.URI) ([]fyne.URI, error) {
 // Storage repositories which support listing, but not creation of listable
 // objects may return repository.ErrOperationNotSupported.
 //
-// CreateListable should generally fail if the parent of it's operand does not
+// CreateListable should generally fail if the parent of its operand does not
 // exist, however this can vary by the implementation details of the specific
 // storage repository. In filesystem terms, this function is "mkdir" not "mkdir
 // -p".

--- a/tools/playground/playground.go
+++ b/tools/playground/playground.go
@@ -31,7 +31,7 @@ func RenderCanvas(c fyne.Canvas) {
 	imageToPlayground(software.RenderCanvas(c, test.DarkTheme(theme.DefaultTheme())))
 }
 
-// RenderWindow takes a window and converts it's canvas into an inline image for showing in the playground
+// RenderWindow takes a window and converts its canvas into an inline image for showing in the playground
 func RenderWindow(w fyne.Window) {
 	RenderCanvas(w.Canvas())
 }

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -289,7 +289,7 @@ func (t *TextGrid) SetStyleRange(startRow, startCol, endRow, endCol int, style T
 	}
 }
 
-// CreateRenderer is a private method to Fyne which links this widget to it's renderer
+// CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *TextGrid) CreateRenderer() fyne.WidgetRenderer {
 	t.ExtendBaseWidget(t)
 	render := &textGridRenderer{text: t}

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -122,7 +122,7 @@ func (w *BaseWidget) Hide() {
 	canvas.Refresh(impl)
 }
 
-// Refresh causes this widget to be redrawn in it's current state
+// Refresh causes this widget to be redrawn in its current state
 func (w *BaseWidget) Refresh() {
 	impl := w.super()
 	if impl == nil {


### PR DESCRIPTION
### Description:

I've fixed all the spelling errors of incorrectly writing "it's" when it should be "its".

### Checklist:

- Tests not needed.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
