### PR TITLE
Add comment about using efficient map clear with Go 1.20 as base

### DIFF
--- a/internal/async/map_migratedfynedo.go
+++ b/internal/async/map_migratedfynedo.go
@@ -69,5 +69,7 @@ func (m *Map[K, V]) Store(key K, value V) {
 
 // Clear removes all entries from the map.
 func (m *Map[K, V]) Clear() {
-	m.m = make(map[any]V)
+	for k := range m.m {
+		delete(m.m, k)
+	}
 }

--- a/internal/async/map_migratedfynedo.go
+++ b/internal/async/map_migratedfynedo.go
@@ -4,9 +4,8 @@ package async
 
 // Map is a generic wrapper around [sync.Map].
 type Map[K any, V any] struct {
-	// once go1.20 is base, can use map[K]V
-	// with K being Comparable instead of any
-	// (CanvasObject, etc aren't Comparable for go1.19)
+	// Use "comparable" as type constraint and map[K]V as the inner type
+	// once Go 1.20 is our minimum version so interfaces can be used as keys.
 	m map[any]V
 }
 
@@ -69,7 +68,5 @@ func (m *Map[K, V]) Store(key K, value V) {
 
 // Clear removes all entries from the map.
 func (m *Map[K, V]) Clear() {
-	for k := range m.m {
-		delete(m.m, k)
-	}
+	m.m = make(map[any]V) // Use range-and-delete loop once Go 1.20 is the minimum version.
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Just a quick fix to make sure we are using the fast map delete pattern instead of allocating a new map on clear. This compiles down to basically the same thing as doing `clear(m.m)` in Go 1.21 or later.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
