### PR TITLE
Fix `lang` tests

### DIFF
--- a/lang/lang.go
+++ b/lang/lang.go
@@ -205,5 +205,4 @@ func updateLocalizer() {
 	}
 	str := closestSupportedLocale(all).LanguageString()
 	setupLang(str)
-	localizer = i18n.NewLocalizer(bundle, str)
 }

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -203,6 +203,5 @@ func updateLocalizer() {
 		fyne.LogError("Failed to load user locales", err)
 		all = []string{"en"}
 	}
-	str := closestSupportedLocale(all).LanguageString()
-	setupLang(str)
+	setupLang(closestSupportedLocale(all).LanguageString())
 }

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -10,19 +10,19 @@ import (
 )
 
 func TestAddTranslations(t *testing.T) {
-	setupLang("en")
 	err := AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
 		"Test": "Match"
 	}`)))
 	if assert.NoError(t, err) {
+		setupLang("en")
 		assert.Equal(t, "Match", L("Test"))
 	}
 
 	err = AddTranslationsForLocale([]byte(`{
 		"Test2": "Match2"
 	}`), "fr")
-	setupLang("fr")
 	if assert.NoError(t, err) {
+		setupLang("fr")
 		assert.Equal(t, "Match2", L("Test2"))
 	}
 }

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"fyne.io/fyne/v2"
 )
@@ -48,12 +49,12 @@ func TestLocalize_Map(t *testing.T) {
 }
 
 func TestLocalizePlural_Fallback(t *testing.T) {
-	_ = AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
+	require.NoError(t, AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
 		"Apple": {
 			"one": "Apple",
 			"other": "Apples"
 		}
-	}`)))
+	}`))))
 
 	setupLang("en")
 	assert.Equal(t, "Missing", N("Missing", 1))
@@ -62,9 +63,9 @@ func TestLocalizePlural_Fallback(t *testing.T) {
 }
 
 func TestLocalizeKey_Fallback(t *testing.T) {
-	_ = AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
+	require.NoError(t, AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
 		"appleID": "Apple Matched"
-	}`)))
+	}`))))
 
 	setupLang("en")
 	assert.Equal(t, "Apple", X("appleIDMissing", "Apple"))
@@ -72,12 +73,12 @@ func TestLocalizeKey_Fallback(t *testing.T) {
 }
 
 func TestLocalizePluralKey_Fallback(t *testing.T) {
-	_ = AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
+	require.NoError(t, AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
 		"appleID": {
 			"one": "Apple",
 			"other": "Apples"
 		}
-	}`)))
+	}`))))
 
 	setupLang("en")
 	assert.Equal(t, "Missing", XN("appleIDMissing", "Missing", 1))

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -3,8 +3,9 @@ package lang
 import (
 	"testing"
 
-	"fyne.io/fyne/v2"
 	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
 )
 
 func TestAddTranslations(t *testing.T) {

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -13,15 +13,17 @@ func TestAddTranslations(t *testing.T) {
 	err := AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
 		"Test": "Match"
 	}`)))
-	assert.Nil(t, err)
-	assert.Equal(t, "Match", L("Test"))
+	if assert.NoError(t, err) {
+		assert.Equal(t, "Match", L("Test"))
+	}
 
 	err = AddTranslationsForLocale([]byte(`{
 		"Test2": "Match2"
 	}`), "fr")
 	setupLang("fr")
-	assert.Nil(t, err)
-	assert.Equal(t, "Match2", L("Test2"))
+	if assert.NoError(t, err) {
+		assert.Equal(t, "Match2", L("Test2"))
+	}
 }
 
 func TestLocalize_Default(t *testing.T) {

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -11,14 +11,14 @@ import (
 func TestAddTranslations(t *testing.T) {
 	setupLang("en")
 	err := AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
-  "Test": "Match"
-}`)))
+		"Test": "Match"
+	}`)))
 	assert.Nil(t, err)
 	assert.Equal(t, "Match", L("Test"))
 
 	err = AddTranslationsForLocale([]byte(`{
-  "Test2": "Match2"
-}`), "fr")
+		"Test2": "Match2"
+	}`), "fr")
 	setupLang("fr")
 	assert.Nil(t, err)
 	assert.Equal(t, "Match2", L("Test2"))
@@ -47,11 +47,11 @@ func TestLocalize_Map(t *testing.T) {
 
 func TestLocalizePlural_Fallback(t *testing.T) {
 	_ = AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
-  "Apple": {
-    "one": "Apple",
-    "other": "Apples"
-  }
-}`)))
+		"Apple": {
+			"one": "Apple",
+			"other": "Apples"
+		}
+	}`)))
 
 	setupLang("en")
 	assert.Equal(t, "Missing", N("Missing", 1))
@@ -61,8 +61,8 @@ func TestLocalizePlural_Fallback(t *testing.T) {
 
 func TestLocalizeKey_Fallback(t *testing.T) {
 	_ = AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
-  "appleID": "Apple Matched"
-}`)))
+		"appleID": "Apple Matched"
+	}`)))
 
 	setupLang("en")
 	assert.Equal(t, "Apple", X("appleIDMissing", "Apple"))
@@ -71,11 +71,11 @@ func TestLocalizeKey_Fallback(t *testing.T) {
 
 func TestLocalizePluralKey_Fallback(t *testing.T) {
 	_ = AddTranslations(fyne.NewStaticResource("en.json", []byte(`{
-  "appleID": {
-    "one": "Apple",
-    "other": "Apples"
-  }
-}`)))
+		"appleID": {
+			"one": "Apple",
+			"other": "Apples"
+		}
+	}`)))
 
 	setupLang("en")
 	assert.Equal(t, "Missing", XN("appleIDMissing", "Missing", 1))


### PR DESCRIPTION
### Description:
Fixes a bug in the `lang` tests for `AddTranslations` on systems without English system locale.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
