### PR TITLE
Allow OnSelected of a tab to focus content

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -161,13 +161,11 @@ func (t *AppTabs) RemoveIndex(index int) {
 // Select sets the specified TabItem to be selected and its content visible.
 func (t *AppTabs) Select(item *TabItem) {
 	selectItem(t, item)
-	t.Refresh()
 }
 
 // SelectIndex sets the TabItem at the specific index to be selected and its content visible.
 func (t *AppTabs) SelectIndex(index int) {
 	selectIndex(t, index)
-	t.Refresh()
 }
 
 // SelectTab sets the specified TabItem to be selected and its content visible.

--- a/container/apptabs_test.go
+++ b/container/apptabs_test.go
@@ -97,6 +97,20 @@ func TestAppTabs_Select(t *testing.T) {
 	assert.Equal(t, tab2, tabs.Selected())
 }
 
+func TestAppTabs_SelectFocus(t *testing.T) {
+	tab1 := &TabItem{Text: "Test1", Content: widget.NewEntry()}
+	tab2 := &TabItem{Text: "Test2", Content: widget.NewEntry()}
+	tabs := NewAppTabs(tab1, tab2)
+	w := test.NewTempWindow(t, tabs)
+
+	tabs.OnSelected = func(t *TabItem) {
+		w.Canvas().Focus(t.Content.(*widget.Entry))
+	}
+
+	tabs.Select(tab2)
+	assert.Equal(t, tab2.Content, w.Canvas().Focused())
+}
+
 func TestAppTabs_SelectIndex(t *testing.T) {
 	tabs := NewAppTabs(&TabItem{Text: "Test1", Content: widget.NewLabel("Test1")},
 		&TabItem{Text: "Test2", Content: widget.NewLabel("Test2")})

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -152,7 +152,6 @@ func (t *DocTabs) Select(item *TabItem) {
 // SelectIndex sets the TabItem at the specific index to be selected and its content visible.
 func (t *DocTabs) SelectIndex(index int) {
 	selectIndex(t, index)
-	t.Refresh()
 }
 
 // Selected returns the currently selected TabItem.

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -204,6 +204,7 @@ func selectIndex(t baseTabs, index int) {
 
 	t.setTransitioning(true)
 	t.setSelected(index)
+	t.Refresh()
 
 	if f := t.onSelected(); f != nil {
 		// Notification of selected


### PR DESCRIPTION
It was a refresh order issue - focus manager could not "see" new item

Fixes #5454

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
