### PR TITLE
enhance functionality of InnerWindow

### DIFF
--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -73,7 +73,6 @@ func (w *InnerWindow) CreateRenderer() fyne.WidgetRenderer {
 			w.Close()
 		}
 	}}
-	close.Resize(fyne.NewSize(15, 15))
 
 	var icon fyne.CanvasObject
 	if w.Icon != nil {

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -44,7 +44,11 @@ type InnerWindow struct {
 //
 // Since: 2.5
 func NewInnerWindow(title string, content fyne.CanvasObject) *InnerWindow {
-	w := &InnerWindow{title: title, content: NewPadded(content)}
+	w := &InnerWindow{
+		title:           title,
+		content:         NewPadded(content),
+		ButtonAlignment: InnerWindowButtonAlignDefault,
+	}
 	w.ExtendBaseWidget(w)
 	return w
 }
@@ -94,13 +98,13 @@ func (w *InnerWindow) CreateRenderer() fyne.WidgetRenderer {
 	isLeftSide := w.ButtonAlignment == InnerWindowButtonAlignLeft || (w.ButtonAlignment == InnerWindowButtonAlignDefault && runtime.GOOS == "darwin")
 
 	if isLeftSide {
-		// Left side (macOS default or explicit left alignment)
-		buttons = NewHBox(min, max, close)
-		bar = NewBorder(nil, nil, icon, buttons, title)
-	} else {
-		// Right side (Windows/Linux default and explicit right alignment)
+		// Left side (darwin default or explicit left alignment)
 		buttons = NewHBox(close, min, max)
 		bar = NewBorder(nil, nil, buttons, icon, title)
+	} else {
+		// Right side (Windows/Linux default and explicit right alignment)
+		buttons = NewHBox(min, max, close)
+		bar = NewBorder(nil, nil, icon, buttons, title)
 	}
 
 	th := w.Theme()

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -22,8 +22,8 @@ type InnerWindow struct {
 
 	// ButtonAlignment specifies where the window buttons (close, minimize, maximize) should be placed.
 	// The default is widget.ButtonAlignCenter which will auto select based on the OS.
-	//	- On Windows and Linux this will be `widget.ButtonAlignTrailing`
 	//	- On Darwin this will be `widget.ButtonAlignLeading`
+	//	- On all other OS this will be `widget.ButtonAlignTrailing`
 	//
 	// Since: 2.6
 	ButtonAlignment                                     widget.ButtonAlign
@@ -42,9 +42,8 @@ type InnerWindow struct {
 // Since: 2.5
 func NewInnerWindow(title string, content fyne.CanvasObject) *InnerWindow {
 	w := &InnerWindow{
-		title:           title,
-		content:         NewPadded(content),
-		ButtonAlignment: widget.ButtonAlignCenter,
+		title:   title,
+		content: NewPadded(content),
 	}
 	w.ExtendBaseWidget(w)
 	return w

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -65,14 +65,6 @@ func (w *InnerWindow) CreateRenderer() fyne.WidgetRenderer {
 		max.Disable()
 	}
 
-	close := &widget.Button{Icon: theme.WindowCloseIcon(), Importance: widget.DangerImportance, OnTapped: func() {
-		if f := w.CloseIntercept; f != nil {
-			f()
-		} else {
-			w.Close()
-		}
-	}}
-
 	var icon fyne.CanvasObject
 	if w.Icon != nil {
 		icon = &widget.Button{Icon: w.Icon, Importance: widget.LowImportance, OnTapped: func() {
@@ -88,11 +80,18 @@ func (w *InnerWindow) CreateRenderer() fyne.WidgetRenderer {
 	title := newDraggableLabel(w.title, w)
 	title.Truncation = fyne.TextTruncateEllipsis
 
-	var buttons *fyne.Container
-	var bar *fyne.Container
+	close := &widget.Button{Icon: theme.WindowCloseIcon(), Importance: widget.DangerImportance, OnTapped: func() {
+		if f := w.CloseIntercept; f != nil {
+			f()
+		} else {
+			w.Close()
+		}
+	}}
 
 	isLeading := w.ButtonAlignment == widget.ButtonAlignLeading || (w.ButtonAlignment == widget.ButtonAlignCenter && runtime.GOOS == "darwin")
 
+	var buttons *fyne.Container
+	var bar *fyne.Container
 	if isLeading {
 		// Left side (darwin default or explicit left alignment)
 		buttons = NewHBox(close, min, max)
@@ -130,7 +129,7 @@ func (w *InnerWindow) SetPadded(pad bool) {
 	w.content.Refresh()
 }
 
-// Title returns the current title of the window
+// Title returns the current title of the window.
 //
 // Since: 2.6
 func (w *InnerWindow) Title() string {

--- a/container/innerwindow_test.go
+++ b/container/innerwindow_test.go
@@ -11,15 +11,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInnerWindow_Close(t *testing.T) {
+func TestInnerWindow_Close_Left(t *testing.T) {
 	w := NewInnerWindow("Thing", widget.NewLabel("Content"))
-
+	w.ButtonAlignment = InnerWindowButtonAlignLeft
 	outer := test.NewTempWindow(t, w)
 	outer.SetPadded(false)
 	outer.Resize(w.MinSize())
 	assert.True(t, w.Visible())
 
 	closePos := fyne.NewPos(10, 10)
+	test.TapCanvas(outer.Canvas(), closePos)
+	assert.False(t, w.Visible())
+
+	w.Show()
+	assert.True(t, w.Visible())
+
+	closing := true
+	w.CloseIntercept = func() {
+		closing = true
+	}
+
+	test.TapCanvas(outer.Canvas(), closePos)
+	assert.True(t, closing)
+	assert.True(t, w.Visible())
+}
+
+func TestInnerWindow_Close_Right(t *testing.T) {
+	w := NewInnerWindow("Thing", widget.NewLabel("Content"))
+	w.ButtonAlignment = InnerWindowButtonAlignRight
+	outer := test.NewTempWindow(t, w)
+	outer.SetPadded(false)
+	outer.Resize(w.MinSize())
+	assert.True(t, w.Visible())
+
+	closePos := fyne.NewPos(w.Size().Width-10, 10)
 	test.TapCanvas(outer.Canvas(), closePos)
 	assert.False(t, w.Visible())
 

--- a/container/innerwindow_test.go
+++ b/container/innerwindow_test.go
@@ -35,7 +35,6 @@ func TestInnerWindowIcon_Tap_Left(t *testing.T) {
 	iconPos := fyne.NewPos(w.Size().Width-10, 10)
 	test.TapCanvas(outer.Canvas(), iconPos)
 	assert.True(t, testValue)
-
 }
 
 func TestInnerWindowIcon_Tap_Right(t *testing.T) {
@@ -56,7 +55,6 @@ func TestInnerWindowIcon_Tap_Right(t *testing.T) {
 	iconPos := fyne.NewPos(10, 10)
 	test.TapCanvas(outer.Canvas(), iconPos)
 	assert.True(t, testValue)
-
 }
 
 func TestInnerWindow_Close_Left(t *testing.T) {

--- a/container/innerwindow_test.go
+++ b/container/innerwindow_test.go
@@ -11,9 +11,57 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestInnerWindow_Title(t *testing.T) {
+	w := NewInnerWindow("Thing", widget.NewLabel("Content"))
+	w.SetTitle("New Title 123")
+	assert.Equal(t, "New Title 123", w.Title())
+}
+
+func TestInnerWindowIcon_Tap_Left(t *testing.T) {
+	w := NewInnerWindow("Thing", widget.NewLabel("Content"))
+	w.Icon = theme.GridIcon()
+
+	var testValue bool
+	w.OnTappedIcon = func() {
+		testValue = true
+	}
+	w.ButtonAlignment = widget.ButtonAlignLeading
+
+	outer := test.NewTempWindow(t, w)
+	outer.SetPadded(false)
+	outer.Resize(w.MinSize())
+	assert.True(t, w.Visible())
+
+	iconPos := fyne.NewPos(w.Size().Width-10, 10)
+	test.TapCanvas(outer.Canvas(), iconPos)
+	assert.True(t, testValue)
+
+}
+
+func TestInnerWindowIcon_Tap_Right(t *testing.T) {
+	w := NewInnerWindow("Thing", widget.NewLabel("Content"))
+	w.Icon = theme.GridIcon()
+
+	var testValue bool
+	w.OnTappedIcon = func() {
+		testValue = true
+	}
+	w.ButtonAlignment = widget.ButtonAlignTrailing
+
+	outer := test.NewTempWindow(t, w)
+	outer.SetPadded(false)
+	outer.Resize(w.MinSize())
+	assert.True(t, w.Visible())
+
+	iconPos := fyne.NewPos(10, 10)
+	test.TapCanvas(outer.Canvas(), iconPos)
+	assert.True(t, testValue)
+
+}
+
 func TestInnerWindow_Close_Left(t *testing.T) {
 	w := NewInnerWindow("Thing", widget.NewLabel("Content"))
-	w.ButtonAlignment = InnerWindowButtonAlignLeft
+	w.ButtonAlignment = widget.ButtonAlignLeading
 	outer := test.NewTempWindow(t, w)
 	outer.SetPadded(false)
 	outer.Resize(w.MinSize())
@@ -38,7 +86,7 @@ func TestInnerWindow_Close_Left(t *testing.T) {
 
 func TestInnerWindow_Close_Right(t *testing.T) {
 	w := NewInnerWindow("Thing", widget.NewLabel("Content"))
-	w.ButtonAlignment = InnerWindowButtonAlignRight
+	w.ButtonAlignment = widget.ButtonAlignTrailing
 	outer := test.NewTempWindow(t, w)
 	outer.SetPadded(false)
 	outer.Resize(w.MinSize())


### PR DESCRIPTION
### Description:

2 changes:

**First:**
allow customization of button location on InnerWindow via InnerWindow.ButtonAlignment

The widget.ButtonAlign constant is used to configure

    ButtonAlignment specifies where the window buttons (close, minimize, maximize) should be placed.
    The default is widget.ButtonAlignCenter which will auto select based on the OS.
    - On Darwin this will be `widget.ButtonAlignLeading`
    - On all other OS this will be `widget.ButtonAlignTrailing`

**Second**
Added `Title() string` function to retrieve the title of the current inner window