### PR TITLE
Don't use custom scroll acceleration on MacOS

### DIFF
--- a/internal/driver/glfw/scroll_speed_darwin.go
+++ b/internal/driver/glfw/scroll_speed_darwin.go
@@ -3,7 +3,9 @@
 package glfw
 
 const (
-	scrollAccelerateRate   = float64(5)
+	// MacOS applies its own scroll accelerate curve, so set
+	// scrollAccelerateRate to 1 for no acceleration effect
+	scrollAccelerateRate   = float64(1)
 	scrollAccelerateCutoff = float64(5)
 	scrollSpeed            = float32(10)
 )


### PR DESCRIPTION
### Description:
On MacOS, the OS applies a scroll acceleration curve automatically. Applying one of our own, on top of the OS curve, results in "jumpy" scrolling that is too fast and disconcerting for users

Fixes #5067 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

