### PR TITLE
Don't store time function in each cursor animation

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -16,7 +16,7 @@ var (
 	skippedCleanWithCanvasRefresh = false
 
 	// testing purpose only
-	timeNow func() time.Time = time.Now
+	timeNow = time.Now
 )
 
 func init() {

--- a/widget/entry_cursor_anim.go
+++ b/widget/entry_cursor_anim.go
@@ -11,6 +11,8 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
+var timeNow = time.Now // used in tests
+
 const (
 	cursorInterruptTime = 300 * time.Millisecond
 	cursorFadeAlpha     = uint8(0x16)
@@ -18,17 +20,14 @@ const (
 )
 
 type entryCursorAnimation struct {
-	mu                *sync.RWMutex
+	mu                sync.RWMutex
 	cursor            *canvas.Rectangle
 	anim              *fyne.Animation
 	lastInterruptTime time.Time
-
-	timeNow func() time.Time // useful for testing
 }
 
 func newEntryCursorAnimation(cursor *canvas.Rectangle) *entryCursorAnimation {
-	a := &entryCursorAnimation{mu: &sync.RWMutex{}, cursor: cursor, timeNow: time.Now}
-	return a
+	return &entryCursorAnimation{cursor: cursor}
 }
 
 // creates fyne animation
@@ -55,7 +54,7 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 	interrupted := false
 	anim := fyne.NewAnimation(time.Second/2, func(f float32) {
 		a.mu.RLock()
-		shouldInterrupt := a.timeNow().Sub(a.lastInterruptTime) <= cursorInterruptTime
+		shouldInterrupt := timeNow().Sub(a.lastInterruptTime) <= cursorInterruptTime
 		a.mu.RUnlock()
 		if shouldInterrupt {
 			if !interrupted {
@@ -127,7 +126,7 @@ func (a *entryCursorAnimation) start() {
 // temporarily stops the animation by "cursorInterruptTime".
 func (a *entryCursorAnimation) interrupt() {
 	a.mu.Lock()
-	a.lastInterruptTime = a.timeNow()
+	a.lastInterruptTime = timeNow()
 	a.mu.Unlock()
 }
 

--- a/widget/entry_cursor_anim_test.go
+++ b/widget/entry_cursor_anim_test.go
@@ -42,7 +42,7 @@ func TestEntryCursorAnim(t *testing.T) {
 	a.anim.Tick(1.0)
 	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
 
-	a.timeNow = func() time.Time {
+	timeNow = func() time.Time {
 		return time.Now().Add(cursorInterruptTime)
 	}
 	// animation should be restarted inverting the colors
@@ -54,12 +54,12 @@ func TestEntryCursorAnim(t *testing.T) {
 	a.anim.Tick(1.0)
 	assert.True(t, alphaEquals(cursorDim, a.cursor.FillColor))
 
-	a.timeNow = time.Now
+	timeNow = time.Now
 	a.interrupt()
 	a.anim.Tick(0.0)
 	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
 
-	a.timeNow = func() time.Time {
+	timeNow = func() time.Time {
 		return time.Now().Add(cursorInterruptTime)
 	}
 	a.anim.Tick(0.0)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This avoids carrying around the baggage of each entry cursor animation having a field for the time value. Lets just define it globally and change it in tests. The compiler should be able to remove the variable in an optimisation pass somewhere.

NOTE: We can likely remove all of these custom time variables when the `synctest` package lands (Go 1.24 or newer).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

