### PR TITLE
Improve documentation for file dialogs

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -831,33 +831,40 @@ func (f *FileDialog) SetView(v ViewLayout) {
 }
 
 // NewFileOpen creates a file dialog allowing the user to choose a file to open.
-// The callback function will run when the dialog closes. The URI will be nil
-// when the user cancels or when nothing is selected.
+//
+// The callback function will run when the dialog closes and provide a reader for the chosen file.
+// The reader must be closed by the callback.
+// The reader will be nil, when the user cancels or when nothing is selected.
 //
 // The dialog will appear over the window specified when Show() is called.
-func NewFileOpen(callback func(fyne.URIReadCloser, error), parent fyne.Window) *FileDialog {
+func NewFileOpen(callback func(reader fyne.URIReadCloser, err error), parent fyne.Window) *FileDialog {
 	dialog := &FileDialog{callback: callback, parent: parent}
 	return dialog
 }
 
 // NewFileSave creates a file dialog allowing the user to choose a file to save
 // to (new or overwrite). If the user chooses an existing file they will be
-// asked if they are sure. The callback function will run when the dialog
-// closes. The URI will be nil when the user cancels or when nothing is
-// selected.
+// asked if they are sure.
+//
+// The callback function will run when the dialog closes and provide a writer for the chosen file.
+// The writer must be closed by the callback.
+// The writer will be nil, when the user cancels or when nothing is selected.
 //
 // The dialog will appear over the window specified when Show() is called.
-func NewFileSave(callback func(fyne.URIWriteCloser, error), parent fyne.Window) *FileDialog {
+func NewFileSave(callback func(writer fyne.URIWriteCloser, err error), parent fyne.Window) *FileDialog {
 	dialog := &FileDialog{callback: callback, parent: parent, save: true}
 	return dialog
 }
 
 // ShowFileOpen creates and shows a file dialog allowing the user to choose a
-// file to open. The callback function will run when the dialog closes. The URI
-// will be nil when the user cancels or when nothing is selected.
+// file to open.
+//
+// The callback function will run when the dialog closes and provide a reader for the chosen file.
+// The reader must be closed by the callback.
+// The reader will be nil, when the user cancels or when nothing is selected.
 //
 // The dialog will appear over the window specified.
-func ShowFileOpen(callback func(fyne.URIReadCloser, error), parent fyne.Window) {
+func ShowFileOpen(callback func(reader fyne.URIReadCloser, err error), parent fyne.Window) {
 	dialog := NewFileOpen(callback, parent)
 	if fileOpenOSOverride(dialog) {
 		return
@@ -867,12 +874,14 @@ func ShowFileOpen(callback func(fyne.URIReadCloser, error), parent fyne.Window) 
 
 // ShowFileSave creates and shows a file dialog allowing the user to choose a
 // file to save to (new or overwrite). If the user chooses an existing file they
-// will be asked if they are sure. The callback function will run when the
-// dialog closes. The URI will be nil when the user cancels or when nothing is
-// selected.
+// will be asked if they are sure.
+//
+// The callback function will run when the dialog closes and provide a writer for the chosen file.
+// The writer must be closed by the callback.
+// The writer will be nil, when the user cancels or when nothing is selected.
 //
 // The dialog will appear over the window specified.
-func ShowFileSave(callback func(fyne.URIWriteCloser, error), parent fyne.Window) {
+func ShowFileSave(callback func(writer fyne.URIWriteCloser, err error), parent fyne.Window) {
 	dialog := NewFileSave(callback, parent)
 	if fileSaveOSOverride(dialog) {
 		return

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -833,8 +833,8 @@ func (f *FileDialog) SetView(v ViewLayout) {
 // NewFileOpen creates a file dialog allowing the user to choose a file to open.
 //
 // The callback function will run when the dialog closes and provide a reader for the chosen file.
-// The reader must be closed by the callback.
-// The reader will be nil, when the user cancels or when nothing is selected.
+// The reader will be nil when the user cancels or when nothing is selected.
+// When the reader isn't nil it must be closed by the callback.
 //
 // The dialog will appear over the window specified when Show() is called.
 func NewFileOpen(callback func(reader fyne.URIReadCloser, err error), parent fyne.Window) *FileDialog {
@@ -847,8 +847,8 @@ func NewFileOpen(callback func(reader fyne.URIReadCloser, err error), parent fyn
 // asked if they are sure.
 //
 // The callback function will run when the dialog closes and provide a writer for the chosen file.
-// The writer must be closed by the callback.
-// The writer will be nil, when the user cancels or when nothing is selected.
+// The writer will be nil when the user cancels or when nothing is selected.
+// When the writer isn't nil it must be closed by the callback.
 //
 // The dialog will appear over the window specified when Show() is called.
 func NewFileSave(callback func(writer fyne.URIWriteCloser, err error), parent fyne.Window) *FileDialog {
@@ -860,8 +860,8 @@ func NewFileSave(callback func(writer fyne.URIWriteCloser, err error), parent fy
 // file to open.
 //
 // The callback function will run when the dialog closes and provide a reader for the chosen file.
-// The reader must be closed by the callback.
-// The reader will be nil, when the user cancels or when nothing is selected.
+// The reader will be nil when the user cancels or when nothing is selected.
+// When the reader isn't nil it must be closed by the callback.
 //
 // The dialog will appear over the window specified.
 func ShowFileOpen(callback func(reader fyne.URIReadCloser, err error), parent fyne.Window) {
@@ -877,8 +877,8 @@ func ShowFileOpen(callback func(reader fyne.URIReadCloser, err error), parent fy
 // will be asked if they are sure.
 //
 // The callback function will run when the dialog closes and provide a writer for the chosen file.
-// The writer must be closed by the callback.
-// The writer will be nil, when the user cancels or when nothing is selected.
+// The writer will be nil when the user cancels or when nothing is selected.
+// When the writer isn't nil it must be closed by the callback.
 //
 // The dialog will appear over the window specified.
 func ShowFileSave(callback func(writer fyne.URIWriteCloser, err error), parent fyne.Window) {


### PR DESCRIPTION
### Description:

When using file dialogs it is currently unclear from the documentation whether the reader/writer passed in the callbacks need to be closed. This may lead to obscure bugs, since the file is often still read/created. I therefore like to propose extending the comments to clarify that those in fact must be closed by the callback.

I further like to propose adding variable names in the callbacks to make it clearer to the user what they are (e.g. those will be added to the users code though auto-complete). 

See also related conversation with Andy on [Discord](https://discord.com/channels/953020122690359327/953030515152281650/1289557458804805694).

### Checklist:

- [ ] Tests included. (N/A)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

N/A