### PR TITLE
Fyne_Demo now running free from race reports

### DIFF
--- a/cmd/fyne_demo/tutorials/canvas.go
+++ b/cmd/fyne_demo/tutorials/canvas.go
@@ -24,11 +24,13 @@ func canvasScreen(_ fyne.Window) fyne.CanvasObject {
 		for {
 			time.Sleep(time.Second)
 
-			gradient.Angle += 45
-			if gradient.Angle >= 360 {
-				gradient.Angle -= 360
-			}
-			canvas.Refresh(gradient)
+			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+				gradient.Angle += 45
+				if gradient.Angle >= 360 {
+					gradient.Angle -= 360
+				}
+				canvas.Refresh(gradient)
+			})
 		}
 	}()
 


### PR DESCRIPTION
This is not using the final API but I wanted to progress tasks as while working on trickier details. I will move this to public API when it is decided, a simple refactor will cover it.

In the meantime I can no longer get any reports from  in fyne_demo

Fixes #4568 
Relates to #4654 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- run as usual with `-race` - tests are a separate PR
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
