### PR TITLE
internal/driver/glfw: clean the cache periodically.

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -212,7 +212,7 @@ func (d *gLDriver) repaintWindow(w *window) {
 			w.shouldExpand = true
 			w.viewLock.Unlock()
 		}
-		canvas.FreeDirtyTextures()
+		refresh := canvas.FreeDirtyTextures() > 0
 
 		updateGLContext(w)
 		canvas.paint(canvas.Size())
@@ -225,6 +225,7 @@ func (d *gLDriver) repaintWindow(w *window) {
 		if view != nil && visible {
 			view.SwapBuffers()
 		}
+		cache.Clean(refresh)
 	})
 }
 


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
The cache is supposed to be cleaned periodically, but the glfw driver does not do this as the mobile driver does.

This commit adds similar logic to the glfw driver as exists in the mobile driver, to periodically clean the cache on paint events.

Fixes #4903

### Notes to Reviewers:

I'm calling `cache.Clean` in a similar way to how it's done in the mobile driver: https://github.com/fyne-io/fyne/blob/5fb3d75695de88c5e0898b0af48b863540295684/internal/driver/mobile/driver.go#L280-L293

I don't fully understand what the boolean value passed to clean represents, or if what I'm doing makes sense. I'm just mimicking the code from mobile.

I have not written regression tests for this, as I'm not familiar enough with the code to confidently do so.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

Not all the tests pass on the current `develop` branch, but this PR does not cause new test failures.



