### PR TITLE
Adding scrolling to TextGrid and a new Append method too

### DIFF
--- a/widget/testdata/textgrid/basic.xml
+++ b/widget/testdata/textgrid/basic.xml
@@ -1,0 +1,62 @@
+<canvas size="72x32">
+	<content>
+		<widget size="72x32" type="*widget.TextGrid">
+			<widget size="72x32" type="*widget.textGridContent">
+				<rectangle size="8x16"/>
+				<text monospace size="0x0">S</text>
+				<line pos="0,16" size="8x0"/>
+				<rectangle pos="8,0" size="8x16"/>
+				<text monospace pos="8,0" size="0x0">o</text>
+				<line pos="8,16" size="8x0"/>
+				<rectangle pos="16,0" size="8x16"/>
+				<text monospace pos="16,0" size="0x0">m</text>
+				<line pos="16,16" size="8x0"/>
+				<rectangle pos="24,0" size="8x16"/>
+				<text monospace pos="24,0" size="0x0">e</text>
+				<line pos="24,16" size="8x0"/>
+				<rectangle pos="32,0" size="8x16"/>
+				<text monospace pos="32,0" size="0x0">t</text>
+				<line pos="32,16" size="8x0"/>
+				<rectangle pos="40,0" size="8x16"/>
+				<text monospace pos="40,0" size="0x0">h</text>
+				<line pos="40,16" size="8x0"/>
+				<rectangle pos="48,0" size="8x16"/>
+				<text monospace pos="48,0" size="0x0">i</text>
+				<line pos="48,16" size="8x0"/>
+				<rectangle pos="56,0" size="8x16"/>
+				<text monospace pos="56,0" size="0x0">n</text>
+				<line pos="56,16" size="8x0"/>
+				<rectangle pos="64,0" size="8x16"/>
+				<text monospace pos="64,0" size="0x0">g</text>
+				<line pos="64,16" size="8x0"/>
+				<rectangle pos="0,16" size="8x16"/>
+				<text monospace pos="0,16" size="0x0">E</text>
+				<line pos="0,32" size="8x0"/>
+				<rectangle pos="8,16" size="8x16"/>
+				<text monospace pos="8,16" size="0x0">l</text>
+				<line pos="8,32" size="8x0"/>
+				<rectangle pos="16,16" size="8x16"/>
+				<text monospace pos="16,16" size="0x0">s</text>
+				<line pos="16,32" size="8x0"/>
+				<rectangle pos="24,16" size="8x16"/>
+				<text monospace pos="24,16" size="0x0">e</text>
+				<line pos="24,32" size="8x0"/>
+				<rectangle pos="32,16" size="8x16"/>
+				<text monospace pos="32,16" size="0x0"> </text>
+				<line pos="32,32" size="8x0"/>
+				<rectangle pos="40,16" size="8x16"/>
+				<text monospace pos="40,16" size="0x0"> </text>
+				<line pos="40,32" size="8x0"/>
+				<rectangle pos="48,16" size="8x16"/>
+				<text monospace pos="48,16" size="0x0"> </text>
+				<line pos="48,32" size="8x0"/>
+				<rectangle pos="56,16" size="8x16"/>
+				<text monospace pos="56,16" size="0x0"> </text>
+				<line pos="56,32" size="8x0"/>
+				<rectangle pos="64,16" size="8x16"/>
+				<text monospace pos="64,16" size="0x0"> </text>
+				<line pos="64,32" size="8x0"/>
+			</widget>
+		</widget>
+	</content>
+</canvas>

--- a/widget/testdata/textgrid/basic.xml
+++ b/widget/testdata/textgrid/basic.xml
@@ -60,6 +60,35 @@
 					<text monospace size="0x0"> </text>
 					<line size="0x0"/>
 				</widget>
+				<widget pos="0,32" size="72x16" type="*widget.textGridRow">
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+				</widget>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/textgrid/basic.xml
+++ b/widget/testdata/textgrid/basic.xml
@@ -2,60 +2,64 @@
 	<content>
 		<widget size="72x32" type="*widget.TextGrid">
 			<widget size="72x32" type="*widget.textGridContent">
-				<rectangle size="8x16"/>
-				<text monospace size="0x0">S</text>
-				<line pos="0,16" size="8x0"/>
-				<rectangle pos="8,0" size="8x16"/>
-				<text monospace pos="8,0" size="0x0">o</text>
-				<line pos="8,16" size="8x0"/>
-				<rectangle pos="16,0" size="8x16"/>
-				<text monospace pos="16,0" size="0x0">m</text>
-				<line pos="16,16" size="8x0"/>
-				<rectangle pos="24,0" size="8x16"/>
-				<text monospace pos="24,0" size="0x0">e</text>
-				<line pos="24,16" size="8x0"/>
-				<rectangle pos="32,0" size="8x16"/>
-				<text monospace pos="32,0" size="0x0">t</text>
-				<line pos="32,16" size="8x0"/>
-				<rectangle pos="40,0" size="8x16"/>
-				<text monospace pos="40,0" size="0x0">h</text>
-				<line pos="40,16" size="8x0"/>
-				<rectangle pos="48,0" size="8x16"/>
-				<text monospace pos="48,0" size="0x0">i</text>
-				<line pos="48,16" size="8x0"/>
-				<rectangle pos="56,0" size="8x16"/>
-				<text monospace pos="56,0" size="0x0">n</text>
-				<line pos="56,16" size="8x0"/>
-				<rectangle pos="64,0" size="8x16"/>
-				<text monospace pos="64,0" size="0x0">g</text>
-				<line pos="64,16" size="8x0"/>
-				<rectangle pos="0,16" size="8x16"/>
-				<text monospace pos="0,16" size="0x0">E</text>
-				<line pos="0,32" size="8x0"/>
-				<rectangle pos="8,16" size="8x16"/>
-				<text monospace pos="8,16" size="0x0">l</text>
-				<line pos="8,32" size="8x0"/>
-				<rectangle pos="16,16" size="8x16"/>
-				<text monospace pos="16,16" size="0x0">s</text>
-				<line pos="16,32" size="8x0"/>
-				<rectangle pos="24,16" size="8x16"/>
-				<text monospace pos="24,16" size="0x0">e</text>
-				<line pos="24,32" size="8x0"/>
-				<rectangle pos="32,16" size="8x16"/>
-				<text monospace pos="32,16" size="0x0"> </text>
-				<line pos="32,32" size="8x0"/>
-				<rectangle pos="40,16" size="8x16"/>
-				<text monospace pos="40,16" size="0x0"> </text>
-				<line pos="40,32" size="8x0"/>
-				<rectangle pos="48,16" size="8x16"/>
-				<text monospace pos="48,16" size="0x0"> </text>
-				<line pos="48,32" size="8x0"/>
-				<rectangle pos="56,16" size="8x16"/>
-				<text monospace pos="56,16" size="0x0"> </text>
-				<line pos="56,32" size="8x0"/>
-				<rectangle pos="64,16" size="8x16"/>
-				<text monospace pos="64,16" size="0x0"> </text>
-				<line pos="64,32" size="8x0"/>
+				<widget size="72x16" type="*widget.textGridRow">
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">S</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">o</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">m</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">e</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">t</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">h</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">i</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">n</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">g</text>
+					<line size="0x0"/>
+				</widget>
+				<widget pos="0,16" size="72x16" type="*widget.textGridRow">
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">E</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">l</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">s</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0">e</text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+					<rectangle size="0x0"/>
+					<text monospace size="0x0"> </text>
+					<line size="0x0"/>
+				</widget>
 			</widget>
 		</widget>
 	</content>

--- a/widget/testdata/textgrid/scroll.xml
+++ b/widget/testdata/textgrid/scroll.xml
@@ -1,0 +1,72 @@
+<canvas size="32x32">
+	<content>
+		<widget size="32x32" type="*widget.TextGrid">
+			<widget size="32x32" type="*widget.Scroll">
+				<widget size="32x32" type="*widget.textGridContent">
+					<rectangle size="8x16"/>
+					<text monospace size="0x0">S</text>
+					<line pos="0,16" size="8x0"/>
+					<rectangle pos="8,0" size="8x16"/>
+					<text monospace pos="8,0" size="0x0">o</text>
+					<line pos="8,16" size="8x0"/>
+					<rectangle pos="16,0" size="8x16"/>
+					<text monospace pos="16,0" size="0x0">m</text>
+					<line pos="16,16" size="8x0"/>
+					<rectangle pos="24,0" size="8x16"/>
+					<text monospace pos="24,0" size="0x0">e</text>
+					<line pos="24,16" size="8x0"/>
+					<rectangle pos="32,0" size="8x16"/>
+					<text monospace pos="32,0" size="0x0">t</text>
+					<line pos="32,16" size="8x0"/>
+					<rectangle pos="40,0" size="8x16"/>
+					<text monospace pos="40,0" size="0x0">h</text>
+					<line pos="40,16" size="8x0"/>
+					<rectangle pos="48,0" size="8x16"/>
+					<text monospace pos="48,0" size="0x0">i</text>
+					<line pos="48,16" size="8x0"/>
+					<rectangle pos="56,0" size="8x16"/>
+					<text monospace pos="56,0" size="0x0">n</text>
+					<line pos="56,16" size="8x0"/>
+					<rectangle pos="64,0" size="8x16"/>
+					<text monospace pos="64,0" size="0x0">g</text>
+					<line pos="64,16" size="8x0"/>
+					<rectangle pos="0,16" size="8x16"/>
+					<text monospace pos="0,16" size="0x0">E</text>
+					<line pos="0,32" size="8x0"/>
+					<rectangle pos="8,16" size="8x16"/>
+					<text monospace pos="8,16" size="0x0">l</text>
+					<line pos="8,32" size="8x0"/>
+					<rectangle pos="16,16" size="8x16"/>
+					<text monospace pos="16,16" size="0x0">s</text>
+					<line pos="16,32" size="8x0"/>
+					<rectangle pos="24,16" size="8x16"/>
+					<text monospace pos="24,16" size="0x0">e</text>
+					<line pos="24,32" size="8x0"/>
+					<rectangle pos="32,16" size="8x16"/>
+					<text monospace pos="32,16" size="0x0"> </text>
+					<line pos="32,32" size="8x0"/>
+					<rectangle pos="40,16" size="8x16"/>
+					<text monospace pos="40,16" size="0x0"> </text>
+					<line pos="40,32" size="8x0"/>
+					<rectangle pos="48,16" size="8x16"/>
+					<text monospace pos="48,16" size="0x0"> </text>
+					<line pos="48,32" size="8x0"/>
+					<rectangle pos="56,16" size="8x16"/>
+					<text monospace pos="56,16" size="0x0"> </text>
+					<line pos="56,32" size="8x0"/>
+					<rectangle pos="64,16" size="8x16"/>
+					<text monospace pos="64,16" size="0x0"> </text>
+					<line pos="64,32" size="8x0"/>
+				</widget>
+				<widget pos="32,0" size="0x32" type="*widget.Shadow">
+					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x32"/>
+				</widget>
+				<widget pos="0,26" size="32x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="16x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" radius="3" size="16x3"/>
+					</widget>
+				</widget>
+			</widget>
+		</widget>
+	</content>
+</canvas>

--- a/widget/testdata/textgrid/scroll.xml
+++ b/widget/testdata/textgrid/scroll.xml
@@ -2,8 +2,8 @@
 	<content>
 		<widget size="50x32" type="*widget.TextGrid">
 			<widget size="50x32" type="*widget.Scroll">
-				<widget size="50x32" type="*widget.textGridContent">
-					<widget size="50x16" type="*widget.textGridRow">
+				<widget size="72x32" type="*widget.textGridContent">
+					<widget size="72x16" type="*widget.textGridRow">
 						<rectangle size="0x0"/>
 						<text monospace size="0x0">S</text>
 						<line size="0x0"/>
@@ -32,7 +32,7 @@
 						<text monospace size="0x0">g</text>
 						<line size="0x0"/>
 					</widget>
-					<widget pos="0,16" size="50x16" type="*widget.textGridRow">
+					<widget pos="0,16" size="72x16" type="*widget.textGridRow">
 						<rectangle size="0x0"/>
 						<text monospace size="0x0">E</text>
 						<line size="0x0"/>
@@ -61,7 +61,7 @@
 						<text monospace size="0x0"> </text>
 						<line size="0x0"/>
 					</widget>
-					<widget pos="0,32" size="50x16" type="*widget.textGridRow">
+					<widget pos="0,32" size="72x16" type="*widget.textGridRow">
 						<rectangle size="0x0"/>
 						<text monospace size="0x0"> </text>
 						<line size="0x0"/>

--- a/widget/testdata/textgrid/scroll.xml
+++ b/widget/testdata/textgrid/scroll.xml
@@ -3,60 +3,64 @@
 		<widget size="32x32" type="*widget.TextGrid">
 			<widget size="32x32" type="*widget.Scroll">
 				<widget size="32x32" type="*widget.textGridContent">
-					<rectangle size="8x16"/>
-					<text monospace size="0x0">S</text>
-					<line pos="0,16" size="8x0"/>
-					<rectangle pos="8,0" size="8x16"/>
-					<text monospace pos="8,0" size="0x0">o</text>
-					<line pos="8,16" size="8x0"/>
-					<rectangle pos="16,0" size="8x16"/>
-					<text monospace pos="16,0" size="0x0">m</text>
-					<line pos="16,16" size="8x0"/>
-					<rectangle pos="24,0" size="8x16"/>
-					<text monospace pos="24,0" size="0x0">e</text>
-					<line pos="24,16" size="8x0"/>
-					<rectangle pos="32,0" size="8x16"/>
-					<text monospace pos="32,0" size="0x0">t</text>
-					<line pos="32,16" size="8x0"/>
-					<rectangle pos="40,0" size="8x16"/>
-					<text monospace pos="40,0" size="0x0">h</text>
-					<line pos="40,16" size="8x0"/>
-					<rectangle pos="48,0" size="8x16"/>
-					<text monospace pos="48,0" size="0x0">i</text>
-					<line pos="48,16" size="8x0"/>
-					<rectangle pos="56,0" size="8x16"/>
-					<text monospace pos="56,0" size="0x0">n</text>
-					<line pos="56,16" size="8x0"/>
-					<rectangle pos="64,0" size="8x16"/>
-					<text monospace pos="64,0" size="0x0">g</text>
-					<line pos="64,16" size="8x0"/>
-					<rectangle pos="0,16" size="8x16"/>
-					<text monospace pos="0,16" size="0x0">E</text>
-					<line pos="0,32" size="8x0"/>
-					<rectangle pos="8,16" size="8x16"/>
-					<text monospace pos="8,16" size="0x0">l</text>
-					<line pos="8,32" size="8x0"/>
-					<rectangle pos="16,16" size="8x16"/>
-					<text monospace pos="16,16" size="0x0">s</text>
-					<line pos="16,32" size="8x0"/>
-					<rectangle pos="24,16" size="8x16"/>
-					<text monospace pos="24,16" size="0x0">e</text>
-					<line pos="24,32" size="8x0"/>
-					<rectangle pos="32,16" size="8x16"/>
-					<text monospace pos="32,16" size="0x0"> </text>
-					<line pos="32,32" size="8x0"/>
-					<rectangle pos="40,16" size="8x16"/>
-					<text monospace pos="40,16" size="0x0"> </text>
-					<line pos="40,32" size="8x0"/>
-					<rectangle pos="48,16" size="8x16"/>
-					<text monospace pos="48,16" size="0x0"> </text>
-					<line pos="48,32" size="8x0"/>
-					<rectangle pos="56,16" size="8x16"/>
-					<text monospace pos="56,16" size="0x0"> </text>
-					<line pos="56,32" size="8x0"/>
-					<rectangle pos="64,16" size="8x16"/>
-					<text monospace pos="64,16" size="0x0"> </text>
-					<line pos="64,32" size="8x0"/>
+					<widget size="32x16" type="*widget.textGridRow">
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">S</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">o</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">m</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">e</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">t</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">h</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">i</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">n</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">g</text>
+						<line size="0x0"/>
+					</widget>
+					<widget pos="0,16" size="32x16" type="*widget.textGridRow">
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">E</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">l</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">s</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0">e</text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+					</widget>
 				</widget>
 				<widget pos="32,0" size="0x32" type="*widget.Shadow">
 					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x32"/>

--- a/widget/testdata/textgrid/scroll.xml
+++ b/widget/testdata/textgrid/scroll.xml
@@ -1,9 +1,9 @@
-<canvas size="32x32">
+<canvas size="50x32">
 	<content>
-		<widget size="32x32" type="*widget.TextGrid">
-			<widget size="32x32" type="*widget.Scroll">
-				<widget size="32x32" type="*widget.textGridContent">
-					<widget size="32x16" type="*widget.textGridRow">
+		<widget size="50x32" type="*widget.TextGrid">
+			<widget size="50x32" type="*widget.Scroll">
+				<widget size="50x32" type="*widget.textGridContent">
+					<widget size="50x16" type="*widget.textGridRow">
 						<rectangle size="0x0"/>
 						<text monospace size="0x0">S</text>
 						<line size="0x0"/>
@@ -32,7 +32,7 @@
 						<text monospace size="0x0">g</text>
 						<line size="0x0"/>
 					</widget>
-					<widget pos="0,16" size="32x16" type="*widget.textGridRow">
+					<widget pos="0,16" size="50x16" type="*widget.textGridRow">
 						<rectangle size="0x0"/>
 						<text monospace size="0x0">E</text>
 						<line size="0x0"/>
@@ -61,13 +61,42 @@
 						<text monospace size="0x0"> </text>
 						<line size="0x0"/>
 					</widget>
+					<widget pos="0,32" size="50x16" type="*widget.textGridRow">
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+						<rectangle size="0x0"/>
+						<text monospace size="0x0"> </text>
+						<line size="0x0"/>
+					</widget>
 				</widget>
-				<widget pos="32,0" size="0x32" type="*widget.Shadow">
+				<widget pos="50,0" size="0x32" type="*widget.Shadow">
 					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x32"/>
 				</widget>
-				<widget pos="0,26" size="32x6" type="*widget.scrollBarArea">
-					<widget pos="0,3" size="16x3" type="*widget.scrollBar">
-						<rectangle fillColor="scrollbar" radius="3" size="16x3"/>
+				<widget pos="0,26" size="50x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="34x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" radius="3" size="34x3"/>
 					</widget>
 				</widget>
 			</widget>

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -475,7 +475,6 @@ type textGridContentRenderer struct {
 
 	visible  []fyne.CanvasObject
 	itemPool async.Pool[*textGridRow]
-	current  fyne.Canvas
 }
 
 func (t *textGridContentRenderer) Destroy() {
@@ -611,7 +610,6 @@ type textGridRowRenderer struct {
 	cols int
 
 	objects []fyne.CanvasObject
-	current fyne.Canvas
 }
 
 func (t *textGridRowRenderer) appendTextCell(str rune) {
@@ -678,12 +676,12 @@ func (t *textGridRowRenderer) setCellRune(str rune, pos int, style, rowStyle Tex
 		text.Text = newStr
 		text.Color = fg
 		text.TextStyle = textStyle
-		t.refresh(text)
+		text.Refresh()
 	}
 
 	if underlineStrokeWidth != underline.StrokeWidth || underlineStrokeColor != underline.StrokeColor {
 		underline.StrokeWidth, underline.StrokeColor = underlineStrokeWidth, underlineStrokeColor
-		t.refresh(underline)
+		underline.Refresh()
 	}
 
 	bg := color.Color(color.Transparent)
@@ -694,7 +692,7 @@ func (t *textGridRowRenderer) setCellRune(str rune, pos int, style, rowStyle Tex
 	}
 	if rect.FillColor != bg {
 		rect.FillColor = bg
-		t.refresh(rect)
+		rect.Refresh()
 	}
 }
 
@@ -833,11 +831,6 @@ func (t *textGridRowRenderer) MinSize() fyne.Size {
 }
 
 func (t *textGridRowRenderer) Refresh() {
-	// we may be on a new canvas, so just update it to be sure
-	if fyne.CurrentApp() != nil && fyne.CurrentApp().Driver() != nil {
-		t.current = fyne.CurrentApp().Driver().CanvasForObject(t.obj.text.text)
-	}
-
 	th := t.obj.text.text.Theme()
 	v := fyne.CurrentApp().Settings().ThemeVariant()
 	TextGridStyleWhitespace = &CustomTextGridStyle{FGColor: th.Color(theme.ColorNameDisabled, v)}
@@ -853,19 +846,4 @@ func (t *textGridRowRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (t *textGridRowRenderer) Destroy() {
-}
-
-func (t *textGridRowRenderer) refresh(obj fyne.CanvasObject) {
-	if t.current == nil {
-		if fyne.CurrentApp() != nil && fyne.CurrentApp().Driver() != nil {
-			// cache canvas for this widget, so we don't look it up many times for every cell/row refresh!
-			t.current = fyne.CurrentApp().Driver().CanvasForObject(t.obj.text.text)
-		}
-
-		if t.current == nil {
-			return // not yet set up perhaps?
-		}
-	}
-
-	t.current.Refresh(obj)
 }

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -385,10 +385,7 @@ type textGridRenderer struct {
 }
 
 func (t *textGridRenderer) Layout(s fyne.Size) {
-	if t.scroll.Content != nil {
-		t.scroll.Resize(s)
-	}
-	t.text.Resize(s)
+	t.Objects()[0].Resize(s)
 }
 
 func (t *textGridRenderer) MinSize() fyne.Size {
@@ -528,7 +525,6 @@ func (t *textGridContentRenderer) addRowsIfRequired() {
 	for _, row := range t.visible {
 		if row.(*textGridRow).row < start || row.(*textGridRow).row > end {
 			toRemove = append(toRemove, row.(*textGridRow))
-			break
 		}
 	}
 
@@ -706,7 +702,7 @@ func (t *textGridRowRenderer) addCellsIfRequired() {
 func (t *textGridRowRenderer) refreshCells() {
 	x := 0
 	if t.obj.row >= len(t.obj.text.text.Rows) {
-		return // empty?
+		return // we can have more rows than content rows (filling space)
 	}
 
 	row := t.obj.text.text.Rows[t.obj.row]

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -481,14 +481,11 @@ func (t *textGridContentRenderer) Destroy() {
 }
 
 func (t *textGridContentRenderer) Layout(s fyne.Size) {
-	pos := fyne.NewPos(0, 0)
 	size := fyne.NewSize(s.Width, t.text.cellSize.Height)
 	t.updateGridSize(s)
 
 	for _, o := range t.visible {
-		pos = fyne.NewPos(0, float32(o.(*textGridRow).row)*t.text.cellSize.Height)
-
-		o.Move(pos)
+		o.Move(fyne.NewPos(0, float32(o.(*textGridRow).row)*t.text.cellSize.Height))
 		o.Resize(size)
 	}
 }

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -88,6 +88,17 @@ type TextGrid struct {
 	Scroll widget.ScrollDirection
 }
 
+// Append will add new lines to the end of this TextGrid.
+// The first character will be at the beginning of a new line and any newline characters will split the text further.
+//
+// Since: 2.6
+func (t *TextGrid) Append(text string) {
+	rows := t.parseRows(text)
+
+	t.Rows = append(t.Rows, rows...)
+	t.Refresh()
+}
+
 // MinSize returns the smallest size this widget can shrink to
 func (t *TextGrid) MinSize() fyne.Size {
 	t.ExtendBaseWidget(t)
@@ -105,22 +116,7 @@ func (t *TextGrid) Resize(size fyne.Size) {
 // The grid will use default text style and any previous content and style will be removed.
 // Tab characters are padded with spaces to the next tab stop.
 func (t *TextGrid) SetText(text string) {
-	lines := strings.Split(text, "\n")
-	rows := make([]TextGridRow, len(lines))
-	for i, line := range lines {
-		cells := make([]TextGridCell, 0, len(line))
-		for _, r := range line {
-			cells = append(cells, TextGridCell{Rune: r})
-			if r == '\t' {
-				col := len(cells)
-				next := nextTab(col-1, t.tabWidth())
-				for i := col; i < next; i++ {
-					cells = append(cells, TextGridCell{Rune: ' '})
-				}
-			}
-		}
-		rows[i] = TextGridRow{Cells: cells}
-	}
+	rows := t.parseRows(text)
 
 	t.Rows = rows
 	t.Refresh()
@@ -332,6 +328,27 @@ func (t *TextGrid) ensureCells(row, col int) {
 		data.Cells = append(data.Cells, TextGridCell{})
 		t.Rows[row] = data
 	}
+}
+
+func (t *TextGrid) parseRows(text string) []TextGridRow {
+	lines := strings.Split(text, "\n")
+	rows := make([]TextGridRow, len(lines))
+	for i, line := range lines {
+		cells := make([]TextGridCell, 0, len(line))
+		for _, r := range line {
+			cells = append(cells, TextGridCell{Rune: r})
+			if r == '\t' {
+				col := len(cells)
+				next := nextTab(col-1, t.tabWidth())
+				for i := col; i < next; i++ {
+					cells = append(cells, TextGridCell{Rune: ' '})
+				}
+			}
+		}
+		rows[i] = TextGridRow{Cells: cells}
+	}
+
+	return rows
 }
 
 func (t *TextGrid) refreshCell(row, col int) {

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -21,6 +21,13 @@ func TestNewTextGrid(t *testing.T) {
 	assert.Len(t, grid.Rows[0].Cells, 1)
 }
 
+func TestTextGrid_Append(t *testing.T) {
+	grid := NewTextGridFromString("Something\nElse")
+	grid.Append("Newline")
+
+	assert.Equal(t, "Something\nElse\nNewline", grid.Text())
+}
+
 func TestTextGrid_Scroll(t *testing.T) {
 	grid := NewTextGridFromString("Something\nElse")
 	grid.Resize(fyne.NewSize(50, 20))

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -7,6 +7,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
 
@@ -15,16 +16,35 @@ import (
 
 func TestNewTextGrid(t *testing.T) {
 	grid := NewTextGridFromString("A")
-	test.TempWidgetRenderer(t, grid).Refresh()
 
 	assert.Len(t, grid.Rows, 1)
 	assert.Len(t, grid.Rows[0].Cells, 1)
 }
 
+func TestTextGrid_Scroll(t *testing.T) {
+	grid := NewTextGridFromString("Something\nElse")
+	test.AssertObjectRendersToMarkup(t, "textgrid/basic.xml", grid)
+
+	scrolling := NewTextGridFromString("Something\nElse")
+	scrolling.Scroll = widget.ScrollBoth
+	scrolling.Refresh()
+	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
+
+	scrolling = NewTextGrid()
+	scrolling.Scroll = widget.ScrollBoth
+	scrolling.SetText("Something\nElse")
+	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
+
+	scrolling.Scroll = widget.ScrollNone
+	scrolling.Refresh()
+	test.AssertObjectRendersToMarkup(t, "textgrid/basic.xml", grid)
+}
+
 func TestTextGrid_CreateRendererRows(t *testing.T) {
 	grid := NewTextGrid()
 	grid.Resize(fyne.NewSize(52, 22))
-	rend := test.TempWidgetRenderer(t, grid).(*textGridRenderer)
+	wrap := test.TempWidgetRenderer(t, grid).(*textGridRenderer).text
+	rend := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
 	rend.Refresh()
 
 	assert.Len(t, rend.objects, 18)
@@ -168,7 +188,8 @@ func TestTextGridRenderer_ShowLineNumbers(t *testing.T) {
 func TestTextGridRender_Size(t *testing.T) {
 	grid := NewTextGrid()
 	grid.Resize(fyne.NewSize(30, 42)) // causes refresh
-	rend := test.TempWidgetRenderer(t, grid).(*textGridRenderer)
+	wrap := test.TempWidgetRenderer(t, grid).(*textGridRenderer).text
+	rend := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
 
 	assert.Equal(t, 3, rend.cols)
 	assert.Equal(t, 2, rend.rows)
@@ -236,7 +257,8 @@ func TestTextGridRender_TextColor(t *testing.T) {
 
 func assertGridContent(t *testing.T, g *TextGrid, expected string) {
 	lines := strings.Split(expected, "\n")
-	renderer := test.TempWidgetRenderer(t, g).(*textGridRenderer)
+	wrap := test.TempWidgetRenderer(t, g).(*textGridRenderer).text
+	renderer := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
 
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes
@@ -250,7 +272,8 @@ func assertGridContent(t *testing.T, g *TextGrid, expected string) {
 
 func assertGridStyle(t *testing.T, g *TextGrid, content string, expectedStyles map[string]TextGridStyle) {
 	lines := strings.Split(content, "\n")
-	renderer := test.TempWidgetRenderer(t, g).(*textGridRenderer)
+	wrap := test.TempWidgetRenderer(t, g).(*textGridRenderer).text
+	renderer := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
 
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes
@@ -286,7 +309,7 @@ func assertGridStyle(t *testing.T, g *TextGrid, content string, expectedStyles m
 	}
 }
 
-func rendererCell(r *textGridRenderer, row, col int) (*canvas.Rectangle, *canvas.Text) {
+func rendererCell(r *textGridContentRenderer, row, col int) (*canvas.Rectangle, *canvas.Text) {
 	i := (row*r.cols + col) * 3
 	return r.objects[i].(*canvas.Rectangle), r.objects[i+1].(*canvas.Text)
 }

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -23,19 +23,25 @@ func TestNewTextGrid(t *testing.T) {
 
 func TestTextGrid_Scroll(t *testing.T) {
 	grid := NewTextGridFromString("Something\nElse")
+	grid.Resize(fyne.NewSize(50, 20))
 	test.AssertObjectRendersToMarkup(t, "textgrid/basic.xml", grid)
 
 	scrolling := NewTextGridFromString("Something\nElse")
 	scrolling.Scroll = widget.ScrollBoth
+	scrolling.Resize(fyne.NewSize(50, 20))
 	scrolling.Refresh()
+	scrolling.scroll.ScrollToTop()
 	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
 
 	scrolling = NewTextGrid()
 	scrolling.Scroll = widget.ScrollBoth
+	scrolling.Resize(fyne.NewSize(50, 20))
 	scrolling.SetText("Something\nElse")
+	scrolling.scroll.ScrollToTop()
 	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
 
 	scrolling.Scroll = widget.ScrollNone
+	scrolling.Resize(fyne.NewSize(50, 20))
 	scrolling.Refresh()
 	test.AssertObjectRendersToMarkup(t, "textgrid/basic.xml", grid)
 }
@@ -47,7 +53,7 @@ func TestTextGrid_CreateRendererRows(t *testing.T) {
 	rend := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
 	rend.Refresh()
 
-	row := rend.rowObjects[0].(fyne.Widget)
+	row := rend.visible[0].(fyne.Widget)
 	rr := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
 	assert.Len(t, rr.objects, 18)
 }
@@ -195,7 +201,7 @@ func TestTextGridRender_Size(t *testing.T) {
 
 	assert.Equal(t, 2, rend.text.rows)
 
-	row := rend.rowObjects[0].(fyne.Widget)
+	row := rend.visible[0].(fyne.Widget)
 	rend2 := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
 	assert.Equal(t, 3, rend2.cols)
 }
@@ -268,7 +274,7 @@ func assertGridContent(t *testing.T, g *TextGrid, expected string) {
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes
 		for _, r := range line {
-			row := renderer.rowObjects[y].(fyne.Widget)
+			row := renderer.visible[y].(fyne.Widget)
 			rend2 := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
 
 			_, fg := rendererCell(rend2, x)
@@ -286,7 +292,7 @@ func assertGridStyle(t *testing.T, g *TextGrid, content string, expectedStyles m
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes
 
-		row := renderer.rowObjects[y].(fyne.Widget)
+		row := renderer.visible[y].(fyne.Widget)
 		rend2 := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
 
 		for _, r := range line {


### PR DESCRIPTION
Super fast monospace text is now possible.

Congratulations to anyone using Fyne for their first app by logging text ;)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.

```go
package main

import (
	"strconv"
	"time"

	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/container"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.New()
	w := a.NewWindow("Hello")

	tg := widget.NewTextGrid()
	tg.ShowLineNumbers = true
	tg.Scroll = container.ScrollBoth
	w.SetContent(tg)
	w.Resize(fyne.NewSize(120, 100))

	go func() {
		i := 0
		for {
			time.Sleep(time.Millisecond * 25)
			fyne.Do(func() {
				tg.Append("Another line added, this time it's..." + strconv.Itoa(i))
				i++
			})
		}
	}()
	w.ShowAndRun()
}
```