### PR TITLE
Fixes #4758, set the correct parameter memory and size for DwmSetWindowAttribute and DWMWA_USE_IMMERSIVE_DARK_MODE on windows.

### DIFF
--- a/internal/driver/glfw/window_windows.go
+++ b/internal/driver/glfw/window_windows.go
@@ -24,9 +24,9 @@ func (w *window) setDarkMode() {
 		dwm := syscall.NewLazyDLL("dwmapi.dll")
 		setAtt := dwm.NewProc("DwmSetWindowAttribute")
 		ret, _, err := setAtt.Call(uintptr(unsafe.Pointer(hwnd)), // window handle
-			20,                             // DWMWA_USE_IMMERSIVE_DARK_MODE
+			20,                                // DWMWA_USE_IMMERSIVE_DARK_MODE
 			uintptr(unsafe.Pointer(&winBool)), // on or off
-			4)                              // sizeof(bool for windows)
+			4)                                 // sizeof(bool for windows)
 
 		if ret != 0 && ret != 0x80070057 { // err is always non-nil, we check return value (except erroneous code)
 			fyne.LogError("Failed to set dark mode", err)

--- a/internal/driver/glfw/window_windows.go
+++ b/internal/driver/glfw/window_windows.go
@@ -16,13 +16,17 @@ func (w *window) setDarkMode() {
 	if runtime.GOOS == "windows" {
 		hwnd := w.view().GetWin32Window()
 		dark := isDark()
-
+		// cannot use a go bool.
+		var winBool int32
+		if dark {
+			winBool = 1
+		}
 		dwm := syscall.NewLazyDLL("dwmapi.dll")
 		setAtt := dwm.NewProc("DwmSetWindowAttribute")
 		ret, _, err := setAtt.Call(uintptr(unsafe.Pointer(hwnd)), // window handle
 			20,                             // DWMWA_USE_IMMERSIVE_DARK_MODE
-			uintptr(unsafe.Pointer(&dark)), // on or off
-			8)                              // sizeof(darkMode)
+			uintptr(unsafe.Pointer(&winBool)), // on or off
+			4)                              // sizeof(bool for windows)
 
 		if ret != 0 && ret != 0x80070057 { // err is always non-nil, we check return value (except erroneous code)
 			fyne.LogError("Failed to set dark mode", err)


### PR DESCRIPTION
### Description:
For windows this will set the correct parameter memory and size for DmwSetWindowAttribute and DWMWA_USE_IMMERSIVE_DARK_MODE.  This resolves random memory access errors and that immersive mode might sometimes be set incorrectly as seen by the wrong color title bar.

Fixes #4758 

### Checklist:

- [ ] Tests included. - NA based on location of issue.
- [x] Lint and formatter run with no errors.
- [ ] Tests 
all pass. - No, but all my errors appear unrelated and based on window specific testing issues: [testlog.txt](https://github.com/user-attachments/files/17265595/testlog.txt)
