### PR TITLE
Allow a theme to override the form factor of the tabs to be mobile

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -215,7 +215,7 @@ func (t *AppTabs) SetItems(items []*TabItem) {
 
 // SetTabLocation sets the location of the tab bar
 func (t *AppTabs) SetTabLocation(l TabLocation) {
-	t.location = tabsAdjustedLocation(l)
+	t.location = tabsAdjustedLocation(l, t)
 	t.Refresh()
 }
 
@@ -357,7 +357,7 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 	buttons := &fyne.Container{}
 
 	var iconPos buttonIconPosition
-	if fyne.CurrentDevice().IsMobile() {
+	if isMobile(r.tabs) {
 		cells := count
 		if cells == 0 {
 			cells = 1
@@ -381,6 +381,7 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 		if item.button == nil {
 			item.button = &tabButton{
 				onTapped: func() { r.appTabs.Select(item) },
+				tabs:     r.tabs,
 			}
 		}
 		button := item.button

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -173,7 +173,7 @@ func (t *DocTabs) SetItems(items []*TabItem) {
 
 // SetTabLocation sets the location of the tab bar
 func (t *DocTabs) SetTabLocation(l TabLocation) {
-	t.location = tabsAdjustedLocation(l)
+	t.location = tabsAdjustedLocation(l, t)
 	t.Refresh()
 }
 
@@ -338,6 +338,7 @@ func (r *docTabsRenderer) buildTabButtons(count int, buttons *fyne.Container) {
 			item.button = &tabButton{
 				onTapped: func() { r.docTabs.Select(item) },
 				onClosed: func() { r.docTabs.close(item) },
+				tabs:     r.tabs,
 			}
 		}
 		button := item.button

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -12,6 +12,8 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
+const sizeNameDeviceForm = "deviceType"
+
 // TabItem represents a single view in a tab view.
 // The Text and Icon are used for the tab button and the Content is shown when the corresponding tab is active.
 //
@@ -91,10 +93,19 @@ type baseTabs interface {
 	setTransitioning(bool)
 }
 
-func tabsAdjustedLocation(l TabLocation) TabLocation {
+func isMobile(b baseTabs) bool {
+	d := fyne.CurrentDevice()
+	if t := theme.SizeForWidget(sizeNameDeviceForm, b); t != 0 {
+		return t == 1
+	}
+
+	return d.IsMobile()
+}
+
+func tabsAdjustedLocation(l TabLocation, b baseTabs) TabLocation {
 	// Mobile has limited screen space, so don't put app tab bar on long edges
-	if d := fyne.CurrentDevice(); d.IsMobile() {
-		if o := d.Orientation(); fyne.IsVertical(o) {
+	if isMobile(b) {
+		if o := fyne.CurrentDevice().Orientation(); fyne.IsVertical(o) {
 			if l == TabLocationLeading {
 				return TabLocationTop
 			} else if l == TabLocationTrailing {
@@ -511,6 +522,8 @@ type tabButton struct {
 	onClosed      func()
 	text          string
 	textAlignment fyne.TextAlign
+
+	tabs baseTabs
 }
 
 func (b *tabButton) CreateRenderer() fyne.WidgetRenderer {
@@ -720,7 +733,7 @@ func (r *tabButtonRenderer) Refresh() {
 		r.icon.Hide()
 	}
 
-	if d := fyne.CurrentDevice(); r.button.onClosed != nil && (d.IsMobile() || r.button.hovered || r.close.hovered) {
+	if r.button.onClosed != nil && (isMobile(r.button.tabs) || r.button.hovered || r.close.hovered) {
 		r.close.Show()
 	} else {
 		r.close.Hide()


### PR DESCRIPTION
This avoids being forced to respect the singleton device reported from hardware

Opening for discussion about this use for the `Size` callback avoiding a breaking change or new API requirement for a "theme feature".

Also test to follow.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
