### PR TITLE
Minor cleanup for handling of disabled animations

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -12,8 +12,6 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-var noAnimations bool // set to true at compile time if no_animations tag is passed
-
 // SettingsSchema is used for loading and storing global settings
 type SettingsSchema struct {
 	// these items are used for global settings load
@@ -82,7 +80,7 @@ func (s *settings) SetTheme(theme fyne.Theme) {
 }
 
 func (s *settings) ShowAnimations() bool {
-	return !s.schema.DisableAnimations && !noAnimations
+	return !s.schema.DisableAnimations && !build.NoAnimations
 }
 
 func (s *settings) ThemeVariant() fyne.ThemeVariant {

--- a/app/settings_noanimation.go
+++ b/app/settings_noanimation.go
@@ -1,7 +1,0 @@
-//go:build no_animations
-
-package app
-
-func init() {
-	noAnimations = true
-}

--- a/internal/build/animations_disabled.go
+++ b/internal/build/animations_disabled.go
@@ -1,0 +1,7 @@
+//go:build no_animations
+
+package build
+
+// NoAnimations is true if the application was built without animations by
+// passing the no_animations build tag.
+const NoAnimations = true

--- a/internal/build/animations_enabled.go
+++ b/internal/build/animations_enabled.go
@@ -1,0 +1,7 @@
+//go:build !no_animations
+
+package build
+
+// NoAnimations is true if the application was built without animations by
+// passing the no_animations build tag.
+const NoAnimations = false


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Just a very simple cleanup PR to move the `no_animations` tag handling to use existing infrastructure in the `internal/build` package. The biggest win here is reducing the number of files in the `app` package but it might theoretically (due to now using a constant for the value) also help the compiler deadcode eliminate more branches when building without animations (although the latter is unlikely to matter in most cases). 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

