### PR TITLE
Add installDir (-o) option to get command

### DIFF
--- a/cmd/fyne/internal/commands/get.go
+++ b/cmd/fyne/internal/commands/get.go
@@ -35,6 +35,12 @@ func Get() *cli.Command {
 				Usage:       "For darwin and Windows targets an appID in the form of a reversed domain name is required, for ios this must match a valid provisioning profile",
 				Destination: &g.AppID,
 			},
+			&cli.StringFlag{
+				Name:        "installDir",
+				Aliases:     []string{"o"},
+				Usage:       "A specific location to install to, rather than the OS default.",
+				Destination: &g.installDir,
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			if ctx.Args().Len() != 1 {
@@ -50,6 +56,7 @@ func Get() *cli.Command {
 // Getter is the command that can handle downloading and installing Fyne apps to the current platform.
 type Getter struct {
 	*appData
+	installDir string
 }
 
 // NewGetter returns a command that can handle the download and install of GUI apps built using Fyne.
@@ -98,7 +105,7 @@ func (g *Getter) Get(pkg string) error {
 		path = filepath.Join(path, dir)
 	}
 
-	install := &Installer{appData: g.appData, srcDir: path, release: true}
+	install := &Installer{appData: g.appData, installDir: g.installDir, srcDir: path, release: true}
 	if err := install.validate(); err != nil {
 		return fmt.Errorf("failed to set up installer: %w", err)
 	}


### PR DESCRIPTION
to allow users to specify the directory of where the got application should be installed.

Hi @andydotxyz 👋,
today's fyneconf and our conversations over lunch and dinner got me so inspired I had to dig my fingers into fyne and Slydes!
Only to run into a minor issue using it with my quirky user setup, so why not seize the opportunity and start contributing right away 😄

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

On macOS (darwin) running  `go run ./cmd/fyne get github.com/andydotxyz/slydes`

fails with

```
2024/09/20 22:43:14 Fyne error:  Failed to create dirrectory
2024/09/20 22:43:14   Cause: mkdir /Applications/Slydes.app: permission denied
```

when the user running `fyne` isn't in the `admin` group (which owns the `/Applications` directory). While admittedly this is likely an uncommon scenario, it is not an unthinkable/impossible one.
Please view this PR as a quick fix as there might be better approaches to solve the issue, e.g. fallback to `~/Applications` if writing to `/Applications` fails.

<details><summary>(full log)</summary>

```
Cloning into '/var/folders/h0/948x8bgn0kd7b1d7hf0bnlr00000gp/T/fyne-get-slydes-2170229880'...
remote: Enumerating objects: 31, done.
remote: Counting objects: 100% (31/31), done.
remote: Compressing objects: 100% (28/28), done.
remote: Total 31 (delta 0), reused 13 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (31/31), 223.10 KiB | 709.00 KiB/s, done.
2024/09/20 22:43:14 Fyne error:  Failed to create dirrectory
2024/09/20 22:43:14   Cause: mkdir /Applications/Slydes.app: permission denied
2024/09/20 22:43:14   At: /Users/afh/Developer/fyne/cmd/fyne/internal/util/file.go:36
2024/09/20 22:43:14 Fyne error:  Failed to create dirrectory
2024/09/20 22:43:14   Cause: mkdir /Applications/Slydes.app/Contents: no such file or directory
2024/09/20 22:43:14   At: /Users/afh/Developer/fyne/cmd/fyne/internal/util/file.go:36
failed to create plist template: open /Applications/Slydes.app/Contents/Info.plist: no such file or directory
exit status 1
```

</details> 

~~Fixes #(issue)~~

### Checklist:
<!-- Please tick these as appropriate using [x] -->

Apologies for not having read up on contributing to fyne before putting up this PR. Do point me to documentation on how to best contribute to fyne, including adding/running tests, linter/formatter etc.

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
