### PR TITLE
load markdown images from origin when not a URL

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -3,16 +3,13 @@ package widget
 import (
 	"io"
 	"net/url"
-	"runtime"
 	"strings"
-	"syscall/js"
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/storage"
 )
 
 // NewRichTextFromMarkdown configures a RichText widget by parsing the provided markdown content.
@@ -129,23 +126,7 @@ func renderNode(source []byte, n ast.Node, blockquote bool) ([]RichTextSegment, 
 	case *ast.Blockquote:
 		return renderChildren(source, n, true)
 	case *ast.Image:
-		dest := string(t.Destination)
-		u, err := storage.ParseURI(dest)
-		if err != nil {
-			if runtime.GOOS == "js" || runtime.GOOS == "wasip1" {
-				if !strings.HasPrefix(dest, "/") {
-					dest = "/" + dest
-				}
-				origin := js.Global().Get("location").Get("origin").String()
-				u, err = storage.ParseURI(origin + dest)
-				if err != nil {
-					return nil, nil
-				}
-			} else {
-				u = storage.NewFileURI(dest)
-			}
-		}
-		return []RichTextSegment{&ImageSegment{Source: u, Title: string(t.Title), Alignment: fyne.TextAlignCenter}}, nil
+		return parseMarkdownImage(t), nil
 	}
 	return nil, nil
 }

--- a/widget/markdown_image_native.go
+++ b/widget/markdown_image_native.go
@@ -1,0 +1,18 @@
+//go:build ci || !(wasm || test_web_driver)
+
+package widget
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/storage"
+	"github.com/yuin/goldmark/ast"
+)
+
+func parseMarkdownImage(t *ast.Image) []RichTextSegment {
+	dest := string(t.Destination)
+	u, err := storage.ParseURI(dest)
+	if err != nil {
+		u = storage.NewFileURI(dest)
+	}
+	return []RichTextSegment{&ImageSegment{Source: u, Title: string(t.Title), Alignment: fyne.TextAlignCenter}}
+}

--- a/widget/markdown_image_notweb.go
+++ b/widget/markdown_image_notweb.go
@@ -1,4 +1,4 @@
-//go:build ci || !(wasm || test_web_driver)
+//go:build !wasm && !test_web_driver
 
 package widget
 

--- a/widget/markdown_image_wasm.go
+++ b/widget/markdown_image_wasm.go
@@ -1,0 +1,28 @@
+//go:build !ci && (!android || !ios || !mobile) && (wasm || test_web_driver)
+
+package widget
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/storage"
+	"github.com/yuin/goldmark/ast"
+	"strings"
+	"syscall/js"
+)
+
+func parseMarkdownImage(t *ast.Image) []RichTextSegment {
+	dest := string(t.Destination)
+	u, err := storage.ParseURI(dest)
+	if err != nil {
+		if !strings.HasPrefix(dest, "/") {
+			dest = "/" + dest
+		}
+		origin := js.Global().Get("location").Get("origin").String()
+		u, err = storage.ParseURI(origin + dest)
+		if err != nil {
+			fyne.LogError("Can't load image in markdown", err)
+			return []RichTextSegment{}
+		}
+	}
+	return []RichTextSegment{&ImageSegment{Source: u, Title: string(t.Title), Alignment: fyne.TextAlignCenter}}
+}

--- a/widget/markdown_image_wasm.go
+++ b/widget/markdown_image_wasm.go
@@ -3,11 +3,12 @@
 package widget
 
 import (
+	"strings"
+	"syscall/js"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/storage"
 	"github.com/yuin/goldmark/ast"
-	"strings"
-	"syscall/js"
 )
 
 func parseMarkdownImage(t *ast.Image) []RichTextSegment {


### PR DESCRIPTION
### Description:

Markdown supports loading local images off disk.  Currently, in fyne, when in the web, this doesn't work, because the browser can't access the local file system like that.  However, what I've seen from other markdown implementations is that in the web, a "local" file means from the same origin as the markdown file.  For example `![](foo.png)` in a markdown loaded from `fyne.io` should be interpreted as `![](fyne.io/foo.png)`.

This change adds that behavior to Fyne's markdown parser.  This has been tested locally for a website I'm working on with Fyne.

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
