### PR TITLE
Allow disabling of the thread checks as a "migration" - a pattern we can re-use

### DIFF
--- a/app.go
+++ b/app.go
@@ -118,11 +118,14 @@ type AppMetadata struct {
 	// Icon contains, if present, a resource of the icon that was bundled at build time.
 	Icon Resource
 	// Release if true this binary was build in release mode
-	// Since 2.3
+	// Since: 2.3
 	Release bool
 	// Custom contain the custom metadata defined either in FyneApp.toml or on the compile command line
-	// Since 2.3
+	// Since: 2.3
 	Custom map[string]string
+	// Migrations allows an app to opt into features before they are standard
+	// Since: 2.6
+	Migrations map[string]bool
 }
 
 // Lifecycle represents the various phases that an app can transition through.

--- a/app/meta.go
+++ b/app/meta.go
@@ -5,12 +5,13 @@ import (
 )
 
 var meta = fyne.AppMetadata{
-	ID:      "",
-	Name:    "",
-	Version: "0.0.1",
-	Build:   1,
-	Release: false,
-	Custom:  map[string]string{},
+	ID:         "",
+	Name:       "",
+	Version:    "0.0.1",
+	Build:      1,
+	Release:    false,
+	Custom:     map[string]string{},
+	Migrations: map[string]bool{},
 }
 
 // SetMetadata overrides the packaged application metadata.
@@ -20,6 +21,9 @@ func SetMetadata(m fyne.AppMetadata) {
 
 	if meta.Custom == nil {
 		meta.Custom = map[string]string{}
+	}
+	if meta.Migrations == nil {
+		meta.Migrations = map[string]bool{}
 	}
 }
 

--- a/app/meta.go
+++ b/app/meta.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/build"
 )
 
 var meta = fyne.AppMetadata{
@@ -25,8 +24,6 @@ func SetMetadata(m fyne.AppMetadata) {
 	}
 	if meta.Migrations == nil {
 		meta.Migrations = map[string]bool{}
-	} else {
-		setupMigrations(m.Migrations)
 	}
 }
 
@@ -36,10 +33,4 @@ func (a *fyneApp) Metadata() fyne.AppMetadata {
 	}
 
 	return meta
-}
-
-func setupMigrations(data map[string]bool) {
-	if done, ok := data["fyneDo"]; ok && done {
-		build.DisableThreadChecks = true
-	}
 }

--- a/app/meta.go
+++ b/app/meta.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/build"
 )
 
 var meta = fyne.AppMetadata{
@@ -24,6 +25,8 @@ func SetMetadata(m fyne.AppMetadata) {
 	}
 	if meta.Migrations == nil {
 		meta.Migrations = map[string]bool{}
+	} else {
+		setupMigrations(m.Migrations)
 	}
 }
 
@@ -33,4 +36,10 @@ func (a *fyneApp) Metadata() fyne.AppMetadata {
 	}
 
 	return meta
+}
+
+func setupMigrations(data map[string]bool) {
+	if done, ok := data["fyneDo"]; ok && done {
+		build.DisableThreadChecks = true
+	}
 }

--- a/app/meta_development.go
+++ b/app/meta_development.go
@@ -43,6 +43,7 @@ func checkLocalMetadata() {
 
 	meta.Release = false
 	meta.Custom = data.Development
+	meta.Migrations = data.Migrations
 }
 
 func getProjectPath() string {

--- a/app/meta_development.go
+++ b/app/meta_development.go
@@ -44,6 +44,7 @@ func checkLocalMetadata() {
 	meta.Release = false
 	meta.Custom = data.Development
 	meta.Migrations = data.Migrations
+	setupMigrations(data.Migrations)
 }
 
 func getProjectPath() string {

--- a/app/meta_development.go
+++ b/app/meta_development.go
@@ -44,7 +44,6 @@ func checkLocalMetadata() {
 	meta.Release = false
 	meta.Custom = data.Development
 	meta.Migrations = data.Migrations
-	setupMigrations(data.Migrations)
 }
 
 func getProjectPath() string {

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -230,6 +230,9 @@ func (b *Builder) build() error {
 	if b.release {
 		tags = append(tags, "release")
 	}
+	if ok, set := b.appData.Migrations["fyneDo"]; ok && set {
+		tags = append(tags, "migrated_fynedo")
+	}
 	if len(tags) > 0 {
 		args = append(args, "-tags", strings.Join(tags, ","))
 	}

--- a/cmd/fyne/internal/commands/data.go
+++ b/cmd/fyne/internal/commands/data.go
@@ -9,6 +9,7 @@ type appData struct {
 	ResGoString       string
 	Release, rawIcon  bool
 	CustomMetadata    map[string]string
+	Migrations        map[string]bool
 	VersionAtLeast2_3 bool
 }
 
@@ -47,4 +48,5 @@ func (a *appData) mergeMetadata(data *metadata.FyneApp) {
 	} else {
 		a.appendCustomMetadata(data.Development)
 	}
+	a.Migrations = data.Migrations
 }

--- a/cmd/hello/FyneApp.toml
+++ b/cmd/hello/FyneApp.toml
@@ -4,3 +4,6 @@
   ID = "io.fyne.hello"
   Version = "2.5.3"
   Build = 2
+
+[Migrations]
+  fyneDo = true

--- a/internal/async/goroutine.go
+++ b/internal/async/goroutine.go
@@ -30,7 +30,7 @@ func IsMainGoroutine() bool {
 //
 // This will be removed later and should never be public
 func EnsureNotMain(fn func()) {
-	if (build.DisableThreadChecks || !build.HasHints) || !IsMainGoroutine() {
+	if build.DisableThreadChecks || !build.HasHints || !IsMainGoroutine() {
 		fn()
 		return
 	}
@@ -47,7 +47,7 @@ func EnsureNotMain(fn func()) {
 //
 // This will be removed later and should never be public
 func EnsureMain(fn func()) {
-	if (build.DisableThreadChecks || !build.HasHints) || IsMainGoroutine() {
+	if build.DisableThreadChecks || !build.HasHints || IsMainGoroutine() {
 		fn()
 		return
 	}

--- a/internal/async/goroutine.go
+++ b/internal/async/goroutine.go
@@ -30,7 +30,7 @@ func IsMainGoroutine() bool {
 //
 // This will be removed later and should never be public
 func EnsureNotMain(fn func()) {
-	if build.DisableThreadChecks || !build.HasHints || !IsMainGoroutine() {
+	if build.MigratedToFyneDo() || !build.HasHints || !IsMainGoroutine() {
 		fn()
 		return
 	}
@@ -47,7 +47,7 @@ func EnsureNotMain(fn func()) {
 //
 // This will be removed later and should never be public
 func EnsureMain(fn func()) {
-	if build.DisableThreadChecks || !build.HasHints || IsMainGoroutine() {
+	if build.MigratedToFyneDo() || !build.HasHints || IsMainGoroutine() {
 		fn()
 		return
 	}

--- a/internal/async/goroutine.go
+++ b/internal/async/goroutine.go
@@ -30,7 +30,7 @@ func IsMainGoroutine() bool {
 //
 // This will be removed later and should never be public
 func EnsureNotMain(fn func()) {
-	if (build.MigratedToFyneDo() || !build.HasHints) || !IsMainGoroutine() {
+	if (build.DisableThreadChecks || !build.HasHints) || !IsMainGoroutine() {
 		fn()
 		return
 	}
@@ -47,7 +47,7 @@ func EnsureNotMain(fn func()) {
 //
 // This will be removed later and should never be public
 func EnsureMain(fn func()) {
-	if (build.MigratedToFyneDo() || !build.HasHints) || IsMainGoroutine() {
+	if (build.DisableThreadChecks || !build.HasHints) || IsMainGoroutine() {
 		fn()
 		return
 	}

--- a/internal/async/goroutine.go
+++ b/internal/async/goroutine.go
@@ -30,7 +30,7 @@ func IsMainGoroutine() bool {
 //
 // This will be removed later and should never be public
 func EnsureNotMain(fn func()) {
-	if build.DisableThreadChecks || !IsMainGoroutine() {
+	if (build.MigratedToFyneDo() || !build.HasHints) || !IsMainGoroutine() {
 		fn()
 		return
 	}
@@ -47,7 +47,7 @@ func EnsureNotMain(fn func()) {
 //
 // This will be removed later and should never be public
 func EnsureMain(fn func()) {
-	if build.DisableThreadChecks || IsMainGoroutine() {
+	if (build.MigratedToFyneDo() || !build.HasHints) || IsMainGoroutine() {
 		fn()
 		return
 	}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,16 +1,29 @@
 // Package build contains information about they type of build currently running.
 package build
 
-import "fyne.io/fyne/v2"
+import (
+	"sync"
+
+	"fyne.io/fyne/v2"
+)
+
+var (
+	migrateCheck sync.Once
+
+	migratedFyneDo bool
+)
 
 func MigratedToFyneDo() bool {
 	if DisableThreadChecks {
 		return true
 	}
 
-	v, ok := fyne.CurrentApp().Metadata().Migrations["fyneDo"]
-	if ok {
-		return v
-	}
-	return false
+	migrateCheck.Do(func() {
+		v, ok := fyne.CurrentApp().Metadata().Migrations["fyneDo"]
+		if ok {
+			migratedFyneDo = v
+		}
+	})
+
+	return migratedFyneDo
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,16 +1,2 @@
 // Package build contains information about they type of build currently running.
 package build
-
-import "fyne.io/fyne/v2"
-
-func MigratedToFyneDo() bool {
-	if DisableThreadChecks {
-		return true
-	}
-
-	v, ok := fyne.CurrentApp().Metadata().Migrations["fyneDo"]
-	if ok {
-		return v
-	}
-	return false
-}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,4 +1,16 @@
 // Package build contains information about they type of build currently running.
 package build
 
-const DisableThreadChecks = false
+import "fyne.io/fyne/v2"
+
+func MigratedToFyneDo() bool {
+	if DisableThreadChecks {
+		return true
+	}
+
+	v, ok := fyne.CurrentApp().Metadata().Migrations["fyneDo"]
+	if ok {
+		return v
+	}
+	return false
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,2 +1,16 @@
 // Package build contains information about they type of build currently running.
 package build
+
+import "fyne.io/fyne/v2"
+
+func MigratedToFyneDo() bool {
+	if DisableThreadChecks {
+		return true
+	}
+
+	v, ok := fyne.CurrentApp().Metadata().Migrations["fyneDo"]
+	if ok {
+		return v
+	}
+	return false
+}

--- a/internal/build/migrated_fynedo.go
+++ b/internal/build/migrated_fynedo.go
@@ -2,4 +2,4 @@
 
 package build
 
-const DisableThreadChecks = true
+var DisableThreadChecks = true

--- a/internal/build/migrated_fynedo.go
+++ b/internal/build/migrated_fynedo.go
@@ -1,0 +1,5 @@
+//go:build migrated_fynedo
+
+package build
+
+const DisableThreadChecks = true

--- a/internal/build/migrated_fynedo.go
+++ b/internal/build/migrated_fynedo.go
@@ -3,4 +3,4 @@
 package build
 
 // DisableThreadChecks disables the thread safety checks for performance.
-var DisableThreadChecks = true
+const DisableThreadChecks = true

--- a/internal/build/migrated_fynedo.go
+++ b/internal/build/migrated_fynedo.go
@@ -2,4 +2,5 @@
 
 package build
 
+// DisableThreadChecks disables the thread safety checks for performance.
 var DisableThreadChecks = true

--- a/internal/build/migrated_notfynedo.go
+++ b/internal/build/migrated_notfynedo.go
@@ -3,4 +3,4 @@
 package build
 
 // DisableThreadChecks set to false enables the thread safety checks for logging of incorrect usage.
-var DisableThreadChecks = false
+const DisableThreadChecks = false

--- a/internal/build/migrated_notfynedo.go
+++ b/internal/build/migrated_notfynedo.go
@@ -1,0 +1,5 @@
+//go:build !migrated_fynedo
+
+package build
+
+const DisableThreadChecks = false

--- a/internal/build/migrated_notfynedo.go
+++ b/internal/build/migrated_notfynedo.go
@@ -2,4 +2,5 @@
 
 package build
 
+// DisableThreadChecks set to false enables the thread safety checks for logging of incorrect usage.
 var DisableThreadChecks = false

--- a/internal/build/migrated_notfynedo.go
+++ b/internal/build/migrated_notfynedo.go
@@ -2,4 +2,4 @@
 
 package build
 
-const DisableThreadChecks = false
+var DisableThreadChecks = false

--- a/internal/metadata/data.go
+++ b/internal/metadata/data.go
@@ -9,6 +9,7 @@ type FyneApp struct {
 	Source      *AppSource        `toml:",omitempty"`
 	LinuxAndBSD *LinuxAndBSD      `toml:",omitempty"`
 	Languages   []string          `toml:",omitempty"`
+	Migrations  map[string]bool   `toml:",omitempty"`
 }
 
 // AppDetails describes the build information, this group may be OS or arch specific

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -4,6 +4,7 @@ package widget // import "fyne.io/fyne/v2/widget"
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/cache"
 	internalWidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -111,14 +112,16 @@ func (w *BaseWidget) Hide() {
 
 // Refresh causes this widget to be redrawn in its current state
 func (w *BaseWidget) Refresh() {
-	impl := w.super()
-	if impl == nil {
-		return
-	}
+	async.EnsureMain(func() {
+		impl := w.super()
+		if impl == nil {
+			return
+		}
 
-	w.themeCache = nil
+		w.themeCache = nil
 
-	cache.Renderer(impl).Refresh()
+		cache.Renderer(impl).Refresh()
+	})
 }
 
 // Theme returns a cached Theme instance for this widget (or its extending widget).


### PR DESCRIPTION
Reasoning:
* Build tags are great to run a specific build with a feature on or off but can be forgotten
* App metadata is great for marking a project as migrated but are not part of the binary
* So we have both. Use the tag if you want and add the migration to file when you're looking to make it permanent.

With this pattern we could (like the Go module tooling approach) change how apps work based on metadata, but build it in to the app through compiler flags.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
