### PR TITLE
Fix table scroll reset

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -270,7 +270,7 @@ func (t *Table) Select(id TableCellID) {
 	}
 
 	rows, cols := t.Length()
-	if id.Row >= rows || id.Col >= cols {
+	if id.Row < 0 || id.Row >= rows || id.Col < 0 || id.Col >= cols {
 		return
 	}
 
@@ -575,11 +575,11 @@ func (t *Table) Tapped(e *fyne.PointEvent) {
 	}
 
 	col := t.columnAt(e.Position)
-	if col == noCellMatch {
+	if col == noCellMatch || col < 0 {
 		return // out of col range
 	}
 	row := t.rowAt(e.Position)
-	if row == noCellMatch {
+	if row == noCellMatch || row < 0 {
 		return // out of row range
 	}
 	t.Select(TableCellID{row, col})

--- a/widget/table.go
+++ b/widget/table.go
@@ -281,6 +281,7 @@ func (t *Table) Select(id TableCellID) {
 		f(*t.selectedCell)
 	}
 	t.selectedCell = &id
+	t.currentFocus = id
 
 	t.ScrollTo(id)
 
@@ -589,7 +590,6 @@ func (t *Table) Tapped(e *fyne.PointEvent) {
 		if canvas != nil {
 			canvas.Focus(t)
 		}
-		t.currentFocus = TableCellID{row, col}
 		t.RefreshItem(t.currentFocus)
 	}
 }

--- a/widget/table_internal_test.go
+++ b/widget/table_internal_test.go
@@ -143,6 +143,10 @@ func TestTable_Focus(t *testing.T) {
 
 	canvas.Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeySpace})
 	assert.Equal(t, &TableCellID{0, 0}, table.selectedCell)
+
+	table.Select(TableCellID{Row: 1, Col: 1})
+	assert.Equal(t, &TableCellID{1, 1}, table.selectedCell)
+	assert.Equal(t, TableCellID{1, 1}, table.currentFocus)
 }
 
 func TestTable_Headers(t *testing.T) {

--- a/widget/table_internal_test.go
+++ b/widget/table_internal_test.go
@@ -706,6 +706,18 @@ func TestTable_Select(t *testing.T) {
 	assert.Equal(t, 3, selectedCol)
 	assert.Equal(t, 4, selectedRow)
 	test.AssertRendersToMarkup(t, "table/selected_scrolled.xml", w.Canvas())
+
+	table.Select(TableCellID{1, -1})
+	assert.Equal(t, 3, table.selectedCell.Col)
+	assert.Equal(t, 4, table.selectedCell.Row)
+	assert.Equal(t, 3, selectedCol)
+	assert.Equal(t, 4, selectedRow)
+
+	table.Select(TableCellID{-1, -1})
+	assert.Equal(t, 3, table.selectedCell.Col)
+	assert.Equal(t, 4, table.selectedCell.Row)
+	assert.Equal(t, 3, selectedCol)
+	assert.Equal(t, 4, selectedRow)
 }
 
 func TestTable_SetColumnWidth(t *testing.T) {


### PR DESCRIPTION
### Description:
As described in #5538, the first time the user clicks on a cell the table scroll to the to. This is because the focus is still initialized to (0, 0). I change the behaviour of the focus. Now when the user click on a cell, the focus is set on this cell. This is more user friendly because now when the user uses the arrow to change the focus, it starts from the selected cell

There is a second issue that can reset the scroll. When the user click between two cells, the function columnAt return an negative index. Because of this the table tries to scroll to this negative index. This was also the bug reported in #4917

Fixes #5538
Fixes #4917

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
