### PR TITLE
Avoid allocating for each binding trigger

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -57,42 +57,37 @@ func (l *listener) DataChanged() {
 }
 
 type base struct {
-	listenerLock sync.Mutex
-	listeners    []DataListener
+	listeners []DataListener
 
 	lock sync.RWMutex
 }
 
 // AddListener allows a data listener to be informed of changes to this item.
 func (b *base) AddListener(l DataListener) {
-	b.listenerLock.Lock()
-	b.listeners = append(b.listeners, l)
-	b.listenerLock.Unlock()
-	queueItem(l.DataChanged)
+	queueItem(func() {
+		b.listeners = append(b.listeners, l)
+		l.DataChanged()
+	})
 }
 
 // RemoveListener should be called if the listener is no longer interested in being informed of data change events.
 func (b *base) RemoveListener(l DataListener) {
-	b.listenerLock.Lock()
-	defer b.listenerLock.Unlock()
-
-	for i, listener := range b.listeners {
-		if listener == l {
-			// Delete without preserving order:
-			lastIndex := len(b.listeners) - 1
-			b.listeners[i] = b.listeners[lastIndex]
-			b.listeners[lastIndex] = nil
-			b.listeners = b.listeners[:lastIndex]
-			return
+	queueItem(func() {
+		for i, listener := range b.listeners {
+			if listener == l {
+				// Delete without preserving order:
+				lastIndex := len(b.listeners) - 1
+				b.listeners[i] = b.listeners[lastIndex]
+				b.listeners[lastIndex] = nil
+				b.listeners = b.listeners[:lastIndex]
+				return
+			}
 		}
-	}
-
+	})
 }
 
 func (b *base) trigger() {
 	queueItem(func() {
-		b.listenerLock.Lock()
-		defer b.listenerLock.Unlock()
 		for _, listen := range b.listeners {
 			listen.DataChanged()
 		}

--- a/data/binding/binding_test.go
+++ b/data/binding/binding_test.go
@@ -12,14 +12,14 @@ type simpleItem struct {
 
 func TestBase_AddListener(t *testing.T) {
 	data := &simpleItem{}
-	assert.Equal(t, 0, data.listeners.Len())
+	assert.Equal(t, 0, len(data.listeners))
 
 	called := false
 	fn := NewDataListener(func() {
 		called = true
 	})
 	data.AddListener(fn)
-	assert.Equal(t, 1, data.listeners.Len())
+	assert.Equal(t, 1, len(data.listeners))
 	assert.True(t, called)
 }
 
@@ -29,11 +29,11 @@ func TestBase_RemoveListener(t *testing.T) {
 		called = true
 	})
 	data := &simpleItem{}
-	data.listeners.Store(fn, true)
+	data.listeners = append(data.listeners, fn)
 
-	assert.Equal(t, 1, data.listeners.Len())
+	assert.Equal(t, 1, len(data.listeners))
 	data.RemoveListener(fn)
-	assert.Equal(t, 0, data.listeners.Len())
+	assert.Equal(t, 0, len(data.listeners))
 
 	data.trigger()
 	assert.False(t, called)

--- a/data/binding/lists_test.go
+++ b/data/binding/lists_test.go
@@ -12,14 +12,14 @@ type simpleList struct {
 
 func TestListBase_AddListener(t *testing.T) {
 	data := &simpleList{}
-	assert.Equal(t, 0, data.listeners.Len())
+	assert.Equal(t, 0, len(data.listeners))
 
 	called := false
 	fn := NewDataListener(func() {
 		called = true
 	})
 	data.AddListener(fn)
-	assert.Equal(t, 1, data.listeners.Len())
+	assert.Equal(t, 1, len(data.listeners))
 
 	data.trigger()
 	assert.True(t, called)
@@ -55,11 +55,11 @@ func TestListBase_RemoveListener(t *testing.T) {
 		called = true
 	})
 	data := &simpleList{}
-	data.listeners.Store(fn, true)
+	data.listeners = append(data.listeners, fn)
 
-	assert.Equal(t, 1, data.listeners.Len())
+	assert.Equal(t, 1, len(data.listeners))
 	data.RemoveListener(fn)
-	assert.Equal(t, 0, data.listeners.Len())
+	assert.Equal(t, 0, len(data.listeners))
 
 	data.trigger()
 	assert.False(t, called)

--- a/data/binding/trees_test.go
+++ b/data/binding/trees_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestTreeBase_AddListener(t *testing.T) {
 	data := newSimpleTree()
-	assert.Equal(t, 0, data.listeners.Len())
+	assert.Equal(t, 0, len(data.listeners))
 
 	called := false
 	fn := NewDataListener(func() {
 		called = true
 	})
 	data.AddListener(fn)
-	assert.Equal(t, 1, data.listeners.Len())
+	assert.Equal(t, 1, len(data.listeners))
 
 	data.trigger()
 	assert.True(t, called)
@@ -52,11 +52,11 @@ func TestTreeBase_RemoveListener(t *testing.T) {
 		called = true
 	})
 	data := newSimpleTree()
-	data.listeners.Store(fn, true)
+	data.listeners = append(data.listeners, fn)
 
-	assert.Equal(t, 1, data.listeners.Len())
+	assert.Equal(t, 1, len(data.listeners))
 	data.RemoveListener(fn)
-	assert.Equal(t, 0, data.listeners.Len())
+	assert.Equal(t, 0, len(data.listeners))
 
 	data.trigger()
 	assert.False(t, called)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This reworks data listeners for bindings to be a bit smarter. Instead of using a map (with unnecessary bool parameter) to store the listener, we just use a regular slice. We iterate over this slice in the queued operation without needing to append to a new slice first. Delete is a bit more expensive (and more code because with don't use Go 1.21 yet and can't use the `slices` package) but add is the one that is more common and trigger is the most common so it makes sense to optimise for the common path. A second lock is needed to not deadlock tests for some reason and it also avoids contention between value updates.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

