### PR TITLE
Remove unnecessary method overrides from Entry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -218,20 +218,6 @@ func (e *Entry) Cursor() desktop.Cursor {
 	return desktop.TextCursor
 }
 
-// Disable this widget so that it cannot be interacted with, updating any style appropriately.
-//
-// Implements: fyne.Disableable
-func (e *Entry) Disable() {
-	e.DisableableWidget.Disable()
-}
-
-// Disabled returns whether the entry is disabled or read-only.
-//
-// Implements: fyne.Disableable
-func (e *Entry) Disabled() bool {
-	return e.DisableableWidget.disabled.Load()
-}
-
 // DoubleTapped is called when this entry has been double tapped so we should select text below the pointer
 //
 // Implements: fyne.DoubleTappable
@@ -287,13 +273,6 @@ func (e *Entry) Dragged(d *fyne.DragEvent) {
 		e.selecting = true
 	}
 	e.updateMousePointer(pos, false)
-}
-
-// Enable this widget, updating any style or features appropriately.
-//
-// Implements: fyne.Disableable
-func (e *Entry) Enable() {
-	e.DisableableWidget.Enable()
 }
 
 // ExtendBaseWidget is used by an extending widget to make use of BaseWidget functionality.


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I don't know if more widgets do this but I found that Entry was overriding functionality that matched 100% to what the extended `DisableableWidget` already provides. No need to extend them once again and provide two implementations that do the same thing.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

