### PR TITLE
Add a new InfiniteAnimation

### DIFF
--- a/animation.go
+++ b/animation.go
@@ -77,15 +77,15 @@ func (a *Animation) Start() {
 	CurrentApp().Driver().StartAnimation(a)
 }
 
+// Stop will end this animation and remove it from the run-loop.
+func (a *Animation) Stop() {
+	CurrentApp().Driver().StopAnimation(a)
+}
+
 // Start registers the animation with the application run-loop and starts its execution.
 func (i *IndefiniteAnimation) Start() {
 	i.setupAnimation()
 	i.animation.Start()
-}
-
-// Stop will end this animation and remove it from the run-loop.
-func (a *Animation) Stop() {
-	CurrentApp().Driver().StopAnimation(a)
 }
 
 // Stop will end this animation and remove it from the run-loop.

--- a/animation.go
+++ b/animation.go
@@ -63,38 +63,38 @@ func (a *Animation) Stop() {
 	CurrentApp().Driver().StopAnimation(a)
 }
 
-// IndefiniteAnimation represents an animation that continues indefinitely. It has no duration
+// InfiniteAnimation represents an animation that continues infinitely unless stopped. It has no duration
 // or curve, and when started, the Tick function will be called every frame until Stop is invoked.
 //
 // Since: 2.6
-type IndefiniteAnimation struct {
+type InfiniteAnimation struct {
 	Tick func()
 
 	isSetup   bool
 	animation Animation
 }
 
-// NewIndefiniteAnimation creates an indefinite animation where the callback function will be called
+// NewInfiniteAnimation creates an infinite animation where the callback function will be called
 // for every rendered frame once started, until stopped.
 //
 // Since: 2.6
-func NewIndefiniteAnimation(fn func()) *IndefiniteAnimation {
-	return &IndefiniteAnimation{Tick: fn}
+func NewInfiniteAnimation(fn func()) *InfiniteAnimation {
+	return &InfiniteAnimation{Tick: fn}
 }
 
 // Start registers the animation with the application run-loop and starts its execution.
-func (i *IndefiniteAnimation) Start() {
+func (i *InfiniteAnimation) Start() {
 	i.setupAnimation()
 	i.animation.Start()
 }
 
 // Stop will end this animation and remove it from the run-loop.
-func (i *IndefiniteAnimation) Stop() {
+func (i *InfiniteAnimation) Stop() {
 	i.setupAnimation()
 	i.animation.Stop()
 }
 
-func (i *IndefiniteAnimation) setupAnimation() {
+func (i *InfiniteAnimation) setupAnimation() {
 	if i.isSetup {
 		return
 	}

--- a/animation.go
+++ b/animation.go
@@ -44,6 +44,25 @@ type Animation struct {
 	Tick        func(float32)
 }
 
+// NewAnimation creates a very basic animation where the callback function will be called for every
+// rendered frame between [time.Now] and the specified duration. The callback values start at 0.0 and
+// will be 1.0 when the animation completes.
+//
+// Since: 2.0
+func NewAnimation(d time.Duration, fn func(float32)) *Animation {
+	return &Animation{Duration: d, Tick: fn}
+}
+
+// Start registers the animation with the application run-loop and starts its execution.
+func (a *Animation) Start() {
+	CurrentApp().Driver().StartAnimation(a)
+}
+
+// Stop will end this animation and remove it from the run-loop.
+func (a *Animation) Stop() {
+	CurrentApp().Driver().StopAnimation(a)
+}
+
 // IndefiniteAnimation represents an animation that continues indefinitely. It has no duration
 // or curve, and when started, the Tick function will be called every frame until Stop is invoked.
 //
@@ -55,31 +74,12 @@ type IndefiniteAnimation struct {
 	animation Animation
 }
 
-// NewAnimation creates a very basic animation where the callback function will be called for every
-// rendered frame between [time.Now] and the specified duration. The callback values start at 0.0 and
-// will be 1.0 when the animation completes.
-//
-// Since: 2.0
-func NewAnimation(d time.Duration, fn func(float32)) *Animation {
-	return &Animation{Duration: d, Tick: fn}
-}
-
 // NewIndefiniteAnimation creates an indefinite animation where the callback function will be called
 // for every rendered frame once started, until stopped.
 //
 // Since: 2.6
 func NewIndefiniteAnimation(fn func()) *IndefiniteAnimation {
 	return &IndefiniteAnimation{Tick: fn}
-}
-
-// Start registers the animation with the application run-loop and starts its execution.
-func (a *Animation) Start() {
-	CurrentApp().Driver().StartAnimation(a)
-}
-
-// Stop will end this animation and remove it from the run-loop.
-func (a *Animation) Stop() {
-	CurrentApp().Driver().StopAnimation(a)
 }
 
 // Start registers the animation with the application run-loop and starts its execution.

--- a/animation.go
+++ b/animation.go
@@ -95,17 +95,19 @@ func (i *IndefiniteAnimation) Stop() {
 }
 
 func (i *IndefiniteAnimation) setupAnimation() {
-	if !i.isSetup {
-		i.animation = Animation{
-			Tick: func(_ float32) {
-				i.Tick()
-			},
-			Curve:       AnimationLinear, // any curve will work
-			Duration:    1 * time.Second, // anything positive here will work
-			RepeatCount: AnimationRepeatForever,
-		}
-		i.isSetup = true
+	if i.isSetup {
+		return
 	}
+
+	i.animation = Animation{
+		Tick: func(_ float32) {
+			i.Tick()
+		},
+		Curve:       AnimationLinear, // any curve will work
+		Duration:    1 * time.Second, // anything positive here will work
+		RepeatCount: AnimationRepeatForever,
+	}
+	i.isSetup = true
 }
 
 func animationEaseIn(val float32) float32 {

--- a/animation.go
+++ b/animation.go
@@ -100,6 +100,8 @@ func (i *IndefiniteAnimation) setupAnimation() {
 			Tick: func(_ float32) {
 				i.Tick()
 			},
+			Curve:       AnimationLinear, // any curve will work
+			Duration:    1 * time.Second, // anything positive here will work
 			RepeatCount: AnimationRepeatForever,
 		}
 		i.isSetup = true


### PR DESCRIPTION
### Description:
Adds a new type of animation that has no curve or duration, and simply ticks a function every frame until stopped.
This will be useful in 2.6 to schedule an ongoing "update loop" to run on the main app thread, for example in the `fyne-io/life` repo to replace the goroutine that currently drives the updates.

**Note:** Since this is implemented entirely using the existing animation type, it's debatable whether it's even needed as it can be fully implemented in user code with the current set of public APIs. However, it's more clean to have a public API specifically for this purpose and a Tick function that takes no arguments, instead of user code having to supply one that simply ignores its argument.

Also, it's possible other names could be more descriptive of its more general use case, like `fyne.FrameTicker`?

Fixes #4735 

### Checklist:

- [ ] Tests included. // we don't currently have animation tests
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.

