### PR TITLE
Correct the order of locale init to fix Android language lookup

### DIFF
--- a/lang/lang.go
+++ b/lang/lang.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"log"
 	"strings"
+	"sync"
 	"text/template"
 
 	"github.com/jeandeaual/go-locale"
@@ -37,6 +38,7 @@ var (
 
 	bundle    *i18n.Bundle
 	localizer *i18n.Localizer
+	setupOnce sync.Once
 
 	//go:embed translations
 	translations embed.FS
@@ -198,6 +200,8 @@ func setupLang(lang string) {
 
 // updateLocalizer Finds the closest translation from the user's locale list and sets it up
 func updateLocalizer() {
+	setupOnce.Do(initRuntime)
+
 	all, err := locale.GetLocales()
 	if err != nil {
 		fyne.LogError("Failed to load user locales", err)

--- a/lang/lang_android.go
+++ b/lang/lang_android.go
@@ -6,6 +6,6 @@ import (
 	"github.com/jeandeaual/go-locale"
 )
 
-func init() {
+func initRuntime() {
 	locale.SetRunOnJVM(app.RunOnJVM)
 }

--- a/lang/lang_notandroid.go
+++ b/lang/lang_notandroid.go
@@ -1,0 +1,5 @@
+//go:build !android
+
+package lang
+
+func initRuntime() {}


### PR DESCRIPTION

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- run on an android device - see it no longer logs "you first need to call SetRunOnJVM"
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
