### PR TITLE
Fixup glfw races in app package by respecting the ci flag we removed

### DIFF
--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -14,8 +14,9 @@ jobs:
         include:
           - os: ubuntu-latest
             runner: xvfb-run
+            tags: ci
           - os: macos-latest
-            tags: no_glfw
+            tags: no_glfw,ci
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Removing a race because we're running GLFW app in app tests, which we shouldn't.
The `ci` tag marks when the code should run in a different mode (in this case for the app package race).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- re-enabling an old build feature
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
