### PR TITLE
Clear out pending window operations after start

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -789,7 +789,7 @@ func (w *window) create() {
 	for _, fn := range w.pending {
 		fn()
 	}
-	w.pending = nil // Clear out any pending operations.
+	w.pending = nil
 
 	if w.FixedSize() && (w.requestedWidth == 0 || w.requestedHeight == 0) {
 		bigEnough := w.canvas.canvasSize(w.canvas.Content().MinSize())

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -789,6 +789,7 @@ func (w *window) create() {
 	for _, fn := range w.pending {
 		fn()
 	}
+	w.pending = nil // Clear out any pending operations.
 
 	if w.FixedSize() && (w.requestedWidth == 0 || w.requestedHeight == 0) {
 		bigEnough := w.canvas.canvasSize(w.canvas.Content().MinSize())

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1745,9 +1745,8 @@ func TestWindow_SetContent_Twice(t *testing.T) {
 }
 
 func TestWindow_SetFullScreen(t *testing.T) {
-	var w *window
 	runOnMain(func() { // tests launch in a different context
-		w = d.CreateWindow("Full").(*window)
+		w := d.CreateWindow("Full").(*window)
 		w.SetFullScreen(true)
 		w.create()
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Found a small memory leak when looking through the code. Let's make sure to clear out the pending operations once when have executed them. This is hard to test with how glfw tests works so did not figure a way to add a test.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

