### PR TITLE
Fix GridWrap crash when resized to same size before renderer created

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -152,8 +152,10 @@ func (l *GridWrap) RefreshItem(id GridWrapItemID) {
 func (l *GridWrap) Resize(s fyne.Size) {
 	l.colCountCache = 0
 	l.BaseWidget.Resize(s)
-	l.offsetUpdated(l.scroller.Offset)
-	l.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).updateGrid(true)
+	if l.scroller != nil {
+		l.offsetUpdated(l.scroller.Offset)
+		l.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).updateGrid(true)
+	}
 }
 
 // Select adds the item identified by the given ID to the selection.

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -242,3 +242,14 @@ func TestGridWrap_Selection(t *testing.T) {
 	assert.Equal(t, -1, selected)
 	assert.Equal(t, 9, unselected)
 }
+
+func TestGridWrap_ResizeToSameSizeBeforeRender(t *testing.T) {
+	g := NewGridWrap(
+		func() int { return 1 },
+		func() fyne.CanvasObject { return NewLabel("") },
+		func(gwii GridWrapItemID, co fyne.CanvasObject) { co.(*Label).SetText("foo") },
+	)
+	// will not create renderer.
+	// will crash if GridWrap scroller (not yet created) is accessed
+	g.Resize(fyne.NewSize(0, 0))
+}


### PR DESCRIPTION
### Description:

GridWrap would crash if resized to its current size before its renderer is created (since BaseWidget.Resize to the same size is a no-op and doesn't create the renderer). I ran into this in Supersonic and had worked around it but figured out the root cause and a proper fix.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.


