### PR TITLE
 cache: use one lock/unclock cycle to remove expired items (Issue5129)

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -12,7 +12,6 @@ var (
 	cacheDuration     = 1 * time.Minute
 	cleanTaskInterval = cacheDuration / 2
 
-	expiredObjects                = make([]fyne.CanvasObject, 0, 50)
 	lastClean                     time.Time
 	skippedCleanWithCanvasRefresh = false
 
@@ -161,45 +160,27 @@ func ResetThemeCaches() {
 
 // destroyExpiredCanvases deletes objects from the canvases cache.
 func destroyExpiredCanvases(now time.Time) {
-	expiredObjects = expiredObjects[:0]
-	canvasesLock.RLock()
+	canvasesLock.Lock()
 	for obj, cinfo := range canvases {
 		if cinfo.isExpired(now) {
-			expiredObjects = append(expiredObjects, obj)
+			delete(canvases, obj)
 		}
 	}
-	canvasesLock.RUnlock()
-	if len(expiredObjects) > 0 {
-		canvasesLock.Lock()
-		for i, exp := range expiredObjects {
-			delete(canvases, exp)
-			expiredObjects[i] = nil
-		}
-		canvasesLock.Unlock()
-	}
+	canvasesLock.Unlock()
 }
 
 // destroyExpiredRenderers deletes the renderer from the cache and calls
 // renderer.Destroy()
 func destroyExpiredRenderers(now time.Time) {
-	expiredObjects = expiredObjects[:0]
-	renderersLock.RLock()
+	renderersLock.Lock()
 	for wid, rinfo := range renderers {
 		if rinfo.isExpired(now) {
 			rinfo.renderer.Destroy()
 			overrides.Delete(wid)
-			expiredObjects = append(expiredObjects, wid)
+			delete(renderers, wid)
 		}
 	}
-	renderersLock.RUnlock()
-	if len(expiredObjects) > 0 {
-		renderersLock.Lock()
-		for i, exp := range expiredObjects {
-			delete(renderers, exp.(fyne.Widget))
-			expiredObjects[i] = nil
-		}
-		renderersLock.Unlock()
-	}
+	renderersLock.Unlock()
 }
 
 // matchesACanvas returns true if the canvas represented by the canvasInfo object matches one of

--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -264,7 +264,6 @@ func (t *timeMock) setTime(min, sec int) {
 }
 
 func testClearAll() {
-	expiredObjects = make([]fyne.CanvasObject, 0, 50)
 	skippedCleanWithCanvasRefresh = false
 	canvases = make(map[fyne.CanvasObject]*canvasInfo, 1024)
 	svgs.Range(func(key, _ any) bool {

--- a/internal/cache/svg.go
+++ b/internal/cache/svg.go
@@ -46,18 +46,13 @@ type svgInfo struct {
 
 // destroyExpiredSvgs destroys expired svgs cache data.
 func destroyExpiredSvgs(now time.Time) {
-	expiredSvgs := make([]string, 0, 20)
 	svgs.Range(func(key, value any) bool {
-		s, sinfo := key.(string), value.(*svgInfo)
+		sinfo := value.(*svgInfo)
 		if sinfo.isExpired(now) {
-			expiredSvgs = append(expiredSvgs, s)
+			svgs.Delete(key)
 		}
 		return true
 	})
-
-	for _, exp := range expiredSvgs {
-		svgs.Delete(exp)
-	}
 }
 
 func overriddenName(name string, o fyne.CanvasObject) string {

--- a/internal/cache/text.go
+++ b/internal/cache/text.go
@@ -58,18 +58,11 @@ func SetFontMetrics(text string, fontSize float32, style fyne.TextStyle, source 
 
 // destroyExpiredFontMetrics destroys expired fontSizeCache entries
 func destroyExpiredFontMetrics(now time.Time) {
-	expiredObjs := make([]fontSizeEntry, 0, 50)
-	fontSizeLock.RLock()
+	fontSizeLock.Lock()
 	for k, v := range fontSizeCache {
 		if v.isExpired(now) {
-			expiredObjs = append(expiredObjs, k)
+			delete(fontSizeCache, k)
 		}
-	}
-	fontSizeLock.RUnlock()
-
-	fontSizeLock.Lock()
-	for _, k := range expiredObjs {
-		delete(fontSizeCache, k)
 	}
 	fontSizeLock.Unlock()
 }


### PR DESCRIPTION
### Description:

Previous implementation collected expired items while under an Rlock then proceeded to
remove them from the map they sat in while under a Lock. A race can occur while the map
is changed or accessed between the RUnlock and the Lock.
Deleting a map item while iterating it is actually fine, the only issue might be if you delete 
an item not yet seen by the loop. This is never the case here as we delete the item being
iterated. Therefore, we can simply iterate the map and remove expired items right away while
being protected by a Lock.

Fixes #5129.