### PR TITLE
Fix memory leak in font metrics cache on desktop

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -109,6 +109,7 @@ func CleanCanvases(refreshingCanvases []fyne.Canvas) {
 	}
 
 	destroyExpiredSvgs(now)
+	destroyExpiredFontMetrics(now)
 
 	deletingObjs := make([]fyne.CanvasObject, 0, 50)
 


### PR DESCRIPTION
### Description:
Adds the missed call to destroyExpiredFontMetrics in the desktop driver cache clean task

Fixes #4010 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
