### PR TITLE
widget: make Button trigger unfocus when tapped.

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -191,6 +191,12 @@ func (b *Button) Tapped(*fyne.PointEvent) {
 	b.tapAnimation()
 	b.Refresh()
 
+	if !b.focused {
+		// Grab the focus to unfocus any previous widget, then release it.
+		focusIfNotMobile(b.super())
+		b.FocusLost()
+	}
+
 	if onTapped := b.OnTapped; onTapped != nil {
 		onTapped()
 	}

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -235,3 +235,47 @@ func TestButtonRenderer_TapAnimation(t *testing.T) {
 	button.tapAnim.Tick(0.5)
 	test.AssertImageMatches(t, "button/tap_animation.png", w.Canvas().Capture())
 }
+
+func TestButton_TappedFocus(t *testing.T) {
+	test.NewApp()
+	entry := NewEntry()
+	button := NewButton("ok", nil)
+	w := test.NewTempWindow(t, newCont(entry, button))
+
+	c := w.Canvas()
+	c.Focus(entry)
+	assert.True(t, entry.focused, "entry is not focused")
+
+	// NB. we cannot use test.Tap(button) as it handles focus,
+	// and we want to specifically test Button's handling of focus.
+	button.Tapped(&fyne.PointEvent{})
+	assert.False(t, entry.focused, "entry still has focus")
+	assert.False(t, button.focused, "button still has focus")
+}
+
+type cont struct {
+	BaseWidget
+	objects []fyne.CanvasObject
+}
+
+type contRenderer struct {
+	cont *cont
+}
+
+var _ fyne.CanvasObject = (*cont)(nil)
+
+func newCont(objects ...fyne.CanvasObject) *cont {
+	c := &cont{objects: objects}
+	c.ExtendBaseWidget(c)
+	return c
+}
+
+func (c *cont) CreateRenderer() fyne.WidgetRenderer {
+	return &contRenderer{cont: c}
+}
+
+func (r *contRenderer) Destroy()                     {}
+func (r *contRenderer) Layout(fyne.Size)             {}
+func (r *contRenderer) MinSize() fyne.Size           { return fyne.NewSize(10, 10) }
+func (r *contRenderer) Objects() []fyne.CanvasObject { return r.cont.objects }
+func (r *contRenderer) Refresh()                     {}

--- a/widget/check.go
+++ b/widget/check.go
@@ -380,7 +380,7 @@ func (c *checkRenderer) updateFocusIndicator(th fyne.Theme, v fyne.ThemeVariant)
 }
 
 func focusIfNotMobile(w fyne.Widget) {
-	if !fyne.CurrentDevice().IsMobile() {
+	if w != nil && !fyne.CurrentDevice().IsMobile() {
 		if c := fyne.CurrentApp().Driver().CanvasForObject(w); c != nil {
 			c.Focus(w.(fyne.Focusable))
 		}


### PR DESCRIPTION
Fixes #5107.

### Description:
Previously, widget.Button did not grab the focus when tapped, resulting in any focused widget on the canvas remaining focused. Now it does gab the focus and then releases it as this should be transient for a button.

Fixes #5107.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass. 
  (besides language related ones)
