### PR TITLE
Check menu items ahead of focused item in a canvas for shortcuts

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -855,7 +855,7 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key fyne.KeyNam
 
 func (w *window) triggerMenuShortcut(sh fyne.Shortcut, m *fyne.Menu) bool {
 	for _, i := range m.Items {
-		if i.Shortcut == sh {
+		if i.Shortcut.ShortcutName() == sh.ShortcutName() {
 			if f := i.Action; f != nil {
 				f()
 				return true

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -829,6 +829,9 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key fyne.KeyNam
 	}
 
 	if shortcut != nil {
+		if w.triggerMainMenuShortcut(shortcut) {
+			return true
+		}
 		if focused, ok := w.canvas.Focused().(fyne.Shortcutable); ok {
 			shouldRunShortcut := true
 			type selectableText interface {
@@ -845,6 +848,37 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key fyne.KeyNam
 		}
 		w.canvas.TypedShortcut(shortcut)
 		return true
+	}
+
+	return false
+}
+
+func (w *window) triggerMenuShortcut(sh fyne.Shortcut, m *fyne.Menu) bool {
+	for _, i := range m.Items {
+		if i.Shortcut == sh {
+			if f := i.Action; f != nil {
+				f()
+				return true
+			}
+		}
+
+		if i.ChildMenu != nil && w.triggerMenuShortcut(sh, i.ChildMenu) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (w *window) triggerMainMenuShortcut(sh fyne.Shortcut) bool {
+	if w.mainmenu == nil {
+		return false
+	}
+
+	for _, m := range w.mainmenu.Items {
+		if w.triggerMenuShortcut(sh, m) {
+			return true
+		}
 	}
 
 	return false

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -855,7 +855,7 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key fyne.KeyNam
 
 func (w *window) triggerMenuShortcut(sh fyne.Shortcut, m *fyne.Menu) bool {
 	for _, i := range m.Items {
-		if i.Shortcut.ShortcutName() == sh.ShortcutName() {
+		if i.Shortcut != nil && i.Shortcut.ShortcutName() == sh.ShortcutName() {
 			if f := i.Action; f != nil {
 				f()
 				return true

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1807,6 +1807,11 @@ func TestWindow_Shortcut(t *testing.T) {
 	w.Canvas().Focus(content)
 	trigger()
 	assert.Equal(t, 1, len(content.capturedShortcuts))
+	assert.Equal(t, "menu", called)
+
+	called = "obj"
+	w.triggersShortcut("9", fyne.KeyD, fyne.KeyModifierSuper) // not in the menu
+	assert.Equal(t, 2, len(content.capturedShortcuts))
 	assert.Equal(t, "obj", called)
 }
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1803,11 +1803,11 @@ func TestWindow_Shortcut(t *testing.T) {
 		assert.Equal(t, "menu", called)
 	}
 
-	called = ""
+	called = "obj"
 	w.Canvas().Focus(content)
 	trigger()
 	assert.Equal(t, 1, len(content.capturedShortcuts))
-	assert.Equal(t, "", called)
+	assert.Equal(t, "obj", called)
 }
 
 func createWindow(title string) *safeWindow {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1806,12 +1806,12 @@ func TestWindow_Shortcut(t *testing.T) {
 	called = "obj"
 	w.Canvas().Focus(content)
 	trigger()
-	assert.Equal(t, 1, len(content.capturedShortcuts))
+	assert.Equal(t, 0, len(content.capturedShortcuts))
 	assert.Equal(t, "menu", called)
 
 	called = "obj"
-	w.triggersShortcut("9", fyne.KeyD, fyne.KeyModifierSuper) // not in the menu
-	assert.Equal(t, 2, len(content.capturedShortcuts))
+	w.triggersShortcut("D", fyne.KeyD, fyne.KeyModifierSuper) // not in the menu
+	assert.Equal(t, 1, len(content.capturedShortcuts))
 	assert.Equal(t, "obj", called)
 }
 


### PR DESCRIPTION
Fixes #2627


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included. <- macOS is a partial test as they handle shortcuts this way already!
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
