### PR TITLE
Avoid deadlock in button renderer by aquiring read lock twice.

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -393,7 +393,7 @@ func (r *buttonRenderer) padding(th fyne.Theme) fyne.Size {
 
 // must be called with r.button.propertyLock RLocked
 func (r *buttonRenderer) updateIconAndText() {
-	if r.button.Icon != nil && r.button.Visible() {
+	if r.button.Icon != nil && !r.button.Hidden {
 		icon := r.button.Icon
 		if r.icon == nil {
 			r.icon = canvas.NewImageFromResource(icon)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #5114

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
