### PR TITLE
Add safety around the fontMap

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -37,6 +37,8 @@ var (
 )
 
 func loadMap() {
+	loaded = true
+
 	fm = fontscan.NewFontMap(noopLogger{})
 	err := loadSystemFonts(fm)
 	if err != nil {

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -31,8 +31,9 @@ const (
 )
 
 var (
-	fm   *fontscan.FontMap
-	load sync.Once
+	fm           *fontscan.FontMap
+	fontScanLock sync.Mutex
+	load         sync.Once
 )
 
 func loadMap() {
@@ -44,6 +45,9 @@ func loadMap() {
 }
 
 func lookupLangFont(family string, aspect font.Aspect) *font.Face {
+	fontScanLock.Lock()
+	defer fontScanLock.Unlock()
+
 	load.Do(loadMap)
 	if fm == nil {
 		return nil
@@ -55,6 +59,9 @@ func lookupLangFont(family string, aspect font.Aspect) *font.Face {
 }
 
 func lookupRuneFont(r rune, family string, aspect font.Aspect) *font.Face {
+	fontScanLock.Lock()
+	defer fontScanLock.Unlock()
+
 	load.Do(loadMap)
 	if fm == nil {
 		return nil

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -33,7 +33,7 @@ const (
 var (
 	fm           *fontscan.FontMap
 	fontScanLock sync.Mutex
-	load         sync.Once
+	loaded       bool
 )
 
 func loadMap() {
@@ -48,7 +48,9 @@ func lookupLangFont(family string, aspect font.Aspect) *font.Face {
 	fontScanLock.Lock()
 	defer fontScanLock.Unlock()
 
-	load.Do(loadMap)
+	if !loaded {
+		loadMap()
+	}
 	if fm == nil {
 		return nil
 	}
@@ -62,7 +64,9 @@ func lookupRuneFont(r rune, family string, aspect font.Aspect) *font.Face {
 	fontScanLock.Lock()
 	defer fontScanLock.Unlock()
 
-	load.Do(loadMap)
+	if !loaded {
+		loadMap()
+	}
 	if fm == nil {
 		return nil
 	}


### PR DESCRIPTION
Fixing a single instance where concurrency in migration could cause crashes.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
