### PR TITLE
Fix races within flatpak portal dialogs

### DIFF
--- a/dialog/file_xdg_flatpak.go
+++ b/dialog/file_xdg_flatpak.go
@@ -12,103 +12,112 @@ import (
 	"github.com/rymdport/portal/filechooser"
 )
 
-func openFolder(parentWindowHandle string, callback func(fyne.ListableURI, error), options *filechooser.OpenFileOptions) {
+func openFolder(parentWindowHandle string, options *filechooser.OpenFileOptions) (fyne.ListableURI, error) {
 	uris, err := filechooser.OpenFile(parentWindowHandle, "Open Folder", options)
 	if err != nil {
-		callback(nil, err)
+		return nil, err
 	}
 
 	if len(uris) == 0 {
-		callback(nil, nil)
-		return
+		return nil, nil
 	}
 
 	uri, err := storage.ParseURI(uris[0])
 	if err != nil {
-		callback(nil, err)
-		return
+		return nil, err
 	}
 
-	callback(storage.ListerForURI(uri))
+	return storage.ListerForURI(uri)
 }
 
-func openFile(parentWindowHandle string, callback func(fyne.URIReadCloser, error), options *filechooser.OpenFileOptions) {
+func openFile(parentWindowHandle string, options *filechooser.OpenFileOptions) (fyne.URIReadCloser, error) {
 	uris, err := filechooser.OpenFile(parentWindowHandle, "Open File", options)
 	if err != nil {
-		callback(nil, err)
-		return
+		return nil, err
 	}
 
 	if len(uris) == 0 {
-		callback(nil, nil)
-		return
+		return nil, nil
 	}
 
 	uri, err := storage.ParseURI(uris[0])
 	if err != nil {
-		callback(nil, err)
-		return
+		return nil, err
 	}
 
-	callback(storage.Reader(uri))
+	return storage.Reader(uri)
+}
+
+func saveFile(parentWindowHandle string, options *filechooser.SaveFileOptions) (fyne.URIWriteCloser, error) {
+	uris, err := filechooser.SaveFile(parentWindowHandle, "Save File", options)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(uris) == 0 {
+		return nil, nil
+	}
+
+	uri, err := storage.ParseURI(uris[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return storage.Writer(uri)
 }
 
 func fileOpenOSOverride(d *FileDialog) bool {
-	go func() {
-		folderCallback, folder := d.callback.(func(fyne.ListableURI, error))
-		options := &filechooser.OpenFileOptions{
-			Directory:   folder,
-			AcceptLabel: d.confirmText,
-		}
-		if d.startingLocation != nil {
-			options.CurrentFolder = d.startingLocation.Path()
-		}
+	folderCallback, folder := d.callback.(func(fyne.ListableURI, error))
+	fileCallback, _ := d.callback.(func(fyne.URIReadCloser, error))
+	options := &filechooser.OpenFileOptions{
+		Directory:   folder,
+		AcceptLabel: d.confirmText,
+	}
 
-		parentWindowHandle := windowHandleForPortal(d.parent)
+	if d.startingLocation != nil {
+		options.CurrentFolder = d.startingLocation.Path()
+	}
 
-		if folder {
-			openFolder(parentWindowHandle, folderCallback, options)
-			return
-		}
+	windowHandle := windowHandleForPortal(d.parent)
 
-		fileCallback := d.callback.(func(fyne.URIReadCloser, error))
-		openFile(parentWindowHandle, fileCallback, options)
-	}()
+	if folder {
+		go func() {
+			folder, err := openFolder(windowHandle, options)
+			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+				folderCallback(folder, err)
+			})
+		}()
+	} else {
+		go func() {
+			file, err := openFile(windowHandle, options)
+			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+				fileCallback(file, err)
+			})
+		}()
+	}
+
 	return true
 }
 
 func fileSaveOSOverride(d *FileDialog) bool {
+	options := &filechooser.SaveFileOptions{
+		AcceptLabel: d.confirmText,
+		CurrentName: d.initialFileName,
+	}
+	if d.startingLocation != nil {
+		options.CurrentFolder = d.startingLocation.Path()
+	}
+
+	callback := d.callback.(func(fyne.URIWriteCloser, error))
+	windowHandle := windowHandleForPortal(d.parent)
+
 	go func() {
-		options := &filechooser.SaveFileOptions{
-			AcceptLabel: d.confirmText,
-			CurrentName: d.initialFileName,
-		}
-		if d.startingLocation != nil {
-			options.CurrentFolder = d.startingLocation.Path()
-		}
-
-		parentWindowHandle := windowHandleForPortal(d.parent)
-
-		callback := d.callback.(func(fyne.URIWriteCloser, error))
-		uris, err := filechooser.SaveFile(parentWindowHandle, "Open File", options)
-		if err != nil {
-			callback(nil, err)
-			return
-		}
-
-		if len(uris) == 0 {
-			callback(nil, nil)
-			return
-		}
-
-		uri, err := storage.ParseURI(uris[0])
-		if err != nil {
-			callback(nil, err)
-			return
-		}
-
-		callback(storage.Writer(uri))
+		file, err := saveFile(windowHandle, options)
+		fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+			callback(file, err)
+		})
 	}()
+
 	return true
 }
 
@@ -117,14 +126,14 @@ func x11WindowHandleToString(handle uintptr) string {
 }
 
 func windowHandleForPortal(window fyne.Window) string {
-	parentWindowHandle := ""
+	windowHandle := ""
 	if !build.IsWayland {
 		window.(driver.NativeWindow).RunNative(func(context any) {
 			handle := context.(driver.X11WindowContext).WindowHandle
-			parentWindowHandle = x11WindowHandleToString(handle)
+			windowHandle = x11WindowHandleToString(handle)
 		})
 	}
 
 	// TODO: We need to get the Wayland handle from the xdg_foreign protocol and convert to string on the form "wayland:{id}".
-	return parentWindowHandle
+	return windowHandle
 }

--- a/dialog/file_xdg_flatpak.go
+++ b/dialog/file_xdg_flatpak.go
@@ -83,14 +83,14 @@ func fileOpenOSOverride(d *FileDialog) bool {
 	if folder {
 		go func() {
 			folder, err := openFolder(windowHandle, options)
-			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+			fyne.Do(func() {
 				folderCallback(folder, err)
 			})
 		}()
 	} else {
 		go func() {
 			file, err := openFile(windowHandle, options)
-			fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+			fyne.Do(func() {
 				fileCallback(file, err)
 			})
 		}()
@@ -113,7 +113,7 @@ func fileSaveOSOverride(d *FileDialog) bool {
 
 	go func() {
 		file, err := saveFile(windowHandle, options)
-		fyne.CurrentApp().Driver().CallFromGoroutine(func() {
+		fyne.Do(func() {
 			callback(file, err)
 		})
 	}()

--- a/internal/driver/glfw/window_darwin.go
+++ b/internal/driver/glfw/window_darwin.go
@@ -10,13 +10,10 @@ import (
 var _ driver.NativeWindow = (*window)(nil)
 
 func (w *window) RunNative(f func(any)) {
-	runOnMain(func() {
-		var nsWindow uintptr
-		if v := w.view(); v != nil {
-			nsWindow = uintptr(v.GetCocoaWindow())
-		}
-		f(driver.MacWindowContext{
-			NSWindow: nsWindow,
-		})
-	})
+	context := driver.MacWindowContext{}
+	if v := w.view(); v != nil {
+		context.NSWindow = uintptr(v.GetCocoaWindow())
+	}
+
+	f(context)
 }

--- a/internal/driver/glfw/window_wayland.go
+++ b/internal/driver/glfw/window_wayland.go
@@ -12,13 +12,10 @@ import (
 var _ driver.NativeWindow = (*window)(nil)
 
 func (w *window) RunNative(f func(any)) {
-	runOnMain(func() {
-		var waylandSurface uintptr
-		if v := w.view(); v != nil {
-			waylandSurface = uintptr(unsafe.Pointer(v.GetWaylandWindow()))
-		}
-		f(driver.WaylandWindowContext{
-			WaylandSurface: waylandSurface,
-		})
-	})
+	context := driver.WaylandWindowContext{}
+	if v := w.view(); v != nil {
+		context.WaylandSurface = uintptr(unsafe.Pointer(v.GetWaylandWindow()))
+	}
+
+	f(context)
 }

--- a/internal/driver/glfw/window_windows.go
+++ b/internal/driver/glfw/window_windows.go
@@ -60,13 +60,10 @@ func (w *window) computeCanvasSize(width, height int) fyne.Size {
 var _ driver.NativeWindow = (*window)(nil)
 
 func (w *window) RunNative(f func(any)) {
-	var hwnd uintptr
+	context := driver.WindowsWindowContext{}
 	if v := w.view(); v != nil {
-		hwnd = uintptr(unsafe.Pointer(v.GetWin32Window()))
+		context.HWND = uintptr(unsafe.Pointer(v.GetWin32Window()))
 	}
-	runOnMain(func() {
-		f(driver.WindowsWindowContext{
-			HWND: hwnd,
-		})
-	})
+
+	f(context)
 }

--- a/internal/driver/glfw/window_x11.go
+++ b/internal/driver/glfw/window_x11.go
@@ -8,13 +8,10 @@ import "fyne.io/fyne/v2/driver"
 var _ driver.NativeWindow = (*window)(nil)
 
 func (w *window) RunNative(f func(any)) {
-	var handle uintptr
+	context := driver.X11WindowContext{}
 	if v := w.view(); v != nil {
-		handle = uintptr(v.GetX11Window())
+		context.WindowHandle = uintptr(v.GetX11Window())
 	}
-	runOnMain(func() {
-		f(driver.X11WindowContext{
-			WindowHandle: handle,
-		})
-	})
+
+	f(context)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This cleans up and refactors the dialog code for desktop portals on flatpak and it does so while fixing some races in it. I also fixed RunNative not behaving correctly (or as expected) with the new threading model.

For #4654 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
