### PR TITLE
Defer to system theme when a custom theme delegates to DefaultTheme

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -172,10 +172,6 @@ func newAppWithDriver(d fyne.Driver, clipboard fyne.Clipboard, id string) fyne.A
 	return newApp
 }
 
-func rootConfigDir() string {
-	return app.RootConfigDir()
-}
-
 // marker interface to pass system tray to supporting drivers
 type systrayDriver interface {
 	SetSystemTrayMenu(*fyne.Menu)

--- a/app/app.go
+++ b/app/app.go
@@ -172,6 +172,10 @@ func newAppWithDriver(d fyne.Driver, clipboard fyne.Clipboard, id string) fyne.A
 	return newApp
 }
 
+func rootConfigDir() string {
+	return app.RootConfigDir()
+}
+
 // marker interface to pass system tray to supporting drivers
 type systrayDriver interface {
 	SetSystemTrayMenu(*fyne.Menu)

--- a/app/app_desktop_darwin.go
+++ b/app/app_desktop_darwin.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 
 	"fyne.io/fyne/v2"
 )
@@ -39,13 +38,6 @@ func (a *fyneApp) SetSystemTrayMenu(menu *fyne.Menu) {
 	if desk, ok := a.Driver().(systrayDriver); ok {
 		desk.SetSystemTrayMenu(menu)
 	}
-}
-
-func rootConfigDir() string {
-	homeDir, _ := os.UserHomeDir()
-
-	desktopConfig := filepath.Join(filepath.Join(homeDir, "Library"), "Preferences")
-	return filepath.Join(desktopConfig, "fyne")
 }
 
 //export themeChanged

--- a/app/app_goxjs.go
+++ b/app/app_goxjs.go
@@ -50,10 +50,6 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 	}
 }
 
-func rootConfigDir() string {
-	return "/data/"
-}
-
 var themeChanged = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 	if len(args) > 0 && args[0].Type() == js.TypeObject {
 		fyne.CurrentApp().Settings().(*settings).setupTheme()

--- a/app/app_mobile_and.go
+++ b/app/app_mobile_and.go
@@ -12,10 +12,7 @@ void sendNotification(uintptr_t java_vm, uintptr_t jni_env, uintptr_t ctx, char 
 */
 import "C"
 import (
-	"log"
 	"net/url"
-	"os"
-	"path/filepath"
 	"unsafe"
 
 	"fyne.io/fyne/v2"
@@ -43,14 +40,4 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 		C.sendNotification(C.uintptr_t(vm), C.uintptr_t(env), C.uintptr_t(ctx), titleStr, contentStr)
 		return nil
 	})
-}
-
-func rootConfigDir() string {
-	filesDir := os.Getenv("FILESDIR")
-	if filesDir == "" {
-		log.Println("FILESDIR env was not set by android native code")
-		return "/data/data" // probably won't work, but we can't make a better guess
-	}
-
-	return filepath.Join(filesDir, "fyne")
 }

--- a/app/app_mobile_and_test.go
+++ b/app/app_mobile_and_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"fyne.io/fyne/v2/internal/app"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +15,7 @@ func Test_RootConfigDir(t *testing.T) {
 	oldEnv := os.Getenv("FILESPATH")
 	os.Setenv("FILESPATH", "/tmp")
 
-	assert.Equal(t, "/tmp", rootConfigDir())
+	assert.Equal(t, "/tmp", app.RootConfigDir())
 	os.Setenv("FILESPATH", oldEnv)
 }
 

--- a/app/app_mobile_ios.go
+++ b/app/app_mobile_ios.go
@@ -15,14 +15,8 @@ void sendNotification(char *title, char *content);
 import "C"
 import (
 	"net/url"
-	"path/filepath"
 	"unsafe"
 )
-
-func rootConfigDir() string {
-	root := C.documentsPath()
-	return filepath.Join(C.GoString(root), "fyne")
-}
 
 func (a *fyneApp) OpenURL(url *url.URL) error {
 	urlStr := C.CString(url.String())

--- a/app/app_other.go
+++ b/app/app_other.go
@@ -5,15 +5,9 @@ package app
 import (
 	"errors"
 	"net/url"
-	"os"
-	"path/filepath"
 
 	"fyne.io/fyne/v2"
 )
-
-func rootConfigDir() string {
-	return filepath.Join(os.TempDir(), "fyne-test")
-}
 
 func (a *fyneApp) OpenURL(_ *url.URL) error {
 	return errors.New("Unable to open url for unknown operating system")

--- a/app/app_windows.go
+++ b/app/app_windows.go
@@ -29,13 +29,6 @@ $xml.LoadXml($toastXml.OuterXml)
 $toast = [Windows.UI.Notifications.ToastNotification]::new($xml)
 [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("%s").Show($toast);`
 
-func rootConfigDir() string {
-	homeDir, _ := os.UserHomeDir()
-
-	desktopConfig := filepath.Join(filepath.Join(homeDir, "AppData"), "Roaming")
-	return filepath.Join(desktopConfig, "fyne")
-}
-
 func (a *fyneApp) OpenURL(url *url.URL) error {
 	cmd := exec.Command("rundll32", "url.dll,FileProtocolHandler", url.String())
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sync/atomic"
 
 	"github.com/godbus/dbus/v5"
@@ -112,11 +111,6 @@ func (a *fyneApp) SetSystemTrayIcon(icon fyne.Resource) {
 	if desk, ok := a.Driver().(systrayDriver); ok { // don't use this on mobile tag
 		desk.SetSystemTrayIcon(icon)
 	}
-}
-
-func rootConfigDir() string {
-	desktopConfig, _ := os.UserConfigDir()
-	return filepath.Join(desktopConfig, "fyne")
 }
 
 func watchTheme(s *settings) {

--- a/app/preferences_android.go
+++ b/app/preferences_android.go
@@ -2,7 +2,11 @@
 
 package app
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"fyne.io/fyne/v2/internal/app"
+)
 
 // storagePath returns the location of the settings storage
 func (p *preferences) storagePath() string {
@@ -12,7 +16,7 @@ func (p *preferences) storagePath() string {
 
 // storageRoot returns the location of the app storage
 func (a *fyneApp) storageRoot() string {
-	return rootConfigDir() // we are in a sandbox, so no app ID added to this path
+	return app.RootConfigDir() // we are in a sandbox, so no app ID added to this path
 }
 
 func (p *preferences) watch() {

--- a/app/preferences_ios.go
+++ b/app/preferences_ios.go
@@ -4,6 +4,8 @@ package app
 
 import (
 	"path/filepath"
+
+	"fyne.io/fyne/v2/internal/app"
 )
 import "C"
 
@@ -15,7 +17,7 @@ func (p *preferences) storagePath() string {
 
 // storageRoot returns the location of the app storage
 func (a *fyneApp) storageRoot() string {
-	return rootConfigDir() // we are in a sandbox, so no app ID added to this path
+	return app.RootConfigDir() // we are in a sandbox, so no app ID added to this path
 }
 
 func (p *preferences) watch() {

--- a/app/preferences_mobile.go
+++ b/app/preferences_mobile.go
@@ -2,7 +2,11 @@
 
 package app
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"fyne.io/fyne/v2/internal/app"
+)
 
 // storagePath returns the location of the settings storage
 func (p *preferences) storagePath() string {
@@ -11,7 +15,7 @@ func (p *preferences) storagePath() string {
 
 // storageRoot returns the location of the app storage
 func (a *fyneApp) storageRoot() string {
-	return filepath.Join(rootConfigDir(), a.UniqueID())
+	return filepath.Join(app.RootConfigDir(), a.UniqueID())
 }
 
 func (p *preferences) watch() {

--- a/app/preferences_other.go
+++ b/app/preferences_other.go
@@ -2,7 +2,11 @@
 
 package app
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"fyne.io/fyne/v2/internal/app"
+)
 
 // storagePath returns the location of the settings storage
 func (p *preferences) storagePath() string {
@@ -11,7 +15,7 @@ func (p *preferences) storagePath() string {
 
 // storageRoot returns the location of the app storage
 func (a *fyneApp) storageRoot() string {
-	return filepath.Join(rootConfigDir(), a.UniqueID())
+	return filepath.Join(app.RootConfigDir(), a.UniqueID())
 }
 
 func (p *preferences) watch() {

--- a/app/settings.go
+++ b/app/settings.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"fyne.io/fyne/v2"
-	internalapp "fyne.io/fyne/v2/internal/app"
+	"fyne.io/fyne/v2/internal/app"
 	"fyne.io/fyne/v2/internal/build"
 	"fyne.io/fyne/v2/theme"
 )
@@ -27,7 +27,7 @@ type SettingsSchema struct {
 
 // StoragePath returns the location of the settings storage
 func (sc *SettingsSchema) StoragePath() string {
-	return filepath.Join(rootConfigDir(), "settings.json")
+	return filepath.Join(app.RootConfigDir(), "settings.json")
 }
 
 // Declare conformity with Settings interface
@@ -129,7 +129,7 @@ func (s *settings) fileChanged() {
 }
 
 func (s *settings) loadSystemTheme() fyne.Theme {
-	path := filepath.Join(rootConfigDir(), "theme.json")
+	path := filepath.Join(app.RootConfigDir(), "theme.json")
 	data, err := fyne.LoadResourceFromPath(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -153,7 +153,7 @@ func (s *settings) setupTheme() {
 		name = env
 	}
 
-	variant := internalapp.DefaultVariant()
+	variant := app.DefaultVariant()
 	effectiveTheme := s.theme
 	if !s.themeSpecified {
 		effectiveTheme = s.loadSystemTheme()

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,0 +1,5 @@
+package app
+
+func RootConfigDir() string {
+	return rootConfigDir()
+}

--- a/internal/app/config_desktop_darwin.go
+++ b/internal/app/config_desktop_darwin.go
@@ -1,0 +1,15 @@
+//go:build !ci && !ios && !wasm && !test_web_driver && !mobile
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func rootConfigDir() string {
+	homeDir, _ := os.UserHomeDir()
+
+	desktopConfig := filepath.Join(filepath.Join(homeDir, "Library"), "Preferences")
+	return filepath.Join(desktopConfig, "fyne")
+}

--- a/internal/app/config_goxjs.go
+++ b/internal/app/config_goxjs.go
@@ -1,0 +1,7 @@
+//go:build !ci && (!android || !ios || !mobile) && (wasm || test_web_driver)
+
+package app
+
+func rootConfigDir() string {
+	return "/data/"
+}

--- a/internal/app/config_mobile_and.go
+++ b/internal/app/config_mobile_and.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 )

--- a/internal/app/config_mobile_and.go
+++ b/internal/app/config_mobile_and.go
@@ -2,6 +2,11 @@
 
 package app
 
+import (
+	"os"
+	"path/filepath"
+)
+
 func rootConfigDir() string {
 	filesDir := os.Getenv("FILESDIR")
 	if filesDir == "" {

--- a/internal/app/config_mobile_and.go
+++ b/internal/app/config_mobile_and.go
@@ -1,0 +1,13 @@
+//go:build !ci && android
+
+package app
+
+func rootConfigDir() string {
+	filesDir := os.Getenv("FILESDIR")
+	if filesDir == "" {
+		log.Println("FILESDIR env was not set by android native code")
+		return "/data/data" // probably won't work, but we can't make a better guess
+	}
+
+	return filepath.Join(filesDir, "fyne")
+}

--- a/internal/app/config_mobile_ios.go
+++ b/internal/app/config_mobile_ios.go
@@ -2,6 +2,10 @@
 
 package app
 
+import (
+	"path/filepath"
+)
+
 func rootConfigDir() string {
 	root := C.documentsPath()
 	return filepath.Join(C.GoString(root), "fyne")

--- a/internal/app/config_mobile_ios.go
+++ b/internal/app/config_mobile_ios.go
@@ -1,0 +1,8 @@
+//go:build !ci && ios && !mobile
+
+package app
+
+func rootConfigDir() string {
+	root := C.documentsPath()
+	return filepath.Join(C.GoString(root), "fyne")
+}

--- a/internal/app/config_other.go
+++ b/internal/app/config_other.go
@@ -1,0 +1,12 @@
+//go:build ci || (mobile && !android && !ios) || (!linux && !darwin && !windows && !freebsd && !openbsd && !netbsd && !wasm && !test_web_driver)
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func rootConfigDir() string {
+	return filepath.Join(os.TempDir(), "fyne-test")
+}

--- a/internal/app/config_windows.go
+++ b/internal/app/config_windows.go
@@ -1,0 +1,10 @@
+//go:build !ci && !android && !ios && !wasm && !test_web_driver
+
+package app
+
+func rootConfigDir() string {
+	homeDir, _ := os.UserHomeDir()
+
+	desktopConfig := filepath.Join(filepath.Join(homeDir, "AppData"), "Roaming")
+	return filepath.Join(desktopConfig, "fyne")
+}

--- a/internal/app/config_windows.go
+++ b/internal/app/config_windows.go
@@ -2,6 +2,11 @@
 
 package app
 
+import (
+	"os"
+	"path/filepath"
+)
+
 func rootConfigDir() string {
 	homeDir, _ := os.UserHomeDir()
 

--- a/internal/app/config_xdg.go
+++ b/internal/app/config_xdg.go
@@ -2,6 +2,11 @@
 
 package app
 
+import (
+	"os"
+	"path/filepath"
+)
+
 func rootConfigDir() string {
 	desktopConfig, _ := os.UserConfigDir()
 	return filepath.Join(desktopConfig, "fyne")

--- a/internal/app/config_xdg.go
+++ b/internal/app/config_xdg.go
@@ -1,0 +1,8 @@
+//go:build !ci && !wasm && !test_web_driver && !android && !ios && !mobile && (linux || openbsd || freebsd || netbsd)
+
+package app
+
+func rootConfigDir() string {
+	desktopConfig, _ := os.UserConfigDir()
+	return filepath.Join(desktopConfig, "fyne")
+}

--- a/internal/app/theme_darwin.go
+++ b/internal/app/theme_darwin.go
@@ -13,7 +13,7 @@ bool isDarkMode();
 import "C"
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/internal/theme"
 )
 
 // DefaultVariant returns the systems default fyne.ThemeVariant.

--- a/internal/app/theme_other.go
+++ b/internal/app/theme_other.go
@@ -4,7 +4,7 @@ package app
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/internal/theme"
 )
 
 // DefaultVariant returns the systems default fyne.ThemeVariant.

--- a/internal/app/theme_wasm.go
+++ b/internal/app/theme_wasm.go
@@ -6,7 +6,7 @@ import (
 	"syscall/js"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/internal/theme"
 )
 
 // DefaultVariant returns the systems default fyne.ThemeVariant.

--- a/internal/app/theme_web.go
+++ b/internal/app/theme_web.go
@@ -4,7 +4,7 @@ package app
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/internal/theme"
 )
 
 // DefaultVariant returns the systems default fyne.ThemeVariant.

--- a/internal/app/theme_windows.go
+++ b/internal/app/theme_windows.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/internal/theme"
 )
 
 const themeRegKey = `SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize`

--- a/theme/color_test.go
+++ b/theme/color_test.go
@@ -12,12 +12,12 @@ import (
 func Test_BackgroundColor(t *testing.T) {
 	t.Run("dark theme", func(t *testing.T) {
 		fyne.CurrentApp().Settings().SetTheme(theme.DarkTheme())
-		assert.Equal(t, theme.DefaultTheme().Color(theme.ColorNameBackground, theme.VariantDark), theme.BackgroundColor(), "wrong dark theme background color")
+		assert.Equal(t, theme.Current().Color(theme.ColorNameBackground, theme.VariantDark), theme.BackgroundColor(), "wrong dark theme background color")
 	})
 	t.Run("light theme", func(t *testing.T) {
 		fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
 		bg := theme.BackgroundColor()
-		assert.Equal(t, theme.DefaultTheme().Color(theme.ColorNameBackground, theme.VariantLight), bg, "wrong light theme background color")
+		assert.Equal(t, theme.Current().Color(theme.ColorNameBackground, theme.VariantLight), bg, "wrong light theme background color")
 	})
 }
 

--- a/theme/json.go
+++ b/theme/json.go
@@ -27,12 +27,16 @@ func FromJSON(data string) (fyne.Theme, error) {
 //
 // Since: 2.2
 func FromJSONReader(r io.Reader) (fyne.Theme, error) {
+	return fromJSONWithFallback(r, DefaultTheme())
+}
+
+func fromJSONWithFallback(r io.Reader, fallback fyne.Theme) (fyne.Theme, error) {
 	var th *schema
 	if err := json.NewDecoder(r).Decode(&th); err != nil {
-		return DefaultTheme(), err
+		return fallback, err
 	}
 
-	return &jsonTheme{data: th, fallback: DefaultTheme()}, nil
+	return &jsonTheme{data: th, fallback: fallback}, nil
 }
 
 type hexColor string

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"fyne.io/fyne/v2"
+	internalApp "fyne.io/fyne/v2/internal/app"
 	"fyne.io/fyne/v2/internal/cache"
 	internaltheme "fyne.io/fyne/v2/internal/theme"
 )
@@ -391,9 +392,7 @@ func setupDefaultTheme() fyne.Theme {
 }
 
 func setupSystemTheme(fallback fyne.Theme) fyne.Theme {
-	// TODO rootURI code to internal/app
-	home, _ := os.UserHomeDir()
-	root := filepath.Join(home, ".config", "fyne")
+	root := internalApp.RootConfigDir()
 
 	path := filepath.Join(root, "theme.json")
 	data, err := fyne.LoadResourceFromPath(path)


### PR DESCRIPTION
I discovered that an app with a partial custom theme will delegate to the builtin theme instead of the rendered one. These can be different if you have a system theme installed.

- [x] I still have to refactor the base config dir code

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
