### PR TITLE
Fix tar flags (and filename) on OpenBSD

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"fyne.io/fyne/v2/cmd/fyne/internal/templates"
@@ -96,8 +97,14 @@ func (p *Packager) packageUNIX() error {
 			return fmt.Errorf("failed to write Makefile string: %w", err)
 		}
 
+		tarCmdArgs := []string{"-Jcf", filepath.Join(p.dir, p.Name+".tar.xz")}
+		if runtime.GOOS == "openbsd" {
+			tarCmdArgs = []string{"-zcf", filepath.Join(p.dir, p.Name+".tar.gz")}
+		}
+		tarCmdArgs = append(tarCmdArgs, "-C", filepath.Join(p.dir, tempDir), "usr", "Makefile")
+
 		var buf bytes.Buffer
-		tarCmd := execabs.Command("tar", "-Jcf", filepath.Join(p.dir, p.Name+".tar.xz"), "-C", filepath.Join(p.dir, tempDir), "usr", "Makefile")
+		tarCmd := execabs.Command("tar", tarCmdArgs...)
 		tarCmd.Stderr = &buf
 		if err = tarCmd.Run(); err != nil {
 			return fmt.Errorf("failed to create archive with tar: %s - %w", buf.String(), err)

--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"fyne.io/fyne/v2/cmd/fyne/internal/templates"
@@ -98,7 +97,7 @@ func (p *Packager) packageUNIX() error {
 		}
 
 		tarCmdArgs := []string{"-Jcf", filepath.Join(p.dir, p.Name+".tar.xz")}
-		if runtime.GOOS == "openbsd" {
+		if p.os == "openbsd" {
 			tarCmdArgs = []string{"-zcf", filepath.Join(p.dir, p.Name+".tar.gz")}
 		}
 		tarCmdArgs = append(tarCmdArgs, "-C", filepath.Join(p.dir, tempDir), "usr", "Makefile")


### PR DESCRIPTION
This PR addresses #5195 and makes sure the compression is supported by `tar` in the base system, as well as using the corresponding file name.

Without this patch:
```
$ fyne package --os openbsd --release
failed to create archive with tar: tar: unknown option -- J
usage: tar {crtux}[014578befHhjLmNOoPpqsvwXZz]
           [blocking-factor | archive | replstr] [-C directory] [-I file]
           [file ...]
       tar {-crtux} [-014578eHhjLmNOoPpqvwXZz] [-b blocking-factor]
           [-C directory] [-f archive] [-I file] [-s replstr] [file ...]
```