### PR TITLE
Add missing arrow key mapping for mobile devices

### DIFF
--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -438,6 +438,11 @@ var keyCodeMap = map[key.Code]fyne.KeyName{
 	key.CodeHome:            fyne.KeyHome,
 	key.CodeEnd:             fyne.KeyEnd,
 
+	key.CodeLeftArrow:  fyne.KeyLeft,
+	key.CodeRightArrow: fyne.KeyRight,
+	key.CodeUpArrow:    fyne.KeyUp,
+	key.CodeDownArrow:  fyne.KeyDown,
+
 	key.CodeF1:  fyne.KeyF1,
 	key.CodeF2:  fyne.KeyF2,
 	key.CodeF3:  fyne.KeyF3,


### PR DESCRIPTION

Fixes #5258

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- no infra for mobile hardware tests. Use any mobile device with a keyboard or use "-tags mobile" and use the arrow keys
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
