### PR TITLE
Avoid wasm clipboard having to look up window

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fredbi/uri v1.1.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/fyne-io/gl-js v0.1.0
-	github.com/fyne-io/glfw-js v0.1.0
+	github.com/fyne-io/glfw-js v0.2.0
 	github.com/fyne-io/image v0.1.0
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fyne-io/gl-js v0.1.0 h1:8luJzNs0ntEAJo+8x8kfUOXujUlP8gB3QMOxO2mUdpM=
 github.com/fyne-io/gl-js v0.1.0/go.mod h1:ZcepK8vmOYLu96JoxbCKJy2ybr+g1pTnaBDdl7c3ajI=
-github.com/fyne-io/glfw-js v0.1.0 h1:RGGMmVjcsG17Oifl3X2UJ5vH3PgS4B1UY3ASeN5BXbI=
-github.com/fyne-io/glfw-js v0.1.0/go.mod h1:Ri6te7rdZtBgBpxLW19uBpp3Dl6K9K/bRaYdJ22G8Jk=
+github.com/fyne-io/glfw-js v0.2.0 h1:8GUZtN2aCoTPNqgRDxK5+kn9OURINhBEBc7M4O1KrmM=
+github.com/fyne-io/glfw-js v0.2.0/go.mod h1:Ri6te7rdZtBgBpxLW19uBpp3Dl6K9K/bRaYdJ22G8Jk=
 github.com/fyne-io/image v0.1.0 h1:Vm2TQJ2PWGHCf3jYi1/XroaNNMu+GfI/O2QpSbZd4XQ=
 github.com/fyne-io/image v0.1.0/go.mod h1:xrfYBh6yspc+KjkgdZU/ifUC9sPA5Iv7WYUBzQKK7JM=
 github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 h1:5BVwOaUSBTlVZowGO6VZGw2H/zl9nrd3eCZfYV+NfQA=

--- a/internal/driver/glfw/clipboard_wasm.go
+++ b/internal/driver/glfw/clipboard_wasm.go
@@ -4,33 +4,25 @@ package glfw
 
 import (
 	"fyne.io/fyne/v2"
+	"github.com/fyne-io/glfw-js"
 )
 
 // Declare conformity with Clipboard interface
-var _ fyne.Clipboard = &clipboard{}
+var _ fyne.Clipboard = clipboard{}
 
 func NewClipboard() fyne.Clipboard {
-	return &clipboard{}
+	return clipboard{}
 }
 
 // clipboard represents the system clipboard
-type clipboard struct {
-}
+type clipboard struct{}
 
 // Content returns the clipboard content
-func (c *clipboard) Content() string {
-	content := ""
-	runOnMain(func() {
-		win := fyne.CurrentApp().Driver().AllWindows()[0].(*window).viewport
-		content, _ = win.GetClipboardString()
-	})
-	return content
+func (c clipboard) Content() string {
+	return glfw.GetClipboardString()
 }
 
 // SetContent sets the clipboard content
-func (c *clipboard) SetContent(content string) {
-	runOnMain(func() {
-		win := fyne.CurrentApp().Driver().AllWindows()[0].(*window).viewport
-		win.SetClipboardString(content)
-	})
+func (c clipboard) SetContent(content string) {
+	glfw.SetClipboardString(content)
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

With the move in both GLFW and v2.6.0 away from needing the window to get the clipboard, we can hook up the same for WASM to make sure we are a bit faster there. 

Requires https://github.com/fyne-io/glfw-js/pull/19

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

