### PR TITLE
Support canvas.Image to parse gif images.

### DIFF
--- a/internal/gif/gif.go
+++ b/internal/gif/gif.go
@@ -1,0 +1,28 @@
+package gif
+
+import (
+	"bytes"
+	"fyne.io/fyne/v2"
+	"path/filepath"
+	"strings"
+)
+
+func IsFileGIF(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".gif")
+}
+
+// IsResourceGIF checks if the resource is a GIF or not.
+func IsResourceGIF(res fyne.Resource) bool {
+	if IsFileGIF(res.Name()) {
+		return true
+	}
+
+	var content []byte = res.Content()
+	// Check if content starts with GIF header "GIF87a" or "GIF89a"
+	if len(content) >= 6 {
+		if bytes.Equal(content[:6], []byte("GIF87a")) || bytes.Equal(content[:6], []byte("GIF89a")) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gif/is_gif_test.go
+++ b/internal/gif/is_gif_test.go
@@ -1,0 +1,23 @@
+package gif
+
+import (
+	"fyne.io/fyne/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsFileGIF(t *testing.T) {
+	assert.True(t, IsFileGIF("test.gif"))
+	assert.True(t, IsFileGIF("test.GIF"))
+	assert.False(t, IsFileGIF("testgif"))
+	assert.False(t, IsFileGIF("test.png"))
+}
+
+func TestIsResourceGIF(t *testing.T) {
+	res, err := fyne.LoadResourceFromPath("../../cmd/fyne/internal/templates/data/spinner_light.gif")
+	assert.Nil(t, err)
+	assert.True(t, IsResourceGIF(res))
+
+	res.(*fyne.StaticResource).StaticName = "stroke"
+	assert.True(t, IsResourceGIF(res))
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Support canvas.Image to parse gif images. Like `canvas.NewImageFromFile("xx.gif")`

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

