### PR TITLE
Ensure text and SVG textures re-rasterize when window is dragged to new monitor

### DIFF
--- a/internal/cache/texture_common.go
+++ b/internal/cache/texture_common.go
@@ -78,6 +78,20 @@ func RangeTexturesFor(canvas fyne.Canvas, f func(fyne.CanvasObject)) {
 	})
 }
 
+// DeleteTextTexturesFor deletes all text textures for the given canvas.
+func DeleteTextTexturesFor(canvas fyne.Canvas) {
+	textures.Range(func(key, value any) bool {
+		if _, ok := key.(FontCacheEntry); ok {
+			tinfo := value.(*textureInfo)
+			if tinfo.canvas == canvas {
+				textures.Delete(key)
+				tinfo.textFree()
+			}
+		}
+		return true
+	})
+}
+
 // SetTextTexture sets cached texture for a text run.
 func SetTextTexture(ent FontCacheEntry, texture TextureType, canvas fyne.Canvas, free func()) {
 	store(ent, texture, canvas, free)

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -15,6 +15,7 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal/build"
+	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/painter/gl"
 	"fyne.io/fyne/v2/internal/scale"
@@ -703,6 +704,10 @@ func (w *window) rescaleOnMain() {
 	size := w.canvas.size.Max(w.canvas.MinSize())
 	newWidth, newHeight := w.screenSize(size)
 	w.viewport.SetSize(newWidth, newHeight)
+
+	// Ensure textures re-rasterize at the new scale
+	cache.DeleteTextTexturesFor(w.canvas)
+	w.canvas.content.Refresh()
 }
 
 func (w *window) create() {

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/painter/gl"
 	"fyne.io/fyne/v2/internal/scale"
 
@@ -474,7 +475,11 @@ func (w *window) rescaleOnMain() {
 		scale.ToFyneCoordinate(w.canvas, w.width),
 		scale.ToFyneCoordinate(w.canvas, w.height))
 	w.canvas.Resize(scaledFull)
-	return
+
+	// Ensure textures re-rasterize at the new scale
+	cache.DeleteTextTexturesFor(w.canvas)
+	w.canvas.content.Refresh()
+	//return
 	//	}
 
 	//	size := w.canvas.size.Union(w.canvas.MinSize())

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -469,7 +469,6 @@ func (w *window) rescaleOnMain() {
 		return
 	}
 
-	//	if w.fullScreen {
 	w.width, w.height = w.viewport.GetSize()
 	scaledFull := fyne.NewSize(
 		scale.ToFyneCoordinate(w.canvas, w.width),
@@ -479,12 +478,6 @@ func (w *window) rescaleOnMain() {
 	// Ensure textures re-rasterize at the new scale
 	cache.DeleteTextTexturesFor(w.canvas)
 	w.canvas.content.Refresh()
-	//return
-	//	}
-
-	//	size := w.canvas.size.Union(w.canvas.MinSize())
-	//	newWidth, newHeight := w.screenSize(size)
-	//	w.viewport.SetSize(newWidth, newHeight)
 }
 
 func (w *window) create() {


### PR DESCRIPTION
### Description:
A regression in 2.5.3 resulted in text and SVG rasterizations not re-rasterizing when the window was moved between monitors, resulting in blurriness if the window went from low DPI to high DPI.

Fixes #5323 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. -- Tested manually
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
