### PR TITLE
Make data binding thread safe

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -26,7 +26,7 @@ var (
 type DataItem interface {
 	// AddListener attaches a new change listener to this DataItem.
 	// Listeners are called each time the data inside this DataItem changes.
-	// Additionally the listener will be triggered upon successful connection to get the current value.
+	// Additionally, the listener will be triggered upon successful connection to get the current value.
 	AddListener(DataListener)
 	// RemoveListener will detach the specified change listener from the DataItem.
 	// Disconnected listener will no longer be triggered when changes occur.
@@ -74,9 +74,16 @@ func (b *base) RemoveListener(l DataListener) {
 }
 
 func (b *base) trigger() {
+	var listeners []DataListener
 	b.listeners.Range(func(key, _ any) bool {
-		queueItem(key.(DataListener).DataChanged)
+		listeners = append(listeners, key.(DataListener))
 		return true
+	})
+
+	queueItem(func() {
+		for _, listen := range listeners {
+			listen.DataChanged()
+		}
 	})
 }
 

--- a/data/binding/binding_exted_test.go
+++ b/data/binding/binding_exted_test.go
@@ -18,20 +18,17 @@ func TestBindUserType(t *testing.T) {
 		called = true
 	})
 	u.AddListener(fn)
-	waitForItems()
 	assert.True(t, called)
 
 	called = false
 	err = u.Set(user{name: "Replace"})
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, "User: Replace", val.String())
 	assert.True(t, called)
 
 	called = false
 	val = user{name: "Direct"}
 	_ = u.Reload()
-	waitForItems()
 	assert.True(t, called)
 	v, err = u.Get()
 	assert.Nil(t, err)
@@ -40,7 +37,6 @@ func TestBindUserType(t *testing.T) {
 	called = false
 	val.name = "FieldSet"
 	_ = u.Reload()
-	waitForItems()
 	assert.True(t, called)
 	v, err = u.Get()
 	assert.Nil(t, err)

--- a/data/binding/binding_test.go
+++ b/data/binding/binding_test.go
@@ -29,8 +29,6 @@ func TestBase_AddListener(t *testing.T) {
 	})
 	data.AddListener(fn)
 	assert.Equal(t, 1, syncMapLen(&data.listeners))
-
-	waitForItems()
 	assert.True(t, called)
 }
 
@@ -46,7 +44,6 @@ func TestBase_RemoveListener(t *testing.T) {
 	data.RemoveListener(fn)
 	assert.Equal(t, 0, syncMapLen(&data.listeners))
 
-	waitForItems()
 	data.trigger()
 	assert.False(t, called)
 }
@@ -57,7 +54,6 @@ func TestNewDataItemListener(t *testing.T) {
 		called = true
 	})
 
-	waitForItems()
 	fn.DataChanged()
 	assert.True(t, called)
 }

--- a/data/binding/binditems.go
+++ b/data/binding/binditems.go
@@ -67,11 +67,12 @@ func (b *boundBool) Get() (bool, error) {
 
 func (b *boundBool) Set(val bool) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if *b.val == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -85,12 +86,13 @@ type boundExternalBool struct {
 
 func (b *boundExternalBool) Set(val bool) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if b.old == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -158,11 +160,12 @@ func (b *boundBytes) Get() ([]byte, error) {
 
 func (b *boundBytes) Set(val []byte) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if bytes.Equal(*b.val, val) {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -176,12 +179,13 @@ type boundExternalBytes struct {
 
 func (b *boundExternalBytes) Set(val []byte) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if bytes.Equal(b.old, val) {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -249,11 +253,12 @@ func (b *boundFloat) Get() (float64, error) {
 
 func (b *boundFloat) Set(val float64) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if *b.val == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -267,12 +272,13 @@ type boundExternalFloat struct {
 
 func (b *boundExternalFloat) Set(val float64) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if b.old == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -340,11 +346,12 @@ func (b *boundInt) Get() (int, error) {
 
 func (b *boundInt) Set(val int) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if *b.val == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -358,12 +365,13 @@ type boundExternalInt struct {
 
 func (b *boundExternalInt) Set(val int) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if b.old == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -431,11 +439,12 @@ func (b *boundRune) Get() (rune, error) {
 
 func (b *boundRune) Set(val rune) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if *b.val == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -449,12 +458,13 @@ type boundExternalRune struct {
 
 func (b *boundExternalRune) Set(val rune) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if b.old == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -522,11 +532,12 @@ func (b *boundString) Get() (string, error) {
 
 func (b *boundString) Set(val string) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if *b.val == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -540,12 +551,13 @@ type boundExternalString struct {
 
 func (b *boundExternalString) Set(val string) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if b.old == val {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -613,11 +625,12 @@ func (b *boundURI) Get() (fyne.URI, error) {
 
 func (b *boundURI) Set(val fyne.URI) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if compareURI(*b.val, val) {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -631,12 +644,13 @@ type boundExternalURI struct {
 
 func (b *boundExternalURI) Set(val fyne.URI) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if compareURI(b.old, val) {
+		b.lock.Unlock()
 		return nil
 	}
 	*b.val = val
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil

--- a/data/binding/binditems_extend_test.go
+++ b/data/binding/binditems_extend_test.go
@@ -19,14 +19,12 @@ func TestBindTime(t *testing.T) {
 		called = true
 	})
 	f.AddListener(fn)
-	waitForItems()
 	assert.True(t, called)
 
 	newTime := val.Add(time.Hour)
 	called = false
 	err = f.Set(newTime)
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, newTime.Unix(), val.Unix())
 	assert.True(t, called)
 
@@ -34,7 +32,6 @@ func TestBindTime(t *testing.T) {
 	called = false
 	val = newTime
 	_ = f.Reload()
-	waitForItems()
 	assert.True(t, called)
 	v, err = f.Get()
 	assert.Nil(t, err)

--- a/data/binding/binditems_test.go
+++ b/data/binding/binditems_test.go
@@ -1,12 +1,17 @@
 package binding
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"fyne.io/fyne/v2/storage"
 )
+
+func init() {
+	runtime.LockOSThread()
+}
 
 func TestBindFloat(t *testing.T) {
 	val := 0.5
@@ -20,20 +25,17 @@ func TestBindFloat(t *testing.T) {
 		called = true
 	})
 	f.AddListener(fn)
-	waitForItems()
 	assert.True(t, called)
 
 	called = false
 	err = f.Set(0.3)
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 0.3, val)
 	assert.True(t, called)
 
 	called = false
 	val = 1.2
 	f.Reload()
-	waitForItems()
 	assert.True(t, called)
 	v, err = f.Get()
 	assert.Nil(t, err)
@@ -53,20 +55,17 @@ func TestBindUntyped(t *testing.T) {
 		called = true
 	})
 	f.AddListener(fn)
-	waitForItems()
 	assert.True(t, called)
 
 	called = false
 	err = f.Set(0.3)
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 0.3, val)
 	assert.True(t, called)
 
 	called = false
 	val = 1.2
 	f.Reload()
-	waitForItems()
 	assert.True(t, called)
 	v, err = f.Get()
 	assert.Nil(t, err)
@@ -93,41 +92,35 @@ func TestBindFloat_TriggerOnlyWhenChange(t *testing.T) {
 	f.AddListener(NewDataListener(func() {
 		triggered++
 	}))
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	for i := 0; i < 5; i++ {
 		err := f.Set(9.0)
 		assert.Nil(t, err)
-		waitForItems()
 		assert.Equal(t, 1, triggered)
 	}
 
 	triggered = 0
 	err := f.Set(9.1)
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	err = f.Set(8.0)
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	v = 8.0
 	err = f.Reload()
 	assert.NoError(t, err)
-	waitForItems()
 	assert.Equal(t, 0, triggered)
 
 	triggered = 0
 	v = 9.2
 	err = f.Reload()
 	assert.NoError(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 }
 
@@ -137,27 +130,23 @@ func TestNewFloat_TriggerOnlyWhenChange(t *testing.T) {
 	f.AddListener(NewDataListener(func() {
 		triggered++
 	}))
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	for i := 0; i < 5; i++ {
 		err := f.Set(9.0)
 		assert.Nil(t, err)
-		waitForItems()
 		assert.Equal(t, 1, triggered)
 	}
 
 	triggered = 0
 	err := f.Set(9.1)
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	err = f.Set(8.0)
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 }
 
@@ -173,20 +162,17 @@ func TestBindURI(t *testing.T) {
 		called = true
 	})
 	f.AddListener(fn)
-	waitForItems()
 	assert.True(t, called)
 
 	called = false
 	err = f.Set(storage.NewFileURI("/tmp/test.txt"))
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, "file:///tmp/test.txt", val.String())
 	assert.True(t, called)
 
 	called = false
 	val = storage.NewFileURI("/hello")
 	_ = f.Reload()
-	waitForItems()
 	assert.True(t, called)
 	v, err = f.Get()
 	assert.Nil(t, err)
@@ -200,41 +186,35 @@ func TestBindURI_TriggerOnlyWhenChange(t *testing.T) {
 	b.AddListener(NewDataListener(func() {
 		triggered++
 	}))
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	for i := 0; i < 5; i++ {
 		err := b.Set(storage.NewFileURI("second"))
 		assert.Nil(t, err)
-		waitForItems()
 		assert.Equal(t, 1, triggered)
 	}
 
 	triggered = 0
 	err := b.Set(storage.NewFileURI("third"))
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	err = b.Set(storage.NewFileURI("fourth"))
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	v = storage.NewFileURI("fourth")
 	err = b.Reload()
 	assert.NoError(t, err)
-	waitForItems()
 	assert.Equal(t, 0, triggered)
 
 	triggered = 0
 	v = storage.NewFileURI("fifth")
 	err = b.Reload()
 	assert.NoError(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 }
 
@@ -257,26 +237,22 @@ func TestNewURI_TriggerOnlyWhenChange(t *testing.T) {
 	b.AddListener(NewDataListener(func() {
 		triggered++
 	}))
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	for i := 0; i < 5; i++ {
 		err := b.Set(storage.NewFileURI("first"))
 		assert.Nil(t, err)
-		waitForItems()
 		assert.Equal(t, 1, triggered)
 	}
 
 	triggered = 0
 	err := b.Set(storage.NewFileURI("second"))
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	err = b.Set(storage.NewFileURI("third"))
 	assert.Nil(t, err)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 }

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -67,11 +67,16 @@ type boundBoolList struct {
 
 func (l *boundBoolList) Append(val bool) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundBoolList) Get() ([]bool, error) {
@@ -94,17 +99,28 @@ func (l *boundBoolList) GetValue(i int) (bool, error) {
 
 func (l *boundBoolList) Prepend(val bool) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([]bool{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundBoolList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified bool out of the list.
@@ -112,10 +128,10 @@ func (l *boundBoolList) Reload() error {
 // Since: 2.5
 func (l *boundBoolList) Remove(val bool) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if v[0] == val {
@@ -132,35 +148,48 @@ func (l *boundBoolList) Remove(val bool) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundBoolList) Set(v []bool) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundBoolList) doReload() (retErr error) {
+func (l *boundBoolList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindBoolListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -170,13 +199,9 @@ func (l *boundBoolList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalBoolListItem).lock.Lock()
 			err = item.(*boundExternalBoolListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalBoolListItem).lock.Unlock()
 		} else {
-			item.(*boundBoolListItem).lock.Lock()
 			err = item.(*boundBoolListItem).doSet((*l.val)[i])
-			item.(*boundBoolListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -235,14 +260,13 @@ func (b *boundBoolListItem) Get() (bool, error) {
 }
 
 func (b *boundBoolListItem) Set(val bool) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundBoolListItem) doSet(val bool) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -255,12 +279,15 @@ type boundExternalBoolListItem struct {
 }
 
 func (b *boundExternalBoolListItem) setIfChanged(val bool) error {
+	b.lock.Lock()
 	if val == b.old {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }
@@ -323,11 +350,16 @@ type boundBytesList struct {
 
 func (l *boundBytesList) Append(val []byte) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundBytesList) Get() ([][]byte, error) {
@@ -350,17 +382,28 @@ func (l *boundBytesList) GetValue(i int) ([]byte, error) {
 
 func (l *boundBytesList) Prepend(val []byte) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([][]byte{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundBytesList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified []byte out of the list.
@@ -368,10 +411,10 @@ func (l *boundBytesList) Reload() error {
 // Since: 2.5
 func (l *boundBytesList) Remove(val []byte) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if bytes.Equal(v[0], val) {
@@ -388,35 +431,48 @@ func (l *boundBytesList) Remove(val []byte) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundBytesList) Set(v [][]byte) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundBytesList) doReload() (retErr error) {
+func (l *boundBytesList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindBytesListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -426,13 +482,9 @@ func (l *boundBytesList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalBytesListItem).lock.Lock()
 			err = item.(*boundExternalBytesListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalBytesListItem).lock.Unlock()
 		} else {
-			item.(*boundBytesListItem).lock.Lock()
 			err = item.(*boundBytesListItem).doSet((*l.val)[i])
-			item.(*boundBytesListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -491,14 +543,13 @@ func (b *boundBytesListItem) Get() ([]byte, error) {
 }
 
 func (b *boundBytesListItem) Set(val []byte) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundBytesListItem) doSet(val []byte) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -511,12 +562,15 @@ type boundExternalBytesListItem struct {
 }
 
 func (b *boundExternalBytesListItem) setIfChanged(val []byte) error {
+	b.lock.Lock()
 	if bytes.Equal(val, b.old) {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }
@@ -579,11 +633,16 @@ type boundFloatList struct {
 
 func (l *boundFloatList) Append(val float64) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundFloatList) Get() ([]float64, error) {
@@ -606,17 +665,28 @@ func (l *boundFloatList) GetValue(i int) (float64, error) {
 
 func (l *boundFloatList) Prepend(val float64) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([]float64{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundFloatList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified float64 out of the list.
@@ -624,10 +694,10 @@ func (l *boundFloatList) Reload() error {
 // Since: 2.5
 func (l *boundFloatList) Remove(val float64) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if v[0] == val {
@@ -644,35 +714,48 @@ func (l *boundFloatList) Remove(val float64) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundFloatList) Set(v []float64) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundFloatList) doReload() (retErr error) {
+func (l *boundFloatList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindFloatListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -682,13 +765,9 @@ func (l *boundFloatList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalFloatListItem).lock.Lock()
 			err = item.(*boundExternalFloatListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalFloatListItem).lock.Unlock()
 		} else {
-			item.(*boundFloatListItem).lock.Lock()
 			err = item.(*boundFloatListItem).doSet((*l.val)[i])
-			item.(*boundFloatListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -747,14 +826,13 @@ func (b *boundFloatListItem) Get() (float64, error) {
 }
 
 func (b *boundFloatListItem) Set(val float64) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundFloatListItem) doSet(val float64) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -767,12 +845,15 @@ type boundExternalFloatListItem struct {
 }
 
 func (b *boundExternalFloatListItem) setIfChanged(val float64) error {
+	b.lock.Lock()
 	if val == b.old {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }
@@ -835,11 +916,16 @@ type boundIntList struct {
 
 func (l *boundIntList) Append(val int) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundIntList) Get() ([]int, error) {
@@ -862,17 +948,28 @@ func (l *boundIntList) GetValue(i int) (int, error) {
 
 func (l *boundIntList) Prepend(val int) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([]int{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundIntList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified int out of the list.
@@ -880,10 +977,10 @@ func (l *boundIntList) Reload() error {
 // Since: 2.5
 func (l *boundIntList) Remove(val int) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if v[0] == val {
@@ -900,35 +997,48 @@ func (l *boundIntList) Remove(val int) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundIntList) Set(v []int) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundIntList) doReload() (retErr error) {
+func (l *boundIntList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindIntListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -938,13 +1048,9 @@ func (l *boundIntList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalIntListItem).lock.Lock()
 			err = item.(*boundExternalIntListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalIntListItem).lock.Unlock()
 		} else {
-			item.(*boundIntListItem).lock.Lock()
 			err = item.(*boundIntListItem).doSet((*l.val)[i])
-			item.(*boundIntListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1003,14 +1109,13 @@ func (b *boundIntListItem) Get() (int, error) {
 }
 
 func (b *boundIntListItem) Set(val int) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundIntListItem) doSet(val int) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -1023,12 +1128,15 @@ type boundExternalIntListItem struct {
 }
 
 func (b *boundExternalIntListItem) setIfChanged(val int) error {
+	b.lock.Lock()
 	if val == b.old {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }
@@ -1091,11 +1199,16 @@ type boundRuneList struct {
 
 func (l *boundRuneList) Append(val rune) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundRuneList) Get() ([]rune, error) {
@@ -1118,17 +1231,28 @@ func (l *boundRuneList) GetValue(i int) (rune, error) {
 
 func (l *boundRuneList) Prepend(val rune) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([]rune{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundRuneList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified rune out of the list.
@@ -1136,10 +1260,10 @@ func (l *boundRuneList) Reload() error {
 // Since: 2.5
 func (l *boundRuneList) Remove(val rune) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if v[0] == val {
@@ -1156,35 +1280,48 @@ func (l *boundRuneList) Remove(val rune) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundRuneList) Set(v []rune) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundRuneList) doReload() (retErr error) {
+func (l *boundRuneList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindRuneListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -1194,13 +1331,9 @@ func (l *boundRuneList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalRuneListItem).lock.Lock()
 			err = item.(*boundExternalRuneListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalRuneListItem).lock.Unlock()
 		} else {
-			item.(*boundRuneListItem).lock.Lock()
 			err = item.(*boundRuneListItem).doSet((*l.val)[i])
-			item.(*boundRuneListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1259,14 +1392,13 @@ func (b *boundRuneListItem) Get() (rune, error) {
 }
 
 func (b *boundRuneListItem) Set(val rune) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundRuneListItem) doSet(val rune) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -1279,12 +1411,15 @@ type boundExternalRuneListItem struct {
 }
 
 func (b *boundExternalRuneListItem) setIfChanged(val rune) error {
+	b.lock.Lock()
 	if val == b.old {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }
@@ -1347,11 +1482,16 @@ type boundStringList struct {
 
 func (l *boundStringList) Append(val string) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundStringList) Get() ([]string, error) {
@@ -1374,17 +1514,28 @@ func (l *boundStringList) GetValue(i int) (string, error) {
 
 func (l *boundStringList) Prepend(val string) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([]string{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundStringList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified string out of the list.
@@ -1392,10 +1543,10 @@ func (l *boundStringList) Reload() error {
 // Since: 2.5
 func (l *boundStringList) Remove(val string) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if v[0] == val {
@@ -1412,35 +1563,48 @@ func (l *boundStringList) Remove(val string) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundStringList) Set(v []string) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundStringList) doReload() (retErr error) {
+func (l *boundStringList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindStringListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -1450,13 +1614,9 @@ func (l *boundStringList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalStringListItem).lock.Lock()
 			err = item.(*boundExternalStringListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalStringListItem).lock.Unlock()
 		} else {
-			item.(*boundStringListItem).lock.Lock()
 			err = item.(*boundStringListItem).doSet((*l.val)[i])
-			item.(*boundStringListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1515,14 +1675,13 @@ func (b *boundStringListItem) Get() (string, error) {
 }
 
 func (b *boundStringListItem) Set(val string) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundStringListItem) doSet(val string) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -1535,12 +1694,15 @@ type boundExternalStringListItem struct {
 }
 
 func (b *boundExternalStringListItem) setIfChanged(val string) error {
+	b.lock.Lock()
 	if val == b.old {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }
@@ -1603,11 +1765,16 @@ type boundUntypedList struct {
 
 func (l *boundUntypedList) Append(val any) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundUntypedList) Get() ([]any, error) {
@@ -1630,17 +1797,28 @@ func (l *boundUntypedList) GetValue(i int) (any, error) {
 
 func (l *boundUntypedList) Prepend(val any) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([]any{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundUntypedList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified any out of the list.
@@ -1648,10 +1826,10 @@ func (l *boundUntypedList) Reload() error {
 // Since: 2.5
 func (l *boundUntypedList) Remove(val any) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if v[0] == val {
@@ -1668,35 +1846,48 @@ func (l *boundUntypedList) Remove(val any) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundUntypedList) Set(v []any) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundUntypedList) doReload() (retErr error) {
+func (l *boundUntypedList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindUntypedListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -1706,13 +1897,9 @@ func (l *boundUntypedList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalUntypedListItem).lock.Lock()
 			err = item.(*boundExternalUntypedListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalUntypedListItem).lock.Unlock()
 		} else {
-			item.(*boundUntypedListItem).lock.Lock()
 			err = item.(*boundUntypedListItem).doSet((*l.val)[i])
-			item.(*boundUntypedListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1771,14 +1958,13 @@ func (b *boundUntypedListItem) Get() (any, error) {
 }
 
 func (b *boundUntypedListItem) Set(val any) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundUntypedListItem) doSet(val any) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -1791,12 +1977,15 @@ type boundExternalUntypedListItem struct {
 }
 
 func (b *boundExternalUntypedListItem) setIfChanged(val any) error {
+	b.lock.Lock()
 	if val == b.old {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }
@@ -1859,11 +2048,16 @@ type boundURIList struct {
 
 func (l *boundURIList) Append(val fyne.URI) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
-
 	*l.val = append(*l.val, val)
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundURIList) Get() ([]fyne.URI, error) {
@@ -1886,17 +2080,28 @@ func (l *boundURIList) GetValue(i int) (fyne.URI, error) {
 
 func (l *boundURIList) Prepend(val fyne.URI) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = append([]fyne.URI{val}, *l.val...)
+	
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundURIList) Reload() error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified fyne.URI out of the list.
@@ -1904,10 +2109,10 @@ func (l *boundURIList) Reload() error {
 // Since: 2.5
 func (l *boundURIList) Remove(val fyne.URI) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 
 	v := *l.val
 	if len(v) == 0 {
+		l.lock.Unlock()
 		return nil
 	}
 	if compareURI(v[0], val) {
@@ -1924,35 +2129,48 @@ func (l *boundURIList) Remove(val fyne.URI) error {
 		}
 
 		if id == -1 {
+			l.lock.Unlock()
 			return nil
 		}
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	return l.doReload()
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
+
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
 func (l *boundURIList) Set(v []fyne.URI) error {
 	l.lock.Lock()
-	defer l.lock.Unlock()
 	*l.val = v
+	trigger, err :=  l.doReload()
+	l.lock.Unlock()
 
-	return l.doReload()
+	if trigger {
+		l.trigger()
+	}
+
+	return err
 }
 
-func (l *boundURIList) doReload() (retErr error) {
+func (l *boundURIList) doReload() (trigger bool, retErr error) {
 	oldLen := len(l.items)
 	newLen := len(*l.val)
 	if oldLen > newLen {
 		for i := oldLen - 1; i >= newLen; i-- {
 			l.deleteItem(i)
 		}
-		l.trigger()
+		trigger = true
 	} else if oldLen < newLen {
 		for i := oldLen; i < newLen; i++ {
 			l.appendItem(bindURIListItem(l.val, i, l.updateExternal))
 		}
-		l.trigger()
+		trigger = true
 	}
 
 	for i, item := range l.items {
@@ -1962,13 +2180,9 @@ func (l *boundURIList) doReload() (retErr error) {
 
 		var err error
 		if l.updateExternal {
-			item.(*boundExternalURIListItem).lock.Lock()
 			err = item.(*boundExternalURIListItem).setIfChanged((*l.val)[i])
-			item.(*boundExternalURIListItem).lock.Unlock()
 		} else {
-			item.(*boundURIListItem).lock.Lock()
 			err = item.(*boundURIListItem).doSet((*l.val)[i])
-			item.(*boundURIListItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -2027,14 +2241,13 @@ func (b *boundURIListItem) Get() (fyne.URI, error) {
 }
 
 func (b *boundURIListItem) Set(val fyne.URI) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	return b.doSet(val)
 }
 
 func (b *boundURIListItem) doSet(val fyne.URI) error {
+	b.lock.Lock()
 	(*b.val)[b.index] = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -2047,12 +2260,15 @@ type boundExternalURIListItem struct {
 }
 
 func (b *boundExternalURIListItem) setIfChanged(val fyne.URI) error {
+	b.lock.Lock()
 	if compareURI(val, b.old) {
+		b.lock.Unlock()
 		return nil
 	}
 	(*b.val)[b.index] = val
 	b.old = val
 
+	b.lock.Unlock()
 	b.trigger()
 	return nil
 }

--- a/data/binding/bindlists.go
+++ b/data/binding/bindlists.go
@@ -69,7 +69,7 @@ func (l *boundBoolList) Append(val bool) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -100,8 +100,8 @@ func (l *boundBoolList) GetValue(i int) (bool, error) {
 func (l *boundBoolList) Prepend(val bool) error {
 	l.lock.Lock()
 	*l.val = append([]bool{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -113,7 +113,7 @@ func (l *boundBoolList) Prepend(val bool) error {
 
 func (l *boundBoolList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -154,7 +154,7 @@ func (l *boundBoolList) Remove(val bool) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -167,7 +167,7 @@ func (l *boundBoolList) Remove(val bool) error {
 func (l *boundBoolList) Set(v []bool) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -352,7 +352,7 @@ func (l *boundBytesList) Append(val []byte) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -383,8 +383,8 @@ func (l *boundBytesList) GetValue(i int) ([]byte, error) {
 func (l *boundBytesList) Prepend(val []byte) error {
 	l.lock.Lock()
 	*l.val = append([][]byte{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -396,7 +396,7 @@ func (l *boundBytesList) Prepend(val []byte) error {
 
 func (l *boundBytesList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -437,7 +437,7 @@ func (l *boundBytesList) Remove(val []byte) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -450,7 +450,7 @@ func (l *boundBytesList) Remove(val []byte) error {
 func (l *boundBytesList) Set(v [][]byte) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -635,7 +635,7 @@ func (l *boundFloatList) Append(val float64) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -666,8 +666,8 @@ func (l *boundFloatList) GetValue(i int) (float64, error) {
 func (l *boundFloatList) Prepend(val float64) error {
 	l.lock.Lock()
 	*l.val = append([]float64{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -679,7 +679,7 @@ func (l *boundFloatList) Prepend(val float64) error {
 
 func (l *boundFloatList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -720,7 +720,7 @@ func (l *boundFloatList) Remove(val float64) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -733,7 +733,7 @@ func (l *boundFloatList) Remove(val float64) error {
 func (l *boundFloatList) Set(v []float64) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -918,7 +918,7 @@ func (l *boundIntList) Append(val int) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -949,8 +949,8 @@ func (l *boundIntList) GetValue(i int) (int, error) {
 func (l *boundIntList) Prepend(val int) error {
 	l.lock.Lock()
 	*l.val = append([]int{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -962,7 +962,7 @@ func (l *boundIntList) Prepend(val int) error {
 
 func (l *boundIntList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1003,7 +1003,7 @@ func (l *boundIntList) Remove(val int) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1016,7 +1016,7 @@ func (l *boundIntList) Remove(val int) error {
 func (l *boundIntList) Set(v []int) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1201,7 +1201,7 @@ func (l *boundRuneList) Append(val rune) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1232,8 +1232,8 @@ func (l *boundRuneList) GetValue(i int) (rune, error) {
 func (l *boundRuneList) Prepend(val rune) error {
 	l.lock.Lock()
 	*l.val = append([]rune{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1245,7 +1245,7 @@ func (l *boundRuneList) Prepend(val rune) error {
 
 func (l *boundRuneList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1286,7 +1286,7 @@ func (l *boundRuneList) Remove(val rune) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1299,7 +1299,7 @@ func (l *boundRuneList) Remove(val rune) error {
 func (l *boundRuneList) Set(v []rune) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1484,7 +1484,7 @@ func (l *boundStringList) Append(val string) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1515,8 +1515,8 @@ func (l *boundStringList) GetValue(i int) (string, error) {
 func (l *boundStringList) Prepend(val string) error {
 	l.lock.Lock()
 	*l.val = append([]string{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1528,7 +1528,7 @@ func (l *boundStringList) Prepend(val string) error {
 
 func (l *boundStringList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1569,7 +1569,7 @@ func (l *boundStringList) Remove(val string) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1582,7 +1582,7 @@ func (l *boundStringList) Remove(val string) error {
 func (l *boundStringList) Set(v []string) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1767,7 +1767,7 @@ func (l *boundUntypedList) Append(val any) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1798,8 +1798,8 @@ func (l *boundUntypedList) GetValue(i int) (any, error) {
 func (l *boundUntypedList) Prepend(val any) error {
 	l.lock.Lock()
 	*l.val = append([]any{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1811,7 +1811,7 @@ func (l *boundUntypedList) Prepend(val any) error {
 
 func (l *boundUntypedList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1852,7 +1852,7 @@ func (l *boundUntypedList) Remove(val any) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1865,7 +1865,7 @@ func (l *boundUntypedList) Remove(val any) error {
 func (l *boundUntypedList) Set(v []any) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -2050,7 +2050,7 @@ func (l *boundURIList) Append(val fyne.URI) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -2081,8 +2081,8 @@ func (l *boundURIList) GetValue(i int) (fyne.URI, error) {
 func (l *boundURIList) Prepend(val fyne.URI) error {
 	l.lock.Lock()
 	*l.val = append([]fyne.URI{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -2094,7 +2094,7 @@ func (l *boundURIList) Prepend(val fyne.URI) error {
 
 func (l *boundURIList) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -2135,7 +2135,7 @@ func (l *boundURIList) Remove(val fyne.URI) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -2148,7 +2148,7 @@ func (l *boundURIList) Remove(val fyne.URI) error {
 func (l *boundURIList) Set(v []fyne.URI) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {

--- a/data/binding/bindlists_test.go
+++ b/data/binding/bindlists_test.go
@@ -35,7 +35,6 @@ func TestExternalFloatList_Reload(t *testing.T) {
 	f.AddListener(NewDataListener(func() {
 		calledList = true
 	}))
-	waitForItems()
 	assert.True(t, calledList)
 
 	child, err := f.GetItem(1)
@@ -43,7 +42,6 @@ func TestExternalFloatList_Reload(t *testing.T) {
 	child.AddListener(NewDataListener(func() {
 		calledChild = true
 	}))
-	waitForItems()
 	assert.True(t, calledChild)
 
 	assert.NotNil(t, f.(*boundFloatList).val)
@@ -55,7 +53,6 @@ func TestExternalFloatList_Reload(t *testing.T) {
 	calledList, calledChild = false, false
 	l[1] = 4.8
 	f.Reload()
-	waitForItems()
 	v, err = f.GetValue(1)
 	assert.Nil(t, err)
 	assert.Equal(t, 4.8, v)
@@ -65,7 +62,6 @@ func TestExternalFloatList_Reload(t *testing.T) {
 	calledList, calledChild = false, false
 	l = []float64{1.0, 4.2}
 	f.Reload()
-	waitForItems()
 	v, err = f.GetValue(1)
 	assert.Nil(t, err)
 	assert.Equal(t, 4.2, v)
@@ -75,7 +71,6 @@ func TestExternalFloatList_Reload(t *testing.T) {
 	calledList, calledChild = false, false
 	l = []float64{1.0, 4.2, 5.3}
 	f.Reload()
-	waitForItems()
 	v, err = f.GetValue(1)
 	assert.Nil(t, err)
 	assert.Equal(t, 4.2, v)
@@ -180,36 +175,29 @@ func TestFloatList_NotifyOnlyOnceWhenChange(t *testing.T) {
 	f.AddListener(NewDataListener(func() {
 		triggered++
 	}))
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.Set([]float64{55, 77})
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.SetValue(0, 5)
-	waitForItems()
 	assert.Zero(t, triggered)
 
 	triggered = 0
 	f.Set([]float64{101, 98})
-	waitForItems()
 	assert.Zero(t, triggered)
 
 	triggered = 0
 	f.Append(88)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.Prepend(23)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.Set([]float64{32})
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 }

--- a/data/binding/bindtrees.go
+++ b/data/binding/bindtrees.go
@@ -305,7 +305,7 @@ type boundExternalBoolTreeItem struct {
 func (t *boundExternalBoolTreeItem) setIfChanged(val bool) error {
 	t.lock.Lock()
 	if val == t.old {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
@@ -612,7 +612,7 @@ type boundExternalBytesTreeItem struct {
 func (t *boundExternalBytesTreeItem) setIfChanged(val []byte) error {
 	t.lock.Lock()
 	if bytes.Equal(val, t.old) {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
@@ -919,7 +919,7 @@ type boundExternalFloatTreeItem struct {
 func (t *boundExternalFloatTreeItem) setIfChanged(val float64) error {
 	t.lock.Lock()
 	if val == t.old {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
@@ -1226,7 +1226,7 @@ type boundExternalIntTreeItem struct {
 func (t *boundExternalIntTreeItem) setIfChanged(val int) error {
 	t.lock.Lock()
 	if val == t.old {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
@@ -1533,7 +1533,7 @@ type boundExternalRuneTreeItem struct {
 func (t *boundExternalRuneTreeItem) setIfChanged(val rune) error {
 	t.lock.Lock()
 	if val == t.old {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
@@ -1840,7 +1840,7 @@ type boundExternalStringTreeItem struct {
 func (t *boundExternalStringTreeItem) setIfChanged(val string) error {
 	t.lock.Lock()
 	if val == t.old {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
@@ -2147,7 +2147,7 @@ type boundExternalUntypedTreeItem struct {
 func (t *boundExternalUntypedTreeItem) setIfChanged(val any) error {
 	t.lock.Lock()
 	if val == t.old {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
@@ -2454,7 +2454,7 @@ type boundExternalURITreeItem struct {
 func (t *boundExternalURITreeItem) setIfChanged(val fyne.URI) error {
 	t.lock.Lock()
 	if compareURI(val, t.old) {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val

--- a/data/binding/bindtrees.go
+++ b/data/binding/bindtrees.go
@@ -75,7 +75,6 @@ type boundBoolTree struct {
 
 func (t *boundBoolTree) Append(parent, id string, val bool) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -85,7 +84,14 @@ func (t *boundBoolTree) Append(parent, id string, val bool) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundBoolTree) Get() (map[string][]string, map[string]bool, error) {
@@ -108,7 +114,6 @@ func (t *boundBoolTree) GetValue(id string) (bool, error) {
 
 func (t *boundBoolTree) Prepend(parent, id string, val bool) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -118,7 +123,14 @@ func (t *boundBoolTree) Prepend(parent, id string, val bool) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -127,14 +139,19 @@ func (t *boundBoolTree) Prepend(parent, id string, val bool) error {
 // Since: 2.5
 func (t *boundBoolTree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundBoolTree) removeChildren(id string) {
@@ -149,23 +166,33 @@ func (t *boundBoolTree) removeChildren(id string) {
 
 func (t *boundBoolTree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundBoolTree) Set(ids map[string][]string, v map[string]bool) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundBoolTree) doReload() (retErr error) {
+func (t *boundBoolTree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -199,20 +226,13 @@ func (t *boundBoolTree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalBoolTreeItem).lock.Lock()
 			err = item.(*boundExternalBoolTreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalBoolTreeItem).lock.Unlock()
 		} else {
-			item.(*boundBoolTreeItem).lock.Lock()
 			err = item.(*boundBoolTreeItem).doSet((*t.val)[id])
-			item.(*boundBoolTreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -264,14 +284,13 @@ func (t *boundBoolTreeItem) Get() (bool, error) {
 }
 
 func (t *boundBoolTreeItem) Set(val bool) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundBoolTreeItem) doSet(val bool) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -284,11 +303,14 @@ type boundExternalBoolTreeItem struct {
 }
 
 func (t *boundExternalBoolTreeItem) setIfChanged(val bool) error {
+	t.lock.Lock()
 	if val == t.old {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -360,7 +382,6 @@ type boundBytesTree struct {
 
 func (t *boundBytesTree) Append(parent, id string, val []byte) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -370,7 +391,14 @@ func (t *boundBytesTree) Append(parent, id string, val []byte) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundBytesTree) Get() (map[string][]string, map[string][]byte, error) {
@@ -393,7 +421,6 @@ func (t *boundBytesTree) GetValue(id string) ([]byte, error) {
 
 func (t *boundBytesTree) Prepend(parent, id string, val []byte) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -403,7 +430,14 @@ func (t *boundBytesTree) Prepend(parent, id string, val []byte) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -412,14 +446,19 @@ func (t *boundBytesTree) Prepend(parent, id string, val []byte) error {
 // Since: 2.5
 func (t *boundBytesTree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundBytesTree) removeChildren(id string) {
@@ -434,23 +473,33 @@ func (t *boundBytesTree) removeChildren(id string) {
 
 func (t *boundBytesTree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundBytesTree) Set(ids map[string][]string, v map[string][]byte) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundBytesTree) doReload() (retErr error) {
+func (t *boundBytesTree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -484,20 +533,13 @@ func (t *boundBytesTree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalBytesTreeItem).lock.Lock()
 			err = item.(*boundExternalBytesTreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalBytesTreeItem).lock.Unlock()
 		} else {
-			item.(*boundBytesTreeItem).lock.Lock()
 			err = item.(*boundBytesTreeItem).doSet((*t.val)[id])
-			item.(*boundBytesTreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -549,14 +591,13 @@ func (t *boundBytesTreeItem) Get() ([]byte, error) {
 }
 
 func (t *boundBytesTreeItem) Set(val []byte) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundBytesTreeItem) doSet(val []byte) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -569,11 +610,14 @@ type boundExternalBytesTreeItem struct {
 }
 
 func (t *boundExternalBytesTreeItem) setIfChanged(val []byte) error {
+	t.lock.Lock()
 	if bytes.Equal(val, t.old) {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -645,7 +689,6 @@ type boundFloatTree struct {
 
 func (t *boundFloatTree) Append(parent, id string, val float64) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -655,7 +698,14 @@ func (t *boundFloatTree) Append(parent, id string, val float64) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundFloatTree) Get() (map[string][]string, map[string]float64, error) {
@@ -678,7 +728,6 @@ func (t *boundFloatTree) GetValue(id string) (float64, error) {
 
 func (t *boundFloatTree) Prepend(parent, id string, val float64) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -688,7 +737,14 @@ func (t *boundFloatTree) Prepend(parent, id string, val float64) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -697,14 +753,19 @@ func (t *boundFloatTree) Prepend(parent, id string, val float64) error {
 // Since: 2.5
 func (t *boundFloatTree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundFloatTree) removeChildren(id string) {
@@ -719,23 +780,33 @@ func (t *boundFloatTree) removeChildren(id string) {
 
 func (t *boundFloatTree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundFloatTree) Set(ids map[string][]string, v map[string]float64) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundFloatTree) doReload() (retErr error) {
+func (t *boundFloatTree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -769,20 +840,13 @@ func (t *boundFloatTree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalFloatTreeItem).lock.Lock()
 			err = item.(*boundExternalFloatTreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalFloatTreeItem).lock.Unlock()
 		} else {
-			item.(*boundFloatTreeItem).lock.Lock()
 			err = item.(*boundFloatTreeItem).doSet((*t.val)[id])
-			item.(*boundFloatTreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -834,14 +898,13 @@ func (t *boundFloatTreeItem) Get() (float64, error) {
 }
 
 func (t *boundFloatTreeItem) Set(val float64) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundFloatTreeItem) doSet(val float64) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -854,11 +917,14 @@ type boundExternalFloatTreeItem struct {
 }
 
 func (t *boundExternalFloatTreeItem) setIfChanged(val float64) error {
+	t.lock.Lock()
 	if val == t.old {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -930,7 +996,6 @@ type boundIntTree struct {
 
 func (t *boundIntTree) Append(parent, id string, val int) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -940,7 +1005,14 @@ func (t *boundIntTree) Append(parent, id string, val int) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundIntTree) Get() (map[string][]string, map[string]int, error) {
@@ -963,7 +1035,6 @@ func (t *boundIntTree) GetValue(id string) (int, error) {
 
 func (t *boundIntTree) Prepend(parent, id string, val int) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -973,7 +1044,14 @@ func (t *boundIntTree) Prepend(parent, id string, val int) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -982,14 +1060,19 @@ func (t *boundIntTree) Prepend(parent, id string, val int) error {
 // Since: 2.5
 func (t *boundIntTree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundIntTree) removeChildren(id string) {
@@ -1004,23 +1087,33 @@ func (t *boundIntTree) removeChildren(id string) {
 
 func (t *boundIntTree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundIntTree) Set(ids map[string][]string, v map[string]int) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundIntTree) doReload() (retErr error) {
+func (t *boundIntTree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -1054,20 +1147,13 @@ func (t *boundIntTree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalIntTreeItem).lock.Lock()
 			err = item.(*boundExternalIntTreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalIntTreeItem).lock.Unlock()
 		} else {
-			item.(*boundIntTreeItem).lock.Lock()
 			err = item.(*boundIntTreeItem).doSet((*t.val)[id])
-			item.(*boundIntTreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1119,14 +1205,13 @@ func (t *boundIntTreeItem) Get() (int, error) {
 }
 
 func (t *boundIntTreeItem) Set(val int) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundIntTreeItem) doSet(val int) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -1139,11 +1224,14 @@ type boundExternalIntTreeItem struct {
 }
 
 func (t *boundExternalIntTreeItem) setIfChanged(val int) error {
+	t.lock.Lock()
 	if val == t.old {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -1215,7 +1303,6 @@ type boundRuneTree struct {
 
 func (t *boundRuneTree) Append(parent, id string, val rune) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -1225,7 +1312,14 @@ func (t *boundRuneTree) Append(parent, id string, val rune) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundRuneTree) Get() (map[string][]string, map[string]rune, error) {
@@ -1248,7 +1342,6 @@ func (t *boundRuneTree) GetValue(id string) (rune, error) {
 
 func (t *boundRuneTree) Prepend(parent, id string, val rune) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -1258,7 +1351,14 @@ func (t *boundRuneTree) Prepend(parent, id string, val rune) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -1267,14 +1367,19 @@ func (t *boundRuneTree) Prepend(parent, id string, val rune) error {
 // Since: 2.5
 func (t *boundRuneTree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundRuneTree) removeChildren(id string) {
@@ -1289,23 +1394,33 @@ func (t *boundRuneTree) removeChildren(id string) {
 
 func (t *boundRuneTree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundRuneTree) Set(ids map[string][]string, v map[string]rune) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundRuneTree) doReload() (retErr error) {
+func (t *boundRuneTree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -1339,20 +1454,13 @@ func (t *boundRuneTree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalRuneTreeItem).lock.Lock()
 			err = item.(*boundExternalRuneTreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalRuneTreeItem).lock.Unlock()
 		} else {
-			item.(*boundRuneTreeItem).lock.Lock()
 			err = item.(*boundRuneTreeItem).doSet((*t.val)[id])
-			item.(*boundRuneTreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1404,14 +1512,13 @@ func (t *boundRuneTreeItem) Get() (rune, error) {
 }
 
 func (t *boundRuneTreeItem) Set(val rune) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundRuneTreeItem) doSet(val rune) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -1424,11 +1531,14 @@ type boundExternalRuneTreeItem struct {
 }
 
 func (t *boundExternalRuneTreeItem) setIfChanged(val rune) error {
+	t.lock.Lock()
 	if val == t.old {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -1500,7 +1610,6 @@ type boundStringTree struct {
 
 func (t *boundStringTree) Append(parent, id string, val string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -1510,7 +1619,14 @@ func (t *boundStringTree) Append(parent, id string, val string) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundStringTree) Get() (map[string][]string, map[string]string, error) {
@@ -1533,7 +1649,6 @@ func (t *boundStringTree) GetValue(id string) (string, error) {
 
 func (t *boundStringTree) Prepend(parent, id string, val string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -1543,7 +1658,14 @@ func (t *boundStringTree) Prepend(parent, id string, val string) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -1552,14 +1674,19 @@ func (t *boundStringTree) Prepend(parent, id string, val string) error {
 // Since: 2.5
 func (t *boundStringTree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundStringTree) removeChildren(id string) {
@@ -1574,23 +1701,33 @@ func (t *boundStringTree) removeChildren(id string) {
 
 func (t *boundStringTree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundStringTree) Set(ids map[string][]string, v map[string]string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundStringTree) doReload() (retErr error) {
+func (t *boundStringTree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -1624,20 +1761,13 @@ func (t *boundStringTree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalStringTreeItem).lock.Lock()
 			err = item.(*boundExternalStringTreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalStringTreeItem).lock.Unlock()
 		} else {
-			item.(*boundStringTreeItem).lock.Lock()
 			err = item.(*boundStringTreeItem).doSet((*t.val)[id])
-			item.(*boundStringTreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1689,14 +1819,13 @@ func (t *boundStringTreeItem) Get() (string, error) {
 }
 
 func (t *boundStringTreeItem) Set(val string) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundStringTreeItem) doSet(val string) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -1709,11 +1838,14 @@ type boundExternalStringTreeItem struct {
 }
 
 func (t *boundExternalStringTreeItem) setIfChanged(val string) error {
+	t.lock.Lock()
 	if val == t.old {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -1785,7 +1917,6 @@ type boundUntypedTree struct {
 
 func (t *boundUntypedTree) Append(parent, id string, val any) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -1795,7 +1926,14 @@ func (t *boundUntypedTree) Append(parent, id string, val any) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundUntypedTree) Get() (map[string][]string, map[string]any, error) {
@@ -1818,7 +1956,6 @@ func (t *boundUntypedTree) GetValue(id string) (any, error) {
 
 func (t *boundUntypedTree) Prepend(parent, id string, val any) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -1828,7 +1965,14 @@ func (t *boundUntypedTree) Prepend(parent, id string, val any) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -1837,14 +1981,19 @@ func (t *boundUntypedTree) Prepend(parent, id string, val any) error {
 // Since: 2.5
 func (t *boundUntypedTree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundUntypedTree) removeChildren(id string) {
@@ -1859,23 +2008,33 @@ func (t *boundUntypedTree) removeChildren(id string) {
 
 func (t *boundUntypedTree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundUntypedTree) Set(ids map[string][]string, v map[string]any) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundUntypedTree) doReload() (retErr error) {
+func (t *boundUntypedTree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -1909,20 +2068,13 @@ func (t *boundUntypedTree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalUntypedTreeItem).lock.Lock()
 			err = item.(*boundExternalUntypedTreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalUntypedTreeItem).lock.Unlock()
 		} else {
-			item.(*boundUntypedTreeItem).lock.Lock()
 			err = item.(*boundUntypedTreeItem).doSet((*t.val)[id])
-			item.(*boundUntypedTreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -1974,14 +2126,13 @@ func (t *boundUntypedTreeItem) Get() (any, error) {
 }
 
 func (t *boundUntypedTreeItem) Set(val any) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundUntypedTreeItem) doSet(val any) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -1994,11 +2145,14 @@ type boundExternalUntypedTreeItem struct {
 }
 
 func (t *boundExternalUntypedTreeItem) setIfChanged(val any) error {
+	t.lock.Lock()
 	if val == t.old {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -2070,7 +2224,6 @@ type boundURITree struct {
 
 func (t *boundURITree) Append(parent, id string, val fyne.URI) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -2080,7 +2233,14 @@ func (t *boundURITree) Append(parent, id string, val fyne.URI) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundURITree) Get() (map[string][]string, map[string]fyne.URI, error) {
@@ -2103,7 +2263,6 @@ func (t *boundURITree) GetValue(id string) (fyne.URI, error) {
 
 func (t *boundURITree) Prepend(parent, id string, val fyne.URI) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	ids, ok := t.ids[parent]
 	if !ok {
 		ids = make([]string, 0)
@@ -2113,7 +2272,14 @@ func (t *boundURITree) Prepend(parent, id string, val fyne.URI) error {
 	v := *t.val
 	v[id] = val
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 // Remove takes the specified id out of the tree.
@@ -2122,14 +2288,19 @@ func (t *boundURITree) Prepend(parent, id string, val fyne.URI) error {
 // Since: 2.5
 func (t *boundURITree) Remove(id string) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	t.removeChildren(id)
 	delete(t.ids, id)
 	v := *t.val
 	delete(v, id)
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundURITree) removeChildren(id string) {
@@ -2144,23 +2315,33 @@ func (t *boundURITree) removeChildren(id string) {
 
 func (t *boundURITree) Reload() error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
 
-	return t.doReload()
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
 func (t *boundURITree) Set(ids map[string][]string, v map[string]fyne.URI) error {
 	t.lock.Lock()
-	defer t.lock.Unlock()
 	t.ids = ids
 	*t.val = v
 
-	return t.doReload()
+	trigger, err := t.doReload()
+	t.lock.Unlock()
+
+	if trigger {
+		t.trigger()
+	}
+
+	return err
 }
 
-func (t *boundURITree) doReload() (retErr error) {
+func (t *boundURITree) doReload() (fire bool, retErr error) {
 	updated := []string{}
-	fire := false
 	for id := range *t.val {
 		found := false
 		for child := range t.items {
@@ -2194,20 +2375,13 @@ func (t *boundURITree) doReload() (retErr error) {
 			t.deleteItem(id, parentIDFor(id, t.ids))
 		}
 	}
-	if fire {
-		t.trigger()
-	}
 
 	for id, item := range t.items {
 		var err error
 		if t.updateExternal {
-			item.(*boundExternalURITreeItem).lock.Lock()
 			err = item.(*boundExternalURITreeItem).setIfChanged((*t.val)[id])
-			item.(*boundExternalURITreeItem).lock.Unlock()
 		} else {
-			item.(*boundURITreeItem).lock.Lock()
 			err = item.(*boundURITreeItem).doSet((*t.val)[id])
-			item.(*boundURITreeItem).lock.Unlock()
 		}
 		if err != nil {
 			retErr = err
@@ -2259,14 +2433,13 @@ func (t *boundURITreeItem) Get() (fyne.URI, error) {
 }
 
 func (t *boundURITreeItem) Set(val fyne.URI) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.doSet(val)
 }
 
 func (t *boundURITreeItem) doSet(val fyne.URI) error {
+	t.lock.Lock()
 	(*t.val)[t.id] = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil
@@ -2279,11 +2452,14 @@ type boundExternalURITreeItem struct {
 }
 
 func (t *boundExternalURITreeItem) setIfChanged(val fyne.URI) error {
+	t.lock.Lock()
 	if compareURI(val, t.old) {
+	t.lock.Unlock()
 		return nil
 	}
 	(*t.val)[t.id] = val
 	t.old = val
+	t.lock.Unlock()
 
 	t.trigger()
 	return nil

--- a/data/binding/bindtrees_test.go
+++ b/data/binding/bindtrees_test.go
@@ -37,7 +37,6 @@ func TestExternalFloatTree_Reload(t *testing.T) {
 	f.AddListener(NewDataListener(func() {
 		calledTree = true
 	}))
-	waitForItems()
 	assert.True(t, calledTree)
 
 	child, err := f.GetItem("2")
@@ -45,7 +44,6 @@ func TestExternalFloatTree_Reload(t *testing.T) {
 	child.AddListener(NewDataListener(func() {
 		calledChild = true
 	}))
-	waitForItems()
 	assert.True(t, calledChild)
 
 	assert.NotNil(t, f.(*boundFloatTree).val)
@@ -57,7 +55,6 @@ func TestExternalFloatTree_Reload(t *testing.T) {
 	calledTree, calledChild = false, false
 	m["2"] = 4.8
 	f.Reload()
-	waitForItems()
 	v, err = f.GetValue("2")
 	assert.Nil(t, err)
 	assert.Equal(t, 4.8, v)
@@ -67,7 +64,6 @@ func TestExternalFloatTree_Reload(t *testing.T) {
 	calledTree, calledChild = false, false
 	m = map[string]float64{"1": 1.0, "2": 4.2}
 	f.Reload()
-	waitForItems()
 	v, err = f.GetValue("2")
 	assert.Nil(t, err)
 	assert.Equal(t, 4.2, v)
@@ -77,7 +73,6 @@ func TestExternalFloatTree_Reload(t *testing.T) {
 	calledTree, calledChild = false, false
 	m = map[string]float64{"1": 1.0, "2": 4.2, "3": 5.3}
 	f.Reload()
-	waitForItems()
 	v, err = f.GetValue("2")
 	assert.Nil(t, err)
 	assert.Equal(t, 4.2, v)
@@ -185,36 +180,29 @@ func TestFloatTree_NotifyOnlyOnceWhenChange(t *testing.T) {
 	f.AddListener(NewDataListener(func() {
 		triggered++
 	}))
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.Set(map[string][]string{"": {"1", "2"}}, map[string]float64{"1": 55, "2": 77})
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.SetValue("1", 5)
-	waitForItems()
 	assert.Zero(t, triggered)
 
 	triggered = 0
 	f.Set(map[string][]string{"": {"1", "2"}}, map[string]float64{"1": 101, "2": 98})
-	waitForItems()
 	assert.Zero(t, triggered)
 
 	triggered = 0
 	f.Append("1", "3", 88)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.Prepend("", "4", 23)
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 
 	triggered = 0
 	f.Set(map[string][]string{"": {"1"}}, map[string]float64{"1": 32})
-	waitForItems()
 	assert.Equal(t, 1, triggered)
 }

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -94,13 +94,11 @@ func (s *stringFromBool) Set(str string) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringFromBool) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -181,13 +179,11 @@ func (s *stringFromFloat) Set(str string) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringFromFloat) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -229,13 +225,11 @@ func (s *intToFloat) Set(val float64) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *intToFloat) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -278,13 +272,11 @@ func (s *intFromFloat) Set(v int) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *intFromFloat) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -365,13 +357,11 @@ func (s *stringFromInt) Set(str string) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringFromInt) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -418,13 +408,11 @@ func (s *stringFromURI) Set(str string) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringFromURI) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -506,13 +494,11 @@ func (s *stringToBool) Set(val bool) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringToBool) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -594,13 +580,11 @@ func (s *stringToFloat) Set(val float64) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringToFloat) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -682,13 +666,11 @@ func (s *stringToInt) Set(val int) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringToInt) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }
 
@@ -732,12 +714,10 @@ func (s *stringToURI) Set(val fyne.URI) error {
 		return err
 	}
 
-	s.DataChanged()
+	queueItem(s.DataChanged)
 	return nil
 }
 
 func (s *stringToURI) DataChanged() {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
 	s.trigger()
 }

--- a/data/binding/gen.go
+++ b/data/binding/gen.go
@@ -525,7 +525,7 @@ func (l *bound{{ .Name }}List) Append(val {{ .Type }}) error {
 	l.lock.Lock()
 	*l.val = append(*l.val, val)
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -556,8 +556,8 @@ func (l *bound{{ .Name }}List) GetValue(i int) ({{ .Type }}, error) {
 func (l *bound{{ .Name }}List) Prepend(val {{ .Type }}) error {
 	l.lock.Lock()
 	*l.val = append([]{{ .Type }}{val}, *l.val...)
-	
-	trigger, err :=  l.doReload()
+
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -569,7 +569,7 @@ func (l *bound{{ .Name }}List) Prepend(val {{ .Type }}) error {
 
 func (l *bound{{ .Name }}List) Reload() error {
 	l.lock.Lock()
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -626,7 +626,7 @@ func (l *bound{{ .Name }}List) Remove(val {{ .Type }}) error {
 		*l.val = append(v[:id], v[id+1:]...)
 	}
 
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -639,7 +639,7 @@ func (l *bound{{ .Name }}List) Remove(val {{ .Type }}) error {
 func (l *bound{{ .Name }}List) Set(v []{{ .Type }}) error {
 	l.lock.Lock()
 	*l.val = v
-	trigger, err :=  l.doReload()
+	trigger, err := l.doReload()
 	l.lock.Unlock()
 
 	if trigger {
@@ -1082,12 +1082,12 @@ func (t *boundExternal{{ .Name }}TreeItem) setIfChanged(val {{ .Type }}) error {
 	t.lock.Lock()
 	{{- if eq .Comparator "" }}
 	if val == t.old {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	{{- else }}
 	if {{ .Comparator }}(val, t.old) {
-	t.lock.Unlock()
+		t.lock.Unlock()
 		return nil
 	}
 	{{- end }}

--- a/data/binding/listbinding_test.go
+++ b/data/binding/listbinding_test.go
@@ -22,7 +22,6 @@ func TestListBase_AddListener(t *testing.T) {
 	assert.Equal(t, 1, syncMapLen(&data.listeners))
 
 	data.trigger()
-	waitForItems()
 	assert.True(t, called)
 }
 
@@ -63,6 +62,5 @@ func TestListBase_RemoveListener(t *testing.T) {
 	assert.Equal(t, 0, syncMapLen(&data.listeners))
 
 	data.trigger()
-	waitForItems()
 	assert.False(t, called)
 }

--- a/data/binding/mapbinding_test.go
+++ b/data/binding/mapbinding_test.go
@@ -93,13 +93,11 @@ func TestBindStruct_Reload(t *testing.T) {
 	b.AddListener(NewDataListener(func() {
 		calledMap = true
 	}))
-	waitForItems()
 	assert.True(t, calledMap)
 
 	item.AddListener(NewDataListener(func() {
 		calledItem = true
 	}))
-	waitForItems()
 	assert.True(t, calledItem)
 
 	s = struct {
@@ -114,7 +112,6 @@ func TestBindStruct_Reload(t *testing.T) {
 
 	calledMap, calledItem = false, false
 	b.Reload()
-	waitForItems()
 	v, err = b.GetValue("Foo")
 	assert.Nil(t, err)
 	assert.Equal(t, "bas", v)
@@ -126,7 +123,6 @@ func TestBindStruct_Reload(t *testing.T) {
 
 	calledMap, calledItem = false, false
 	b.Reload()
-	waitForItems()
 	v, err = b.GetValue("Foo")
 	assert.Nil(t, err)
 	assert.Equal(t, "bas", v)
@@ -185,7 +181,6 @@ func TestExternalUntypedMap_Reload(t *testing.T) {
 	b.AddListener(NewDataListener(func() {
 		calledMap = true
 	}))
-	waitForItems()
 	assert.True(t, calledMap)
 
 	child, err := b.GetItem("foo")
@@ -193,13 +188,11 @@ func TestExternalUntypedMap_Reload(t *testing.T) {
 	child.AddListener(NewDataListener(func() {
 		calledChild = true
 	}))
-	waitForItems()
 	assert.True(t, calledChild)
 
 	calledMap, calledChild = false, false
 	m["foo"] = "boo"
 	b.Reload()
-	waitForItems()
 	v, err = b.GetValue("foo")
 	assert.Nil(t, err)
 	assert.Equal(t, "boo", v)
@@ -212,7 +205,6 @@ func TestExternalUntypedMap_Reload(t *testing.T) {
 		"val": 5,
 	}
 	b.Reload()
-	waitForItems()
 	v, err = b.GetValue("foo")
 	assert.Nil(t, err)
 	assert.Equal(t, "bar", v)
@@ -226,7 +218,6 @@ func TestExternalUntypedMap_Reload(t *testing.T) {
 		"new": "longer",
 	}
 	b.Reload()
-	waitForItems()
 	v, err = b.GetValue("foo")
 	assert.Nil(t, err)
 	assert.Equal(t, "bar", v)

--- a/data/binding/queue.go
+++ b/data/binding/queue.go
@@ -1,30 +1,12 @@
 package binding
 
 import (
-	"runtime"
-
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/async"
 )
 
-var mainGoroutineID uint64
-
-func init() {
-	runtime.LockOSThread()
-	mainGoroutineID = goroutineID()
-}
-
-func goroutineID() (id uint64) {
-	var buf [30]byte
-	runtime.Stack(buf[:], false)
-	for i := 10; buf[i] != ' '; i++ {
-		id = id*10 + uint64(buf[i]&15)
-	}
-
-	return id
-}
-
 func queueItem(f func()) {
-	if goroutineID() == mainGoroutineID {
+	if async.IsMainGoroutine() {
 		f()
 		return
 	}

--- a/data/binding/queue_test.go
+++ b/data/binding/queue_test.go
@@ -20,12 +20,6 @@ func TestMain(m *testing.M) {
 // Note that this test may fail, if any of other tests in this package
 // calls t.Parallel().
 func TestQueueLazyInit(t *testing.T) {
-	if queue != nil { // Reset queues
-		queue.Close()
-		queue = nil
-		once = sync.Once{}
-	}
-
 	initialGoRoutines := runtime.NumGoroutine()
 
 	wg := sync.WaitGroup{}
@@ -45,7 +39,6 @@ func TestQueueItem(t *testing.T) {
 	called := 0
 	queueItem(func() { called++ })
 	queueItem(func() { called++ })
-	waitForItems()
 	assert.Equal(t, 2, called)
 }
 

--- a/data/binding/sprintf_test.go
+++ b/data/binding/sprintf_test.go
@@ -29,10 +29,7 @@ func TestSprintfConversionRead(t *testing.T) {
 	expected := fmt.Sprintf(format, b, f, i, r, s, u)
 	assert.NotNil(t, sp)
 
-	waitForItems()
-
 	sGenerated, err := sp.Get()
-
 	assert.Nil(t, err)
 	assert.NotNil(t, sGenerated)
 	assert.Equal(t, expected, sGenerated)
@@ -45,10 +42,7 @@ func TestSprintfConversionRead(t *testing.T) {
 
 	expectedChange := fmt.Sprintf(format, b, f, i, r, s, u)
 
-	waitForItems()
-
 	sChange, err := sp.Get()
-
 	assert.Nil(t, err)
 	assert.NotNil(t, sChange)
 	assert.Equal(t, expectedChange, sChange)
@@ -75,19 +69,13 @@ func TestSprintfConversionReadWrite(t *testing.T) {
 	expected := fmt.Sprintf(format, b, f, i, r, s, u)
 	assert.NotNil(t, sp)
 
-	waitForItems()
-
 	sGenerated, err := sp.Get()
-
 	assert.Nil(t, err)
 	assert.NotNil(t, sGenerated)
 	assert.Equal(t, expected, sGenerated)
 
 	err = sp.Set("Bool false , Float 7.000000 , Int 42 , Rune 67 , String nospacestring , URI file:///var/")
-
 	assert.Nil(t, err)
-
-	waitForItems()
 
 	assert.Equal(t, b, false)
 	assert.Equal(t, f, float64(7))
@@ -115,8 +103,6 @@ func TestNewStringWithFormat(t *testing.T) {
 	expected := fmt.Sprintf(format, s)
 	assert.NotNil(t, sp)
 
-	waitForItems()
-
 	sGenerated, err := sp.Get()
 	assert.Nil(t, err)
 	assert.NotNil(t, sGenerated)
@@ -124,8 +110,6 @@ func TestNewStringWithFormat(t *testing.T) {
 
 	err = sp.Set("String nospacestring")
 	assert.Nil(t, err)
-
-	waitForItems()
 
 	assert.Equal(t, s, "nospacestring")
 	expectedChange := fmt.Sprintf(format, s)

--- a/data/binding/treebinding_test.go
+++ b/data/binding/treebinding_test.go
@@ -18,7 +18,6 @@ func TestTreeBase_AddListener(t *testing.T) {
 	assert.Equal(t, 1, syncMapLen(&data.listeners))
 
 	data.trigger()
-	waitForItems()
 	assert.True(t, called)
 }
 
@@ -60,7 +59,6 @@ func TestTreeBase_RemoveListener(t *testing.T) {
 	assert.Equal(t, 0, syncMapLen(&data.listeners))
 
 	data.trigger()
-	waitForItems()
 	assert.False(t, called)
 }
 

--- a/driver.go
+++ b/driver.go
@@ -25,7 +25,7 @@ type Driver interface {
 	// Run starts the main event loop of the driver.
 	Run()
 	// Quit closes the driver and open windows, then exit the application.
-	// On some some operating systems this does nothing, for example iOS and Android.
+	// On some operating systems this does nothing, for example iOS and Android.
 	Quit()
 
 	// StartAnimation registers a new animation with this driver and requests it be started.
@@ -43,4 +43,9 @@ type Driver interface {
 	//
 	// Since: 2.5
 	SetDisableScreenBlanking(bool)
+
+	// CallFromGoroutine provides a way to queue a function that is running on a goroutine back to the main thread.
+	// This is required when background tasks want to execute code safely in the graphical context.
+	// Since: 2.6
+	CallFromGoroutine(func())
 }

--- a/internal/async/goroutine.go
+++ b/internal/async/goroutine.go
@@ -1,5 +1,9 @@
 package async
 
+// mainGoroutineID stores the main goroutine ID.
+// This ID must be initialized in main.init because
+// a main goroutine may not equal to 1 due to the
+// influence of a garbage collector.
 var mainGoroutineID uint64
 
 func init() {

--- a/internal/async/goroutine.go
+++ b/internal/async/goroutine.go
@@ -1,0 +1,11 @@
+package async
+
+var mainGoroutineID uint64
+
+func init() {
+	mainGoroutineID = goroutineID()
+}
+
+func IsMainGoroutine() bool {
+	return goroutineID() == mainGoroutineID
+}

--- a/internal/async/goroutine_desktop.go
+++ b/internal/async/goroutine_desktop.go
@@ -1,0 +1,15 @@
+//go:build !wasm
+
+package async
+
+import "runtime"
+
+func goroutineID() (id uint64) {
+	var buf [30]byte
+	runtime.Stack(buf[:], false)
+	for i := 10; buf[i] != ' '; i++ {
+		id = id*10 + uint64(buf[i]&15)
+	}
+
+	return id
+}

--- a/internal/async/goroutine_goxjs.go
+++ b/internal/async/goroutine_goxjs.go
@@ -1,6 +1,6 @@
 //go:build wasm
 
-package glfw
+package async
 
 func goroutineID() uint64 {
 	return mainGoroutineID

--- a/internal/async/goroutine_test.go
+++ b/internal/async/goroutine_test.go
@@ -1,0 +1,39 @@
+package async
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mainRoutineID uint64
+
+func init() {
+	mainRoutineID = goroutineID()
+}
+
+func TestGoroutineID(t *testing.T) {
+	assert.Equal(t, uint64(1), mainRoutineID)
+
+	var childID1, childID2 uint64
+	testID1 := goroutineID()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		childID1 = goroutineID()
+		wg.Done()
+	}()
+	go func() {
+		childID2 = goroutineID()
+		wg.Done()
+	}()
+	wg.Wait()
+	testID2 := goroutineID()
+
+	assert.Equal(t, testID1, testID2)
+	assert.Greater(t, childID1, uint64(0))
+	assert.NotEqual(t, testID1, childID1)
+	assert.Greater(t, childID2, uint64(0))
+	assert.NotEqual(t, childID1, childID2)
+}

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sync"
 
+	"fyne.io/fyne/v2/internal/async"
 	"github.com/fyne-io/image/ico"
 
 	"fyne.io/fyne/v2"
@@ -156,7 +157,7 @@ func (d *gLDriver) initFailed(msg string, err error) {
 }
 
 func (d *gLDriver) Run() {
-	if goroutineID() != mainGoroutineID {
+	if !async.IsMainGoroutine() {
 		panic("Run() or ShowAndRun() must be called from main goroutine")
 	}
 

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -22,12 +22,6 @@ import (
 	"fyne.io/fyne/v2/storage/repository"
 )
 
-// mainGoroutineID stores the main goroutine ID.
-// This ID must be initialized in main.init because
-// a main goroutine may not equal to 1 due to the
-// influence of a garbage collector.
-var mainGoroutineID uint64
-
 var curWindow *window
 
 // Declare conformity with Driver

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -64,6 +64,10 @@ func toOSIcon(icon []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (d *gLDriver) CallFromGoroutine(f func()) {
+	runOnMain(f)
+}
+
 func (d *gLDriver) RenderedTextSize(text string, textSize float32, style fyne.TextStyle, source fyne.Resource) (size fyne.Size, baseline float32) {
 	return painter.RenderedTextSize(text, textSize, style, source)
 }

--- a/internal/driver/glfw/driver_darwin.go
+++ b/internal/driver/glfw/driver_darwin.go
@@ -15,7 +15,7 @@ func setDisableScreenBlank(disable bool) {
 	C.setDisableDisplaySleep(C.bool(disable))
 }
 
-func (g *gLDriver) DoubleTapDelay() time.Duration {
+func (d *gLDriver) DoubleTapDelay() time.Duration {
 	millis := int64(float64(C.doubleClickInterval()) * 1000)
 	return time.Duration(millis) * time.Millisecond
 }

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -29,15 +29,6 @@ var (
 	setup       sync.Once
 )
 
-func goroutineID() (id uint64) {
-	var buf [30]byte
-	runtime.Stack(buf[:], false)
-	for i := 10; buf[i] != ' '; i++ {
-		id = id*10 + uint64(buf[i]&15)
-	}
-	return id
-}
-
 func (d *gLDriver) SetSystemTrayMenu(m *fyne.Menu) {
 	setup.Do(func() {
 		d.trayStart, d.trayStop = systray.RunWithExternalLoop(func() {

--- a/internal/driver/glfw/driver_test.go
+++ b/internal/driver/glfw/driver_test.go
@@ -3,7 +3,6 @@
 package glfw
 
 import (
-	"sync"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -121,35 +120,4 @@ func Test_gLDriver_AbsolutePositionForObject(t *testing.T) {
 			assert.Equal(t, tt.wantY, int(pos.Y))
 		})
 	}
-}
-
-var mainRoutineID uint64
-
-func init() {
-	mainRoutineID = goroutineID()
-}
-
-func TestGoroutineID(t *testing.T) {
-	assert.Equal(t, uint64(1), mainRoutineID)
-
-	var childID1, childID2 uint64
-	testID1 := goroutineID()
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		childID1 = goroutineID()
-		wg.Done()
-	}()
-	go func() {
-		childID2 = goroutineID()
-		wg.Done()
-	}()
-	wg.Wait()
-	testID2 := goroutineID()
-
-	assert.Equal(t, testID1, testID2)
-	assert.Greater(t, childID1, uint64(0))
-	assert.NotEqual(t, testID1, childID1)
-	assert.Greater(t, childID2, uint64(0))
-	assert.NotEqual(t, childID1, childID2)
 }

--- a/internal/driver/glfw/driver_web.go
+++ b/internal/driver/glfw/driver_web.go
@@ -21,6 +21,6 @@ func setDisableScreenBlank(disable bool) {
 	// awaiting complete support for WakeLock
 }
 
-func (g *gLDriver) DoubleTapDelay() time.Duration {
+func (d *gLDriver) DoubleTapDelay() time.Duration {
 	return webDefaultDoubleTapDelay
 }

--- a/internal/driver/glfw/driver_windows.go
+++ b/internal/driver/glfw/driver_windows.go
@@ -72,7 +72,7 @@ func setDisableScreenBlank(disable bool) {
 	syscall.Syscall(executionState.Addr(), 1, uintptr(uType), 0, 0)
 }
 
-func (g *gLDriver) DoubleTapDelay() time.Duration {
+func (d *gLDriver) DoubleTapDelay() time.Duration {
 	// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdoubleclicktime
 	if getDoubleClickTime == nil {
 		return desktopDefaultDoubleTapDelay

--- a/internal/driver/glfw/driver_xdg.go
+++ b/internal/driver/glfw/driver_xdg.go
@@ -45,6 +45,6 @@ func setDisableScreenBlank(disable bool) {
 	}
 }
 
-func (g *gLDriver) DoubleTapDelay() time.Duration {
+func (d *gLDriver) DoubleTapDelay() time.Duration {
 	return desktopDefaultDoubleTapDelay
 }

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -27,7 +27,6 @@ var initOnce = &sync.Once{}
 // Arrange that main.main runs on main thread.
 func init() {
 	runtime.LockOSThread()
-	mainGoroutineID = goroutineID()
 }
 
 // force a function f to run on the main thread

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/animation"
 	intapp "fyne.io/fyne/v2/internal/app"
+	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/build"
 	"fyne.io/fyne/v2/internal/cache"
 	intdriver "fyne.io/fyne/v2/internal/driver"
@@ -61,6 +62,7 @@ type driver struct {
 	onConfigChanged func(*Configuration)
 	painting        bool
 	running         atomic.Bool
+	queuedFuncs     *async.UnboundedFuncChan
 }
 
 // Declare conformity with Driver
@@ -69,6 +71,10 @@ var _ ConfiguredDriver = (*driver)(nil)
 
 func init() {
 	runtime.LockOSThread()
+}
+
+func (d *driver) CallFromGoroutine(fn func()) {
+	d.queuedFuncs.In() <- fn
 }
 
 func (d *driver) CreateWindow(title string) fyne.Window {
@@ -147,6 +153,7 @@ func (d *driver) Run() {
 	app.Main(func(a app.App) {
 		d.app = a
 		settingsChange := make(chan fyne.Settings)
+		d.queuedFuncs = async.NewUnboundedFuncChan()
 		fyne.CurrentApp().Settings().AddChangeListener(settingsChange)
 		draw := time.NewTicker(time.Second / 60)
 		defer func() {
@@ -169,6 +176,8 @@ func (d *driver) Run() {
 					}
 					c.applyThemeOutOfTreeObjects()
 				})
+			case fn := <-d.queuedFuncs.Out():
+				fn()
 			case e, ok := <-a.Events():
 				if !ok {
 					return // events channel closed, app done

--- a/test/driver.go
+++ b/test/driver.go
@@ -49,6 +49,10 @@ func NewDriverWithPainter(painter SoftwarePainter) fyne.Driver {
 	return &driver{painter: painter}
 }
 
+func (d *driver) CallFromGoroutine(f func()) {
+	f() // This is a simplification that works for now, may have to review if tests are multi-threaded
+}
+
 func (d *driver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position {
 	c := d.CanvasForObject(co)
 	if c == nil {


### PR DESCRIPTION
Get/Set can be called from anywhere, Reload too.
Remove all the tedious waiting in data binding tests.
This is not the final public API for goroutine work, but as drivers needed to add this support first I added it to that interface.

Relates to #4654 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
