### PR TITLE
Implement dead window cleanup without niling out

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -111,9 +111,6 @@ func (d *gLDriver) addWindow(w *window) {
 func (d *gLDriver) focusPreviousWindow() {
 	var chosen *window
 	for _, w := range d.windows {
-		if w == nil {
-			continue
-		}
 		win := w.(*window)
 		if !win.visible {
 			continue


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Reduces the chance of a potential crash for someone not expecting a nil window and is honestly a bit cleaner code wise.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

