### PR TITLE
Fix mobile shutdown

### DIFF
--- a/internal/driver/mobile/app/darwin_desktop.go
+++ b/internal/driver/mobile/app/darwin_desktop.go
@@ -160,8 +160,18 @@ func eventMouseDragged(x, y float32) { sendTouch(touch.TypeMove, x, y) }
 //export eventMouseEnd
 func eventMouseEnd(x, y float32) { sendTouch(touch.TypeEnd, x, y) }
 
+var stopped = false
+
 //export lifecycleDead
-func lifecycleDead() { theApp.sendLifecycle(lifecycle.StageDead) }
+func lifecycleDead() {
+	if stopped {
+		return
+	}
+	stopped = true
+
+	theApp.sendLifecycle(lifecycle.StageDead)
+	theApp.events.Close()
+}
 
 //export eventKey
 func eventKey(runeVal int32, direction uint8, code uint16, flags uint32) {

--- a/internal/driver/mobile/app/darwin_desktop.m
+++ b/internal/driver/mobile/app/darwin_desktop.m
@@ -136,7 +136,7 @@ uint64 threadID() {
 }
 
 - (void)windowWillClose:(NSNotification *)notification {
-	lifecycleAlive();
+	lifecycleDead();
 }
 
 - (BOOL)acceptsFirstResponder {

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -165,7 +165,16 @@ func (d *driver) Run() {
 		draw := time.NewTicker(time.Second / 60)
 		defer func() {
 			l := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle)
-			l.WaitForEvents()
+
+			// exhaust the event queue
+			go func() {
+				l.WaitForEvents()
+				d.queuedFuncs.Close()
+			}()
+			for fn := range d.queuedFuncs.Out() {
+				fn()
+			}
+
 			l.DestroyEventQueue()
 		}()
 


### PR DESCRIPTION
This addresses the ticket issue, but also aligns macOS with X11 (macOS never actually quit the mobile app when window closed).

Fixes #5401

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
