### PR TITLE
Fixing CPU tight loop if we have a visible image with nil content

### DIFF
--- a/canvas/image.go
+++ b/canvas/image.go
@@ -100,7 +100,9 @@ func (i *Image) Hide() {
 // MinSize returns the specified minimum size, if set, or {1, 1} otherwise.
 func (i *Image) MinSize() fyne.Size {
 	if i.Image == nil || i.aspect == 0 {
-		i.Refresh()
+		if i.File != "" || i.Resource != nil {
+			i.Refresh()
+		}
 	}
 	return i.baseObject.MinSize()
 }
@@ -134,6 +136,8 @@ func (i *Image) Refresh() {
 			return
 		}
 		rc = io.NopCloser(r)
+	} else {
+		return
 	}
 
 	if i.File != "" || i.Resource != nil {


### PR DESCRIPTION


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- runtime CPU is high if you include an image object with no file or resource content
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
