### PR TITLE
Initial implementation of navigation container

### DIFF
--- a/container/navigation.go
+++ b/container/navigation.go
@@ -1,0 +1,118 @@
+package container
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+)
+
+// Navigation container is used to provide your application with a control bar and an area for content objects.
+// Objects can be any CanvasObject, and only the most recent one will be visible.
+//
+// Since: 2.6
+type Navigation struct {
+	widget.BaseWidget
+	control *fyne.Container
+	stack   *fyne.Container
+	button  *widget.Button
+	label   *widget.Label
+	title   string
+	titles  []string
+}
+
+// NewNavigation creates a new navigation container allowing to pass in one or more objects.
+//
+// Since: 2.6
+func NewNavigation(s string, objs ...fyne.CanvasObject) *Navigation {
+	button := widget.NewButtonWithIcon("", theme.NavigateBackIcon(), nil)
+	label := widget.NewLabelWithStyle(s, fyne.TextAlignCenter, fyne.TextStyle{Bold: true})
+	titles := make([]string, len(objs))
+	for n := 0; n < len(objs); n++ {
+		titles[n] = s
+	}
+	nav := &Navigation{
+		button:  button,
+		control: NewStack(NewHBox(button), label),
+		stack:   NewStack(objs...),
+		label:   label,
+		title:   s,
+		titles:  titles,
+	}
+	nav.ExtendBaseWidget(nav)
+	nav.button.OnTapped = func() {
+		nav.Pop()
+	}
+	if len(objs) <= 1 {
+		nav.button.Disable()
+	}
+
+	return nav
+}
+
+// Push puts the given object on top of the navigation stack and hides the object below.
+//
+// Since: 2.6
+func (nav *Navigation) Push(obj fyne.CanvasObject) {
+	nav.PushWithTitle(obj, nav.titles[len(nav.titles)-1])
+}
+
+// PushWithTitle puts the given CanvasObject on top, hides the object below, and uses the given title as label text.
+//
+// Since: 2.6
+func (nav *Navigation) PushWithTitle(obj fyne.CanvasObject, s string) {
+	objs := nav.stack.Objects
+	if len(objs) > 0 {
+		objs[len(objs)-1].Hide()
+	}
+	nav.stack.Objects = append(objs, obj)
+	if len(nav.stack.Objects) > 1 {
+		nav.button.Enable()
+	}
+
+	nav.titles = append(nav.titles, s)
+	nav.label.SetText(s)
+}
+
+// Pop return the top level CanvasObject, adjusts the title accordingly, and disabled the back button
+// when no more objects are left to go back to.
+//
+// Since: 2.6
+func (nav *Navigation) Pop() fyne.CanvasObject {
+	objs := nav.stack.Objects
+	if len(objs) == 0 {
+		return nil
+	}
+	obj := objs[len(objs)-1]
+	objs = objs[:len(objs)-1]
+	if len(objs) > 0 {
+		objs[len(objs)-1].Show()
+	}
+	nav.stack.Objects = objs
+	if len(nav.stack.Objects) <= 1 {
+		nav.button.Disable()
+	}
+
+	if len(nav.titles) > 0 {
+		nav.titles = nav.titles[:len(nav.titles)-1]
+	}
+	title := nav.title
+	if len(nav.titles) > 0 {
+		title = nav.titles[len(nav.titles)-1]
+	}
+	nav.label.SetText(title)
+
+	return obj
+}
+
+// SetTitle changes the navigation title and the title for the current object.
+//
+// Since: 2.6
+func (nav *Navigation) SetTitle(s string) {
+	nav.title = s
+	nav.titles[len(nav.titles)-1] = s
+	nav.label.SetText(s)
+}
+
+func (nav *Navigation) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(NewBorder(nav.control, nil, nil, nil, nav.stack))
+}

--- a/container/navigation_test.go
+++ b/container/navigation_test.go
@@ -1,0 +1,104 @@
+package container
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNavigation_Basics(t *testing.T) {
+	l := widget.NewLabel("something")
+	nav := NewNavigation("Title", l)
+
+	assert.Equal(t, true, nav.button.Disabled())
+	assert.Equal(t, 1, len(nav.stack.Objects))
+	assert.Equal(t, 1, len(nav.titles))
+
+	assert.Equal(t, l, nav.Pop())
+
+	assert.Equal(t, "Title", nav.label.Text)
+}
+
+func TestNavigation_NewWithMultiple(t *testing.T) {
+	a := widget.NewLabel("a")
+	b := widget.NewLabel("b")
+	c := widget.NewLabel("c")
+	nav := NewNavigation("Title", a, b, c)
+
+	assert.Equal(t, false, nav.button.Disabled())
+	assert.Equal(t, 3, len(nav.stack.Objects))
+	assert.Equal(t, 3, len(nav.titles))
+
+	assert.Equal(t, c, nav.Pop())
+	assert.Equal(t, "Title", nav.label.Text)
+	assert.Equal(t, 2, len(nav.stack.Objects))
+	assert.Equal(t, 2, len(nav.titles))
+	assert.Equal(t, false, nav.button.Disabled())
+
+	assert.Equal(t, b, nav.Pop())
+	assert.Equal(t, "Title", nav.label.Text)
+	assert.Equal(t, 1, len(nav.stack.Objects))
+	assert.Equal(t, 1, len(nav.titles))
+	assert.Equal(t, true, nav.button.Disabled())
+}
+
+func TestNavigation_PushWithTitle(t *testing.T) {
+	a := widget.NewLabel("a")
+	b := widget.NewLabel("b")
+	c := widget.NewLabel("c")
+	nav := NewNavigation("Title")
+
+	assert.Equal(t, true, nav.button.Disabled())
+	assert.Equal(t, 0, len(nav.stack.Objects))
+	assert.Equal(t, 0, len(nav.titles))
+
+	nav.PushWithTitle(a, "A")
+	assert.Equal(t, "A", nav.label.Text)
+	assert.Equal(t, true, nav.button.Disabled())
+
+	nav.PushWithTitle(b, "B")
+	assert.Equal(t, "B", nav.label.Text)
+	assert.Equal(t, false, nav.button.Disabled())
+
+	nav.PushWithTitle(c, "C")
+	assert.Equal(t, "C", nav.label.Text)
+	assert.Equal(t, false, nav.button.Disabled())
+
+	assert.Equal(t, c, nav.Pop())
+	assert.Equal(t, "B", nav.label.Text)
+	assert.Equal(t, 2, len(nav.stack.Objects))
+	assert.Equal(t, 2, len(nav.titles))
+	assert.Equal(t, false, nav.button.Disabled())
+
+	assert.Equal(t, b, nav.Pop())
+	assert.Equal(t, "A", nav.label.Text)
+	assert.Equal(t, 1, len(nav.stack.Objects))
+	assert.Equal(t, 1, len(nav.titles))
+	assert.Equal(t, true, nav.button.Disabled())
+
+	assert.Equal(t, a, nav.Pop())
+	assert.Equal(t, "Title", nav.label.Text)
+	assert.Equal(t, 0, len(nav.stack.Objects))
+	assert.Equal(t, 0, len(nav.titles))
+	assert.Equal(t, true, nav.button.Disabled())
+
+	assert.Nil(t, nav.Pop())
+	assert.Equal(t, "Title", nav.label.Text)
+	assert.Equal(t, 0, len(nav.stack.Objects))
+	assert.Equal(t, 0, len(nav.titles))
+	assert.Equal(t, true, nav.button.Disabled())
+}
+
+func TestNavigation_Empty(t *testing.T) {
+	nav := NewNavigation("Title")
+
+	assert.Equal(t, true, nav.button.Disabled())
+	assert.Equal(t, 0, len(nav.stack.Objects))
+	assert.Equal(t, 0, len(nav.titles))
+
+	assert.Nil(t, nav.Pop())
+
+	assert.Equal(t, "Title", nav.label.Text)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

This add a basic navigation container type with back button and title. Sponsored by Fyne Labs.

How it looks like:


https://github.com/user-attachments/assets/e8e70946-1dae-4d9d-824e-6905717ef5d0




Example code:
```go
package main

import (
	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/container"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.NewWithID("fyne-navigation")
	w := a.NewWindow("Hello World")

	var nav *container.Navigation
	var view1, view2, view3 *fyne.Container

	view1 = container.NewVBox(
		widget.NewLabel("Foo"),
		widget.NewButton("Push!", func() {
			nav.PushWithTitle(view2, "Bar Title")
		}),
	)

	view2 = container.NewVBox(
		widget.NewLabel("Bar"),
		widget.NewButton("More!", func() {
			nav.PushWithTitle(view3, "Baz Title")
		}),
	)

	view3 = container.NewVBox(
		widget.NewLabel("Baz"),
	)

	nav = container.NewNavigation("NavNavNav", view1)

	w.SetContent(nav)
	w.Resize(fyne.NewSize(400, 400))
	w.ShowAndRun()
}
```




### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [X] Public APIs match existing style and have Since: line.