### PR TITLE
Add a noCopy struct so `go vet` complains about copying widgets

### DIFF
--- a/widget/widget.go
+++ b/widget/widget.go
@@ -9,12 +9,6 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-type noCopy struct{}
-
-func (*noCopy) Lock() {}
-
-func (*noCopy) Unlock() {}
-
 // BaseWidget provides a helper that handles basic widget behaviours.
 type BaseWidget struct {
 	noCopy noCopy // so `go vet` can complain if a widget is passed by value (copied)
@@ -220,3 +214,9 @@ const (
 	// Since: 2.5
 	Adaptive Orientation = 2
 )
+
+type noCopy struct{}
+
+func (*noCopy) Lock() {}
+
+func (*noCopy) Unlock() {}

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -17,7 +17,7 @@ func (*noCopy) Unlock() {}
 
 // BaseWidget provides a helper that handles basic widget behaviours.
 type BaseWidget struct {
-	noCopy // so `go vet` can complain if a widget is passed by value (copied)
+	noCopy noCopy // so `go vet` can complain if a widget is passed by value (copied)
 
 	size     fyne.Size
 	position fyne.Position

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -9,8 +9,16 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
+type noCopy struct{}
+
+func (*noCopy) Lock() {}
+
+func (*noCopy) Unlock() {}
+
 // BaseWidget provides a helper that handles basic widget behaviours.
 type BaseWidget struct {
+	noCopy // so `go vet` can complain if a widget is passed by value (copied)
+
 	size     fyne.Size
 	position fyne.Position
 	Hidden   bool


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Pre-2.6 we had an actual lock in BaseWidget so we got this warning "for free". Adding back a dummy `sync.Locker` implementation so we can still warn if widget structs are copied or passed by value.

<img width="974" alt="image" src="https://github.com/user-attachments/assets/fa27bb29-d676-4931-a267-af56f99aed17" />


For #4654 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

