### PR TITLE
Fix an issue where the Tree scroll and content are created twice beca…

### DIFF
--- a/widget/tree.go
+++ b/widget/tree.go
@@ -52,6 +52,7 @@ type Tree struct {
 	offset        fyne.Position
 	open          map[TreeNodeID]bool
 	scroller      *widget.Scroll
+	content       *treeContent
 	selected      []TreeNodeID
 }
 
@@ -65,6 +66,7 @@ type Tree struct {
 func NewTree(childUIDs func(TreeNodeID) []TreeNodeID, isBranch func(TreeNodeID) bool, create func(bool) fyne.CanvasObject, update func(TreeNodeID, bool, fyne.CanvasObject)) *Tree {
 	t := &Tree{ChildUIDs: childUIDs, IsBranch: isBranch, CreateNode: create, UpdateNode: update}
 	t.ExtendBaseWidget(t)
+	t.initContentAndScroll()
 	return t
 }
 
@@ -87,7 +89,6 @@ func NewTreeWithData(data binding.DataTree, createItem func(bool) fyne.CanvasObj
 			}
 			updateItem(item, branch, o)
 		})
-
 	data.AddListener(binding.NewDataListener(t.Refresh))
 	return t
 }
@@ -114,6 +115,7 @@ func NewTreeWithStrings(data map[string][]string) (t *Tree) {
 		},
 	}
 	t.ExtendBaseWidget(t)
+	t.initContentAndScroll()
 	return
 }
 
@@ -139,17 +141,12 @@ func (t *Tree) CloseBranch(uid TreeNodeID) {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
 func (t *Tree) CreateRenderer() fyne.WidgetRenderer {
-	t.ExtendBaseWidget(t)
-	c := newTreeContent(t)
-	s := widget.NewScroll(c)
-	t.scroller = s
 	r := &treeRenderer{
-		BaseRenderer: widget.NewBaseRenderer([]fyne.CanvasObject{s}),
+		BaseRenderer: widget.NewBaseRenderer([]fyne.CanvasObject{t.scroller}),
 		tree:         t,
-		content:      c,
-		scroller:     s,
+		content:      t.content,
+		scroller:     t.scroller,
 	}
-	s.OnScrolled = t.offsetUpdated
 	r.updateMinSizes()
 	r.content.viewport = r.MinSize()
 	return r
@@ -193,7 +190,6 @@ func (t *Tree) FocusLost() {
 
 // MinSize returns the size that this widget should not shrink below.
 func (t *Tree) MinSize() fyne.Size {
-	t.ExtendBaseWidget(t)
 	return t.BaseWidget.MinSize()
 }
 
@@ -311,6 +307,7 @@ func (t *Tree) Select(uid TreeNodeID) {
 		}
 	}
 	t.selected = []TreeNodeID{uid}
+	t.currentFocus = uid
 	t.ScrollTo(uid)
 	if f := t.OnSelected; f != nil {
 		f(uid)
@@ -430,6 +427,12 @@ func (t *Tree) UnselectAll() {
 			f(uid)
 		}
 	}
+}
+
+func (t *Tree) initContentAndScroll() {
+	t.content = newTreeContent(t)
+	t.scroller = widget.NewScroll(t.content)
+	t.scroller.OnScrolled = t.offsetUpdated
 }
 
 func (t *Tree) ensureOpenMap() {


### PR DESCRIPTION
…use the renderer is created twice. Fixes https://github.com/fyne-io/fyne/issues/5093.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
