### PR TITLE
Clean up cleanup function queue in fyne_demo

### DIFF
--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -229,7 +229,7 @@ func makeNav(setTutorial func(tutorial tutorials.Tutorial), loadPrevious bool) f
 		OnSelected: func(uid string) {
 			if t, ok := tutorials.Tutorials[uid]; ok {
 				for _, f := range tutorials.OnChangeFuncs {
-					f(uid)
+					f()
 				}
 				tutorials.OnChangeFuncs = nil // Loading a page registers a new cleanup.
 

--- a/cmd/fyne_demo/tutorials/advanced.go
+++ b/cmd/fyne_demo/tutorials/advanced.go
@@ -37,12 +37,7 @@ func advancedScreen(win fyne.Window) fyne.CanvasObject {
 	))
 
 	ticker := time.NewTicker(time.Second)
-
-	OnChangeFuncs = append(OnChangeFuncs, func(page string) {
-		if page != "advanced" {
-			ticker.Stop()
-		}
-	})
+	OnChangeFuncs = append(OnChangeFuncs, ticker.Stop)
 
 	go func(canvas fyne.Canvas) {
 		for range ticker.C {

--- a/cmd/fyne_demo/tutorials/animation.go
+++ b/cmd/fyne_demo/tutorials/animation.go
@@ -46,12 +46,7 @@ func makeAnimationCanvas() fyne.CanvasObject {
 	a2.Curve = fyne.AnimationLinear
 	a2.Start()
 
-	OnChangeFuncs = append(OnChangeFuncs, func(page string) {
-		if page != "animations" {
-			a.Stop()
-			a2.Stop()
-		}
-	})
+	OnChangeFuncs = append(OnChangeFuncs, a.Stop, a2.Stop)
 
 	running := true
 	var toggle *widget.Button
@@ -78,14 +73,7 @@ func makeAnimationCurves() fyne.CanvasObject {
 	label3, box3, a3 := makeAnimationCurveItem("EaseOut", fyne.AnimationEaseOut, 60+theme.Padding()*2)
 	label4, box4, a4 := makeAnimationCurveItem("Linear", fyne.AnimationLinear, 90+theme.Padding()*3)
 
-	OnChangeFuncs = append(OnChangeFuncs, func(page string) {
-		if page != "animations" {
-			a1.Stop()
-			a2.Stop()
-			a3.Stop()
-			a4.Stop()
-		}
-	})
+	OnChangeFuncs = append(OnChangeFuncs, a1.Stop, a2.Stop, a3.Stop, a4.Stop)
 
 	start := widget.NewButton("Compare", func() {
 		a1.Start()

--- a/cmd/fyne_demo/tutorials/canvas.go
+++ b/cmd/fyne_demo/tutorials/canvas.go
@@ -22,11 +22,7 @@ func canvasScreen(_ fyne.Window) fyne.CanvasObject {
 	gradient := canvas.NewHorizontalGradient(color.NRGBA{0x80, 0, 0, 0xff}, color.NRGBA{0, 0x80, 0, 0xff})
 	ticker := time.NewTicker(time.Second)
 
-	OnChangeFuncs = append(OnChangeFuncs, func(page string) {
-		if page != "canvas" {
-			ticker.Stop()
-		}
-	})
+	OnChangeFuncs = append(OnChangeFuncs, ticker.Stop)
 
 	go func() {
 		for range ticker.C {

--- a/cmd/fyne_demo/tutorials/data.go
+++ b/cmd/fyne_demo/tutorials/data.go
@@ -6,7 +6,7 @@ import (
 
 // OnChangeFuncs is a slice of functions that can be registered
 // to run when the user switches tutorial.
-var OnChangeFuncs []func(string)
+var OnChangeFuncs []func()
 
 // Tutorial defines the data structure for a tutorial
 type Tutorial struct {

--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -418,12 +418,7 @@ func makeProgressTab(_ fyne.Window) fyne.CanvasObject {
 
 	progressAnimation.Start()
 
-	OnChangeFuncs = append(OnChangeFuncs, func(page string) {
-		if page != "progress" {
-			progressAnimation.Stop()
-			infProgress.Stop()
-		}
-	})
+	OnChangeFuncs = append(OnChangeFuncs, progressAnimation.Stop, infProgress.Stop)
 
 	return container.NewVBox(
 		widget.NewLabel("Percent"), progress,


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Right after having merged and read https://github.com/fyne-io/fyne/pull/5450#pullrequestreview-2573571888, I realised that the checks and page input string just was a leftover from before I cleared the queue of functions after having executed them. This means that I can just remove that part and use `func()` directly.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

