### PR TITLE
Fix color picker dismissed callback

### DIFF
--- a/dialog/color.go
+++ b/dialog/color.go
@@ -141,6 +141,9 @@ func (p *ColorPickerDialog) updateUI() {
 		p.dialog.create(container.NewGridWithColumns(2, p.dialog.dismiss, confirm))
 	} else {
 		p.dialog.content = container.NewVBox(p.createSimplePickers()...)
+		p.dialog.dismiss.OnTapped = func() {
+			p.callback(nil)
+		}
 		p.dialog.create(container.NewGridWithColumns(1, p.dialog.dismiss))
 	}
 }

--- a/dialog/color.go
+++ b/dialog/color.go
@@ -135,6 +135,9 @@ func (p *ColorPickerDialog) updateUI() {
 				p.selectColor(p.color)
 			},
 		}
+		p.dialog.dismiss.OnTapped = func() {
+			p.callback(nil)
+		}
 		p.dialog.create(container.NewGridWithColumns(2, p.dialog.dismiss, confirm))
 	} else {
 		p.dialog.content = container.NewVBox(p.createSimplePickers()...)

--- a/dialog/color_test.go
+++ b/dialog/color_test.go
@@ -95,26 +95,50 @@ func TestColorDialog_SetColor(t *testing.T) {
 
 func TestColorDialog_Buttons(t *testing.T) {
 	for name, tt := range map[string]struct {
-		action     func(d *ColorPickerDialog, w fyne.Window)
+		action          func(d *ColorPickerDialog, w fyne.Window)
+		advanced        bool
 		expectedCalled  bool
 		expectedColored bool
 	}{
-		"confirm": {
+		"confirmAdvanced": {
 			action: func(d *ColorPickerDialog, w fyne.Window) {
 				test.FocusNext(w.Canvas()) // advanced accordion
 				test.FocusNext(w.Canvas()) // dismiss button
 				test.FocusNext(w.Canvas()) // confirm button
 				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
 			},
+			advanced:        true,
 			expectedCalled:  true,
 			expectedColored: true,
 		},
-		"dismiss": {
+		"dismissAdvanced": {
 			action: func(d *ColorPickerDialog, w fyne.Window) {
 				test.FocusNext(w.Canvas()) // advanced accordion
 				test.FocusNext(w.Canvas()) // dismiss button
 				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
 			},
+			advanced:        true,
+			expectedCalled:  true,
+			expectedColored: false,
+		},
+		"confirmSimple": {
+			action: func(d *ColorPickerDialog, w fyne.Window) {
+				test.FocusNext(w.Canvas()) // advanced accordion
+				test.FocusNext(w.Canvas()) // dismiss button
+				test.FocusNext(w.Canvas()) // confirm button
+				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+			},
+			advanced:        false,
+			expectedCalled:  true,
+			expectedColored: true,
+		},
+		"dismissSimple": {
+			action: func(d *ColorPickerDialog, w fyne.Window) {
+				test.FocusNext(w.Canvas()) // advanced accordion
+				test.FocusNext(w.Canvas()) // dismiss button
+				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+			},
+			advanced:        false,
 			expectedCalled:  true,
 			expectedColored: false,
 		},

--- a/dialog/color_test.go
+++ b/dialog/color_test.go
@@ -121,20 +121,8 @@ func TestColorDialog_Buttons(t *testing.T) {
 			expectedCalled:  true,
 			expectedColored: false,
 		},
-		"confirmSimple": {
-			action: func(d *ColorPickerDialog, w fyne.Window) {
-				test.FocusNext(w.Canvas()) // advanced accordion
-				test.FocusNext(w.Canvas()) // dismiss button
-				test.FocusNext(w.Canvas()) // confirm button
-				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
-			},
-			advanced:        false,
-			expectedCalled:  true,
-			expectedColored: true,
-		},
 		"dismissSimple": {
 			action: func(d *ColorPickerDialog, w fyne.Window) {
-				test.FocusNext(w.Canvas()) // advanced accordion
 				test.FocusNext(w.Canvas()) // dismiss button
 				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
 			},
@@ -154,7 +142,7 @@ func TestColorDialog_Buttons(t *testing.T) {
 				called = true
 				colored = c != nil
 			}, w)
-			d.Advanced = true
+			d.Advanced = tt.advanced
 			d.Refresh()
 			d.Show()
 			tt.action(d, w)

--- a/dialog/color_test.go
+++ b/dialog/color_test.go
@@ -93,6 +93,54 @@ func TestColorDialog_SetColor(t *testing.T) {
 	d.Show()
 }
 
+func TestColorDialog_Buttons(t *testing.T) {
+	for name, tt := range map[string]struct {
+		action     func(d *ColorPickerDialog, w fyne.Window)
+		expectedCalled  bool
+		expectedColored bool
+	}{
+		"confirm": {
+			action: func(d *ColorPickerDialog, w fyne.Window) {
+				test.FocusNext(w.Canvas()) // advanced accordion
+				test.FocusNext(w.Canvas()) // dismiss button
+				test.FocusNext(w.Canvas()) // confirm button
+				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+			},
+			expectedCalled:  true,
+			expectedColored: true,
+		},
+		"dismiss": {
+			action: func(d *ColorPickerDialog, w fyne.Window) {
+				test.FocusNext(w.Canvas()) // advanced accordion
+				test.FocusNext(w.Canvas()) // dismiss button
+				w.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
+			},
+			expectedCalled:  true,
+			expectedColored: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			test.NewTempApp(t)
+			w := test.NewTempWindow(t, canvas.NewRectangle(color.Transparent))
+			w.Resize(fyne.NewSize(800, 600))
+
+			called := false
+			colored := false
+			d := NewColorPicker("Color Picker", "Pick a Color", func(c color.Color) {
+				called = true
+				colored = c != nil
+			}, w)
+			d.Advanced = true
+			d.Refresh()
+			d.Show()
+			tt.action(d, w)
+
+			assert.Equal(t, tt.expectedCalled, called, "called isn't equal")
+			assert.Equal(t, tt.expectedColored, colored, "colored isn't equal")
+		})
+	}
+}
+
 func TestColorDialogSimple_Theme(t *testing.T) {
 	test.NewTempApp(t)
 


### PR DESCRIPTION
### Description:
Call the callback provided to the color picker dialog with a `nil` color if the dialog is dismissed.
So users can easily distinguish between confirmation and dismissal and react to it.
This is inline with how all the file related dialogs work (fileSave, fileOpen and folderOpen).

Fixes #5237

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
