### PR TITLE
Remove rendererCacheNode painterData field

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -494,11 +494,6 @@ type RenderCacheNode struct {
 	parent      *RenderCacheNode
 	// cache data
 	minSize fyne.Size
-	// painterData is some data from the painter associated with the drawn node
-	// it may for instance point to a GL texture
-	// it should free all associated resources when released
-	// i.e. it should not simply be a texture reference integer
-	painterData any
 }
 
 // Obj returns the node object.

--- a/internal/driver/common/canvas_test.go
+++ b/internal/driver/common/canvas_test.go
@@ -42,22 +42,24 @@ func TestCanvas_walkTree(t *testing.T) {
 		obj                                     fyne.CanvasObject
 		lastBeforeCallIndex, lastAfterCallIndex int
 	}
+
+	painterData := make(map[*RenderCacheNode]nodeInfo)
 	updateInfoBefore := func(node *RenderCacheNode, index int) {
-		pd, _ := node.painterData.(nodeInfo)
-		if (pd != nodeInfo{}) && pd.obj != node.obj {
+		pd, ok := painterData[node]
+		if ok && pd.obj != node.obj {
 			panic("node cache does not match node obj - nodes should not be reused for different objects")
 		}
 		pd.obj = node.obj
 		pd.lastBeforeCallIndex = index
-		node.painterData = pd
+		painterData[node] = pd
 	}
 	updateInfoAfter := func(node *RenderCacheNode, index int) {
-		pd := node.painterData.(nodeInfo)
+		pd := painterData[node]
 		if pd.obj != node.obj {
 			panic("node cache does not match node obj - nodes should not be reused for different objects")
 		}
 		pd.lastAfterCallIndex = index
-		node.painterData = pd
+		painterData[node] = pd
 	}
 
 	//
@@ -122,10 +124,10 @@ func TestCanvas_walkTree(t *testing.T) {
 	nodes := []*RenderCacheNode{}
 
 	c.walkTree(tree, func(node *RenderCacheNode, pos fyne.Position) {
-		secondRunBeforePainterData = append(secondRunBeforePainterData, node.painterData.(nodeInfo))
+		secondRunBeforePainterData = append(secondRunBeforePainterData, painterData[node])
 		nodes = append(nodes, node)
 	}, func(node *RenderCacheNode, _ fyne.Position) {
-		secondRunAfterPainterData = append(secondRunAfterPainterData, node.painterData.(nodeInfo))
+		secondRunAfterPainterData = append(secondRunAfterPainterData, painterData[node])
 	})
 
 	assert.Equal(t, []nodeInfo{
@@ -172,11 +174,11 @@ func TestCanvas_walkTree(t *testing.T) {
 	c.walkTree(tree, func(node *RenderCacheNode, pos fyne.Position) {
 		i++
 		updateInfoBefore(node, i)
-		thirdRunBeforePainterData = append(thirdRunBeforePainterData, node.painterData.(nodeInfo))
+		thirdRunBeforePainterData = append(thirdRunBeforePainterData, painterData[node])
 	}, func(node *RenderCacheNode, _ fyne.Position) {
 		i++
 		updateInfoAfter(node, i)
-		thirdRunAfterPainterData = append(thirdRunAfterPainterData, node.painterData.(nodeInfo))
+		thirdRunAfterPainterData = append(thirdRunAfterPainterData, painterData[node])
 	})
 
 	assert.Equal(t, []nodeInfo{
@@ -217,12 +219,12 @@ func TestCanvas_walkTree(t *testing.T) {
 	c.walkTree(tree, func(node *RenderCacheNode, pos fyne.Position) {
 		i++
 		updateInfoBefore(node, i)
-		fourthRunBeforePainterData = append(fourthRunBeforePainterData, node.painterData.(nodeInfo))
+		fourthRunBeforePainterData = append(fourthRunBeforePainterData, painterData[node])
 		nodes = append(nodes, node)
 	}, func(node *RenderCacheNode, _ fyne.Position) {
 		i++
 		updateInfoAfter(node, i)
-		fourthRunAfterPainterData = append(fourthRunAfterPainterData, node.painterData.(nodeInfo))
+		fourthRunAfterPainterData = append(fourthRunAfterPainterData, painterData[node])
 	})
 
 	assert.Equal(t, []nodeInfo{
@@ -299,12 +301,12 @@ func TestCanvas_walkTree(t *testing.T) {
 	c.walkTree(tree, func(node *RenderCacheNode, pos fyne.Position) {
 		i++
 		updateInfoBefore(node, i)
-		fifthRunBeforePainterData = append(fifthRunBeforePainterData, node.painterData.(nodeInfo))
+		fifthRunBeforePainterData = append(fifthRunBeforePainterData, painterData[node])
 		nodes = append(nodes, node)
 	}, func(node *RenderCacheNode, _ fyne.Position) {
 		i++
 		updateInfoAfter(node, i)
-		fifthRunAfterPainterData = append(fifthRunAfterPainterData, node.painterData.(nodeInfo))
+		fifthRunAfterPainterData = append(fifthRunAfterPainterData, painterData[node])
 	})
 
 	assert.Equal(t, []nodeInfo{


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This was only used in tests to verify that nodes were not reused. Update tests to use a map for that; this makes the size of each renderer cache 25% smaller with now using 48 bytes instead of 64 bytes.

Fixes #4523

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
