### PR TITLE
Don't reload whole theme when variant changes on XDG

### DIFF
--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -122,14 +122,15 @@ func rootConfigDir() string {
 func watchTheme(s *settings) {
 	go func() {
 		// Theme lookup hangs on some desktops. Update theme variant cache from within goroutine.
-		internalapp.CurrentVariant.Store(uint64(findFreedesktopColorScheme()))
-		s.setupTheme()
+		themeVariant := findFreedesktopColorScheme()
+		internalapp.CurrentVariant.Store(uint64(themeVariant))
+		s.applyVariant(themeVariant)
 
 		portalSettings.OnSignalSettingChanged(func(changed portalSettings.Changed) {
 			if changed.Namespace == "org.freedesktop.appearance" && changed.Key == "color-scheme" {
 				themeVariant := colorSchemeToThemeVariant(appearance.ColorScheme(changed.Value.(uint32)))
 				internalapp.CurrentVariant.Store(uint64(themeVariant))
-				s.setupTheme()
+				s.applyVariant(themeVariant)
 			}
 		})
 	}()

--- a/app/app_xdg.go
+++ b/app/app_xdg.go
@@ -127,7 +127,7 @@ func watchTheme(s *settings) {
 		s.applyVariant(themeVariant)
 
 		portalSettings.OnSignalSettingChanged(func(changed portalSettings.Changed) {
-			if changed.Namespace == "org.freedesktop.appearance" && changed.Key == "color-scheme" {
+			if changed.Namespace == appearance.Namespace && changed.Key == "color-scheme" {
 				themeVariant := colorSchemeToThemeVariant(appearance.ColorScheme(changed.Value.(uint32)))
 				internalapp.CurrentVariant.Store(uint64(themeVariant))
 				s.applyVariant(themeVariant)

--- a/app/settings.go
+++ b/app/settings.go
@@ -97,6 +97,13 @@ func (s *settings) applyTheme(theme fyne.Theme, variant fyne.ThemeVariant) {
 	s.apply()
 }
 
+func (s *settings) applyVariant(variant fyne.ThemeVariant) {
+	s.propertyLock.Lock()
+	defer s.propertyLock.Unlock()
+	s.variant = variant
+	s.apply()
+}
+
 func (s *settings) Scale() float32 {
 	s.propertyLock.RLock()
 	defer s.propertyLock.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nicksnyder/go-i18n/v2 v2.4.0
-	github.com/rymdport/portal v0.2.6
+	github.com/rymdport/portal v0.3.0
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/rymdport/portal v0.2.6 h1:HWmU3gORu7vWcpr7VSwUS2Xx1HtJXVcUuTqEZcMEsIg=
-github.com/rymdport/portal v0.2.6/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
+github.com/rymdport/portal v0.3.0 h1:QRHcwKwx3kY5JTQcsVhmhC3TGqGQb9LFghVNUy8AdB8=
+github.com/rymdport/portal v0.3.0/go.mod h1:kFF4jslnJ8pD5uCi17brj/ODlfIidOxlgUDTO5ncnC4=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is a small improvement in the XDG theme watching code to make sure that we only change the variant and not do a full theme reload each time given that we know that just the variant changed. The delay when switching between dark and light mode is decreased.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
