### PR TITLE
Switch a few global slices to arrays

### DIFF
--- a/cmd/fyne_settings/settings/scale.go
+++ b/cmd/fyne_settings/settings/scale.go
@@ -15,7 +15,7 @@ type scaleItems struct {
 	button  *widget.Button
 }
 
-var scales = []*scaleItems{
+var scales = [...]*scaleItems{
 	{scale: 0.5, name: "Tiny"},
 	{scale: 0.8, name: "Small"},
 	{scale: 1, name: "Normal"},

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -57,7 +57,7 @@ type (
 	Uniform int32
 )
 
-var textureFilterToGL = []int32{gl.LINEAR, gl.NEAREST, gl.LINEAR}
+var textureFilterToGL = [...]int32{gl.LINEAR, gl.NEAREST, gl.LINEAR}
 
 func (p *painter) Init() {
 	p.ctx = &coreContext{}

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -57,7 +57,7 @@ type (
 	Uniform int32
 )
 
-var textureFilterToGL = []int32{gl.LINEAR, gl.NEAREST, gl.LINEAR}
+var textureFilterToGL = [...]int32{gl.LINEAR, gl.NEAREST, gl.LINEAR}
 
 func (p *painter) Init() {
 	p.ctx = &esContext{}

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -57,7 +57,7 @@ type (
 var compiled []Program // avoid multiple compilations with the re-used mobile GUI context
 var noBuffer = Buffer{}
 var noShader = Shader{}
-var textureFilterToGL = []int32{gl.Linear, gl.Nearest}
+var textureFilterToGL = [...]int32{gl.Linear, gl.Nearest}
 
 func (p *painter) glctx() gl.Context {
 	return p.contextProvider.Context().(gl.Context)

--- a/internal/painter/gl/gl_wasm.go
+++ b/internal/painter/gl/gl_wasm.go
@@ -54,7 +54,7 @@ type (
 
 var noBuffer = Buffer(gl.NoBuffer)
 var noShader = Shader(gl.NoShader)
-var textureFilterToGL = []int32{gl.LINEAR, gl.NEAREST}
+var textureFilterToGL = [...]int32{gl.LINEAR, gl.NEAREST}
 
 func (p *painter) Init() {
 	p.ctx = &xjsContext{}

--- a/test/theme.go
+++ b/test/theme.go
@@ -14,7 +14,7 @@ import (
 var defaultTheme fyne.Theme
 
 // Try to keep these in sync with the existing color names at theme/color.go.
-var knownColorNames = []fyne.ThemeColorName{
+var knownColorNames = [...]fyne.ThemeColorName{
 	theme.ColorNameBackground,
 	theme.ColorNameButton,
 	theme.ColorNameDisabled,


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Use the [...] syntax to have an array with the capacity of the number of items it has when created. This should likely allow the compiler/runtime to prove that they cannot grow and thus store them in the text section of the binary instead of allocating them on the stack.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
