### PR TITLE
Recover panic "send on closed channel"

### DIFF
--- a/internal/async/chan_test.go
+++ b/internal/async/chan_test.go
@@ -82,6 +82,7 @@ func TestUnboundedChann(t *testing.T) {
 				}()
 				ch.Close()
 				<-done
+				ch.Close() // checking if it will panic (it should not)
 				runtime.GC()
 				if runtime.NumGoroutine() > grs+2 {
 					t.Fatalf("leaking goroutines: %v", n)

--- a/internal/driver/common/window.go
+++ b/internal/driver/common/window.go
@@ -23,6 +23,9 @@ func (w *Window) InitEventQueue() {
 // QueueEvent uses this method to queue up a callback that handles an event. This ensures
 // user interaction events for a given window are processed in order.
 func (w *Window) QueueEvent(fn func()) {
+	defer func() {
+		recover()
+	}()
 	w.eventQueue.In() <- fn
 }
 

--- a/internal/driver/common/window_test.go
+++ b/internal/driver/common/window_test.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestWindow(t *testing.T) {
+	w := &Window{}
+	w.InitEventQueue()
+	w.DestroyEventQueue()
+	runtime.Gosched()
+
+	// checking if it will panic (it should not)
+	w.QueueEvent(func() {})
+}


### PR DESCRIPTION
### Description:
In [my application](https://github.com/xaionaro-go/streamctl) I have a lot of concurrent processes, and I get panics in fyne.
My understanding is that if I close a window in one goroutine, but refresh something else in another, it sometimes may cause a panic.

To mitigate the issue adding a "recover" to the places where it happens.

Feel free to suggest a better solution (I'll try to implement it) :)

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
