### PR TITLE
Just resize/move, not refresh content, for Split.SetOffset

### DIFF
--- a/container/split.go
+++ b/container/split.go
@@ -24,7 +24,7 @@ type Split struct {
 	// to communicate to the renderer that the next refresh
 	// is just an offset update (ie a resize and move only)
 	// cleared by renderer in Refresh()
-	nextRefreshIsOffsetUpdate bool
+	offsetUpdated bool
 }
 
 // NewHSplit creates a horizontally arranged container with the specified leading and trailing elements.
@@ -81,7 +81,7 @@ func (s *Split) SetOffset(offset float64) {
 		return
 	}
 	s.Offset = offset
-	s.nextRefreshIsOffsetUpdate = true
+	s.offsetUpdated = true
 	s.Refresh()
 }
 
@@ -153,9 +153,9 @@ func (r *splitContainerRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (r *splitContainerRenderer) Refresh() {
-	if r.split.nextRefreshIsOffsetUpdate {
+	if r.split.offsetUpdated {
 		r.Layout(r.split.Size())
-		r.split.nextRefreshIsOffsetUpdate = false
+		r.split.offsetUpdated = false
 		return
 	}
 

--- a/container/split.go
+++ b/container/split.go
@@ -20,6 +20,11 @@ type Split struct {
 	Horizontal bool
 	Leading    fyne.CanvasObject
 	Trailing   fyne.CanvasObject
+
+	// to communicate to the renderer that the next refresh
+	// is just an offset update (ie a resize and move only)
+	// cleared by renderer in Refresh()
+	nextRefreshIsOffsetUpdate bool
 }
 
 // NewHSplit creates a horizontally arranged container with the specified leading and trailing elements.
@@ -76,6 +81,7 @@ func (s *Split) SetOffset(offset float64) {
 		return
 	}
 	s.Offset = offset
+	s.nextRefreshIsOffsetUpdate = true
 	s.Refresh()
 }
 
@@ -147,6 +153,12 @@ func (r *splitContainerRenderer) Objects() []fyne.CanvasObject {
 }
 
 func (r *splitContainerRenderer) Refresh() {
+	if r.split.nextRefreshIsOffsetUpdate {
+		r.Layout(r.split.Size())
+		r.split.nextRefreshIsOffsetUpdate = false
+		return
+	}
+
 	r.objects[0] = r.split.Leading
 	// [1] is divider which doesn't change
 	r.objects[2] = r.split.Trailing

--- a/container/split_test.go
+++ b/container/split_test.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -520,4 +521,32 @@ func TestSplitContainer_Hidden(t *testing.T) {
 		sc.SetOffset(1)
 		assert.Equal(t, float32(0), sc.Trailing.Size().Height)
 	})
+}
+
+func TestSplitContainer_UpdateOffsetDoesNotRefreshContent(t *testing.T) {
+	objA := &refreshCountingWidget{}
+	objB := &refreshCountingWidget{}
+	split := NewHSplit(objA, objB)
+	split.SetOffset(0.4)
+	assert.Equal(t, 0, objA.refreshCount)
+	assert.Equal(t, 0, objB.refreshCount)
+
+	split.Refresh()
+	assert.Equal(t, 1, objA.refreshCount)
+	assert.Equal(t, 1, objB.refreshCount)
+}
+
+type refreshCountingWidget struct {
+	widget.BaseWidget
+
+	refreshCount int
+}
+
+func (r *refreshCountingWidget) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(canvas.NewRectangle(color.Transparent))
+}
+
+func (r *refreshCountingWidget) Refresh() {
+	r.refreshCount += 1
+	r.BaseWidget.Refresh()
 }


### PR DESCRIPTION
### Description:

Split.SetOffset, which is also called by the divider when dragged, no longer refreshes content but just resizes/moves.

Fixes #5488 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
