### PR TITLE
Add entry.Insert API to insert text at current cursor position

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -908,12 +908,12 @@ func (e *Entry) Unbind() {
 	e.binder.Unbind()
 }
 
-// Insert inserts the given text into the Entry at the current cursor position.
+// InsertAtCursor inserts the given text into the Entry at the current cursor position.
 // If text is currently selected, the selected text will be replaced
 // with the inserted content.
 //
 // Since: 2.6
-func (e *Entry) Insert(text string) {
+func (e *Entry) InsertAtCursor(text string) {
 	if text == "" {
 		changed := e.selecting && e.eraseSelection()
 
@@ -1061,7 +1061,7 @@ func (e *Entry) getRowCol(p fyne.Position) (int, int) {
 // pasteFromClipboard inserts text from the clipboard content,
 // starting from the cursor position.
 func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
-	e.Insert(clipboard.Content())
+	e.InsertAtCursor(clipboard.Content())
 }
 
 // placeholderProvider returns the placeholder text handler for this entry

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -946,7 +946,7 @@ func TestEntry_OnPaste(t *testing.T) {
 	}
 }
 
-func TestEntry_Insert(t *testing.T) {
+func TestEntry_InsertAtCursor(t *testing.T) {
 	tests := []struct {
 		name             string
 		entry            *widget.Entry
@@ -1014,7 +1014,7 @@ func TestEntry_Insert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.entry.Insert(tt.insertText)
+			tt.entry.InsertAtCursor(tt.insertText)
 			assert.Equal(t, tt.wantText, tt.entry.Text)
 			assert.Equal(t, tt.wantRow, tt.entry.CursorRow)
 			assert.Equal(t, tt.wantCol, tt.entry.CursorColumn)

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -946,6 +946,82 @@ func TestEntry_OnPaste(t *testing.T) {
 	}
 }
 
+func TestEntry_Insert(t *testing.T) {
+	tests := []struct {
+		name             string
+		entry            *widget.Entry
+		insertText       string
+		wantText         string
+		wantRow, wantCol int
+	}{
+		{
+			name:       "singleline: empty content",
+			entry:      widget.NewEntry(),
+			insertText: "",
+			wantText:   "",
+			wantRow:    0,
+			wantCol:    0,
+		},
+		{
+			name:       "singleline: simple text",
+			entry:      widget.NewEntry(),
+			insertText: "clipboard content",
+			wantText:   "clipboard content",
+			wantRow:    0,
+			wantCol:    17,
+		},
+		{
+			name:       "singleline: UTF8 text",
+			entry:      widget.NewEntry(),
+			insertText: "Hié™שרה",
+			wantText:   "Hié™שרה",
+			wantRow:    0,
+			wantCol:    7,
+		},
+		{
+			name:       "singleline: with new line",
+			entry:      widget.NewEntry(),
+			insertText: "clipboard\ncontent",
+			wantText:   "clipboard content",
+			wantRow:    0,
+			wantCol:    17,
+		},
+		{
+			name:       "singleline: with tab",
+			entry:      widget.NewEntry(),
+			insertText: "clipboard\tcontent",
+			wantText:   "clipboard\tcontent",
+			wantRow:    0,
+			wantCol:    17,
+		},
+		{
+			name:       "password: with new line",
+			entry:      widget.NewPasswordEntry(),
+			insertText: "3SB=y+)z\nkHGK(hx6 -e_\"1TZu q^bF3^$u H[:e\"1O.",
+			wantText:   `3SB=y+)z kHGK(hx6 -e_"1TZu q^bF3^$u H[:e"1O.`,
+			wantRow:    0,
+			wantCol:    44,
+		},
+		{
+			name:       "multiline: with new line",
+			entry:      widget.NewMultiLineEntry(),
+			insertText: "clipboard\ncontent",
+			wantText:   "clipboard\ncontent",
+			wantRow:    1,
+			wantCol:    7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.entry.Insert(tt.insertText)
+			assert.Equal(t, tt.wantText, tt.entry.Text)
+			assert.Equal(t, tt.wantRow, tt.entry.CursorRow)
+			assert.Equal(t, tt.wantCol, tt.entry.CursorColumn)
+		})
+	}
+}
+
 func TestEntry_PageUpDown(t *testing.T) {
 	t.Run("single line", func(*testing.T) {
 		e, window := setupImageTest(t, false)


### PR DESCRIPTION
### Description:

Fixes #3445 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
