### PR TITLE
Playing with extended container support

### DIFF
--- a/container.go
+++ b/container.go
@@ -1,11 +1,15 @@
 package fyne
 
+import "fyne.io/fyne/v2/internal/types"
+
 // Declare conformity to [CanvasObject]
 var _ CanvasObject = (*Container)(nil)
 
 // Container is a [CanvasObject] that contains a collection of child objects.
 // The layout of the children is set by the specified Layout.
 type Container struct {
+	types.ContainerRoot
+
 	size     Size     // The current size of the Container
 	position Position // The current position of the Container
 	Hidden   bool     // Is this Container hidden

--- a/internal/types/container.go
+++ b/internal/types/container.go
@@ -1,0 +1,15 @@
+package types
+
+type container interface {
+	fyneTypeContainer()
+}
+
+type ContainerRoot struct {
+}
+
+func (c *ContainerRoot) fyneTypeContainer() {}
+
+func IsContainer(o any) bool { // any to avoid loop if using fyne.CanvasObject
+	_, ok := o.(container)
+	return ok
+}

--- a/internal/types/container_test.go
+++ b/internal/types/container_test.go
@@ -1,0 +1,21 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+	container2 "fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/internal/types"
+)
+
+func TestIsContainer(t *testing.T) {
+	assert.True(t, types.IsContainer(&fyne.Container{}))
+	assert.True(t, types.IsContainer(container2.NewWithoutLayout()))
+	assert.True(t, types.IsContainer(&extendedContainer{}))
+}
+
+type extendedContainer struct {
+	fyne.Container
+}


### PR DESCRIPTION
This allows us to type-check an extended container as though it were a container...

However I also need to solve how it can access the `Objects` and `Layout` fields... Head scratching continues.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
