### PR TITLE
Update cache clean to never delete renderers of widgets still in the object tree

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -107,19 +107,6 @@ func destroyExpiredRenderers(now time.Time) {
 	})
 }
 
-// matchesACanvas returns true if the canvas represented by the canvasInfo object matches one of
-// the canvases passed in 'canvases', otherwise false is returned.
-func matchesACanvas(cinfo *canvasInfo, canvases []fyne.Canvas) bool {
-	canvas := cinfo.canvas
-
-	for _, obj := range canvases {
-		if obj == canvas {
-			return true
-		}
-	}
-	return false
-}
-
 type expiringCache struct {
 	expires time.Time
 }

--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -78,43 +78,6 @@ func CleanCanvas(canvas fyne.Canvas) {
 	})
 }
 
-// CleanCanvases runs cache clean tasks for canvases that are being refreshed. This is called on paint events.
-func CleanCanvases(refreshingCanvases []fyne.Canvas) {
-	now := timeNow()
-	delta := now.Sub(lastClean)
-
-	if delta < 10*time.Second || delta < cleanTaskInterval {
-		return // Do not clean too fast.
-	}
-
-	destroyExpiredSvgs(now)
-	destroyExpiredFontMetrics(now)
-
-	canvases.Range(func(obj fyne.CanvasObject, cinfo *canvasInfo) bool {
-		if !cinfo.isExpired(now) || !matchesACanvas(cinfo, refreshingCanvases) {
-			return true
-		}
-
-		canvases.Delete(obj)
-
-		wid, ok := obj.(fyne.Widget)
-		if !ok {
-			return true
-		}
-
-		rinfo, ok := renderers.LoadAndDelete(wid)
-		if !ok || !rinfo.isExpired(now) {
-			return true
-		}
-
-		rinfo.renderer.Destroy()
-		overrides.Delete(wid)
-		return true
-	})
-
-	lastClean = timeNow()
-}
-
 // ResetThemeCaches clears all the svg and text size cache maps
 func ResetThemeCaches() {
 	svgs.Clear()

--- a/internal/cache/widget.go
+++ b/internal/cache/widget.go
@@ -16,7 +16,7 @@ type isBaseWidget interface {
 // If one does not exist, it creates and caches a renderer for the widget.
 func Renderer(wid fyne.Widget) fyne.WidgetRenderer {
 	renderer, ok := CachedRenderer(wid)
-	if !ok {
+	if !ok && wid != nil {
 		renderer = wid.CreateRenderer()
 		rinfo := &rendererInfo{renderer: renderer}
 		rinfo.setAlive()

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -83,11 +83,15 @@ func (d *gLDriver) drawSingleFrame() {
 			// cache alive if it hasn't been done recently
 			// n.b. we need to make sure threshold is a bit *after*
 			// time.Now() - CacheDuration()
-			threshold := time.Now().Add(time.Second - cache.ValidDuration)
+			threshold := time.Now().Add(10*time.Second - cache.ValidDuration)
 			if w.lastWalkedTime.Before(threshold) {
 				w.canvas.WalkTrees(nil, func(node *common.RenderCacheNode, _ fyne.Position) {
-					// marks canvas for widget cache entry alive
+					// marks canvas for object cache entry alive
 					_ = cache.GetCanvasForObject(node.Obj())
+					// marks renderer cache entry alive
+					if wid, ok := node.Obj().(fyne.Widget); ok {
+						_, _ = cache.CachedRenderer(wid)
+					}
 				})
 				w.lastWalkedTime = time.Now()
 			}

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -56,14 +56,6 @@ func runOnMainWithWait(f func(), wait bool) {
 	}
 }
 
-// Preallocate to avoid allocations on every drawSingleFrame.
-// Note that the capacity of this slice can only grow,
-// but its length will never be longer than the total number of
-// window canvases that are dirty on a single frame.
-// So its memory impact should be negligible and does not
-// need periodic shrinking.
-var refreshingCanvases []fyne.Canvas
-
 func (d *gLDriver) drawSingleFrame() {
 	refreshed := false
 	for _, win := range d.windowList() {
@@ -72,13 +64,11 @@ func (d *gLDriver) drawSingleFrame() {
 			continue
 		}
 
-		canvas := w.canvas
-
 		// CheckDirtyAndClear must be checked after visibility,
 		// because when a window becomes visible, it could be
 		// showing old content without a dirty flag set to true.
 		// Do the clear if and only if the window is visible.
-		if !w.visible || !canvas.CheckDirtyAndClear() {
+		if !w.visible || !w.canvas.CheckDirtyAndClear() {
 			// Window hidden or not being redrawn, mark canvasForObject
 			// cache alive if it hasn't been done recently
 			// n.b. we need to make sure threshold is a bit *after*
@@ -99,16 +89,8 @@ func (d *gLDriver) drawSingleFrame() {
 		}
 
 		refreshed = refreshed || d.repaintWindow(w)
-		refreshingCanvases = append(refreshingCanvases, canvas)
 	}
-	cache.CleanCanvases(refreshingCanvases)
 	cache.Clean(refreshed)
-
-	// cleanup refreshingCanvases slice
-	for i := 0; i < len(refreshingCanvases); i++ {
-		refreshingCanvases[i] = nil
-	}
-	refreshingCanvases = refreshingCanvases[:0]
 }
 
 func (d *gLDriver) runGL() {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -177,9 +177,7 @@ func (w *window) Hide() {
 		}
 
 		w.visible = false
-		v := w.viewport
-
-		v.Hide()
+		w.viewport.Hide()
 
 		// hide top canvas element
 		if content := w.canvas.Content(); content != nil {


### PR DESCRIPTION
### Description:

Follow-up for #5466 

Digging into this more I discovered why there are `Clean` and `CleanCanvases` tasks in the first place. This PR #2543 introduced CleanCanvases to address the issue of window freezing when deleting the cache entries for widgets still in the window. But it has a possible leak (fixed in #5466) where widgets that had a renderer created but were not placed in an object tree within a canvas would leak that renderer into the cache forever. #5466 fixed this but also ended up deleting renderers (but not CanvasForObject entries) for visible widgets. This fix avoids deleting renderers for widgets still in an active object tree (even if the window is hidden/ not redrawn), and also consolidates the cache clean task back to just the single `Clean` (since we're walking the object trees to mark the cache entries alive, we are avoiding the original issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
