### PR TITLE
Add an environment variable to disable scale adjustment based on detected DPI

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -9,6 +9,7 @@ import (
 	_ "image/png" // for the icon
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 
 	"fyne.io/fyne/v2"
@@ -301,16 +302,16 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 }
 
 func (w *window) detectScale() float32 {
-	// check if DPI detection is disabled
-	env := os.Getenv(disableDPIDetectionEnvKey)
-	switch env {
-	case "True", "TRUE", "true", "T", "t", "1":
-		return 1
-	}
-
 	if build.IsWayland { // Wayland controls scale through content scaling
 		return 1
 	}
+
+	// check if DPI detection is disabled
+	env := os.Getenv(disableDPIDetectionEnvKey)
+	if strings.EqualFold(env, "true") || strings.EqualFold(env, "t") || env == "1" {
+		return 1
+	}
+
 	monitor := w.getMonitorForWindow()
 	if monitor == nil {
 		return 1

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -303,7 +303,8 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 func (w *window) detectScale() float32 {
 	// check if DPI detection is disabled
 	env := os.Getenv(disableDPIDetectionEnvKey)
-	if len(env) > 0 && (env[0] == 'T' || env[0] == 't' || env[0] == '1') {
+	switch env {
+	case "True", "TRUE", "true", "T", "t", "1":
 		return 1
 	}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"image"
 	_ "image/png" // for the icon
+	"os"
 	"runtime"
 	"sync"
 
@@ -24,7 +25,10 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
-const defaultTitle = "Fyne Application"
+const (
+	defaultTitle              = "Fyne Application"
+	disableDPIDetectionEnvKey = "FYNE_DISABLE_DPI_DETECTION"
+)
 
 // Input modes.
 const (
@@ -297,6 +301,12 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 }
 
 func (w *window) detectScale() float32 {
+	// check if DPI detection is disabled
+	env := os.Getenv(disableDPIDetectionEnvKey)
+	if len(env) > 0 && (env[0] == 'T' || env[0] == 't' || env[0] == '1') {
+		return 1
+	}
+
 	if build.IsWayland { // Wayland controls scale through content scaling
 		return 1
 	}


### PR DESCRIPTION
### Description:

Adds a new environment variable `FYNE_DISABLE_DPI_DETECTION` which can be set to `true`, `True`, `TRUE` or `1` to disable detecting the screen DPI and adjusting scaling accordingly.

I do not have a dual-monitor Linux setup so I can only confirm that it results in a new Fyne app being drawn at 1:1 pixel scale on a Hi-DPI monitor.

Fixes #5164 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

