### PR TITLE
allow to set a custom title for the FileDialog

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -55,6 +55,7 @@ type fileDialogPanel interface {
 type fileDialog struct {
 	file             *FileDialog
 	fileName         textWidget
+	title            *widget.Label
 	dismiss          *widget.Button
 	open             *widget.Button
 	breadcrumb       *fyne.Container
@@ -87,6 +88,7 @@ type FileDialog struct {
 	parent           fyne.Window
 	dialog           *fileDialog
 
+	titleText                string
 	confirmText, dismissText string
 	desiredSize              fyne.Size
 	filter                   storage.FileFilter
@@ -153,6 +155,10 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 	if f.file.isDirectory() {
 		title = label + " " + lang.L("Folder")
 	}
+	if f.file.titleText != "" {
+		title = f.file.titleText
+	}
+	f.title = widget.NewLabelWithStyle(title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
 
 	view := ViewLayout(fyne.CurrentApp().Preferences().Int(viewLayoutKey))
 
@@ -235,7 +241,7 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 	)
 
 	header := container.NewBorder(nil, nil, nil, optionsbuttons,
-		optionsbuttons, widget.NewLabelWithStyle(title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		optionsbuttons, f.title,
 	)
 
 	footer := container.NewBorder(nil, nil, nil, buttons,
@@ -743,6 +749,18 @@ func (f *FileDialog) Hide() {
 	if f.onClosedCallback != nil {
 		f.onClosedCallback(false)
 	}
+}
+
+// SetTitleText allows custom text to be set in the dialog title
+//
+// Since: 2.6
+func (f *FileDialog) SetTitleText(label string) {
+	f.titleText = label
+	if f.dialog == nil {
+		return
+	}
+	f.dialog.title.SetText(label)
+	f.dialog.win.Refresh()
 }
 
 // SetConfirmText allows custom text to be set in the confirmation button

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -751,18 +751,6 @@ func (f *FileDialog) Hide() {
 	}
 }
 
-// SetTitleText allows custom text to be set in the dialog title
-//
-// Since: 2.6
-func (f *FileDialog) SetTitleText(label string) {
-	f.titleText = label
-	if f.dialog == nil {
-		return
-	}
-	f.dialog.title.SetText(label)
-	f.dialog.win.Refresh()
-}
-
 // SetConfirmText allows custom text to be set in the confirmation button
 //
 // Since: 2.2
@@ -783,6 +771,17 @@ func (f *FileDialog) SetDismissText(label string) {
 	}
 	f.dialog.dismiss.SetText(label)
 	f.dialog.win.Refresh()
+}
+
+// SetTitleText allows custom text to be set in the dialog title
+//
+// Since: 2.6
+func (f *FileDialog) SetTitleText(label string) {
+	f.titleText = label
+	if f.dialog == nil {
+		return
+	}
+	f.dialog.title.SetText(label)
 }
 
 // SetLocation tells this FileDialog which location to display.

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -478,6 +478,7 @@ func TestView(t *testing.T) {
 		assert.Nil(t, reader)
 	}, win)
 
+	dlg.SetTitleText("File Selection")
 	dlg.SetConfirmText("Yes")
 	dlg.SetDismissText("Dismiss")
 	dlg.Show()
@@ -521,6 +522,8 @@ func TestView(t *testing.T) {
 	assert.Equal(t, "", toggleViewButton.Text)
 	assert.Equal(t, theme.ListIcon().Name(), toggleViewButton.Icon.Name())
 
+	title := ui.Objects[1].(*fyne.Container).Objects[1].(*widget.Label)
+	assert.Equal(t, "File Selection", title.Text)
 	confirm := ui.Objects[2].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
 	assert.Equal(t, "Yes", confirm.Text)
 	dismiss := ui.Objects[2].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)
@@ -537,6 +540,7 @@ func TestSetView(t *testing.T) {
 		assert.Nil(t, reader)
 	}, win)
 
+	dlg.SetTitleText("File Selection")
 	dlg.SetConfirmText("Yes")
 	dlg.SetDismissText("Dismiss")
 
@@ -560,6 +564,8 @@ func TestSetView(t *testing.T) {
 	assert.Equal(t, "", toggleViewButton.Text)
 	assert.Equal(t, theme.GridIcon(), toggleViewButton.Icon)
 
+	title := ui.Objects[1].(*fyne.Container).Objects[1].(*widget.Label)
+	assert.Equal(t, "File Selection", title.Text)
 	confirm := ui.Objects[2].(*fyne.Container).Objects[0].(*fyne.Container).Objects[1].(*widget.Button)
 	assert.Equal(t, "Yes", confirm.Text)
 	dismiss := ui.Objects[2].(*fyne.Container).Objects[0].(*fyne.Container).Objects[0].(*widget.Button)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Allow to set a custom title text for the FileDialog.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [ ] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
