### PR TITLE
Make GridWrap more efficient by avoiding unnecessary content refreshes when resizing, scrolling

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -165,15 +165,7 @@ func (l *GridWrap) RefreshItem(id GridWrapItemID) {
 
 // Resize is called when this GridWrap should change size. We refresh to ensure invisible items are drawn.
 func (l *GridWrap) Resize(s fyne.Size) {
-	oldColCount := l.ColumnCount()
 	l.colCountCache = 0
-	newColCount := l.ColumnCount()
-
-	if oldColCount == newColCount && l.size.Height == s.Height {
-		// no content update needed if resizing only horizontally and col count is unchanged
-		l.BaseWidget.Resize(s)
-		return
-	}
 
 	l.BaseWidget.Resize(s)
 	if l.scroller != nil {

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -165,9 +165,16 @@ func (l *GridWrap) RefreshItem(id GridWrapItemID) {
 
 // Resize is called when this GridWrap should change size. We refresh to ensure invisible items are drawn.
 func (l *GridWrap) Resize(s fyne.Size) {
+	oldColCount := l.ColumnCount()
 	l.colCountCache = 0
-
 	l.BaseWidget.Resize(s)
+	newColCount := l.ColumnCount()
+
+	if oldColCount == newColCount && l.size.Height == s.Height {
+		// no content update needed if resizing only horizontally and col count is unchanged
+		return
+	}
+
 	if l.scroller != nil {
 		l.offsetUpdated(l.scroller.Offset)
 		l.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).updateGrid(true)


### PR DESCRIPTION
### Description:
Avoids refreshing content when not necessary during GridWrap.Resize and scrolling. Applies the same optimization from List to only refresh newly visible items unless doing the full Refresh call.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
