### PR TITLE
Add optional Source metadata to the FyneApp.toml

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -21,6 +21,8 @@ type unixData struct {
 	Comment          string
 	Keywords         string
 	ExecParams       string
+
+	SourceRepo, SourceDir string
 }
 
 func (p *Packager) packageUNIX() error {
@@ -74,6 +76,12 @@ func (p *Packager) packageUNIX() error {
 		Categories:  formatDesktopFileList(linuxBSD.Categories),
 		ExecParams:  linuxBSD.ExecParams,
 	}
+
+	if p.sourceMetadata != nil {
+		tplData.SourceRepo = p.sourceMetadata.Repo
+		tplData.SourceDir = p.sourceMetadata.Dir
+	}
+
 	err = templates.DesktopFileUNIX.Execute(deskFile, tplData)
 	if err != nil {
 		return fmt.Errorf("failed to write desktop entry string: %w", err)

--- a/cmd/fyne/internal/commands/package-unix_test.go
+++ b/cmd/fyne/internal/commands/package-unix_test.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
+	"fyne.io/fyne/v2/cmd/fyne/internal/templates"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,4 +13,24 @@ func TestFormatDesktopFileList(t *testing.T) {
 	assert.Equal(t, "", formatDesktopFileList([]string{}))
 	assert.Equal(t, "One;", formatDesktopFileList([]string{"One"}))
 	assert.Equal(t, "One;Two;", formatDesktopFileList([]string{"One", "Two"}))
+}
+
+func TestDesktopFileSource(t *testing.T) {
+	tplData := unixData{
+		Name: "Testing",
+	}
+	buf := &bytes.Buffer{}
+
+	err := templates.DesktopFileUNIX.Execute(buf, tplData)
+	assert.Nil(t, err)
+	assert.False(t, strings.Contains(buf.String(), "[X-Fyne"))
+
+	tplData.SourceRepo = "https://example.com"
+	tplData.SourceDir = "cmd/name"
+
+	err = templates.DesktopFileUNIX.Execute(buf, tplData)
+	assert.Nil(t, err)
+	assert.True(t, strings.Contains(buf.String(), "[X-Fyne"))
+	assert.True(t, strings.Contains(buf.String(), "Repo=https://example.com"))
+	assert.True(t, strings.Contains(buf.String(), "Dir=cmd/name"))
 }

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -137,6 +137,7 @@ type Packager struct {
 
 	customMetadata      keyValueFlag
 	linuxAndBSDMetadata *metadata.LinuxAndBSD
+	sourceMetadata      *metadata.AppSource
 }
 
 // NewPackager returns a command that can handle the packaging a GUI apps built using Fyne from local source code.
@@ -342,6 +343,8 @@ func (p *Packager) validate() (err error) {
 		}
 
 		p.appData.mergeMetadata(data)
+		p.sourceMetadata = data.Source
+
 		p.linuxAndBSDMetadata = data.LinuxAndBSD
 	}
 

--- a/cmd/fyne/internal/templates/bundled.go
+++ b/cmd/fyne/internal/templates/bundled.go
@@ -23,7 +23,7 @@ var resourceMakefile = &fyne.StaticResource{
 var resourceAppDesktop = &fyne.StaticResource{
 	StaticName: "app.desktop",
 	StaticContent: []byte(
-		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}} {{- .ExecParams}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\n{{if ne .Keywords \"\"}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}"),
+		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}} {{- .ExecParams}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\n{{- if ne .Keywords \"\"}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}\n\n{{- if or (ne .SourceRepo \"\") (ne .SourceDir \"\")}}\n[X-Fyne Source]\nRepo={{.SourceRepo}}\nDir={{.SourceDir}}\n{{end}}"),
 }
 var resourceAppManifest = &fyne.StaticResource{
 	StaticName: "app.manifest",

--- a/cmd/fyne/internal/templates/data/app.desktop
+++ b/cmd/fyne/internal/templates/data/app.desktop
@@ -9,4 +9,10 @@ Icon={{.Name}}
 Comment={{.Comment}}{{end}}
 {{- if ne .Categories ""}}
 Categories={{.Categories}}{{end}}
-{{if ne .Keywords ""}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}
+{{- if ne .Keywords ""}}Keywords={{.Keywords}}{{else}}Keywords=fyne;{{end}}
+
+{{- if or (ne .SourceRepo "") (ne .SourceDir "")}}
+[X-Fyne Source]
+Repo={{.SourceRepo}}
+Dir={{.SourceDir}}
+{{end}}

--- a/cmd/fyne_demo/FyneApp.toml
+++ b/cmd/fyne_demo/FyneApp.toml
@@ -5,6 +5,10 @@
   Version = "2.4.0"
   Build = 11
 
+[Source]
+  Repo = "https://github.com/fyne-io/fyne"
+  Dir = "cmd/fyne_demo"
+
 [Development]
   HelperText = "This binary was built with debug symbols"
 

--- a/internal/metadata/data.go
+++ b/internal/metadata/data.go
@@ -6,6 +6,7 @@ type FyneApp struct {
 	Details     AppDetails
 	Development map[string]string `toml:",omitempty"`
 	Release     map[string]string `toml:",omitempty"`
+	Source      *AppSource        `toml:",omitempty"`
 	LinuxAndBSD *LinuxAndBSD      `toml:",omitempty"`
 }
 
@@ -15,6 +16,10 @@ type AppDetails struct {
 	Name, ID string `toml:",omitempty"`
 	Version  string `toml:",omitempty"`
 	Build    int    `toml:",omitempty"`
+}
+
+type AppSource struct {
+	Repo, Dir string `toml:",omitempty"`
 }
 
 // LinuxAndBSD describes specific metadata for desktop files on Linux and BSD.

--- a/internal/metadata/load_test.go
+++ b/internal/metadata/load_test.go
@@ -24,4 +24,8 @@ func TestLoadAppMetadata(t *testing.T) {
 	assert.Equal(t, data.Development["Test"], "Value2")
 	assert.Equal(t, data.Development["InDevelopmentOnly"], "Value4")
 	assert.NotContains(t, data.Development, "InReleaseOnly")
+
+	assert.NotNil(t, data.Source)
+	assert.Equal(t, data.Source.Repo, "https://github.com/fyne-io/fyne")
+	assert.Equal(t, data.Source.Dir, "internal/metadata/testdata")
 }

--- a/internal/metadata/testdata/FyneApp.toml
+++ b/internal/metadata/testdata/FyneApp.toml
@@ -7,6 +7,10 @@ Icon = "https://conf.fyne.io/assets/img/fyne.png"
 Version = "1.0.0"
 Build = 1
 
+[Source]
+Repo = "https://github.com/fyne-io/fyne"
+Dir = "internal/metadata/testdata"
+
 [Release]
 Test = "Value1"
 InReleaseOnly = "Value3"


### PR DESCRIPTION
Use this to write an extension of the .desktop file for Linux. I am not sure if we can extend other package formats with this information also?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

