### PR TITLE
We can ignore warnings if the request for background execution is not waiting

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -57,9 +57,13 @@ func toOSIcon(icon []byte) ([]byte, error) {
 }
 
 func (d *gLDriver) DoFromGoroutine(f func(), wait bool) {
-	async.EnsureNotMain(func() {
-		runOnMainWithWait(f, wait)
-	})
+	if wait {
+		async.EnsureNotMain(func() {
+			runOnMainWithWait(f, true)
+		})
+	} else {
+		runOnMainWithWait(f, false)
+	}
 }
 
 func (d *gLDriver) RenderedTextSize(text string, textSize float32, style fyne.TextStyle, source fyne.Resource) (size fyne.Size, baseline float32) {

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -97,9 +97,7 @@ func (d *driver) DoFromGoroutine(fn func(), wait bool) {
 	}
 
 	if wait {
-		async.EnsureNotMain(func() {
-			caller()
-		})
+		async.EnsureNotMain(caller)
 	} else {
 		caller()
 	}

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -73,7 +73,7 @@ func init() {
 }
 
 func (d *driver) DoFromGoroutine(fn func(), wait bool) {
-	async.EnsureNotMain(func() {
+	caller := func() {
 		if d.queuedFuncs == nil {
 			fn() // before the app actually starts
 			return
@@ -94,7 +94,16 @@ func (d *driver) DoFromGoroutine(fn func(), wait bool) {
 		if wait {
 			<-done
 		}
-	})
+	}
+
+	if wait {
+		async.EnsureNotMain(func() {
+			caller()
+		})
+	} else {
+		caller()
+	}
+
 }
 
 func (d *driver) CreateWindow(title string) fyne.Window {


### PR DESCRIPTION
as discussed on #5508 , main (not waiting) from main is OK now. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
