### PR TITLE
Use async.Map for canvases cache

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -107,7 +107,6 @@ func CleanCanvases(refreshingCanvases []fyne.Canvas) {
 			deletingObjs = append(deletingObjs, obj)
 			canvases.Delete(obj)
 		}
-
 		return true
 	})
 	if len(deletingObjs) == 0 {

--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -57,19 +57,17 @@ func Clean(canvasRefreshed bool) {
 // CleanCanvas performs a complete remove of all the objects that belong to the specified
 // canvas. Usually used to free all objects from a closing windows.
 func CleanCanvas(canvas fyne.Canvas) {
-	deletingObjs := make([]fyne.CanvasObject, 0, 50)
+	deletingObjs := make([]fyne.CanvasObject, 0, 64)
 
-	for obj, cinfo := range canvases {
+	canvases.Range(func(obj fyne.CanvasObject, cinfo *canvasInfo) bool {
 		if cinfo.canvas == canvas {
 			deletingObjs = append(deletingObjs, obj)
+			canvases.Delete(obj)
 		}
-	}
+		return true
+	})
 	if len(deletingObjs) == 0 {
 		return
-	}
-
-	for _, dobj := range deletingObjs {
-		delete(canvases, dobj)
 	}
 
 	for _, dobj := range deletingObjs {
@@ -102,19 +100,18 @@ func CleanCanvases(refreshingCanvases []fyne.Canvas) {
 	destroyExpiredSvgs(now)
 	destroyExpiredFontMetrics(now)
 
-	deletingObjs := make([]fyne.CanvasObject, 0, 50)
+	deletingObjs := make([]fyne.CanvasObject, 0, 64)
 
-	for obj, cinfo := range canvases {
+	canvases.Range(func(obj fyne.CanvasObject, cinfo *canvasInfo) bool {
 		if cinfo.isExpired(now) && matchesACanvas(cinfo, refreshingCanvases) {
 			deletingObjs = append(deletingObjs, obj)
+			canvases.Delete(obj)
 		}
-	}
+
+		return true
+	})
 	if len(deletingObjs) == 0 {
 		return
-	}
-
-	for _, dobj := range deletingObjs {
-		delete(canvases, dobj)
 	}
 
 	for _, dobj := range deletingObjs {
@@ -140,11 +137,12 @@ func ResetThemeCaches() {
 
 // destroyExpiredCanvases deletes objects from the canvases cache.
 func destroyExpiredCanvases(now time.Time) {
-	for obj, cinfo := range canvases {
+	canvases.Range(func(obj fyne.CanvasObject, cinfo *canvasInfo) bool {
 		if cinfo.isExpired(now) {
-			delete(canvases, obj)
+			canvases.Delete(obj)
 		}
-	}
+		return true
+	})
 }
 
 // destroyExpiredRenderers deletes the renderer from the cache and calls

--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -37,7 +37,7 @@ func TestCacheClean(t *testing.T) {
 		Clean(false)
 		assert.Equal(t, svgs.Len(), 40)
 		assert.Equal(t, 40, renderers.Len())
-		assert.Len(t, canvases, 40)
+		assert.Equal(t, 40, canvases.Len())
 		assert.Zero(t, destroyedRenderersCnt)
 		assert.Equal(t, tm.now, lastClean)
 
@@ -45,7 +45,7 @@ func TestCacheClean(t *testing.T) {
 		Clean(true)
 		assert.Equal(t, svgs.Len(), 40)
 		assert.Equal(t, 40, renderers.Len())
-		assert.Len(t, canvases, 40)
+		assert.Equal(t, 40, canvases.Len())
 		assert.Zero(t, destroyedRenderersCnt)
 		assert.Equal(t, tm.now, lastClean)
 	})
@@ -73,7 +73,7 @@ func TestCacheClean(t *testing.T) {
 
 		assert.Equal(t, svgs.Len(), 40)
 		assert.Equal(t, 40, renderers.Len())
-		assert.Len(t, canvases, 40)
+		assert.Equal(t, 40, canvases.Len())
 		assert.Zero(t, destroyedRenderersCnt)
 	})
 
@@ -82,15 +82,15 @@ func TestCacheClean(t *testing.T) {
 		tm.setTime(11, 12)
 		Clean(false)
 		assert.Equal(t, svgs.Len(), 20)
-		assert.Equal(t, 40, renderers.Len())
-		assert.Len(t, canvases, 40)
+		assert.Equal(t, renderers.Len(), 40)
+		assert.Equal(t, canvases.Len(), 40)
 		assert.Zero(t, destroyedRenderersCnt)
 
 		tm.setTime(11, 42)
 		Clean(false)
 		assert.Equal(t, svgs.Len(), 0)
-		assert.Equal(t, 40, renderers.Len())
-		assert.Len(t, canvases, 40)
+		assert.Equal(t, renderers.Len(), 40)
+		assert.Equal(t, canvases.Len(), 40)
 		assert.Zero(t, destroyedRenderersCnt)
 	})
 
@@ -100,14 +100,14 @@ func TestCacheClean(t *testing.T) {
 		Clean(true)
 		assert.Equal(t, svgs.Len(), 0)
 		assert.Equal(t, 20, renderers.Len())
-		assert.Len(t, canvases, 20)
+		assert.Equal(t, 20, canvases.Len())
 		assert.Equal(t, 20, destroyedRenderersCnt)
 
 		tm.setTime(11, 22)
 		Clean(true)
 		assert.Equal(t, svgs.Len(), 0)
 		assert.Equal(t, 0, renderers.Len())
-		assert.Len(t, canvases, 0)
+		assert.Equal(t, 0, canvases.Len())
 		assert.Equal(t, 40, destroyedRenderersCnt)
 	})
 
@@ -159,19 +159,20 @@ func TestCleanCanvas(t *testing.T) {
 	}
 
 	assert.Equal(t, 42, renderers.Len())
-	assert.Len(t, canvases, 42)
+	assert.Equal(t, 42, canvases.Len())
 
 	CleanCanvas(dcanvas1)
 	assert.Equal(t, 22, renderers.Len())
-	assert.Len(t, canvases, 22)
+	assert.Equal(t, 22, canvases.Len())
 	assert.Equal(t, 20, destroyedRenderersCnt)
-	for _, cinfo := range canvases {
+	canvases.Range(func(_ fyne.CanvasObject, cinfo *canvasInfo) bool {
 		assert.Equal(t, dcanvas2, cinfo.canvas)
-	}
+		return true
+	})
 
 	CleanCanvas(dcanvas2)
 	assert.Equal(t, 0, renderers.Len())
-	assert.Len(t, canvases, 0)
+	assert.Equal(t, 0, canvases.Len())
 	assert.Equal(t, 42, destroyedRenderersCnt)
 }
 
@@ -247,7 +248,7 @@ func (t *timeMock) setTime(min, sec int) {
 
 func testClearAll() {
 	skippedCleanWithCanvasRefresh = false
-	canvases = make(map[fyne.CanvasObject]*canvasInfo, 1024)
+	canvases.Clear()
 	svgs.Clear()
 	textTextures.Clear()
 	objectTextures.Clear()

--- a/internal/cache/canvases.go
+++ b/internal/cache/canvases.go
@@ -2,13 +2,14 @@ package cache
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/async"
 )
 
-var canvases = make(map[fyne.CanvasObject]*canvasInfo, 1024)
+var canvases async.Map[fyne.CanvasObject, *canvasInfo]
 
 // GetCanvasForObject returns the canvas for the specified object.
 func GetCanvasForObject(obj fyne.CanvasObject) fyne.Canvas {
-	cinfo, ok := canvases[obj]
+	cinfo, ok := canvases.Load(obj)
 	if cinfo == nil || !ok {
 		return nil
 	}
@@ -21,9 +22,8 @@ func GetCanvasForObject(obj fyne.CanvasObject) fyne.Canvas {
 func SetCanvasForObject(obj fyne.CanvasObject, c fyne.Canvas, setup func()) {
 	cinfo := &canvasInfo{canvas: c}
 	cinfo.setAlive()
-	old, found := canvases[obj]
-	canvases[obj] = cinfo
 
+	old, found := canvases.LoadOrStore(obj, cinfo)
 	if (!found || old.canvas != c) && setup != nil {
 		setup()
 	}

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -365,9 +365,10 @@ func TestGlCanvas_MinSizeShrinkTriggersLayout(t *testing.T) {
 	})
 	repaintWindow(w)
 
+	assert.Equal(t, oldCanvasSize, c.Size())
+	expectedRightColSize := oldRightColSize.Subtract(fyne.NewSize(20, 0))
+
 	runOnMain(func() {
-		assert.Equal(t, oldCanvasSize, c.Size())
-		expectedRightColSize := oldRightColSize.Subtract(fyne.NewSize(20, 0))
 		assert.Equal(t, expectedRightColSize, rightCol.Size())
 		assert.Equal(t, fyne.NewSize(100, 40), leftObj1.Size())
 		assert.Equal(t, fyne.NewSize(80, 30), rightObj1.Size())

--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -348,24 +348,31 @@ func TestGlCanvas_MinSizeShrinkTriggersLayout(t *testing.T) {
 	w.SetContent(content)
 
 	oldCanvasSize := fyne.NewSize(200+3*theme.Padding(), 100+3*theme.Padding())
-	assert.Equal(t, oldCanvasSize, c.Size())
+	runOnMain(func() {
+		assert.Equal(t, oldCanvasSize, c.Size())
+	})
 	repaintWindow(w)
 
-	oldRightColSize := rightCol.Size()
-	leftObj1.SetMinSize(fyne.NewSize(90, 40))
-	rightObj1.SetMinSize(fyne.NewSize(80, 30))
-	rightObj2.SetMinSize(fyne.NewSize(80, 20))
-	c.Refresh(leftObj1)
-	c.Refresh(rightObj1)
-	c.Refresh(rightObj2)
+	var oldRightColSize fyne.Size
+	runOnMain(func() {
+		oldRightColSize = rightCol.Size()
+		leftObj1.SetMinSize(fyne.NewSize(90, 40))
+		rightObj1.SetMinSize(fyne.NewSize(80, 30))
+		rightObj2.SetMinSize(fyne.NewSize(80, 20))
+		c.Refresh(leftObj1)
+		c.Refresh(rightObj1)
+		c.Refresh(rightObj2)
+	})
 	repaintWindow(w)
 
-	assert.Equal(t, oldCanvasSize, c.Size())
-	expectedRightColSize := oldRightColSize.Subtract(fyne.NewSize(20, 0))
-	assert.Equal(t, expectedRightColSize, rightCol.Size())
-	assert.Equal(t, fyne.NewSize(100, 40), leftObj1.Size())
-	assert.Equal(t, fyne.NewSize(80, 30), rightObj1.Size())
-	assert.Equal(t, fyne.NewSize(80, 20), rightObj2.Size())
+	runOnMain(func() {
+		assert.Equal(t, oldCanvasSize, c.Size())
+		expectedRightColSize := oldRightColSize.Subtract(fyne.NewSize(20, 0))
+		assert.Equal(t, expectedRightColSize, rightCol.Size())
+		assert.Equal(t, fyne.NewSize(100, 40), leftObj1.Size())
+		assert.Equal(t, fyne.NewSize(80, 30), rightObj1.Size())
+		assert.Equal(t, fyne.NewSize(80, 20), rightObj2.Size())
+	})
 }
 
 func TestGlCanvas_NilContent(t *testing.T) {

--- a/internal/driver/glfw/menu_bar_test.go
+++ b/internal/driver/glfw/menu_bar_test.go
@@ -315,7 +315,9 @@ func TestMenuBar(t *testing.T) {
 									test.TapCanvas(c, a.pos)
 								}
 							}
-							test.AssertImageMatches(t, s.wantImage, c.Capture())
+							runOnMain(func() {
+								test.AssertImageMatches(t, s.wantImage, c.Capture())
+							})
 							assert.Equal(t, s.wantAction, lastAction, "last action should match expected")
 						})
 					}

--- a/internal/driver/glfw/menu_bar_test.go
+++ b/internal/driver/glfw/menu_bar_test.go
@@ -425,16 +425,19 @@ func TestMenuBar(t *testing.T) {
 				test.TapCanvas(c, fyne.NewPos(0, 0))
 				test.TapCanvas(c, fileMenuPos) // activate menu
 				require.Equal(t, menuBar.Items[0], c.Focused())
-				if test.AssertImageMatches(t, "menu_bar_active_file.png", c.Capture()) {
-					lastAction = ""
-					for _, key := range tt.keys {
-						c.Focused().TypedKey(&fyne.KeyEvent{
-							Name: key,
-						})
+
+				runOnMain(func() {
+					if test.AssertImageMatches(t, "menu_bar_active_file.png", c.Capture()) {
+						lastAction = ""
+						for _, key := range tt.keys {
+							c.Focused().TypedKey(&fyne.KeyEvent{
+								Name: key,
+							})
+						}
+						test.AssertRendersToMarkup(t, "menu_bar_kbdctrl_"+name+".xml", c)
+						assert.Equal(t, tt.wantAction, lastAction, "last action should match expected")
 					}
-					test.AssertRendersToMarkup(t, "menu_bar_kbdctrl_"+name+".xml", c)
-					assert.Equal(t, tt.wantAction, lastAction, "last action should match expected")
-				}
+				})
 			})
 		}
 
@@ -450,7 +453,10 @@ func TestMenuBar(t *testing.T) {
 
 			test.MoveMouse(c, fileMenuPos.Add(fyne.NewPos(1, 0)))
 			assert.Equal(t, menuBar.Items[0], c.Focused())
-			test.AssertImageMatches(t, "menu_bar_active_file.png", c.Capture())
+
+			runOnMain(func() {
+				test.AssertImageMatches(t, "menu_bar_active_file.png", c.Capture())
+			})
 		})
 	})
 }

--- a/internal/driver/glfw/menu_bar_test.go
+++ b/internal/driver/glfw/menu_bar_test.go
@@ -428,18 +428,20 @@ func TestMenuBar(t *testing.T) {
 				test.TapCanvas(c, fileMenuPos) // activate menu
 				require.Equal(t, menuBar.Items[0], c.Focused())
 
+				var captured image.Image
 				runOnMain(func() {
-					if test.AssertImageMatches(t, "menu_bar_active_file.png", c.Capture()) {
-						lastAction = ""
-						for _, key := range tt.keys {
-							c.Focused().TypedKey(&fyne.KeyEvent{
-								Name: key,
-							})
-						}
-						test.AssertRendersToMarkup(t, "menu_bar_kbdctrl_"+name+".xml", c)
-						assert.Equal(t, tt.wantAction, lastAction, "last action should match expected")
-					}
+					captured = c.Capture()
 				})
+				if test.AssertImageMatches(t, "menu_bar_active_file.png", captured) {
+					lastAction = ""
+					for _, key := range tt.keys {
+						c.Focused().TypedKey(&fyne.KeyEvent{
+							Name: key,
+						})
+					}
+					test.AssertRendersToMarkup(t, "menu_bar_kbdctrl_"+name+".xml", c)
+					assert.Equal(t, tt.wantAction, lastAction, "last action should match expected")
+				}
 			})
 		}
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This fixes a crash for unmigrated code bases where a concurrent map write happened. This was due to a lock I removed internally. The lock protected other things than just the map so we should still be faster but now with the lock removed, it made it possible to see a small simplification/optimization that could be done so I cleaned up that code as well. 

For #5411

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

