### PR TITLE
Fix workflow failing due to missing language tag

### DIFF
--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -37,6 +37,11 @@ jobs:
         libxkbcommon-dev
         xorg-dev
         xvfb
+        language-pack-en
+      if: ${{ runner.os == 'Linux' }}
+
+    - name: Set environment variable LANG
+      run: export LANG=en_EN.UTF-8
       if: ${{ runner.os == 'Linux' }}
 
     - name: Tests

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -28,6 +28,10 @@ jobs:
         libx11-dev
         xorg-dev
         xvfb
+        language-pack-en
+
+    - name: Set environment variable LANG
+      run: export LANG=en_EN.UTF-8
 
     - name: Install analysis tools
       run: |


### PR DESCRIPTION
With HEAD of repo (branch `develop`), the workflow run of GitHub action `static-analysis` currently fails. This PR fixes that issue.

### Checklist:

- [x] Workflown run of  action 'static-analysis' is now successful