### PR TITLE
Use "any" instead of "interface{}"

### DIFF
--- a/app/app_goxjs.go
+++ b/app/app_goxjs.go
@@ -29,7 +29,7 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 		base64Str := base64.StdEncoding.EncodeToString(icon)
 		mimeType := http.DetectContentType(icon)
 		base64Img := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Str)
-		notification.New(n.Title, map[string]interface{}{
+		notification.New(n.Title, map[string]any{
 			"body": n.Content,
 			"icon": base64Img,
 		})
@@ -37,7 +37,7 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 	}
 	if permission.Type() != js.TypeString || permission.String() != "granted" {
 		// need to request for permission
-		notification.Call("requestPermission", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		notification.Call("requestPermission", js.FuncOf(func(this js.Value, args []js.Value) any {
 			if len(args) > 0 && args[0].Type() == js.TypeString && args[0].String() == "granted" {
 				showNotification()
 			} else {
@@ -50,7 +50,7 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 	}
 }
 
-var themeChanged = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+var themeChanged = js.FuncOf(func(this js.Value, args []js.Value) any {
 	if len(args) > 0 && args[0].Type() == js.TypeObject {
 		fyne.CurrentApp().Settings().(*settings).setupTheme()
 	}

--- a/cmd/fyne/internal/commands/translate.go
+++ b/cmd/fyne/internal/commands/translate.go
@@ -137,7 +137,7 @@ type translateOpts struct {
 // Create or add to translations file by scanning the given files for translation calls.
 // Works with and without existing translations file.
 func updateTranslationsFile(file string, files []string, opts *translateOpts) error {
-	translations := make(map[string]interface{})
+	translations := make(map[string]any)
 
 	f, err := os.Open(file)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -205,7 +205,7 @@ func writeTranslationsFile(b []byte, file string) error {
 }
 
 // Update translations hash by scanning the given files, then parsing and walking the AST
-func updateTranslationsHash(m map[string]interface{}, srcs []string, opts *translateOpts) error {
+func updateTranslationsHash(m map[string]any, srcs []string, opts *translateOpts) error {
 	fset := token.NewFileSet()
 	specs := []*ast.ImportSpec{}
 
@@ -287,7 +287,7 @@ type visitor struct {
 	name     string
 	key      string
 	fallback string
-	m        map[string]interface{}
+	m        map[string]any
 }
 
 // Method to walk AST using interface for ast.Walk

--- a/cmd/fyne/internal/commands/translate_test.go
+++ b/cmd/fyne/internal/commands/translate_test.go
@@ -89,7 +89,7 @@ func TestUpdateTranslationsFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	translations := make(map[string]interface{})
+	translations := make(map[string]any)
 	dec := json.NewDecoder(f)
 	if err := dec.Decode(&translations); err != nil {
 		t.Fatal(err)
@@ -142,7 +142,7 @@ func TestUpdateTranslationsHash(t *testing.T) {
 	srcpath := filepath.Join(dir, src)
 
 	opts := translateOpts{}
-	translations := make(map[string]interface{})
+	translations := make(map[string]any)
 	if err := updateTranslationsHash(translations, []string{srcpath}, &opts); err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestTranslationsVisitor(t *testing.T) {
 	}
 
 	opts := translateOpts{}
-	translations := make(map[string]interface{})
+	translations := make(map[string]any)
 	ast.Walk(&visitor{opts: &opts, m: translations}, af)
 
 	key := "example"
@@ -203,7 +203,7 @@ func TestTranslateVisitorCall(t *testing.T) {
 }
 
 func TestTranslateVisitorLocalize(t *testing.T) {
-	translations := make(map[string]interface{})
+	translations := make(map[string]any)
 	v := &visitor{
 		opts: &translateOpts{},
 		m:    translations,
@@ -223,7 +223,7 @@ func TestTranslateVisitorLocalize(t *testing.T) {
 }
 
 func TestTranslateVisitorKey(t *testing.T) {
-	translations := make(map[string]interface{})
+	translations := make(map[string]any)
 	v := &visitor{
 		opts: &translateOpts{},
 		m:    translations,
@@ -243,7 +243,7 @@ func TestTranslateVisitorKey(t *testing.T) {
 }
 
 func TestTranslateVisitorFallback(t *testing.T) {
-	translations := make(map[string]interface{})
+	translations := make(map[string]any)
 	v := &visitor{
 		opts: &translateOpts{},
 		m:    translations,

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -349,7 +349,7 @@ var fontCustomCache = &sync.Map{} // map[string]*FontCacheItem for custom resour
 
 type noopLogger struct{}
 
-func (n noopLogger) Printf(string, ...interface{}) {}
+func (n noopLogger) Printf(string, ...any) {}
 
 type dynamicFontMap struct {
 	faces  []*font.Face


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Code style change. I switched all uses over when we migrated to Go 1.19 as base but a few uses of the old name have slipped through since then. Change them to "any".

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

