### PR TITLE
Avoid out of bounds access when dismissing overlay stack

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -531,6 +531,12 @@ func (o *overlayStack) add(overlay fyne.CanvasObject) {
 func (o *overlayStack) remove(overlay fyne.CanvasObject) {
 	o.OverlayStack.Remove(overlay)
 	overlayCount := len(o.List())
+
+	// it is possible that overlays are removed implicitly and render caches already cleared out
+	if overlayCount >= len(o.renderCaches) {
+		return
+	}
+
 	o.renderCaches[overlayCount] = nil // release memory reference to removed element
 	o.renderCaches = o.renderCaches[:overlayCount]
 }


### PR DESCRIPTION

Fixes #5564

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
