### PR TITLE
Add Dismiss (and Confirm where appropriate) to Dialogs to ease testing

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -27,8 +27,15 @@ type Dialog interface {
 	Refresh()
 	Resize(size fyne.Size)
 
+	// MinSize returns the size that this dialog should not shrink below.
+	//
 	// Since: 2.1
 	MinSize() fyne.Size
+
+	// Dismiss instructs the dialog to close without any affirmative action.
+	//
+	// Since: 2.6
+	Dismiss()
 }
 
 // Declare conformity to Dialog interface
@@ -49,11 +56,15 @@ type dialog struct {
 	beforeShowHook func()
 }
 
+func (d *dialog) Dismiss() {
+	d.Hide()
+}
+
 func (d *dialog) Hide() {
 	d.hideWithResponse(false)
 }
 
-// MinSize returns the size that this dialog should not shrink below
+// MinSize returns the size that this dialog should not shrink below.
 //
 // Since: 2.1
 func (d *dialog) MinSize() fyne.Size {

--- a/dialog/confirm.go
+++ b/dialog/confirm.go
@@ -15,6 +15,13 @@ type ConfirmDialog struct {
 	confirm *widget.Button
 }
 
+// Confirm instructs the dialog to close agreeing with whatever content was displayed.
+//
+// Since: 2.6
+func (d *ConfirmDialog) Confirm() {
+	d.hideWithResponse(true)
+}
+
 // SetConfirmText allows custom text to be set in the confirmation button
 func (d *ConfirmDialog) SetConfirmText(label string) {
 	d.confirm.SetText(label)

--- a/dialog/confirm_test.go
+++ b/dialog/confirm_test.go
@@ -26,7 +26,7 @@ func TestDialog_ConfirmDoubleCallback(t *testing.T) {
 	cnf.Show()
 
 	assert.False(t, cnf.win.Hidden)
-	go test.Tap(cnf.dismiss)
+	go cnf.Dismiss()
 	assert.EqualValues(t, 43, <-ch)
 	assert.EqualValues(t, 42, <-ch)
 	assert.True(t, cnf.win.Hidden)
@@ -43,14 +43,18 @@ func TestDialog_ConfirmCallbackOnlyOnClosed(t *testing.T) {
 	cnf.Show()
 
 	assert.False(t, cnf.win.Hidden)
-	go test.Tap(cnf.dismiss)
+	go cnf.Dismiss()
 	assert.EqualValues(t, 43, <-ch)
 	assert.True(t, cnf.win.Hidden)
 }
 
 func TestDialog_ConfirmCallbackOnlyOnConfirm(t *testing.T) {
 	ch := make(chan int)
-	cnf := NewConfirm("Test", "Test", func(_ bool) {
+	cnf := NewConfirm("Test", "Test", func(ok bool) {
+		if !ok {
+			ch <- 0
+			return
+		}
 		ch <- 42
 	}, test.NewTempWindow(t, nil))
 	cnf.SetDismissText("No")
@@ -58,7 +62,13 @@ func TestDialog_ConfirmCallbackOnlyOnConfirm(t *testing.T) {
 	cnf.Show()
 
 	assert.False(t, cnf.win.Hidden)
-	go test.Tap(cnf.dismiss)
+	go cnf.Dismiss()
+	assert.EqualValues(t, 0, <-ch)
+	assert.True(t, cnf.win.Hidden)
+
+	cnf.Show()
+	assert.False(t, cnf.win.Hidden)
+	go cnf.Confirm()
 	assert.EqualValues(t, 42, <-ch)
 	assert.True(t, cnf.win.Hidden)
 }

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -698,6 +698,13 @@ func showFile(file *FileDialog) *fileDialog {
 	return d
 }
 
+// Dismiss instructs the dialog to close without any affirmative action.
+//
+// Since: 2.6
+func (f *FileDialog) Dismiss() {
+	f.dialog.dismiss.OnTapped()
+}
+
 // MinSize returns the size that this dialog should not shrink below
 //
 // Since: 2.1

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -743,7 +743,7 @@ func TestFileFavorites(t *testing.T) {
 		assert.True(t, ok)
 	}
 
-	test.Tap(dlg.dialog.dismiss)
+	dlg.Dismiss()
 }
 
 func TestSetFileNameBeforeShow(t *testing.T) {


### PR DESCRIPTION
Fixes #2771

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
