### PR TITLE
If canvas cannot be located assume HiDPI

### DIFF
--- a/canvas/image.go
+++ b/canvas/image.go
@@ -353,6 +353,9 @@ func (i *Image) renderSVG(width, height float32) (image.Image, error) {
 	if c != nil {
 		// We want real output pixel count not just the screen coordinate space (i.e. macOS Retina)
 		screenWidth, screenHeight = c.PixelCoordinateForPosition(fyne.Position{X: width, Y: height})
+	} else { // no canvas info, assume HiDPI
+		screenWidth *= 2
+		screenHeight *= 2
 	}
 
 	tex := cache.GetSvg(i.name(), i, screenWidth, screenHeight)


### PR DESCRIPTION
This is a better default for most modern systems.
Could be useful pre-attach to context or if using a software canvas mixed with OpenGL

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
