### PR TITLE
widget.SimpleRenderer: use an array instead of a slice

### DIFF
--- a/internal/widget/simple_renderer.go
+++ b/internal/widget/simple_renderer.go
@@ -9,7 +9,7 @@ var _ fyne.WidgetRenderer = (*SimpleRenderer)(nil)
 //
 // Since: 2.1
 type SimpleRenderer struct {
-	objects []fyne.CanvasObject
+	objects [1]fyne.CanvasObject
 }
 
 // NewSimpleRenderer creates a new SimpleRenderer to render a widget using a
@@ -17,7 +17,7 @@ type SimpleRenderer struct {
 //
 // Since: 2.1
 func NewSimpleRenderer(object fyne.CanvasObject) *SimpleRenderer {
-	return &SimpleRenderer{[]fyne.CanvasObject{object}}
+	return &SimpleRenderer{[1]fyne.CanvasObject{object}}
 }
 
 // Destroy does nothing in this implementation.
@@ -52,7 +52,7 @@ func (r *SimpleRenderer) MinSize() fyne.Size {
 //
 // Since: 2.1
 func (r *SimpleRenderer) Objects() []fyne.CanvasObject {
-	return r.objects
+	return r.objects[:]
 }
 
 // Refresh requests the underlying object to redraw.


### PR DESCRIPTION
### Description:
The widget.SimpleRenderer only renders one object and was using a slice to hold it (24 bytes).
By using a single item array instead, its size comes down to 16 bytes.

### Checklist:

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
