### PR TITLE
test: Add RenderObjectToMarkup and RenderToMarkup functions

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -47,6 +47,19 @@ func AssertObjectRendersToImage(t *testing.T, masterFilename string, o fyne.Canv
 	return AssertRendersToImage(t, masterFilename, c, msgAndArgs...)
 }
 
+// RenderObjectToMarkup renders the given [fyne.io/fyne/v2.CanvasObject] to a markup string.
+//
+// Since: 2.6
+func RenderObjectToMarkup(o fyne.CanvasObject) string {
+	c := NewCanvas()
+	c.SetPadded(false)
+	size := o.MinSize().Max(o.Size())
+	c.SetContent(o)
+	c.Resize(size) // ensure we are large enough for current size
+
+	return snapshot(c)
+}
+
 // AssertObjectRendersToMarkup asserts that the given `CanvasObject` renders the same markup as the one stored in the master file.
 // The master filename is relative to the `testdata` directory which is relative to the test.
 // The test `t` fails if the rendered markup is not equal to the loaded master markup.
@@ -87,6 +100,13 @@ func AssertImageMatches(t *testing.T, masterFilename string, img image.Image, ms
 // Since 2.3
 func AssertRendersToImage(t *testing.T, masterFilename string, c fyne.Canvas, msgAndArgs ...any) bool {
 	return test.AssertImageMatches(t, masterFilename, c.Capture(), msgAndArgs...)
+}
+
+// RenderToMarkup renders the given [fyne.io/fyne/v2.Canvas] to a markup string.
+//
+// Since: 2.6
+func RenderToMarkup(c fyne.Canvas) string {
+	return snapshot(c)
 }
 
 // AssertRendersToMarkup asserts that the given canvas renders the same markup as the one stored in the master file.

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,8 +1,10 @@
 package test_test
 
 import (
+	"bytes"
 	"image/color"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +47,10 @@ func TestRenderObjectToMarkup(t *testing.T) {
 
 	want, err := os.ReadFile("testdata/circle.xml")
 	require.NoError(t, err)
-	assert.Equal(t, string(want), test.RenderObjectToMarkup(obj), "existing master is equal to rendered markup")
+	// Fix Windows newlines
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
+	got := strings.ReplaceAll(test.RenderObjectToMarkup(obj), "\r\n", "\n")
+	assert.Equal(t, string(want), got, "existing master is equal to rendered markup")
 }
 
 func TestAssertObjectRendersToMarkup(t *testing.T) {
@@ -97,7 +102,10 @@ func TestRenderToMarkup(t *testing.T) {
 
 	want, err := os.ReadFile("testdata/markup_master.xml")
 	require.NoError(t, err)
-	assert.Equal(t, string(want), test.RenderToMarkup(c), "existing master is equal to rendered markup")
+	// Fix Windows newlines
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
+	got := strings.ReplaceAll(test.RenderToMarkup(c), "\r\n", "\n")
+	assert.Equal(t, string(want), got, "existing master is equal to rendered markup")
 }
 
 func TestAssertRendersToMarkup(t *testing.T) {

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -39,6 +39,15 @@ func TestAssertObjectRendersToImage(t *testing.T) {
 	test.AssertObjectRendersToImage(t, "circle.png", obj)
 }
 
+func TestRenderObjectToMarkup(t *testing.T) {
+	obj := canvas.NewCircle(color.Black)
+	obj.Resize(fyne.NewSize(20, 20))
+
+	want, err := os.ReadFile("testdata/circle.xml")
+	require.NoError(t, err)
+	assert.Equal(t, string(want), test.RenderObjectToMarkup(obj), "existing master is equal to rendered markup")
+}
+
 func TestAssertObjectRendersToMarkup(t *testing.T) {
 	obj := canvas.NewCircle(color.Black)
 	obj.Resize(fyne.NewSize(20, 20))
@@ -80,6 +89,15 @@ func TestAssertRendersToImage(t *testing.T) {
 	if !t.Failed() {
 		_ = os.RemoveAll("testdata/failed")
 	}
+}
+
+func TestRenderToMarkup(t *testing.T) {
+	c := test.NewCanvas()
+	c.SetContent(canvas.NewCircle(color.Black))
+
+	want, err := os.ReadFile("testdata/markup_master.xml")
+	require.NoError(t, err)
+	assert.Equal(t, string(want), test.RenderToMarkup(c), "existing master is equal to rendered markup")
 }
 
 func TestAssertRendersToMarkup(t *testing.T) {


### PR DESCRIPTION
### Description:
Adds RenderObjectToMarkpu and RenderToMarkup functions

Fixes #5124

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
