### PR TITLE
Use atomic.Uint64 for main goroutine ID

### DIFF
--- a/internal/async/goroutine_wasm.go
+++ b/internal/async/goroutine_wasm.go
@@ -3,5 +3,5 @@
 package async
 
 func goroutineID() uint64 {
-	return mainGoroutineID
+	return mainGoroutineID.Load()
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Just a bit faster and allows the `IsMainGoroutineID()` function to be inlined.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

