### PR TITLE
added SetItemHeight to the Tree widget, copying from the List widget

### DIFF
--- a/widget/tree.go
+++ b/widget/tree.go
@@ -48,6 +48,7 @@ type Tree struct {
 	branchMinSize fyne.Size
 	currentFocus  TreeNodeID
 	focused       bool
+	itemHeights   map[TreeNodeID]float32
 	leafMinSize   fyne.Size
 	offset        fyne.Position
 	open          map[TreeNodeID]bool
@@ -263,6 +264,22 @@ func (t *Tree) ScrollToBottom() {
 	t.Refresh()
 }
 
+// SetItemHeight supports changing the height of the specified list item. Items normally take the height of the template
+// returned from the CreateItem callback. The height parameter uses the same units as a fyne.Size type and refers
+// to the internal content height not including the divider size.
+//
+// Since: 2.x
+func (t *Tree) SetItemHeight(id TreeNodeID, height float32) {
+	t.propertyLock.Lock()
+
+	if t.itemHeights == nil {
+		t.itemHeights = make(map[TreeNodeID]float32)
+	}
+
+	t.itemHeights[id] = height
+	t.propertyLock.Unlock()
+}
+
 // ScrollTo scrolls to the node with the given id.
 //
 // Since 2.1
@@ -447,6 +464,9 @@ func (t *Tree) findBottom() (y float32, size fyne.Size) {
 		if branch {
 			size = t.branchMinSize
 		}
+		if n, ok := t.itemHeights[id]; ok {
+			size.Height = n
+		}
 
 		// Root node is not rendered unless it has been customized
 		if t.Root == "" && id == "" {
@@ -474,6 +494,9 @@ func (t *Tree) offsetAndSize(uid TreeNodeID) (y float32, size fyne.Size, found b
 		m := t.leafMinSize
 		if branch {
 			m = t.branchMinSize
+		}
+		if n, ok := t.itemHeights[id]; ok {
+			m.Height = n
 		}
 		if id == uid {
 			found = true
@@ -659,6 +682,9 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 		if isBranch {
 			m = r.treeContent.tree.branchMinSize
 		}
+		if n, ok := r.treeContent.tree.itemHeights[uid]; ok {
+			m.Height = n
+		}
 		if y+m.Height < offsetY {
 			// Node is above viewport and not visible
 		} else if y > offsetY+viewport.Height {
@@ -765,6 +791,9 @@ func (r *treeContentRenderer) MinSize() (min fyne.Size) {
 		m := r.treeContent.tree.leafMinSize
 		if isBranch {
 			m = r.treeContent.tree.branchMinSize
+		}
+		if n, ok := r.treeContent.tree.itemHeights[uid]; ok {
+			m.Height = n
 		}
 		m.Width += float32(depth) * (iconSize + pad)
 		min.Width = fyne.Max(min.Width, m.Width)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This adds `SetItemHeight` to the Tree widget. It is copied from the List widget to keep it similar.

I require dynamic heights for items in the tree, which wasn't supported, this implements them using the same public API as the List widget.

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
