### PR TITLE
driver/glfw: Merge waitForStart and done channels

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -33,10 +33,9 @@ var curWindow *window
 var _ fyne.Driver = (*gLDriver)(nil)
 
 type gLDriver struct {
-	windowLock   sync.RWMutex
-	windows      []fyne.Window
-	done         chan struct{}
-	waitForStart chan struct{}
+	windowLock        sync.RWMutex
+	windows           []fyne.Window
+	waitForTransition chan struct{} // wait for transitioning first from starting and later on to quiting.
 
 	animation animation.Runner
 
@@ -99,7 +98,7 @@ func (d *gLDriver) Quit() {
 
 	// Only call close once to avoid panic.
 	if running.CompareAndSwap(true, false) {
-		close(d.done)
+		close(d.waitForTransition)
 	}
 }
 
@@ -174,7 +173,6 @@ func NewGLDriver() *gLDriver {
 	repository.Register("file", intRepo.NewFileRepository())
 
 	return &gLDriver{
-		done:         make(chan struct{}),
-		waitForStart: make(chan struct{}),
+		waitForTransition: make(chan struct{}),
 	}
 }

--- a/internal/driver/glfw/glfw_test.go
+++ b/internal/driver/glfw/glfw_test.go
@@ -32,10 +32,6 @@ func ensureCanvasSize(t *testing.T, w *window, size fyne.Size) {
 }
 
 func repaintWindow(w *window) {
-	// Wait for GLFW loop to be running.
-	// If we try to paint windows before the context is created, we will end up on the wrong thread.
-	<-w.driver.waitForStart
-
 	runOnMainWithContext(w, func() {
 		d.repaintWindow(w)
 	})

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -140,8 +140,6 @@ func (w *window) doShow() {
 		return
 	}
 
-	<-w.driver.waitForStart
-
 	w.createLock.Do(w.create)
 	if w.view() == nil {
 		return

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -38,9 +38,6 @@ func init() {
 func TestMain(m *testing.M) {
 	d.initGLFW()
 	go func() {
-		// Wait for GLFW loop to be running.
-		// If we try to create windows before the context is created, this will fail with an exception.
-		<-d.waitForStart
 
 		initMainMenu()
 		os.Exit(m.Run())


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

With the threading changes, we no longer need to have separate channels for done and waitForStart given that showing a window no longer is expected to happen on the wrong thread. This allows allows us to first wait for starting and then reopen the channel to wait for shutting down. I.e. we no longer carry around a useless startup channel once we are running.

Follow up to https://github.com/fyne-io/fyne/pull/5322

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

