### PR TITLE
Add fix and test for serializing SVG without width or height attributes

### DIFF
--- a/internal/svg/svg.go
+++ b/internal/svg/svg.go
@@ -119,8 +119,8 @@ func IsResourceSVG(res fyne.Resource) bool {
 type svg struct {
 	XMLName  xml.Name      `xml:"svg"`
 	XMLNS    string        `xml:"xmlns,attr"`
-	Width    string        `xml:"width,attr"`
-	Height   string        `xml:"height,attr"`
+	Width    string        `xml:"width,attr,omitempty"`
+	Height   string        `xml:"height,attr,omitempty"`
 	ViewBox  string        `xml:"viewBox,attr,omitempty"`
 	Paths    []*pathObj    `xml:"path"`
 	Rects    []*rectObj    `xml:"rect"`

--- a/theme/icons_test.go
+++ b/theme/icons_test.go
@@ -3,6 +3,7 @@ package theme_test
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,18 @@ func TestIconThemeChangeContent(t *testing.T) {
 
 	fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())
 	assert.NotEqual(t, content, cancel.Content())
+}
+
+func TestIconThemeResourceWithViewboxOnly(t *testing.T) {
+	r1 := &fyne.StaticResource{
+		StaticName:    "unsplash.svg",
+		StaticContent: []byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.5 6.75V0h9v6.75h-9zm9 3.75H24V24H0V10.5h7.5v6.75h9V10.5z"></path></svg>`),
+	}
+	r2 := theme.NewThemedResource(r1)
+	re := regexp.MustCompile(`\s+fill\S+`)
+	content := re.ReplaceAll(r2.Content(), []byte(""))
+
+	assert.Equal(t, r1.Content(), content)
 }
 
 func TestNewThemedResource_StaticResourceSupport(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

TL;DR: serializing SVG without width and height leads to empty but existing attributes which causes issues.

People worked around this issue by adding width and height, and even went as far as building tools to work around this.
And it came up before: https://github.com/fyne-io/fyne/issues/3900#issuecomment-2052726026

As this affects the developer experience considerably enough in my opinion, I'm marking this as a blocker to get it into the upcoming release.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

