### PR TITLE
Go124 lib wasm path

### DIFF
--- a/cmd/fyne/internal/commands/package-web.go
+++ b/cmd/fyne/internal/commands/package-web.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -72,6 +73,10 @@ func (w webData) packageWebInternal(appDir string, exeWasmSrc string, exeJSSrc s
 	}
 
 	wasmExecSrc := filepath.Join(runtime.GOROOT(), "misc", "wasm", "wasm_exec.js")
+	// go1.24 changed the location of wasm_exec.js so we need to check both paths
+	if _, err := os.Stat(wasmExecSrc); err != nil && os.IsNotExist(err) {
+		wasmExecSrc = filepath.Join(runtime.GOROOT(), "lib", "wasm", "wasm_exec.js")
+	}
 	wasmExecDst := filepath.Join(appDir, "wasm_exec.js")
 	err = util.CopyFile(wasmExecSrc, wasmExecDst)
 	if err != nil {

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -265,7 +265,7 @@ func Test_PackageWasm(t *testing.T) {
 	expectedCopyFileRuns := mockCopyFileRuns{
 		expected: []mockCopyFile{
 			{source: "myTest.png", target: filepath.Join("myTestTarget", "wasm", "icon.png")},
-			{source: filepath.Join(runtime.GOROOT(), "misc", "wasm", "wasm_exec.js"), target: filepath.Join("myTestTarget", "wasm", "wasm_exec.js")},
+			{source: filepath.Join(runtime.GOROOT(), "lib", "wasm", "wasm_exec.js"), target: filepath.Join("myTestTarget", "wasm", "wasm_exec.js")},
 			{source: "myTest.wasm", target: filepath.Join("myTestTarget", "wasm", "myTest.wasm")},
 		},
 	}


### PR DESCRIPTION
 ### Description:
Go 1.24 [changed the location of `wasm_exec.js`](https://go.dev/doc/go1.24#wasm) under GOROOT. 

> The support files for WebAssembly have been moved to lib/wasm from misc/wasm.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
