### PR TITLE
Clean up leftovers from making bindings generic

### DIFF
--- a/data/binding/binding.go
+++ b/data/binding/binding.go
@@ -87,11 +87,13 @@ func (b *base) RemoveListener(l DataListener) {
 }
 
 func (b *base) trigger() {
-	fyne.Do(func() {
-		for _, listen := range b.listeners {
-			listen.DataChanged()
-		}
-	})
+	fyne.Do(b.triggerFromMain)
+}
+
+func (b *base) triggerFromMain() {
+	for _, listen := range b.listeners {
+		listen.DataChanged()
+	}
 }
 
 // Untyped supports binding a any value.

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -208,7 +208,7 @@ type convertBaseItem struct {
 }
 
 func (s *convertBaseItem) DataChanged() {
-	s.trigger()
+	s.triggerFromMain()
 }
 
 type toStringFrom[T any] struct {

--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -203,8 +203,16 @@ func toStringWithFormatComparable[T bool | float64 | int](v bindableItem[T], for
 	return toStringWithFormat(v, format, defaultFormat, formatter, func(t1, t2 T) bool { return t1 == t2 }, parser)
 }
 
-type toStringFrom[T any] struct {
+type convertBaseItem struct {
 	base
+}
+
+func (s *convertBaseItem) DataChanged() {
+	s.trigger()
+}
+
+type toStringFrom[T any] struct {
+	convertBaseItem
 
 	format string
 
@@ -262,12 +270,8 @@ func (s *toStringFrom[T]) Set(str string) error {
 	return nil
 }
 
-func (s *toStringFrom[T]) DataChanged() {
-	s.trigger()
-}
-
 type fromStringTo[T any] struct {
-	base
+	convertBaseItem
 
 	format    string
 	formatter func(string) (T, error)
@@ -328,12 +332,8 @@ func (s *fromStringTo[T]) Set(val T) error {
 	return nil
 }
 
-func (s *fromStringTo[T]) DataChanged() {
-	s.trigger()
-}
-
 type toInt[T float64] struct {
-	base
+	convertBaseItem
 
 	formatter func(int) (T, error)
 	parser    func(T) (int, error)
@@ -371,12 +371,8 @@ func (s *toInt[T]) Set(v int) error {
 	return nil
 }
 
-func (s *toInt[T]) DataChanged() {
-	s.trigger()
-}
-
 type fromIntTo[T float64] struct {
-	base
+	convertBaseItem
 
 	formatter func(int) (T, error)
 	parser    func(T) (int, error)
@@ -410,8 +406,4 @@ func (s *fromIntTo[T]) Set(val T) error {
 
 	s.trigger()
 	return nil
-}
-
-func (s *fromIntTo[T]) DataChanged() {
-	s.trigger()
 }

--- a/data/binding/preference.go
+++ b/data/binding/preference.go
@@ -1,37 +1,25 @@
 package binding
 
-import "fyne.io/fyne/v2"
+import (
+	"sync/atomic"
+
+	"fyne.io/fyne/v2"
+)
+
+// Work around Go not supporting generic methods on non-generic types:
+type preferenceLookupSetter[T any] func(fyne.Preferences) (func(string) T, func(string, T))
 
 const keyTypeMismatchError = "A previous preference binding exists with different type for key: "
-
-type prefBoundBool struct {
-	prefBoundBase[bool]
-}
 
 // BindPreferenceBool returns a bindable bool value that is managed by the application preferences.
 // Changes to this value will be saved to application storage and when the app starts the previous values will be read.
 //
 // Since: 2.0
 func BindPreferenceBool(key string, p fyne.Preferences) Bool {
-	if found, ok := lookupExistingBinding[bool](key, p); ok {
-		return found
-	}
-
-	listen := &prefBoundBool{}
-	listen.setKey(key)
-	listen.replaceProvider(p)
-	binds := prefBinds.ensurePreferencesAttached(p)
-	binds.Store(key, listen)
-	return listen
-}
-
-func (b *prefBoundBool) replaceProvider(p fyne.Preferences) {
-	b.get = p.Bool
-	b.set = p.SetBool
-}
-
-type prefBoundFloat struct {
-	prefBoundBase[float64]
+	return bindPreferenceItem(key, p,
+		func(p fyne.Preferences) (func(string) bool, func(string, bool)) {
+			return p.Bool, p.SetBool
+		})
 }
 
 // BindPreferenceFloat returns a bindable float64 value that is managed by the application preferences.
@@ -39,25 +27,10 @@ type prefBoundFloat struct {
 //
 // Since: 2.0
 func BindPreferenceFloat(key string, p fyne.Preferences) Float {
-	if found, ok := lookupExistingBinding[float64](key, p); ok {
-		return found
-	}
-
-	listen := &prefBoundFloat{}
-	listen.setKey(key)
-	listen.replaceProvider(p)
-	binds := prefBinds.ensurePreferencesAttached(p)
-	binds.Store(key, listen)
-	return listen
-}
-
-func (b *prefBoundFloat) replaceProvider(p fyne.Preferences) {
-	b.get = p.Float
-	b.set = p.SetFloat
-}
-
-type prefBoundInt struct {
-	prefBoundBase[int]
+	return bindPreferenceItem(key, p,
+		func(p fyne.Preferences) (func(string) float64, func(string, float64)) {
+			return p.Float, p.SetFloat
+		})
 }
 
 // BindPreferenceInt returns a bindable int value that is managed by the application preferences.
@@ -65,25 +38,10 @@ type prefBoundInt struct {
 //
 // Since: 2.0
 func BindPreferenceInt(key string, p fyne.Preferences) Int {
-	if found, ok := lookupExistingBinding[int](key, p); ok {
-		return found
-	}
-
-	listen := &prefBoundInt{}
-	listen.setKey(key)
-	listen.replaceProvider(p)
-	binds := prefBinds.ensurePreferencesAttached(p)
-	binds.Store(key, listen)
-	return listen
-}
-
-func (b *prefBoundInt) replaceProvider(p fyne.Preferences) {
-	b.get = p.Int
-	b.set = p.SetInt
-}
-
-type prefBoundString struct {
-	prefBoundBase[string]
+	return bindPreferenceItem(key, p,
+		func(p fyne.Preferences) (func(string) int, func(string, int)) {
+			return p.Int, p.SetInt
+		})
 }
 
 // BindPreferenceString returns a bindable string value that is managed by the application preferences.
@@ -91,19 +49,73 @@ type prefBoundString struct {
 //
 // Since: 2.0
 func BindPreferenceString(key string, p fyne.Preferences) String {
-	if found, ok := lookupExistingBinding[string](key, p); ok {
+	return bindPreferenceItem(key, p,
+		func(p fyne.Preferences) (func(string) string, func(string, string)) {
+			return p.String, p.SetString
+		})
+}
+
+func bindPreferenceItem[T bool | float64 | int | string](key string, p fyne.Preferences, setLookup preferenceLookupSetter[T]) bindableItem[T] {
+	if found, ok := lookupExistingBinding[T](key, p); ok {
 		return found
 	}
 
-	listen := &prefBoundString{}
-	listen.setKey(key)
+	listen := &prefBoundBase[T]{key: key, setLookup: setLookup}
 	listen.replaceProvider(p)
 	binds := prefBinds.ensurePreferencesAttached(p)
 	binds.Store(key, listen)
 	return listen
 }
 
-func (b *prefBoundString) replaceProvider(p fyne.Preferences) {
-	b.get = p.String
-	b.set = p.SetString
+func lookupExistingBinding[T any](key string, p fyne.Preferences) (bindableItem[T], bool) {
+	binds := prefBinds.getBindings(p)
+	if binds == nil {
+		return nil, false
+	}
+
+	if listen, ok := binds.Load(key); listen != nil && ok {
+		if l, ok := listen.(bindableItem[T]); ok {
+			return l, ok
+		}
+		fyne.LogError(keyTypeMismatchError+key, nil)
+	}
+
+	return nil, false
+}
+
+type prefBoundBase[T bool | float64 | int | string] struct {
+	base
+	key string
+
+	get       func(string) T
+	set       func(string, T)
+	setLookup preferenceLookupSetter[T]
+	cache     atomic.Pointer[T]
+}
+
+func (b *prefBoundBase[T]) Get() (T, error) {
+	cache := b.get(b.key)
+	b.cache.Store(&cache)
+	return cache, nil
+}
+
+func (b *prefBoundBase[T]) Set(v T) error {
+	b.set(b.key, v)
+
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+	b.trigger()
+	return nil
+}
+
+func (b *prefBoundBase[T]) checkForChange() {
+	val := b.cache.Load()
+	if val != nil && b.get(b.key) == *val {
+		return
+	}
+	b.trigger()
+}
+
+func (b *prefBoundBase[T]) replaceProvider(p fyne.Preferences) {
+	b.get, b.set = b.setLookup(p)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I finally managed to clean up preferences bindings (and move them to the right file) but I also removed some duplication from convertions.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- covered by existing tests
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
