### PR TITLE
Fix issue where web clipboard crashes

### DIFF
--- a/internal/driver/glfw/clipboard_goxjs.go
+++ b/internal/driver/glfw/clipboard_goxjs.go
@@ -4,7 +4,6 @@ package glfw
 
 import (
 	"fyne.io/fyne/v2"
-	glfw "github.com/fyne-io/glfw-js"
 )
 
 // Declare conformity with Clipboard interface
@@ -12,14 +11,14 @@ var _ fyne.Clipboard = (*clipboard)(nil)
 
 // clipboard represents the system clipboard
 type clipboard struct {
-	window *glfw.Window
 }
 
 // Content returns the clipboard content
 func (c *clipboard) Content() string {
 	content := ""
 	runOnMain(func() {
-		content, _ = c.window.GetClipboardString()
+		win := fyne.CurrentApp().Driver().AllWindows()[0].(*window).viewport
+		content, _ = win.GetClipboardString()
 	})
 	return content
 }
@@ -27,6 +26,7 @@ func (c *clipboard) Content() string {
 // SetContent sets the clipboard content
 func (c *clipboard) SetContent(content string) {
 	runOnMain(func() {
-		c.window.SetClipboardString(content)
+		win := fyne.CurrentApp().Driver().AllWindows()[0].(*window).viewport
+		win.SetClipboardString(content)
 	})
 }


### PR DESCRIPTION
This is already resolved on develop because the semantics of clipboard changed.
This fix is just a plaster over the 2.5 releases.

Fixes #5370 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

