### PR TITLE
Fix quitting on wrong goroutine in response to Ctrl+C

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -181,12 +181,13 @@ func (d *gLDriver) CurrentKeyModifiers() fyne.KeyModifier {
 	return d.currentKeyModifiers
 }
 
+// this function should be invoked from a goroutine
 func (d *gLDriver) catchTerm() {
 	terminateSignal := make(chan os.Signal, 1)
 	signal.Notify(terminateSignal, syscall.SIGINT, syscall.SIGTERM)
 
 	<-terminateSignal
-	d.Quit()
+	fyne.Do(d.Quit)
 }
 
 func addMissingQuitForMenu(menu *fyne.Menu, d *gLDriver) {


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes calling Quit on the wrong thread, sometimes causing crashes on Ctrl+C shutdowns

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

