### PR TITLE
Auto-capitalize error messages in dialog.NewError

### DIFF
--- a/dialog/information.go
+++ b/dialog/information.go
@@ -1,6 +1,9 @@
 package dialog
 
 import (
+	"unicode"
+	"unicode/utf8"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/lang"
@@ -35,7 +38,12 @@ func ShowInformation(title, message string, parent fyne.Window) {
 // The message is extracted from the provided error (should not be nil).
 // After creation you should call Show().
 func NewError(err error, parent fyne.Window) Dialog {
-	return createInformationDialog(lang.L("Error"), err.Error(), theme.ErrorIcon(), parent)
+	dialogText := err.Error()
+	r, size := utf8.DecodeRuneInString(dialogText)
+	if r != utf8.RuneError {
+		dialogText = string(unicode.ToUpper(r)) + dialogText[size:]
+	}
+	return createInformationDialog(lang.L("Error"), dialogText, theme.ErrorIcon(), parent)
 }
 
 // ShowError shows a dialog over the specified window for an application error.

--- a/dialog/information_test.go
+++ b/dialog/information_test.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,4 +109,21 @@ func TestDialog_ErrorCallback(t *testing.T) {
 	test.Tap(information.dismiss)
 	assert.True(t, tapped)
 	assert.True(t, information.win.Hidden)
+}
+
+func TestDialog_ErrorCapitalize(t *testing.T) {
+	err := errors.New("here is an error msg")
+	d := NewError(err, test.NewTempWindow(t, nil))
+	assert.Equal(t, d.(*dialog).content.(*widget.Label).Text,
+		"Here is an error msg")
+
+	err = errors.New("這是一條錯誤訊息")
+	d = NewError(err, test.NewTempWindow(t, nil))
+	assert.Equal(t, d.(*dialog).content.(*widget.Label).Text,
+		"這是一條錯誤訊息")
+
+	err = errors.New("")
+	d = NewError(err, test.NewTempWindow(t, nil))
+	assert.Equal(t, d.(*dialog).content.(*widget.Label).Text,
+		"")
 }


### PR DESCRIPTION
### Description:

Fixes #4876 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

