### PR TITLE
Fall back to old Gnome interface when FreeDesktop Appearance fails

### DIFF
--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -121,7 +121,7 @@ func watchTheme() {
 		internalapp.CurrentVariant.Store(uint64(findFreedesktopColorScheme()))
 
 		portalSettings.OnSignalSettingChanged(func(changed portalSettings.Changed) {
-			if changed.Namespace == "org.freedesktop.appearance" && changed.Key == "color-scheme" {
+			if (changed.Namespace == "org.gnome.desktop.interface" || changed.Namespace == "org.freedesktop.appearance") && changed.Key == "color-scheme" {
 				internalapp.CurrentVariant.Store(uint64(findFreedesktopColorScheme()))
 				fyne.CurrentApp().Settings().(*settings).setupTheme()
 			}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nicksnyder/go-i18n/v2 v2.4.0
-	github.com/rymdport/portal v0.2.2
+	github.com/rymdport/portal v0.2.4
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/rymdport/portal v0.2.2 h1:P2Q/4k673zxdFAsbD8EESZ7psfuO6/4jNu6EDrDICkM=
 github.com/rymdport/portal v0.2.2/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
+github.com/rymdport/portal v0.2.4 h1:GPffdxzl38M/0z2m5d4aEetm9GHH0GHaRRUXzBPuV+4=
+github.com/rymdport/portal v0.2.4/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Should hopefully fix theme lookup on Ubuntu 22.04 and other Linux distros using too old Gnome versions.

Fixes #5029
Replaces #5030

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.