### PR TITLE
Remove closed windows in place without allocating a new slice

### DIFF
--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -427,7 +427,10 @@ func TestGlCanvas_ResizeWithOtherOverlay(t *testing.T) {
 	content := widget.NewLabel("Content")
 	over := widget.NewLabel("Over")
 	w.SetContent(content)
-	w.Canvas().Overlays().Add(over)
+	overlays := w.Canvas().Overlays()
+	runOnMain(func() {
+		overlays.Add(over)
+	})
 	ensureCanvasSize(t, w, fyne.NewSize(69, 36))
 	// TODO: address #707; overlays should always be canvas size
 	size := w.Canvas().Size()

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -148,9 +148,11 @@ func (d *gLDriver) runGL() {
 					}
 				}
 
-				d.animation.TickAnimations()
-				d.drawSingleFrame()
 			}
+
+			d.animation.TickAnimations()
+			d.drawSingleFrame()
+
 			if runWindowCleanup {
 				d.removeDestroyedWindows()
 			}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -113,15 +113,20 @@ func (d *gLDriver) runGL() {
 			f.done <- struct{}{}
 		case <-eventTick.C:
 			d.pollEvents()
-			windowsToRemove := 0
-			for _, win := range d.windowList() {
+			runWindowCleanup := false
+			for i, win := range d.windowList() {
+				if win == nil {
+					continue
+				}
+
 				w := win.(*window)
 				if w.viewport == nil {
 					continue
 				}
 
 				if w.viewport.ShouldClose() {
-					windowsToRemove++
+					d.destroyWindow(w, i)
+					runWindowCleanup = true
 					continue
 				}
 
@@ -142,34 +147,8 @@ func (d *gLDriver) runGL() {
 				d.animation.TickAnimations()
 				d.drawSingleFrame()
 			}
-			if windowsToRemove > 0 {
-				oldWindows := d.windowList()
-				newWindows := make([]fyne.Window, 0, len(oldWindows)-windowsToRemove)
-
-				for _, win := range oldWindows {
-					w := win.(*window)
-					if w.viewport == nil {
-						continue
-					}
-
-					if w.viewport.ShouldClose() {
-						w.visible = false
-						v := w.viewport
-
-						// remove window from window list
-						v.Destroy()
-						w.destroy(d)
-						continue
-					}
-
-					newWindows = append(newWindows, win)
-				}
-
-				d.windows = newWindows
-
-				if len(newWindows) == 0 {
-					d.Quit()
-				}
+			if runWindowCleanup {
+				d.removeDestroyedWindows()
 			}
 		case set := <-settingsChange:
 			painter.ClearFontCache()
@@ -184,6 +163,34 @@ func (d *gLDriver) runGL() {
 			})
 
 		}
+	}
+}
+
+func (d *gLDriver) destroyWindow(w *window, index int) {
+	w.visible = false
+
+	// Remove window from window list:
+	d.windows[index] = nil
+	w.viewport.Destroy()
+	w.destroy(d)
+}
+
+func (d *gLDriver) removeDestroyedWindows() {
+	// Copy items from front to back to move as few objects as possible.
+	for i := len(d.windows) - 1; i >= 0; i-- {
+		if d.windows[i] != nil {
+			continue
+		}
+
+		if i < len(d.windows)-1 {
+			copy(d.windows[i:], d.windows[i+1:])
+		}
+		d.windows[len(d.windows)-1] = nil
+		d.windows = d.windows[:len(d.windows)-1]
+	}
+
+	if len(d.windows) == 0 {
+		d.Quit()
 	}
 }
 
@@ -221,5 +228,5 @@ func updateGLContext(w *window) {
 	winHeight := float32(scale.ToScreenCoordinate(canvas, size.Height)) * canvas.texScale
 
 	canvas.Painter().SetFrameBufferScale(canvas.texScale)
-	w.canvas.Painter().SetOutputSize(int(winWidth), int(winHeight))
+	canvas.Painter().SetOutputSize(int(winWidth), int(winHeight))
 }

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -56,6 +56,10 @@ var refreshingCanvases []fyne.Canvas
 
 func (d *gLDriver) drawSingleFrame() {
 	for _, win := range d.windowList() {
+		if win == nil {
+			continue
+		}
+
 		w := win.(*window)
 		canvas := w.canvas
 		closing := w.closing


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Just a small improvement that I noticed could be done, thanks to everything happening on one thread, while working on #5422. Will give a bit of a merge conflict but this seems to make more sense separately (especially if that for some reason wouldn't be ready in time for 2.6).

This also includes a fix from Drew from the same PR to address window repaints and animation ticking happening once for every window on each frame tick. We were basically doing a frame render `O(n^2)` times, where n is amount of visible windows.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

