### PR TITLE
First stage in text speed improvements

### DIFF
--- a/internal/cache/text.go
+++ b/internal/cache/text.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"image/color"
 	"sync"
 	"time"
 
@@ -19,10 +20,16 @@ type fontMetric struct {
 }
 
 type fontSizeEntry struct {
-	text   string
-	size   float32
-	style  fyne.TextStyle
-	custom string
+	Text   string
+	Size   float32
+	Style  fyne.TextStyle
+	Source string
+}
+
+type FontCacheEntry struct {
+	fontSizeEntry
+
+	Color color.Color
 }
 
 // GetFontMetrics looks up a calculated size and baseline required for the specified text parameters.

--- a/internal/cache/texture_common.go
+++ b/internal/cache/texture_common.go
@@ -60,13 +60,14 @@ func RangeExpiredTexturesFor(canvas fyne.Canvas, f func(fyne.CanvasObject)) {
 }
 
 // RangeTexturesFor range over the textures for the specified canvas.
+// It will not return the texture for a `canvas.Text` as their render lifecycle is handled separately.
 //
 // Note: If this is used to free textures, then it should be called inside a current
 // gl context to ensure textures are deleted from gl.
 func RangeTexturesFor(canvas fyne.Canvas, f func(fyne.CanvasObject)) {
 	textures.Range(func(key, value any) bool {
 		if _, ok := key.(FontCacheEntry); ok {
-			return true // TODO what?
+			return true // do nothing, text cache lives outside the scope of an object
 		}
 
 		obj, tinfo := key.(fyne.CanvasObject), value.(*textureInfo)

--- a/internal/cache/texture_desktop.go
+++ b/internal/cache/texture_desktop.go
@@ -10,7 +10,9 @@ var NoTexture = TextureType(0)
 
 type textureInfo struct {
 	textureCacheBase
-	texture TextureType
+
+	texture  TextureType
+	textFree func()
 }
 
 // IsValid will return true if the passed texture is potentially a texture

--- a/internal/cache/texture_gomobile.go
+++ b/internal/cache/texture_gomobile.go
@@ -11,7 +11,9 @@ var NoTexture = gl.Texture{0}
 
 type textureInfo struct {
 	textureCacheBase
-	texture TextureType
+
+	texture  TextureType
+	textFree func()
 }
 
 // IsValid will return true if the passed texture is potentially a texture

--- a/internal/cache/texture_goxjs.go
+++ b/internal/cache/texture_goxjs.go
@@ -2,7 +2,7 @@
 
 package cache
 
-import gl "github.com/fyne-io/gl-js"
+import "github.com/fyne-io/gl-js"
 
 // TextureType represents an uploaded GL texture
 type TextureType = gl.Texture
@@ -11,7 +11,9 @@ var NoTexture = gl.NoTexture
 
 type textureInfo struct {
 	textureCacheBase
-	texture TextureType
+
+	texture  TextureType
+	textFree func()
 }
 
 // IsValid will return true if the passed texture is potentially a texture

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -33,6 +33,30 @@ func (p *painter) freeTexture(obj fyne.CanvasObject) {
 }
 
 func (p *painter) getTexture(object fyne.CanvasObject, creator func(canvasObject fyne.CanvasObject) Texture) (Texture, error) {
+	if t, ok := object.(*canvas.Text); ok {
+		custom := ""
+		if t.FontSource != nil {
+			custom = t.FontSource.Name()
+		}
+		ent := cache.FontCacheEntry{Color: t.Color}
+		ent.Text = t.Text
+		ent.Size = t.TextSize
+		ent.Style = t.TextStyle
+		ent.Source = custom
+
+		texture, ok := cache.GetTextTexture(ent)
+
+		if !ok {
+			tex := creator(object)
+			texture = cache.TextureType(tex)
+			cache.SetTextTexture(ent, texture, p.canvas, func() {
+				p.ctx.DeleteTexture(tex)
+			})
+		}
+
+		return Texture(texture), nil
+	}
+
 	texture, ok := cache.GetTexture(object)
 
 	if !ok {


### PR DESCRIPTION
It's such a big challenge that I am working on this in stages.

First: Move text cache index to the text details not object reference

Using Terminal app as benchmark (TextGrid gets the biggest boost with this change) when running "top" fullscreen:
* around 20% less memory
* up to 67% lower CPU usage
* App resize feels faster too :)

Next improvements will build on this so other text widgets see bigger improvements.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- as long as existing tests all work this speedup is good :)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
