### PR TITLE
Don't crash if ColorDialog is resized before show

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -77,7 +77,9 @@ func (d *dialog) Refresh() {
 // Resize dialog, call this function after dialog show
 func (d *dialog) Resize(size fyne.Size) {
 	d.desiredSize = size
-	d.win.Resize(size)
+	if d.win != nil { // could be called before popup is created!
+		d.win.Resize(size)
+	}
 }
 
 // SetDismissText allows custom text to be set in the dismiss button

--- a/dialog/color_test.go
+++ b/dialog/color_test.go
@@ -12,6 +12,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestColorDialog_Resize(t *testing.T) {
+	test.NewTempApp(t)
+
+	w := test.NewTempWindow(t, canvas.NewRectangle(color.Transparent))
+	w.Resize(fyne.NewSize(1000, 800))
+
+	d := NewColorPicker("Color Picker", "Pick a Color", nil, w)
+	d.Resize(fyne.NewSize(800, 600))
+	d.Show()
+
+	size := d.dialog.content.Size()
+
+	d.Resize(fyne.NewSize(900, 600))
+	newSize := d.dialog.content.Size()
+
+	assert.Equal(t, float32(100), newSize.Width-size.Width)
+}
+
 func TestColorDialog_Theme(t *testing.T) {
 	test.NewTempApp(t)
 


### PR DESCRIPTION
Fixes #5236

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
