### PR TITLE
Add Nameable and Linkable object interfaces with map of contained objects

### DIFF
--- a/container.go
+++ b/container.go
@@ -1,6 +1,12 @@
 package fyne
 
-import "sync"
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+)
 
 // Declare conformity to CanvasObject
 var _ CanvasObject = (*Container)(nil)
@@ -8,13 +14,16 @@ var _ CanvasObject = (*Container)(nil)
 // Container is a CanvasObject that contains a collection of child objects.
 // The layout of the children is set by the specified Layout.
 type Container struct {
-	size     Size     // The current size of the Container
-	position Position // The current position of the Container
-	Hidden   bool     // Is this Container hidden
+	id       string         // The Object Id of the Container,
+	parent   LinkableObject // The parent object, which contains this container
+	size     Size           // The current size of the Container
+	position Position       // The current position of the Container
+	Hidden   bool           // Is this Container hidden
 
-	Layout  Layout // The Layout algorithm for arranging child CanvasObjects
-	lock    sync.Mutex
-	Objects []CanvasObject // The set of CanvasObjects this container holds
+	Layout     Layout // The Layout algorithm for arranging child CanvasObjects
+	lock       sync.Mutex
+	Objects    []CanvasObject            // The set of CanvasObjects this container holds
+	objectsMap map[string]NameableObject // The map of CanvasObjects this container holds (their Id is the key)
 }
 
 // NewContainer returns a new Container instance holding the specified CanvasObjects.
@@ -52,6 +61,49 @@ func NewContainerWithLayout(layout Layout, objects ...CanvasObject) *Container {
 	return ret
 }
 
+// InitObjectMap initializes the internal object map. Usually it should not be called outside of that library
+func (c *Container) InitObjectMap() {
+	c.objectsMap = make(map[string]NameableObject)
+}
+
+// SetId is used to set the object id, then it can be used to retrieve the object from the parent's object map.
+func (c *Container) SetId(id string) error {
+	if c.id != "" {
+		return errors.New("object ID is already set")
+	} else {
+		c.id = id
+		return nil
+	}
+}
+
+// ID is used to get the object id, then it can be used to retrieve the object from the parent's object map.
+func (c *Container) ID() string {
+	if c.id == "" {
+		c.id = fmt.Sprintf("cntr-%d", rand.Intn(math.MaxInt32))
+	}
+	return c.id
+}
+
+// SetParent is used to set the parent object pointer. Should be used by the object where this widget is added to.
+func (c *Container) SetParent(parent LinkableObject) {
+	c.parent = parent
+}
+
+// Parent is used to get the parent object pointer. Can be used to access the parent object and its object map.
+func (c *Container) Parent() LinkableObject {
+	return c.parent
+}
+
+// LinkedObject is used to get a linked object, registered by the Add method, called by its ID.
+func (c *Container) LinkedObject(id string) CanvasObject {
+	var co NameableObject = c.objectsMap[id]
+	if co == nil {
+		return nil
+	} else {
+		return co.(CanvasObject)
+	}
+}
+
 // Add appends the specified object to the items this container manages.
 //
 // Since: 1.4
@@ -63,6 +115,12 @@ func (c *Container) Add(add CanvasObject) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.Objects = append(c.Objects, add)
+	if nObj, compliant := add.(NameableObject); compliant {
+		c.objectsMap[nObj.ID()] = nObj
+	}
+	if lObj, compliant := add.(LinkableObject); compliant {
+		lObj.SetParent(c)
+	}
 	c.layout()
 }
 
@@ -140,6 +198,14 @@ func (c *Container) Remove(rem CanvasObject) {
 			continue
 		}
 
+		if wid, compliant := rem.(NameableObject); compliant {
+			delete(c.objectsMap, wid.ID())
+		}
+
+		if wid, compliant := rem.(LinkableObject); compliant {
+			wid.SetParent(nil)
+		}
+
 		removed := make([]CanvasObject, len(c.Objects)-1)
 		copy(removed, c.Objects[:i])
 		copy(removed[i:], c.Objects[i+1:])
@@ -154,7 +220,10 @@ func (c *Container) Remove(rem CanvasObject) {
 //
 // Since: 2.2
 func (c *Container) RemoveAll() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.Objects = nil
+	clear(c.objectsMap)
 	c.layout()
 }
 

--- a/container/container.go
+++ b/container/container.go
@@ -9,12 +9,18 @@ import (
 //
 // Since: 2.0
 func New(layout fyne.Layout, objects ...fyne.CanvasObject) *fyne.Container {
-	return &fyne.Container{Layout: layout, Objects: objects}
+	var cntr *fyne.Container = new(fyne.Container)
+	cntr.Layout = layout
+	cntr.InitObjectMap()
+	for _, obj := range objects {
+		cntr.Add(obj)
+	}
+	return cntr
 }
 
 // NewWithoutLayout returns a new Container instance holding the specified CanvasObjects that are manually arranged.
 //
 // Since: 2.0
 func NewWithoutLayout(objects ...fyne.CanvasObject) *fyne.Container {
-	return &fyne.Container{Objects: objects}
+	return New(nil, objects...)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module fyne.io/fyne/v2
 
-go 1.19
+go 1.21
 
 require (
 	fyne.io/systray v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
+github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fredbi/uri v1.1.0 h1:OqLpTXtyRg9ABReqvDGdJPqZUxs8cyBDOMXBbskCaB8=
@@ -104,6 +105,7 @@ github.com/go-text/render v0.1.1-0.20240418202334-dd62631dae9b/go.mod h1:jqEuNMe
 github.com/go-text/typesetting v0.1.0 h1:vioSaLPYcHwPEPLT7gsjCGDCoYSbljxoHJzMnKwVvHw=
 github.com/go-text/typesetting v0.1.0/go.mod h1:d22AnmeKq/on0HNv73UFriMKc4Ez6EqZAofLhAzpSzI=
 github.com/go-text/typesetting-utils v0.0.0-20240329101916-eee87fb235a3 h1:levTnuLLUmpavLGbJYLJA7fQnKeS7P1eCdAlM+vReXk=
+github.com/go-text/typesetting-utils v0.0.0-20240329101916-eee87fb235a3/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -169,6 +171,7 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd h1:1FjCyPC+syAzJ5/2S8fqdZK1R22vvA0J7JZKcuOIQ7Y=
+github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -252,6 +255,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
+github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/widget/base.go
+++ b/internal/widget/base.go
@@ -1,6 +1,10 @@
 package widget
 
 import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
 	"sync/atomic"
 
 	"fyne.io/fyne/v2"
@@ -11,6 +15,8 @@ import (
 
 // Base provides a helper that handles basic widget behaviours.
 type Base struct {
+	id       string
+	parent   fyne.LinkableObject
 	hidden   atomic.Bool
 	position async.Position
 	size     async.Size
@@ -25,6 +31,34 @@ func (w *Base) ExtendBaseWidget(wid fyne.Widget) {
 	}
 
 	w.impl.Store(&wid)
+}
+
+// SetId is used to set the object id, then it can be used to retrieve the object from the parent's object map.
+func (w *Base) SetId(id string) error {
+	if w.id != "" {
+		return errors.New("object ID is already set")
+	} else {
+		w.id = id
+		return nil
+	}
+}
+
+// ID is used to get the object id, then it can be used to retrieve the object from the parent's object map.
+func (w *Base) ID() string {
+	if w.id == "" {
+		w.id = fmt.Sprintf("wid-%d", rand.Intn(math.MaxInt32))
+	}
+	return w.id
+}
+
+// SetParent is used to set the parent object pointer. Should be used by the object where this widget is added to.
+func (w *Base) SetParent(parent fyne.LinkableObject) {
+	w.parent = parent
+}
+
+// Parent is used to get the parent object pointer. Can be used to access the parent object and its object map.
+func (w *Base) Parent() fyne.LinkableObject {
+	return w.parent
 }
 
 // Size gets the current size of this widget.

--- a/linkable_object.go
+++ b/linkable_object.go
@@ -1,0 +1,9 @@
+package fyne
+
+type LinkableObject interface {
+	// SetParent is used to set the parent object pointer. Should be used by the object where this widget is added to.
+	SetParent(object LinkableObject)
+
+	// Parent is used to get the parent object pointer. Can be used to access the parent object and its object map.
+	Parent() LinkableObject
+}

--- a/nameable_object.go
+++ b/nameable_object.go
@@ -1,0 +1,10 @@
+package fyne
+
+// NameableObject defines the standard behaviours of any nameable object
+type NameableObject interface {
+	// ID returns the object ID. It can be used to retrieve the object in the parent's object map.
+	ID() string
+
+	// SetId is used to set the object id, then it can be used to retrieve the object from the parent's object map.
+	SetId(string) error
+}

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -2,6 +2,10 @@
 package widget // import "fyne.io/fyne/v2/widget"
 
 import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 
@@ -15,6 +19,8 @@ import (
 
 // BaseWidget provides a helper that handles basic widget behaviours.
 type BaseWidget struct {
+	id       string
+	parent   fyne.LinkableObject
 	size     async.Size
 	position async.Position
 	Hidden   bool
@@ -22,6 +28,34 @@ type BaseWidget struct {
 	impl         atomic.Pointer[fyne.Widget]
 	propertyLock sync.RWMutex
 	themeCache   fyne.Theme
+}
+
+// SetId is used to set the object id, then it can be used to retrieve the object from the parent's object map.
+func (w *BaseWidget) SetId(id string) error {
+	if w.id != "" {
+		return errors.New("object ID is already set")
+	} else {
+		w.id = id
+		return nil
+	}
+}
+
+// ID is used to get the object id, then it can be used to retrieve the object from the parent's object map.
+func (w *BaseWidget) ID() string {
+	if w.id == "" {
+		w.id = fmt.Sprintf("wid-%d", rand.Intn(math.MaxInt32))
+	}
+	return w.id
+}
+
+// SetParent is used to set the parent object pointer. Should be used by the object where this widget is added to.
+func (w *BaseWidget) SetParent(parent fyne.LinkableObject) {
+	w.parent = parent
+}
+
+// Parent is used to get the parent object pointer. Can be used to access the parent object and its object map.
+func (w *BaseWidget) Parent() fyne.LinkableObject {
+	return w.parent
 }
 
 // ExtendBaseWidget is used by an extending widget to make use of BaseWidget functionality.


### PR DESCRIPTION
### Description:

That allows:
 - to reach a parent object from a given object as long as the objects honor the fyne.LinkableObject interface.
 - to set an ID on a given object as long as the object honors the fyne.NameableObject interface.
 - lookup for an object embedded in a container by its ID.

For example, this allows 2 button objects to interact together without having to reference them directly in the button functions. Now you can call the parent object map to get access to an object in the same container. If your target is in another container, you can navigate to it (with the Parent() and LinkedObject() methods).
This could be useful when you add objects to your UI dynamically, especially when these objects should interact together.

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [x] Tests all pass.
