### PR TITLE
Ensure list.Resize only refreshes newly visible items

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -198,7 +198,7 @@ func (l *List) Resize(s fyne.Size) {
 	}
 
 	l.offsetUpdated(l.scroller.Offset)
-	l.scroller.Content.(*fyne.Container).Layout.(*listLayout).updateList(false)
+	l.scroller.Content.(*fyne.Container).Layout.(*listLayout).updateList(true)
 }
 
 // Select add the item identified by the given ID to the selection.

--- a/widget/list_internal_test.go
+++ b/widget/list_internal_test.go
@@ -624,11 +624,11 @@ func TestList_LimitUpdateItem(t *testing.T) {
 	)
 	w.SetContent(list)
 	w.ShowAndRun()
-	assert.Equal(t, "0.1.0.1.", printOut)
+	assert.Equal(t, "0.1.", printOut)
 	list.scrollTo(1)
-	assert.Equal(t, "0.1.0.1.2.", printOut)
+	assert.Equal(t, "0.1.2.", printOut)
 	list.scrollTo(2)
-	assert.Equal(t, "0.1.0.1.2.3.", printOut)
+	assert.Equal(t, "0.1.2.3.", printOut)
 }
 
 func TestList_RefreshUpdatesAllItems(t *testing.T) {


### PR DESCRIPTION
Ensure resizing a list only refreshes rows that were previously not visible

### Description:

Fixes #4080 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

