### PR TITLE
widget.Table: show first row/column when navigating with keyboard

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -474,7 +474,6 @@ func (t *Table) ScrollTo(id TableCellID) {
 		cellX -= t.stuckXOff + t.stuckWidth
 	}
 	if t.ShowHeaderColumn {
-		cellX += t.headerSize.Width
 		stickCols--
 	}
 	if stickCols == 0 || id.Col > stickCols {
@@ -491,7 +490,6 @@ func (t *Table) ScrollTo(id TableCellID) {
 		cellY -= t.stuckYOff + t.stuckHeight
 	}
 	if t.ShowHeaderRow {
-		cellY += t.headerSize.Height
 		stickRows--
 	}
 	if stickRows == 0 || id.Row >= stickRows {

--- a/widget/table.go
+++ b/widget/table.go
@@ -370,39 +370,31 @@ func (t *Table) TypedKey(event *fyne.KeyEvent) {
 	case fyne.KeyDown:
 		if f := t.Length; f != nil {
 			rows, _ := f()
-			if t.currentFocus.Row >= rows-1 {
-				return
+			if t.currentFocus.Row+1 < rows {
+				t.currentFocus.Row++
 			}
 		}
-		t.RefreshItem(t.currentFocus)
-		t.currentFocus.Row++
 		t.ScrollTo(t.currentFocus)
 		t.RefreshItem(t.currentFocus)
 	case fyne.KeyLeft:
-		if t.currentFocus.Col <= 0 {
-			return
+		if t.currentFocus.Col > 0 {
+			t.currentFocus.Col--
 		}
-		t.RefreshItem(t.currentFocus)
-		t.currentFocus.Col--
 		t.ScrollTo(t.currentFocus)
 		t.RefreshItem(t.currentFocus)
 	case fyne.KeyRight:
 		if f := t.Length; f != nil {
 			_, cols := f()
-			if t.currentFocus.Col >= cols-1 {
-				return
+			if t.currentFocus.Col+1 < cols {
+				t.currentFocus.Col++
 			}
 		}
-		t.RefreshItem(t.currentFocus)
-		t.currentFocus.Col++
 		t.ScrollTo(t.currentFocus)
 		t.RefreshItem(t.currentFocus)
 	case fyne.KeyUp:
-		if t.currentFocus.Row <= 0 {
-			return
+		if t.currentFocus.Row > 0 {
+			t.currentFocus.Row--
 		}
-		t.RefreshItem(t.currentFocus)
-		t.currentFocus.Row--
 		t.ScrollTo(t.currentFocus)
 		t.RefreshItem(t.currentFocus)
 	}

--- a/widget/table_internal_test.go
+++ b/widget/table_internal_test.go
@@ -477,6 +477,44 @@ func TestTable_ScrollTo(t *testing.T) {
 	}
 }
 
+func TestTable_ScrollToShowHeaders(t *testing.T) {
+	test.NewTempApp(t)
+
+	// for this test the separator thickness is 0
+	test.ApplyTheme(t, &paddingZeroTheme{test.Theme()})
+
+	// we will test a 20 row x 5 column table where each cell is 50x50
+	const (
+		maxRows int     = 20
+		maxCols int     = 5
+		width   float32 = 50
+		height  float32 = 50
+	)
+
+	templ := canvas.NewRectangle(color.Gray16{})
+	templ.SetMinSize(fyne.Size{Width: width, Height: height})
+
+	table := NewTable(
+		func() (int, int) { return maxRows, maxCols },
+		func() fyne.CanvasObject { return templ },
+		func(TableCellID, fyne.CanvasObject) {})
+	table.ShowHeaderRow = true
+	table.ShowHeaderColumn = true
+
+	w := test.NewWindow(table)
+	defer w.Close()
+
+	first := TableCellID{}
+	last := TableCellID{Row: maxRows - 1, Col: maxCols - 1}
+	table.ScrollTo(last)
+	lastPos := fyne.NewPos(float32(last.Col)*width, float32(last.Row)*height)
+	assert.Equal(t, lastPos, table.offset)
+	assert.Equal(t, lastPos, table.content.Offset)
+	table.ScrollTo(first)
+	assert.Equal(t, fyne.Position{}, table.offset)
+	assert.Equal(t, fyne.Position{}, table.content.Offset)
+}
+
 func TestTable_ScrollToBottom(t *testing.T) {
 	test.NewTempApp(t)
 	test.ApplyTheme(t, test.NewTheme())


### PR DESCRIPTION
Fixes #5088.

### Description:

When a Table has its header(s) shown, keyboard navigation fails to show the first row or column
if the list was scrolled. This is because the header size is always added to the offset even when 
the first row/column is reached. Disabling this for the first row or column fixes the issue.

Fixes #5088

### Checklist:

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
