### PR TITLE
List and GridWrap threading simplifications

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -31,11 +31,26 @@ type GridWrapItemID = int
 type GridWrap struct {
 	BaseWidget
 
-	Length       func() int                                      `json:"-"`
-	CreateItem   func() fyne.CanvasObject                        `json:"-"`
-	UpdateItem   func(id GridWrapItemID, item fyne.CanvasObject) `json:"-"`
-	OnSelected   func(id GridWrapItemID)                         `json:"-"`
-	OnUnselected func(id GridWrapItemID)                         `json:"-"`
+	// Length is a callback for returning the number of items in the GridWrap.
+	Length func() int `json:"-"`
+
+	// CreateItem is a callback invoked to create a new widget to render
+	// an item in the GridWrap.
+	CreateItem func() fyne.CanvasObject `json:"-"`
+
+	// UpdateItem is a callback invoked to update a GridWrap item widget
+	// to display a new item in the list. The UpdateItem callback should
+	// only update the given item, it should not invoke APIs that would
+	// change other properties of the GridWrap itself.
+	UpdateItem func(id GridWrapItemID, item fyne.CanvasObject) `json:"-"`
+
+	// OnSelected is a callback to be notified when a given item
+	// in the GridWrap has been selected.
+	OnSelected func(id GridWrapItemID) `json:"-"`
+
+	// OnSelected is a callback to be notified when a given item
+	// in the GridWrap has been unselected.
+	OnUnselected func(id GridWrapItemID) `json:"-"`
 
 	currentFocus  ListItemID
 	focused       bool
@@ -505,21 +520,17 @@ type gridItemAndID struct {
 }
 
 type gridWrapLayout struct {
-	list *GridWrap
+	gw *GridWrap
 
-	itemPool  async.Pool[fyne.CanvasObject]
-	slicePool async.Pool[*[]gridItemAndID]
-	visible   []gridItemAndID
+	itemPool   async.Pool[fyne.CanvasObject]
+	visible    []gridItemAndID
+	wasVisible []gridItemAndID
 }
 
-func newGridWrapLayout(list *GridWrap) fyne.Layout {
-	l := &gridWrapLayout{list: list}
-	l.slicePool.New = func() *[]gridItemAndID {
-		s := make([]gridItemAndID, 0)
-		return &s
-	}
-	list.offsetUpdated = l.offsetUpdated
-	return l
+func newGridWrapLayout(gw *GridWrap) fyne.Layout {
+	gwl := &gridWrapLayout{gw: gw}
+	gw.offsetUpdated = gwl.offsetUpdated
+	return gwl
 }
 
 func (l *gridWrapLayout) Layout(_ []fyne.CanvasObject, _ fyne.Size) {
@@ -527,14 +538,14 @@ func (l *gridWrapLayout) Layout(_ []fyne.CanvasObject, _ fyne.Size) {
 }
 
 func (l *gridWrapLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
-	return l.list.contentMinSize()
+	return l.gw.contentMinSize()
 }
 
 func (l *gridWrapLayout) getItem() *gridWrapItem {
 	item := l.itemPool.Get()
 	if item == nil {
-		if f := l.list.CreateItem; f != nil {
-			child := createItemAndApplyThemeScope(f, l.list)
+		if f := l.gw.CreateItem; f != nil {
+			child := createItemAndApplyThemeScope(f, l.gw)
 
 			item = newGridWrapItem(child, nil)
 		}
@@ -543,17 +554,17 @@ func (l *gridWrapLayout) getItem() *gridWrapItem {
 }
 
 func (l *gridWrapLayout) offsetUpdated(pos fyne.Position) {
-	if l.list.offsetY == pos.Y {
+	if l.gw.offsetY == pos.Y {
 		return
 	}
-	l.list.offsetY = pos.Y
+	l.gw.offsetY = pos.Y
 	l.updateGrid(false)
 }
 
 func (l *gridWrapLayout) setupGridItem(li *gridWrapItem, id GridWrapItemID, focus bool) {
 	previousIndicator := li.selected
 	li.selected = false
-	for _, s := range l.list.selected {
+	for _, s := range l.gw.selected {
 		if id == s {
 			li.selected = true
 			break
@@ -566,21 +577,21 @@ func (l *gridWrapLayout) setupGridItem(li *gridWrapItem, id GridWrapItemID, focu
 		li.hovered = false
 		li.Refresh()
 	}
-	if f := l.list.UpdateItem; f != nil {
+	if f := l.gw.UpdateItem; f != nil {
 		f(id, li.child)
 	}
 	li.onTapped = func() {
 		if !fyne.CurrentDevice().IsMobile() {
-			l.list.RefreshItem(l.list.currentFocus)
-			canvas := fyne.CurrentApp().Driver().CanvasForObject(l.list)
+			l.gw.RefreshItem(l.gw.currentFocus)
+			canvas := fyne.CurrentApp().Driver().CanvasForObject(l.gw)
 			if canvas != nil {
-				canvas.Focus(l.list)
+				canvas.Focus(l.gw)
 			}
 
-			l.list.currentFocus = id
+			l.gw.currentFocus = id
 		}
 
-		l.list.Select(id)
+		l.gw.Select(id)
 	}
 }
 
@@ -602,36 +613,32 @@ func (l *GridWrap) ColumnCount() int {
 
 func (l *gridWrapLayout) updateGrid(refresh bool) {
 	// code here is a mashup of listLayout.updateList and gridWrapLayout.Layout
-	padding := l.list.Theme().Size(theme.SizeNamePadding)
+	padding := l.gw.Theme().Size(theme.SizeNamePadding)
 
 	length := 0
-	if f := l.list.Length; f != nil {
+	if f := l.gw.Length; f != nil {
 		length = f()
 	}
 
-	colCount := l.list.ColumnCount()
-	visibleRowsCount := int(math.Ceil(float64(l.list.scroller.Size().Height)/float64(l.list.itemMin.Height+padding))) + 1
+	colCount := l.gw.ColumnCount()
+	visibleRowsCount := int(math.Ceil(float64(l.gw.scroller.Size().Height)/float64(l.gw.itemMin.Height+padding))) + 1
 
-	offY := l.list.offsetY - float32(math.Mod(float64(l.list.offsetY), float64(l.list.itemMin.Height+padding)))
-	minRow := int(offY / (l.list.itemMin.Height + padding))
+	offY := l.gw.offsetY - float32(math.Mod(float64(l.gw.offsetY), float64(l.gw.itemMin.Height+padding)))
+	minRow := int(offY / (l.gw.itemMin.Height + padding))
 	minItem := GridWrapItemID(minRow * colCount)
 	maxRow := int(math.Min(float64(minRow+visibleRowsCount), math.Ceil(float64(length)/float64(colCount))))
 	maxItem := GridWrapItemID(math.Min(float64(maxRow*colCount), float64(length-1)))
 
-	if l.list.UpdateItem == nil {
+	if l.gw.UpdateItem == nil {
 		fyne.LogError("Missing UpdateCell callback required for GridWrap", nil)
 	}
 
-	// Keep pointer reference for copying slice header when returning to the pool
-	// https://blog.mike.norgate.xyz/unlocking-go-slice-performance-navigating-sync-pool-for-enhanced-efficiency-7cb63b0b453e
-	wasVisiblePtr := l.slicePool.Get()
-	wasVisible := (*wasVisiblePtr)[:0]
-	wasVisible = append(wasVisible, l.visible...)
-
-	oldVisibleLen := len(l.visible)
+	// l.wasVisible now represents the currently visible items, while
+	// l.visible will be updated to represent what is visible *after* the update
+	l.wasVisible = append(l.wasVisible, l.visible...)
 	l.visible = l.visible[:0]
 
-	c := l.list.scroller.Content.(*fyne.Container)
+	c := l.gw.scroller.Content.(*fyne.Container)
 	oldObjLen := len(c.Objects)
 	c.Objects = c.Objects[:0]
 	y := offY
@@ -639,57 +646,45 @@ func (l *gridWrapLayout) updateGrid(refresh bool) {
 	for row := minRow; row <= maxRow && curItemID <= maxItem; row++ {
 		x := float32(0)
 		for col := 0; col < colCount && curItemID <= maxItem; col++ {
-			item, ok := l.searchVisible(wasVisible, curItemID)
+			item, ok := l.searchVisible(l.wasVisible, curItemID)
 			if !ok {
 				item = l.getItem()
 				if item == nil {
 					continue
 				}
-				item.Resize(l.list.itemMin)
+				item.Resize(l.gw.itemMin)
 			}
 
 			item.Move(fyne.NewPos(x, y))
 			if refresh {
-				item.Resize(l.list.itemMin)
+				item.Resize(l.gw.itemMin)
 			}
 
-			x += l.list.itemMin.Width + padding
+			x += l.gw.itemMin.Width + padding
 			l.visible = append(l.visible, gridItemAndID{item: item, id: curItemID})
 			c.Objects = append(c.Objects, item)
 			curItemID++
 		}
-		y += l.list.itemMin.Height + padding
+		y += l.gw.itemMin.Height + padding
 	}
 	l.nilOldSliceData(c.Objects, len(c.Objects), oldObjLen)
-	l.nilOldVisibleSliceData(l.visible, len(l.visible), oldVisibleLen)
 
-	for _, old := range wasVisible {
+	for _, old := range l.wasVisible {
 		if _, ok := l.searchVisible(l.visible, old.id); !ok {
 			l.itemPool.Put(old.item)
 		}
 	}
 
-	// make a local deep copy of l.visible since rest of this function is unlocked
-	// and cannot safely access l.visible
-	visiblePtr := l.slicePool.Get()
-	visible := (*visiblePtr)[:0]
-	visible = append(visible, l.visible...)
-
-	for _, obj := range visible {
-		l.setupGridItem(obj.item, obj.id, l.list.focused && l.list.currentFocus == obj.id)
+	for _, obj := range l.visible {
+		l.setupGridItem(obj.item, obj.id, l.gw.focused && l.gw.currentFocus == obj.id)
 	}
 
-	// nil out all references before returning slices to pool
-	for i := 0; i < len(wasVisible); i++ {
-		wasVisible[i].item = nil
+	// we don't need wasVisible now until next call to update
+	// nil out all references before truncating slice
+	for i := 0; i < len(l.wasVisible); i++ {
+		l.wasVisible[i].item = nil
 	}
-	for i := 0; i < len(visible); i++ {
-		visible[i].item = nil
-	}
-	*wasVisiblePtr = wasVisible // Copy the slice header over to the heap
-	*visiblePtr = visible
-	l.slicePool.Put(wasVisiblePtr)
-	l.slicePool.Put(visiblePtr)
+	l.wasVisible = l.wasVisible[:0]
 }
 
 // invariant: visible is in ascending order of IDs
@@ -707,15 +702,6 @@ func (l *gridWrapLayout) nilOldSliceData(objs []fyne.CanvasObject, len, oldLen i
 		objs = objs[:oldLen] // gain view into old data
 		for i := len; i < oldLen; i++ {
 			objs[i] = nil
-		}
-	}
-}
-
-func (l *gridWrapLayout) nilOldVisibleSliceData(objs []gridItemAndID, len, oldLen int) {
-	if oldLen > len {
-		objs = objs[:oldLen] // gain view into old data
-		for i := len; i < oldLen; i++ {
-			objs[i].item = nil
 		}
 	}
 }


### PR DESCRIPTION
### Description:
Previously, complicated logic had been added in List and GridWrap to ensure that the renderer update function was concurrency-safe if the contents of the collection widget were asynchronously updated during a render. Now that is no longer a concern; the only concern would be if the collection widget contents were updated from within an UpdateItem callback, which isn't good practice, and this PR adds documentation to these callbacks that they should only update the item's rendering, not modify properties of the collection as a whole.

Some variable names were updated in GridWrap -- the logic changes are the same between List and GridWrap and easier to see in List since no other changes were made there.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. // Not adding new behavior, current tests sufficient to catch a regression
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
