### PR TITLE
Fix deadlock in untyped binding

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -121,7 +121,6 @@ func (b *boundUntyped) Get() (any, error) {
 
 func (b *boundUntyped) Set(val any) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if b.val.Interface() == val {
 		return nil
 	}
@@ -131,6 +130,7 @@ func (b *boundUntyped) Set(val any) error {
 	} else {
 		b.val.Set(reflect.ValueOf(val))
 	}
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil
@@ -174,12 +174,12 @@ type boundExternalUntyped struct {
 
 func (b *boundExternalUntyped) Set(val any) error {
 	b.lock.Lock()
-	defer b.lock.Unlock()
 	if b.old == val {
 		return nil
 	}
 	b.val.Set(reflect.ValueOf(val))
 	b.old = val
+	b.lock.Unlock()
 
 	b.trigger()
 	return nil

--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -122,6 +122,7 @@ func (b *boundUntyped) Get() (any, error) {
 func (b *boundUntyped) Set(val any) error {
 	b.lock.Lock()
 	if b.val.Interface() == val {
+		b.lock.Unlock()
 		return nil
 	}
 	if val == nil {
@@ -175,6 +176,7 @@ type boundExternalUntyped struct {
 func (b *boundExternalUntyped) Set(val any) error {
 	b.lock.Lock()
 	if b.old == val {
+		b.lock.Unlock()
 		return nil
 	}
 	b.val.Set(reflect.ValueOf(val))


### PR DESCRIPTION
Unlock before triggering callbacks for untyped bind

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
