### PR TITLE
Fixing lockup if quitting from window close

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -189,8 +189,9 @@ func (w *window) Close() {
 	}
 
 	// trigger callbacks - early so window still exists
-	if w.onClosed != nil {
-		w.onClosed()
+	if fn := w.onClosed; fn != nil {
+		w.onClosed = nil // avoid possibility of calling twice
+		fn()
 	}
 
 	w.closing = true


### PR DESCRIPTION

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- I don't think I can test this as we cannot quit the driver in unit tests (yet)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

