### PR TITLE
Fix clicking on empty part of widget.List not unfocusing

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -130,6 +130,7 @@ func (l *List) RefreshItem(id ListItemID) {
 		return
 	}
 	l.BaseWidget.Refresh()
+	l.Unselect(id)
 	lo := l.scroller.Content.(*fyne.Container).Layout.(*listLayout)
 	lo.renderLock.RLock() // ensures we are not changing visible info in render code during the search
 	item, ok := lo.searchVisible(lo.visible, id)
@@ -384,6 +385,17 @@ func (l *List) contentMinSize() fyne.Size {
 	height += float32(items-totalCustom) * templateHeight
 
 	return fyne.NewSize(l.itemMin.Width, height+separatorThickness*float32(items-1))
+}
+
+func (l *List) Tapped(event *fyne.PointEvent) {
+	canvas := fyne.CurrentApp().Driver().CanvasForObject(l)
+	if canvas != nil {
+		// First, unfocus the currently focused widget if any
+		if l.focused {
+			l.FocusLost()
+		}
+		canvas.Focus(l)
+	}
 }
 
 // fills l.visibleRowHeights and also returns offY and minRow


### PR DESCRIPTION
### Description:
This PR fixes the issue where clicking on an empty part of the widget list does not unfocus other widgets.

Fixes #4770 

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

