### PR TITLE
Use Clear() rather than re-assigning to global sync.Map variables

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -161,12 +161,6 @@ func CachedFontFace(style fyne.TextStyle, source fyne.Resource, o fyne.CanvasObj
 	return val.(*FontCacheItem)
 }
 
-// ClearFontCache is used to remove cached fonts in the case that we wish to re-load Font faces
-func ClearFontCache() {
-	fontCache = &sync.Map{}
-	fontCustomCache = &sync.Map{}
-}
-
 // DrawString draws a string into an image.
 func DrawString(dst draw.Image, s string, color color.Color, f shaping.Fontmap, fontSize, scale float32, style fyne.TextStyle) {
 	r := render.Renderer{

--- a/internal/painter/fontcache.go
+++ b/internal/painter/fontcache.go
@@ -1,0 +1,15 @@
+//go:build !1.23
+
+package painter
+
+// ClearFontCache is used to remove cached fonts in the case that we wish to re-load Font faces
+func ClearFontCache() {
+	fontCache.Range(func(key, value interface{}) bool {
+		fontCache.Delete(key)
+		return true
+	})
+	fontCustomCache.Range(func(key, value interface{}) bool {
+		fontCustomCache.Delete(key)
+		return true
+	})
+}

--- a/internal/painter/fontcache_123.go
+++ b/internal/painter/fontcache_123.go
@@ -1,0 +1,9 @@
+//go:build 1.23
+
+package painter
+
+// ClearFontCache is used to remove cached fonts in the case that we wish to re-load Font faces
+func ClearFontCache() {
+	fontCache.Clear()
+	fontCustomCache.Clear()
+}


### PR DESCRIPTION
### Description:
While we're using a pair of `sync.Map`'s for concurrency safety, we don't reset them safely. This should fix that.

Go 1.23 introduced the [sync.Map.Clear]() method, which makes this easy. For earlier versions, I've introduced a loop over all map values, deleting them one-by-one. If this is considered too slow/inefficient, we can revert to the unsafe/racy approach for older versions. But this seems like a very infrequent operation (usually happening 0 times, AFAICT, outside of tests).

Re #4037

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
