### PR TITLE
Fix the last remaining races in fyne_demo

### DIFF
--- a/cmd/fyne_demo/tutorials/advanced.go
+++ b/cmd/fyne_demo/tutorials/advanced.go
@@ -2,6 +2,7 @@ package tutorials
 
 import (
 	"strconv"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -9,11 +10,11 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
-func scaleString(c fyne.Canvas) string {
+func scaleToString(c fyne.Canvas) string {
 	return strconv.FormatFloat(float64(c.Scale()), 'f', 2, 32)
 }
 
-func texScaleString(c fyne.Canvas) string {
+func textureScaleToString(c fyne.Canvas) string {
 	pixels, _ := c.PixelCoordinateForPosition(fyne.NewPos(1, 1))
 	texScale := float32(pixels) / c.Scale()
 	return strconv.FormatFloat(float64(texScale), 'f', 2, 32)
@@ -25,8 +26,8 @@ func prependTo(g *fyne.Container, s string) {
 }
 
 func setScaleText(scale, tex *widget.Label, canvas fyne.Canvas) {
-	scale.SetText(scaleString(canvas))
-	tex.SetText(texScaleString(canvas))
+	scale.SetText(scaleToString(canvas))
+	tex.SetText(textureScaleToString(canvas))
 }
 
 // advancedScreen loads a panel that shows details and settings that are a bit
@@ -40,16 +41,15 @@ func advancedScreen(win fyne.Window) fyne.CanvasObject {
 		&widget.FormItem{Text: "Texture Scale", Widget: tex},
 	))
 
-	setScaleText(scale, tex, win.Canvas())
-	listen := make(chan fyne.Settings)
-	fyne.CurrentApp().Settings().AddChangeListener(listen)
+	canvas := win.Canvas()
+	setScaleText(scale, tex, canvas)
 	go func(canvas fyne.Canvas) {
-		for range listen {
+		for range time.NewTicker(time.Second).C {
 			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
 				setScaleText(scale, tex, canvas)
 			})
 		}
-	}(win.Canvas())
+	}(canvas)
 
 	label := widget.NewLabel("Just type...")
 	generic := container.NewVBox()

--- a/cmd/fyne_demo/tutorials/advanced.go
+++ b/cmd/fyne_demo/tutorials/advanced.go
@@ -25,11 +25,6 @@ func prependTo(g *fyne.Container, s string) {
 	g.Refresh()
 }
 
-func setScaleText(scale, tex *widget.Label, canvas fyne.Canvas) {
-	scale.SetText(scaleToString(canvas))
-	tex.SetText(textureScaleToString(canvas))
-}
-
 // advancedScreen loads a panel that shows details and settings that are a bit
 // more detailed than normally needed.
 func advancedScreen(win fyne.Window) fyne.CanvasObject {
@@ -41,15 +36,14 @@ func advancedScreen(win fyne.Window) fyne.CanvasObject {
 		&widget.FormItem{Text: "Texture Scale", Widget: tex},
 	))
 
-	canvas := win.Canvas()
-	setScaleText(scale, tex, canvas)
 	go func(canvas fyne.Canvas) {
 		for range time.NewTicker(time.Second).C {
 			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
-				setScaleText(scale, tex, canvas)
+				scale.SetText(scaleToString(canvas))
+				tex.SetText(textureScaleToString(canvas))
 			})
 		}
-	}(canvas)
+	}(win.Canvas())
 
 	label := widget.NewLabel("Just type...")
 	generic := container.NewVBox()

--- a/cmd/fyne_demo/tutorials/canvas.go
+++ b/cmd/fyne_demo/tutorials/canvas.go
@@ -21,9 +21,7 @@ func rgbGradient(x, y, w, h int) color.Color {
 func canvasScreen(_ fyne.Window) fyne.CanvasObject {
 	gradient := canvas.NewHorizontalGradient(color.NRGBA{0x80, 0, 0, 0xff}, color.NRGBA{0, 0x80, 0, 0xff})
 	go func() {
-		for {
-			time.Sleep(time.Second)
-
+		for range time.NewTicker(time.Second).C {
 			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
 				gradient.Angle += 45
 				if gradient.Angle >= 360 {

--- a/cmd/fyne_demo/tutorials/welcome.go
+++ b/cmd/fyne_demo/tutorials/welcome.go
@@ -63,13 +63,15 @@ func welcomeScreen(_ fyne.Window) fyne.CanvasObject {
 	fyne.CurrentApp().Settings().AddChangeListener(listen)
 	go func() {
 		for range listen {
-			bgColor = withAlpha(theme.Color(theme.ColorNameBackground), 0xe0)
-			bg.FillColor = bgColor
-			bg.Refresh()
+			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+				bgColor = withAlpha(theme.Color(theme.ColorNameBackground), 0xe0)
+				bg.FillColor = bgColor
+				bg.Refresh()
 
-			shadowColor = withAlpha(theme.Color(theme.ColorNameBackground), 0x33)
-			footerBG.FillColor = bgColor
-			footer.Refresh()
+				shadowColor = withAlpha(theme.Color(theme.ColorNameBackground), 0x33)
+				footerBG.FillColor = bgColor
+				footer.Refresh()
+			})
 		}
 	}()
 

--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -71,12 +71,15 @@ func makeActivityTab(win fyne.Window) fyne.CanvasObject {
 		defer func() {
 			go func() {
 				time.Sleep(time.Second * 10)
-				a1.Stop()
-				a1.Hide()
-				a2.Stop()
-				a2.Hide()
 
-				button.Enable()
+				fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+					a1.Stop()
+					a1.Hide()
+					a2.Stop()
+					a2.Hide()
+
+					button.Enable()
+				})
 			}()
 		}()
 	}
@@ -99,8 +102,11 @@ func makeActivityTab(win fyne.Window) fyne.CanvasObject {
 
 			go func() {
 				time.Sleep(time.Second * 5)
-				a3.Stop()
-				d.Hide()
+
+				fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+					a3.Stop()
+					d.Hide()
+				})
 			}()
 		}))))
 }
@@ -492,16 +498,20 @@ func startProgress() {
 			default:
 			}
 
-			progress.SetValue(num)
-			fprogress.SetValue(num)
+			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+				progress.SetValue(num)
+				fprogress.SetValue(num)
+			})
 			num += 0.002
 		}
 
-		progress.SetValue(1)
-		fprogress.SetValue(1)
+		fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+			progress.SetValue(1)
+			fprogress.SetValue(1)
 
-		// TODO make sure this resets when we hide etc...
-		stopProgress()
+			// TODO make sure this resets when we hide etc...
+			stopProgress()
+		})
 	}()
 	infProgress.Start()
 }

--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -61,20 +61,16 @@ func makeActivityTab(win fyne.Window) fyne.CanvasObject {
 		a2.Start()
 		a2.Show()
 
-		defer func() {
-			go func() {
-				time.Sleep(time.Second * 10)
+		time.AfterFunc(10*time.Second, func() {
+			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+				a1.Stop()
+				a1.Hide()
+				a2.Stop()
+				a2.Hide()
 
-				fyne.CurrentApp().Driver().CallFromGoroutine(func() {
-					a1.Stop()
-					a1.Hide()
-					a2.Stop()
-					a2.Hide()
-
-					button.Enable()
-				})
-			}()
-		}()
+				button.Enable()
+			})
+		})
 	}
 
 	button = widget.NewButton("Animate", start)
@@ -93,14 +89,12 @@ func makeActivityTab(win fyne.Window) fyne.CanvasObject {
 			a3.Start()
 			d.Show()
 
-			go func() {
-				time.Sleep(time.Second * 5)
-
+			time.AfterFunc(5*time.Second, func() {
 				fyne.CurrentApp().Driver().CallFromGoroutine(func() {
 					a3.Stop()
 					d.Hide()
 				})
-			}()
+			})
 		}))))
 }
 

--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -31,13 +31,6 @@ Mauris erat urna, fermentum et quam rhoncus, fringilla consequat ante. Vivamus c
 Suspendisse id maximus felis. Sed mauris odio, mattis eget mi eu, consequat tempus purus.`
 )
 
-var (
-	progress    *widget.ProgressBar
-	fprogress   *widget.ProgressBar
-	infProgress *widget.ProgressBarInfinite
-	endProgress chan any
-)
-
 func makeAccordionTab(_ fyne.Window) fyne.CanvasObject {
 	link, err := url.Parse("https://fyne.io/")
 	if err != nil {
@@ -410,18 +403,15 @@ func makeInputTab(_ fyne.Window) fyne.CanvasObject {
 }
 
 func makeProgressTab(_ fyne.Window) fyne.CanvasObject {
-	stopProgress()
+	progress := widget.NewProgressBar()
 
-	progress = widget.NewProgressBar()
-
-	fprogress = widget.NewProgressBar()
+	fprogress := widget.NewProgressBar()
 	fprogress.TextFormatter = func() string {
 		return fmt.Sprintf("%.2f out of %.2f", fprogress.Value, fprogress.Max)
 	}
 
-	infProgress = widget.NewProgressBarInfinite()
-	endProgress = make(chan any, 1)
-	startProgress()
+	infProgress := widget.NewProgressBarInfinite()
+	startProgress(progress, fprogress)
 
 	return container.NewVBox(
 		widget.NewLabel("Percent"), progress,
@@ -479,54 +469,18 @@ func makeToolbarTab(_ fyne.Window) fyne.CanvasObject {
 	return container.NewBorder(t, nil, nil, nil)
 }
 
-func startProgress() {
-	progress.SetValue(0)
-	fprogress.SetValue(0)
-	select { // ignore stale end message
-	case <-endProgress:
-	default:
+func startProgress(progress, fprogress *widget.ProgressBar) {
+	progressAnimation := fyne.Animation{
+		Curve:    fyne.AnimationLinear,
+		Duration: 10 * time.Second,
+		Tick: func(percentage float32) {
+			value := float64(percentage)
+			progress.SetValue(value)
+			fprogress.SetValue(value)
+		},
 	}
 
-	go func() {
-		end := endProgress
-		num := 0.0
-		for num < 1.0 {
-			time.Sleep(16 * time.Millisecond)
-			select {
-			case <-end:
-				return
-			default:
-			}
-
-			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
-				progress.SetValue(num)
-				fprogress.SetValue(num)
-			})
-			num += 0.002
-		}
-
-		fyne.CurrentApp().Driver().CallFromGoroutine(func() {
-			progress.SetValue(1)
-			fprogress.SetValue(1)
-
-			// TODO make sure this resets when we hide etc...
-			stopProgress()
-		})
-	}()
-	infProgress.Start()
-}
-
-func stopProgress() {
-	if infProgress == nil {
-		return
-	}
-
-	if !infProgress.Running() {
-		return
-	}
-
-	infProgress.Stop()
-	endProgress <- struct{}{}
+	progressAnimation.Start()
 }
 
 // widgetScreen shows a panel containing widget demos

--- a/cmd/fyne_demo/tutorials/window.go
+++ b/cmd/fyne_demo/tutorials/window.go
@@ -71,10 +71,9 @@ func windowScreen(_ fyne.Window) fyne.CanvasObject {
 					fyne.TextAlignCenter, fyne.TextStyle{Bold: true}))
 				w.Show()
 
-				go func() {
-					time.Sleep(time.Second * 3)
+				time.AfterFunc(3*time.Second, func() {
 					fyne.CurrentApp().Driver().CallFromGoroutine(w.Close)
-				}()
+				})
 			}))
 	}
 

--- a/cmd/fyne_demo/tutorials/window.go
+++ b/cmd/fyne_demo/tutorials/window.go
@@ -73,7 +73,7 @@ func windowScreen(_ fyne.Window) fyne.CanvasObject {
 
 				go func() {
 					time.Sleep(time.Second * 3)
-					w.Close()
+					fyne.CurrentApp().Driver().CallFromGoroutine(w.Close)
 				}()
 			}))
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This adds appropriate safety in goroutines and also moves the advanced tab to only redraw when settings actually change (it was drawing each second before and wasting CPU time). I clicked through all the tabs now and can no longer see any races reported.

Fixes #4568

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

