### PR TITLE
Proposal: CustomMessage dialogs

### DIFF
--- a/dialog/information.go
+++ b/dialog/information.go
@@ -51,3 +51,16 @@ func NewError(err error, parent fyne.Window) Dialog {
 func ShowError(err error, parent fyne.Window) {
 	NewError(err, parent).Show()
 }
+
+// NewCustomMessage creates a dialog over the specified window with the desired icon, title and message.
+// The title is used for the dialog window, message for the content and icon for the resource on the right side.
+// After creation you should call Show().
+func NewCustomMessage(title, message string, icon fyne.Resource, parent fyne.Window) Dialog {
+	return createInformationDialog(title, message, icon, parent)
+}
+
+// ShowCustomMessage shows a dialog over the specified window with the desired icon, title and message.
+// The title is used for the dialog window, message for the content and icon for the resource on the right side.
+func ShowCustomMessage(title, message string, icon fyne.Resource, parent fyne.Window) {
+	NewCustomMessage(title, message, icon, parent).Show()
+}

--- a/dialog/information.go
+++ b/dialog/information.go
@@ -55,12 +55,16 @@ func ShowError(err error, parent fyne.Window) {
 // NewCustomMessage creates a dialog over the specified window with the desired icon, title and message.
 // The title is used for the dialog window, message for the content and icon for the resource on the right side.
 // After creation you should call Show().
+// 
+// Since: 
 func NewCustomMessage(title, message string, icon fyne.Resource, parent fyne.Window) Dialog {
 	return createInformationDialog(title, message, icon, parent)
 }
 
 // ShowCustomMessage shows a dialog over the specified window with the desired icon, title and message.
 // The title is used for the dialog window, message for the content and icon for the resource on the right side.
+//
+// Since: 
 func ShowCustomMessage(title, message string, icon fyne.Resource, parent fyne.Window) {
 	NewCustomMessage(title, message, icon, parent).Show()
 }

--- a/widget/entry_password.go
+++ b/widget/entry_password.go
@@ -83,5 +83,5 @@ func (r *passwordRevealerRenderer) Refresh() {
 	if r.entry.disabled.Load() {
 		r.icon.Resource = theme.NewDisabledResource(r.icon.Resource)
 	}
-	canvas.Refresh(r.icon)
+	r.icon.Refresh()
 }


### PR DESCRIPTION
### Description:
I've wanted to include for some time a new API that allows the developer to set whatever resource for the text-based dialog(s) icon. This allows for an example, a success dialog, confirming the user changes.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. (didn't make tests, but it uses the same base as NewInformation)
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [X] Public APIs match existing style and have Since: line. (will be added)

