### PR TITLE
commands/package-web: check go1.24 ./lib/wasm/ for wasm_exec.js

### DIFF
--- a/cmd/fyne/internal/commands/package-web.go
+++ b/cmd/fyne/internal/commands/package-web.go
@@ -71,7 +71,11 @@ func (w webData) packageWebInternal(appDir string, exeWasmSrc string, exeJSSrc s
 		return err
 	}
 
-	wasmExecSrc := filepath.Join(runtime.GOROOT(), "misc", "wasm", "wasm_exec.js")
+	goroot := runtime.GOROOT()
+	wasmExecSrc := filepath.Join(goroot, "lib", "wasm", "wasm_exec.js")
+	if !util.Exists(wasmExecSrc) { // Fallback for Go < 1.24:
+		wasmExecSrc = filepath.Join(goroot, "misc", "wasm", "wasm_exec.js")
+	}
 	wasmExecDst := filepath.Join(appDir, "wasm_exec.js")
 	err = util.CopyFile(wasmExecSrc, wasmExecDst)
 	if err != nil {

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -238,14 +238,25 @@ func Test_PackageWasm(t *testing.T) {
 		return expectedEnsureSubDirRuns.verifyExpectation(t, parent, name)
 	}
 
+	// Handle lookup for wasm_exec.js from lib folder in Go 1.24 and newer:
+	goroot := runtime.GOROOT()
+	wasmExecJSPath := filepath.Join(goroot, "lib", "wasm", "wasm_exec.js")
+	_, err := os.Stat(wasmExecJSPath)
+	execJSLibExists := err == nil || !os.IsNotExist(err)
+
 	expectedExistRuns := mockExistRuns{
 		expected: []mockExist{
 			{"myTest.wasm", false},
 			{"myTest.wasm", true},
+			{wasmExecJSPath, execJSLibExists},
 		},
 	}
 	utilExistsMock = func(path string) bool {
 		return expectedExistRuns.verifyExpectation(t, path)
+	}
+
+	if !execJSLibExists { // Expect location from Go < 1.24 to have been copied:
+		wasmExecJSPath = filepath.Join(goroot, "misc", "wasm", "wasm_exec.js")
 	}
 
 	expectedWriteFileRuns := mockWriteFileRuns{
@@ -265,7 +276,7 @@ func Test_PackageWasm(t *testing.T) {
 	expectedCopyFileRuns := mockCopyFileRuns{
 		expected: []mockCopyFile{
 			{source: "myTest.png", target: filepath.Join("myTestTarget", "wasm", "icon.png")},
-			{source: filepath.Join(runtime.GOROOT(), "misc", "wasm", "wasm_exec.js"), target: filepath.Join("myTestTarget", "wasm", "wasm_exec.js")},
+			{source: wasmExecJSPath, target: filepath.Join("myTestTarget", "wasm", "wasm_exec.js")},
 			{source: "myTest.wasm", target: filepath.Join("myTestTarget", "wasm", "myTest.wasm")},
 		},
 	}
@@ -273,7 +284,7 @@ func Test_PackageWasm(t *testing.T) {
 		return expectedCopyFileRuns.verifyExpectation(t, false, source, target)
 	}
 
-	err := p.doPackage(wasmBuildTest)
+	err = p.doPackage(wasmBuildTest)
 	assert.Nil(t, err)
 	wasmBuildTest.verifyExpectation()
 	expectedTotalCount(t, len(expectedEnsureSubDirRuns.expected), expectedEnsureSubDirRuns.current)


### PR DESCRIPTION
Replacement for https://github.com/fyne-io/fyne/pull/5549 

### Description:
Go 1.24 [changed the location of `wasm_exec.js`](https://go.dev/doc/go1.24#wasm) under GOROOT. 

> The support files for WebAssembly have been moved to lib/wasm from misc/wasm.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

