### PR TITLE
Use Staticcheck v0.5.1 in CI infrastructure

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -10,9 +10,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.13.0
+    - uses: WillAbides/setup-go-faster@v1
       with:      
-        go-version: '1.21.x'
+        go-version: '1.22.x'
 
     - name: Install lian
       run: go install lucor.dev/lian@latest

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -12,7 +12,7 @@ jobs:
         persist-credentials: false
     - uses: WillAbides/setup-go-faster@v1
       with:      
-        go-version: '1.22.x'
+        go-version: '1.23.x'
 
     - name: Install lian
       run: go install lucor.dev/lian@latest

--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19.x', '1.22.x']
+        go-version: ['1.19.x', '1.23.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19.x', '1.21.x']
+        go-version: ['1.19.x', '1.22.x']
 
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.13.0
+    - uses: WillAbides/setup-go-faster@v1
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19.x', '1.21.x']
+        go-version: ['1.19.x', '1.22.x']
         os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.13.0
+    - uses: WillAbides/setup-go-faster@v1
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -51,12 +51,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.20.x', '1.21.x']
+        go-version: ['1.20.x', '1.22.x']
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: WillAbides/setup-go-faster@v1.13.0
+      - uses: WillAbides/setup-go-faster@v1
         with:
           go-version: ${{ matrix.go-version }}
     

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19.x', '1.22.x']
+        go-version: ['1.19.x', '1.23.x']
         os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.13.0
+    - uses: WillAbides/setup-go-faster@v1
       with:
-        go-version: '1.21.x'
+        go-version: '1.22.x'
 
     - name: Get dependencies
       run: >-

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
+        go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
         go install github.com/mattn/goveralls@latest
 
     - name: Vet

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -15,7 +15,7 @@ jobs:
         persist-credentials: false
     - uses: WillAbides/setup-go-faster@v1
       with:
-        go-version: '1.22.x'
+        go-version: '1.23.x'
 
     - name: Get dependencies
       run: >-

--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1.13.0
+    - uses: WillAbides/setup-go-faster@v1
       with:
         go-version: '1.19.x'
 

--- a/cmd/fyne/internal/mobile/binres/binres_test.go
+++ b/cmd/fyne/internal/mobile/binres/binres_test.go
@@ -246,7 +246,7 @@ func compareElements(have, want *XML) error {
 		}
 	}
 	if buf.Len() > 0 {
-		return fmt.Errorf(buf.String())
+		return errors.New(buf.String())
 	}
 	return nil
 }

--- a/cmd/fyne/internal/mobile/binres/binres_test.go
+++ b/cmd/fyne/internal/mobile/binres/binres_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"math"
 	"os"

--- a/widget/check_group.go
+++ b/widget/check_group.go
@@ -182,7 +182,7 @@ type checkGroupRenderer struct {
 // Layout the components of the checks widget
 func (r *checkGroupRenderer) Layout(_ fyne.Size) {
 	count := 1
-	if r.items != nil && len(r.items) > 0 {
+	if len(r.items) > 0 {
 		count = len(r.items)
 	}
 	var itemHeight, itemWidth float32

--- a/widget/list.go
+++ b/widget/list.go
@@ -169,7 +169,7 @@ func (l *List) scrollTo(id ListItemID) {
 	separatorThickness := l.Theme().Size(theme.SizeNamePadding)
 	y := float32(0)
 	lastItemHeight := l.itemMin.Height
-	if l.itemHeights == nil || len(l.itemHeights) == 0 {
+	if len(l.itemHeights) == 0 {
 		y = (float32(id) * l.itemMin.Height) + (float32(id) * separatorThickness)
 	} else {
 		for i := 0; i < id; i++ {
@@ -368,7 +368,7 @@ func (l *List) contentMinSize() fyne.Size {
 	}
 	items := l.Length()
 
-	if l.itemHeights == nil || len(l.itemHeights) == 0 {
+	if len(l.itemHeights) == 0 {
 		return fyne.NewSize(l.itemMin.Width,
 			(l.itemMin.Height+separatorThickness)*float32(items)-separatorThickness)
 	}

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -156,7 +156,7 @@ type radioGroupRenderer struct {
 // Layout the components of the radio widget
 func (r *radioGroupRenderer) Layout(_ fyne.Size) {
 	count := 1
-	if r.items != nil && len(r.items) > 0 {
+	if len(r.items) > 0 {
 		count = len(r.items)
 	}
 	var itemHeight, itemWidth float32


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This makes sure that we are using the latest version in CI and updates the code to fix those issues.
It also includes a patch that I forgot to push a while ago about making the CI use Go 1.22 (then also a bump to Go 1.23 while at it) and also always pull the latest version of the setup-go-faster action.

Should hopefully unblock https://github.com/fyne-io/fyne/pull/5121

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
