### PR TITLE
Feature/selective lang loading

### DIFF
--- a/lang/lang.go
+++ b/lang/lang.go
@@ -174,6 +174,11 @@ func addLanguage(data []byte, name string) error {
 		return err
 	}
 
+	for _, t := range translated {
+		if t == f.Tag {
+			return nil
+		}
+	}
 	translated = append(translated, f.Tag)
 	return nil
 }

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -159,6 +159,15 @@ func AddTranslationsFS(fs embed.FS, dir string) (retErr error) {
 	return retErr
 }
 
+// RegisteredLanguages returns the list of locales we have localization for.
+func RegisteredLanguages() []fyne.Locale {
+	var ret []fyne.Locale
+	for _, l := range translated {
+		ret = append(ret, localeFromTag(l))
+	}
+	return ret
+}
+
 func addLanguage(data []byte, name string) error {
 	f, err := bundle.ParseMessageFileBytes(data, name)
 	if err != nil {

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -1,5 +1,10 @@
 // Package lang introduces a translation and localisation API for Fyne applications
 //
+// By default, a few custom localisation keys for a few default languages are included.
+// They can be overwritten with custom localisations.
+// Without further intervention, the default language will be English. This is overwritten
+// with the language of the first translation that is being registered explicitly.
+//
 // Since 2.5
 package lang
 
@@ -183,6 +188,12 @@ func addLanguage(data []byte, name string) error {
 
 func addLanguageByMessages(msgs []*i18n.Message, tag language.Tag) error {
 	if bundleIsDefault {
+		// This is the first time, the user adds a language on their own. This implies, that
+		// they are aware of localizations and how to use them.
+		// To prevent half-translated applications, we "forget" our base translations and only
+		// use languages for resolution, that the user supplied.
+		// The bundle will still contain our base translations; if a language overlaps with those,
+		// our base strings will be there unless they explicitly get overwritten.
 		bundleIsDefault = false
 		if err := setupBundle(tag); err != nil {
 			return err

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -212,10 +212,13 @@ func setupLang(lang string) {
 
 // updateLocalizer Finds the closest translation from the user's locale list and sets it up
 func updateLocalizer() {
+	var languageStr string
 	all, err := locale.GetLocales()
-	if err != nil {
+	if err == nil {
+		languageStr = closestSupportedLocale(all).LanguageString()
+	} else {
 		fyne.LogError("Failed to load user locales", err)
-		all = []string{"en"}
+		languageStr = translated[0].String()
 	}
-	setupLang(closestSupportedLocale(all).LanguageString())
+	setupLang(languageStr)
 }

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -89,7 +89,7 @@ func TestDefaultLocalizations(t *testing.T) {
 	t.Run("base localizations are loaded by default", func(t *testing.T) {
 		languages := RegisteredLanguages()
 
-		translationFiles, err := translations.ReadDir("translations")
+		translationFiles, err := defaultTranslationFS.ReadDir("translations")
 		require.NoError(t, err)
 		assert.Len(t, languages, len(translationFiles))
 
@@ -127,7 +127,7 @@ func TestDefaultLocalizations(t *testing.T) {
 			setupLang("de")
 			assert.Equal(t, "Beenden", L("Quit"))
 
-			setupLang("en-GB")
+			setupLang("en")
 			assert.Equal(t, "Name", X("file.name", "nope"))
 		})
 	})

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
 )
 
 func TestAddTranslations(t *testing.T) {
@@ -86,6 +87,11 @@ func TestLocalizePluralKey_Fallback(t *testing.T) {
 }
 
 func TestDefaultLocalizations(t *testing.T) {
+	// Not ideal, but other tests might manipulate the global state.
+	// Reset it manually.
+	require.NoError(t, setupBundle(language.English))
+	bundleIsDefault = true
+
 	t.Run("base localizations are loaded by default", func(t *testing.T) {
 		languages := RegisteredLanguages()
 

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -3,10 +3,9 @@ package lang
 import (
 	"testing"
 
+	"fyne.io/fyne/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"fyne.io/fyne/v2"
 )
 
 func TestAddTranslations(t *testing.T) {
@@ -84,4 +83,18 @@ func TestLocalizePluralKey_Fallback(t *testing.T) {
 	assert.Equal(t, "Missing", XN("appleIDMissing", "Missing", 1))
 	assert.Equal(t, "Apple", XN("appleID", "Apple", 1))
 	assert.Equal(t, "Apples", XN("appleID", "Apple", 2))
+}
+
+func TestDefaultLocalizations(t *testing.T) {
+	t.Run("base localizations are loaded by default", func(t *testing.T) {
+		languages := RegisteredLanguages()
+
+		translationFiles, err := translations.ReadDir("translations")
+		require.NoError(t, err)
+		assert.Len(t, languages, len(translationFiles))
+
+		// Two samples for sanity check.
+		assert.Contains(t, languages, fyne.Locale("en-US-Latn"))
+		assert.Contains(t, languages, fyne.Locale("de-DE-Latn"))
+	})
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
At the moment, fyne loads all base translations, sets the default language to English and merges in translations provided by the user.

This approach has a few downsides, though:

1. If the user registers only a subset (or a different set) of languages, than the base translations provided, the `closestSupportedLocale` function is not (and cannot be) aware of this. It might pick a language that has only partial (our base) translations and misses user translations. Example: the user provides custom translations for English but the app runs on a German system. Some buttons and menu items are now translated into German, but all others fall back to the provided English translation.

2. The user may not develop their app with English in mind, so falling back to English might not be the best choice for them; especially when paired with the issue above.

This PR proposes a solution to both issues that is (mostly) backwards compatible:

- We still load all base translations and consider them "available" for matching in `closestSupportedLocale`. So for apps without any custom translations, everything behaves as before.
- Once the user adds their first own translation, we reset the known languages and re-initialize the bundle.
  - The first language becomes the new fallback language. This gives the user (implicit) control, by allowing them to register the languages in their preferred order.
  - The list of known languages is reduced to the ones registered _explicitly_. So if, as in the example above, the user registers a custom translation for English, only English will be considered until they also register further translations for other languages.

The implementation also has two downsides, but IMO smaller ones:
- That the first added translation becomes the default language is more or less implicit. When using `AddTranslationsFS` as the only (or at least first) call, one would have to make sure, that the order makes sense. It can easily be circumvented by either using file name prefixes in that case or by calling one of the other `AddTranslations*` functions first (with an empty JSON).

  > **Note**: Potential improvement: offer an API to explicitly set the order of languages; overwriting the `translations` slice.

- If someone relied on base translations being in place, while they register their own, different, translations, this PR would change behavior; I think it changes for the better, though and IMO it prevents (likely) unexpected side-effects.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
