### PR TITLE
Read double click delay time from OS

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"time"
 
 	"github.com/fyne-io/image/ico"
 
@@ -35,8 +34,6 @@ var _ fyne.Driver = (*gLDriver)(nil)
 
 // A workaround on Apple M1/M2, just use 1 thread until fixed upstream.
 const drawOnMainThread bool = runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
-
-const doubleTapDelay = 300 * time.Millisecond
 
 type gLDriver struct {
 	windowLock   sync.RWMutex
@@ -171,10 +168,6 @@ func (d *gLDriver) Run() {
 	l := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle)
 	l.WaitForEvents()
 	l.DestroyEventQueue()
-}
-
-func (d *gLDriver) DoubleTapDelay() time.Duration {
-	return doubleTapDelay
 }
 
 func (d *gLDriver) SetDisableScreenBlanking(disable bool) {

--- a/internal/driver/glfw/driver_darwin.go
+++ b/internal/driver/glfw/driver_darwin.go
@@ -1,12 +1,21 @@
+//go:build darwin
+
 package glfw
 
 /*
 #import <stdbool.h>
 
 void setDisableDisplaySleep(bool);
+double doubleClickInterval();
 */
 import "C"
+import "time"
 
 func setDisableScreenBlank(disable bool) {
 	C.setDisableDisplaySleep(C.bool(disable))
+}
+
+func (g *gLDriver) DoubleTapDelay() time.Duration {
+	millis := int64(float64(C.doubleClickInterval()) * 1000)
+	return time.Duration(millis) * time.Millisecond
 }

--- a/internal/driver/glfw/driver_darwin.m
+++ b/internal/driver/glfw/driver_darwin.m
@@ -28,6 +28,7 @@ void setDisableDisplaySleep(BOOL disable) {
     }
 }
 
+// https://developer.apple.com/documentation/appkit/nsevent/1528384-doubleclickinterval?language=objc
 double doubleClickInterval() {
     return [NSEvent doubleClickInterval];
 }

--- a/internal/driver/glfw/driver_darwin.m
+++ b/internal/driver/glfw/driver_darwin.m
@@ -1,3 +1,6 @@
+//go:build darwin
+
+#import <AppKit/NSEvent.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
 
 IOPMAssertionID currentDisableID;
@@ -23,4 +26,8 @@ void setDisableDisplaySleep(BOOL disable) {
     if (success == kIOReturnSuccess) {
         currentDisableID = assertionID;
     }
+}
+
+double doubleClickInterval() {
+    return [NSEvent doubleClickInterval];
 }

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"time"
 
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/painter"
@@ -20,6 +21,8 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
 )
+
+const desktopDefaultDoubleTapDelay = 300 * time.Millisecond
 
 var (
 	systrayIcon fyne.Resource

--- a/internal/driver/glfw/driver_web.go
+++ b/internal/driver/glfw/driver_web.go
@@ -8,6 +8,8 @@ import (
 	"fyne.io/fyne/v2"
 )
 
+const webDefaultDoubleTapDelay = 300 * time.Millisecond
+
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 	// no-op for mobile apps using this driver
 }
@@ -20,5 +22,5 @@ func setDisableScreenBlank(disable bool) {
 }
 
 func (g *gLDriver) DoubleTapDelay() time.Duration {
-	return 300 * time.Millisecond
+	return webDefaultDoubleTapDelay
 }

--- a/internal/driver/glfw/driver_web.go
+++ b/internal/driver/glfw/driver_web.go
@@ -2,7 +2,11 @@
 
 package glfw
 
-import "fyne.io/fyne/v2"
+import (
+	"time"
+
+	"fyne.io/fyne/v2"
+)
 
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 	// no-op for mobile apps using this driver
@@ -13,4 +17,8 @@ func (d *gLDriver) catchTerm() {
 
 func setDisableScreenBlank(disable bool) {
 	// awaiting complete support for WakeLock
+}
+
+func (g *gLDriver) DoubleTapDelay() time.Duration {
+	return 300 * time.Millisecond
 }

--- a/internal/driver/glfw/driver_windows.go
+++ b/internal/driver/glfw/driver_windows.go
@@ -71,6 +71,7 @@ func setDisableScreenBlank(disable bool) {
 const defaultDoubleTapDelay = 300 * time.Millisecond
 
 func (g *gLDriver) DoubleTapDelay() time.Duration {
+	// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdoubleclicktime
 	user32 := syscall.NewLazyDLL("user32.dll")
 	if user32 == nil {
 		return defaultDoubleTapDelay

--- a/internal/driver/glfw/driver_windows.go
+++ b/internal/driver/glfw/driver_windows.go
@@ -21,6 +21,15 @@ const (
 	ES_DISPLAY_REQUIRED ES = 0x00000002
 )
 
+var (
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+	user32   = syscall.NewLazyDLL("user32.dll")
+
+	executionState     = kernel32.NewProc("SetThreadExecutionState")
+	MessageBox         = user32.NewProc("MessageBoxW")
+	getDoubleClickTime = user32.NewProc("GetDoubleClickTime")
+)
+
 func toNativePtr(s string) *uint16 {
 	pstr, err := syscall.UTF16PtrFromString(s)
 	if err != nil {
@@ -31,8 +40,6 @@ func toNativePtr(s string) *uint16 {
 
 // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-messageboxw
 func messageBoxError(text, caption string) {
-	user32 := syscall.NewLazyDLL("user32.dll")
-	MessageBox := user32.NewProc("MessageBoxW")
 
 	uType := MB_OK | MB_ICONERROR
 
@@ -57,9 +64,6 @@ func logError(msg string, err error) {
 }
 
 func setDisableScreenBlank(disable bool) {
-	kernel32 := syscall.NewLazyDLL("kernel32.dll")
-	executionState := kernel32.NewProc("SetThreadExecutionState")
-
 	uType := ES_CONTINUOUS
 	if disable {
 		uType |= ES_DISPLAY_REQUIRED
@@ -72,11 +76,6 @@ const defaultDoubleTapDelay = 300 * time.Millisecond
 
 func (g *gLDriver) DoubleTapDelay() time.Duration {
 	// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdoubleclicktime
-	user32 := syscall.NewLazyDLL("user32.dll")
-	if user32 == nil {
-		return defaultDoubleTapDelay
-	}
-	getDoubleClickTime := user32.NewProc("GetDoubleClickTime")
 	if getDoubleClickTime == nil {
 		return defaultDoubleTapDelay
 	}

--- a/internal/driver/glfw/driver_windows.go
+++ b/internal/driver/glfw/driver_windows.go
@@ -72,12 +72,10 @@ func setDisableScreenBlank(disable bool) {
 	syscall.Syscall(executionState.Addr(), 1, uintptr(uType), 0, 0)
 }
 
-const defaultDoubleTapDelay = 300 * time.Millisecond
-
 func (g *gLDriver) DoubleTapDelay() time.Duration {
 	// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdoubleclicktime
 	if getDoubleClickTime == nil {
-		return defaultDoubleTapDelay
+		return desktopDefaultDoubleTapDelay
 	}
 	r1, _, _ := syscall.Syscall(getDoubleClickTime.Addr(), 0, 0, 0, 0)
 	return time.Duration(uint64(r1) * uint64(time.Millisecond))

--- a/internal/driver/glfw/driver_xdg.go
+++ b/internal/driver/glfw/driver_xdg.go
@@ -46,5 +46,5 @@ func setDisableScreenBlank(disable bool) {
 }
 
 func (g *gLDriver) DoubleTapDelay() time.Duration {
-	return 300 * time.Millisecond
+	return desktopDefaultDoubleTapDelay
 }

--- a/internal/driver/glfw/driver_xdg.go
+++ b/internal/driver/glfw/driver_xdg.go
@@ -4,6 +4,8 @@ package glfw
 
 import "C"
 import (
+	"time"
+
 	"github.com/godbus/dbus/v5"
 
 	"fyne.io/fyne/v2"
@@ -41,4 +43,8 @@ func setDisableScreenBlank(disable bool) {
 	} else {
 		fyne.LogError("Failed to send message to bus", call.Err)
 	}
+}
+
+func (g *gLDriver) DoubleTapDelay() time.Duration {
+	return 300 * time.Millisecond
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -653,7 +653,7 @@ func (w *window) mouseClickedHandleTapDoubleTap(co fyne.CanvasObject, ev *fyne.P
 func (w *window) waitForDoubleTap(co fyne.CanvasObject, ev *fyne.PointEvent) {
 	var ctx context.Context
 	w.mouseLock.Lock()
-	ctx, w.mouseCancelFunc = context.WithDeadline(context.TODO(), time.Now().Add(doubleTapDelay))
+	ctx, w.mouseCancelFunc = context.WithDeadline(context.TODO(), time.Now().Add(w.driver.DoubleTapDelay()))
 	defer w.mouseCancelFunc()
 	w.mouseLock.Unlock()
 


### PR DESCRIPTION
### Description:
On Mac and Windows, use OS APIs to read the system double click interval

Fixes #4448 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- tested manually on Mac and Windows
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.