### PR TITLE
Allow validation errors on entries without interaction

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -63,6 +63,10 @@ type Entry struct {
 	onValidationChanged func(error)
 	validationError     error
 
+	// When true, the entry will always display an error (if there is any) without user interaction.
+	// Validator is called when rendered
+	AlwaysShowValidationError bool
+
 	CursorRow, CursorColumn int
 	OnCursorChanged         func() `json:"-"`
 
@@ -1863,8 +1867,8 @@ func (r *entryRenderer) Refresh() {
 		r.entry.ActionItem.Refresh()
 	}
 
-	if r.entry.Validator != nil {
-		if !r.entry.focused && !r.entry.Disabled() && r.entry.dirty && r.entry.validationError != nil {
+	if r.entry.Validator != nil || r.entry.AlwaysShowValidationError {
+		if !r.entry.focused && !r.entry.Disabled() && (r.entry.dirty || r.entry.AlwaysShowValidationError) && r.entry.validationError != nil {
 			r.border.StrokeColor = th.Color(theme.ColorNameError, v)
 		}
 		r.ensureValidationSetup()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -64,7 +64,7 @@ type Entry struct {
 	validationError     error
 
 	// When true, the entry will always display an validation error (if there is any) without user interaction.
-	// Since: 2.5
+	// Since: 2.6
 	AlwaysShowValidationError bool
 
 	CursorRow, CursorColumn int

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -63,8 +63,8 @@ type Entry struct {
 	onValidationChanged func(error)
 	validationError     error
 
-	// When true, the entry will always display an error (if there is any) without user interaction.
-	// Validator is called when rendered
+	// When true, the entry will always display an validation error (if there is any) without user interaction.
+	// Since: 2.5
 	AlwaysShowValidationError bool
 
 	CursorRow, CursorColumn int

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1710,7 +1710,7 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 	}
 
 	validatorIconSize := fyne.NewSize(0, 0)
-	if r.entry.Validator != nil {
+	if r.entry.Validator != nil || r.entry.AlwaysShowValidationError {
 		validatorIconSize = fyne.NewSquareSize(iconSize)
 
 		r.ensureValidationSetup()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -63,8 +63,9 @@ type Entry struct {
 	onValidationChanged func(error)
 	validationError     error
 
-	// When true, the entry will always display an validation error (if there is any) without user interaction.
-	// Since: 2.6
+	// If true, the Validator runs automatically on render without user interaction.
+	// It will reflect any validation errors found or those explicitly set via SetValidationError().
+	// Since: 2.7
 	AlwaysShowValidationError bool
 
 	CursorRow, CursorColumn int

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -39,7 +39,7 @@ func (e *Entry) SetOnValidationChanged(callback func(error)) {
 
 // SetValidationError manually updates the validation status until the next input change.
 func (e *Entry) SetValidationError(err error) {
-	if e.Validator == nil {
+	if e.Validator == nil && !e.AlwaysShowValidationError {
 		return
 	}
 

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -123,10 +123,10 @@ func (r *validationStatusRenderer) Refresh() {
 		return
 	}
 
-	if r.entry.validationError == nil && r.entry.Text != "" {
+	if r.entry.validationError == nil && r.entry.Text != "" && r.entry.Validator != nil {
 		r.icon.Resource = th.Icon(theme.IconNameConfirm)
 		r.icon.Show()
-	} else if r.entry.validationError != nil && !r.entry.focused && r.entry.dirty {
+	} else if r.entry.validationError != nil && !r.entry.focused && (r.entry.dirty || r.entry.AlwaysShowValidationError) {
 		r.icon.Resource = theme.NewErrorThemedResource(th.Icon(theme.IconNameError))
 		r.icon.Show()
 	} else {

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -119,3 +119,64 @@ func TestEntry_SetOnValidationChanged(t *testing.T) {
 	test.Type(entry, "invalid")
 	assert.False(t, modified)
 }
+
+func TestEntry_AlwaysShowValidationError_WithValidator_Error(t *testing.T) {
+	test.NewTempApp(t)
+
+	entry := widget.NewEntry()
+	entry.AlwaysShowValidationError = true
+	entry.Validator = func(s string) error {
+		if s == "success" {
+			return nil
+		}
+
+		return errors.New("mocking failed validation")
+	}
+
+	w := test.NewTempWindow(t, entry)
+	test.AssertRendersToMarkup(t, "entry/always_on_with_validator_error.xml", w.Canvas())
+}
+
+func TestEntry_AlwaysShowValidationError_WithValidator_Success(t *testing.T) {
+	test.NewTempApp(t)
+
+	entry := widget.NewEntry()
+	entry.AlwaysShowValidationError = true
+	entry.Validator = func(s string) error {
+		if s == "success" {
+			return nil
+		}
+
+		return errors.New("error")
+	}
+
+	entry.SetText("success")
+
+	w := test.NewTempWindow(t, entry)
+	test.AssertRendersToMarkup(t, "entry/always_on_with_validator_success.xml", w.Canvas())
+}
+
+func TestEntry_AlwaysShowValidationError_WithoutValidator_Error(t *testing.T) {
+	test.NewTempApp(t)
+
+	entry := widget.NewEntry()
+	entry.AlwaysShowValidationError = true
+
+	entry.SetValidationError(errors.New("error"))
+
+	w := test.NewTempWindow(t, entry)
+	test.AssertRendersToMarkup(t, "entry/always_on_without_validator_error.xml", w.Canvas())
+}
+
+func TestEntry_AlwaysShowValidationError_WithoutValidator_Success(t *testing.T) {
+	test.NewTempApp(t)
+
+	entry := widget.NewEntry()
+	entry.AlwaysShowValidationError = true
+
+	entry.SetValidationError(errors.New("error"))
+	entry.SetValidationError(nil)
+
+	w := test.NewTempWindow(t, entry)
+	test.AssertRendersToMarkup(t, "entry/always_on_without_validator_success.xml", w.Canvas())
+}

--- a/widget/testdata/entry/always_on_with_validator_error.xml
+++ b/widget/testdata/entry/always_on_with_validator_error.xml
@@ -3,12 +3,12 @@
 		<widget pos="4,4" size="60x35" type="*widget.Entry">
 			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
 			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="error" strokeWidth="2"/>
-			<widget pos="0,2" size="36x31" type="*widget.Scroll">
-				<widget size="36x31" type="*widget.entryContent">
-					<widget size="36x31" type="*widget.RichText">
+			<widget pos="0,2" size="28x31" type="*widget.Scroll">
+				<widget size="28x31" type="*widget.entryContent">
+					<widget size="28x31" type="*widget.RichText">
 						<text color="placeholder" pos="8,6" size="0x19"></text>
 					</widget>
-					<widget size="36x31" type="*widget.RichText">
+					<widget size="28x31" type="*widget.RichText">
 						<text pos="8,6" size="0x19"></text>
 					</widget>
 				</widget>

--- a/widget/testdata/entry/always_on_with_validator_error.xml
+++ b/widget/testdata/entry/always_on_with_validator_error.xml
@@ -1,0 +1,21 @@
+<canvas padded size="68x43">
+	<content>
+		<widget pos="4,4" size="60x35" type="*widget.Entry">
+			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
+			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="error" strokeWidth="2"/>
+			<widget pos="0,2" size="36x31" type="*widget.Scroll">
+				<widget size="36x31" type="*widget.entryContent">
+					<widget size="36x31" type="*widget.RichText">
+						<text color="placeholder" pos="8,6" size="0x19"></text>
+					</widget>
+					<widget size="36x31" type="*widget.RichText">
+						<text pos="8,6" size="0x19"></text>
+					</widget>
+				</widget>
+			</widget>
+			<widget pos="32,8" size="20x20" type="*widget.validationStatus">
+				<image rsc="errorIcon" size="iconInlineSize" themed="error"/>
+			</widget>
+		</widget>
+	</content>
+</canvas>

--- a/widget/testdata/entry/always_on_with_validator_success.xml
+++ b/widget/testdata/entry/always_on_with_validator_success.xml
@@ -3,18 +3,18 @@
 		<widget pos="4,4" size="60x35" type="*widget.Entry">
 			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
 			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="inputBorder" strokeWidth="2"/>
-			<widget pos="0,2" size="36x31" type="*widget.Scroll">
+			<widget pos="0,2" size="28x31" type="*widget.Scroll">
 				<widget size="66x31" type="*widget.entryContent">
 					<widget size="66x31" type="*widget.RichText">
 						<text pos="8,6" size="50x19">success</text>
 					</widget>
 				</widget>
-				<widget pos="36,0" size="0x31" type="*widget.Shadow">
+				<widget pos="28,0" size="0x31" type="*widget.Shadow">
 					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x31"/>
 				</widget>
-				<widget pos="0,25" size="36x6" type="*widget.scrollBarArea">
-					<widget pos="0,3" size="19x3" type="*widget.scrollBar">
-						<rectangle fillColor="scrollbar" radius="3" size="19x3"/>
+				<widget pos="0,25" size="28x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="16x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" radius="3" size="16x3"/>
 					</widget>
 				</widget>
 			</widget>

--- a/widget/testdata/entry/always_on_with_validator_success.xml
+++ b/widget/testdata/entry/always_on_with_validator_success.xml
@@ -1,0 +1,26 @@
+<canvas padded size="68x43">
+	<content>
+		<widget pos="4,4" size="60x35" type="*widget.Entry">
+			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
+			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="inputBorder" strokeWidth="2"/>
+			<widget pos="0,2" size="36x31" type="*widget.Scroll">
+				<widget size="66x31" type="*widget.entryContent">
+					<widget size="66x31" type="*widget.RichText">
+						<text pos="8,6" size="50x19">success</text>
+					</widget>
+				</widget>
+				<widget pos="36,0" size="0x31" type="*widget.Shadow">
+					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x31"/>
+				</widget>
+				<widget pos="0,25" size="36x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="19x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" radius="3" size="19x3"/>
+					</widget>
+				</widget>
+			</widget>
+			<widget pos="32,8" size="20x20" type="*widget.validationStatus">
+				<image rsc="confirmIcon" size="iconInlineSize" themed="foreground"/>
+			</widget>
+		</widget>
+	</content>
+</canvas>

--- a/widget/testdata/entry/always_on_without_validator_error.xml
+++ b/widget/testdata/entry/always_on_without_validator_error.xml
@@ -1,0 +1,21 @@
+<canvas padded size="44x43">
+	<content>
+		<widget pos="4,4" size="36x35" type="*widget.Entry">
+			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="32x31"/>
+			<rectangle pos="1,1" radius="4" size="34x32" strokeColor="error" strokeWidth="2"/>
+			<widget pos="0,2" size="36x31" type="*widget.Scroll">
+				<widget size="36x31" type="*widget.entryContent">
+					<widget size="36x31" type="*widget.RichText">
+						<text color="placeholder" pos="8,6" size="0x19"></text>
+					</widget>
+					<widget size="36x31" type="*widget.RichText">
+						<text pos="8,6" size="0x19"></text>
+					</widget>
+				</widget>
+			</widget>
+			<widget pos="8,8" size="20x20" type="*widget.validationStatus">
+				<image rsc="errorIcon" size="iconInlineSize" themed="error"/>
+			</widget>
+		</widget>
+	</content>
+</canvas>

--- a/widget/testdata/entry/always_on_without_validator_success.xml
+++ b/widget/testdata/entry/always_on_without_validator_success.xml
@@ -1,0 +1,20 @@
+<canvas padded size="44x43">
+	<content>
+		<widget pos="4,4" size="36x35" type="*widget.Entry">
+			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="32x31"/>
+			<rectangle pos="1,1" radius="4" size="34x32" strokeColor="inputBorder" strokeWidth="2"/>
+			<widget pos="0,2" size="36x31" type="*widget.Scroll">
+				<widget size="36x31" type="*widget.entryContent">
+					<widget size="36x31" type="*widget.RichText">
+						<text color="placeholder" pos="8,6" size="0x19"></text>
+					</widget>
+					<widget size="36x31" type="*widget.RichText">
+						<text pos="8,6" size="0x19"></text>
+					</widget>
+				</widget>
+			</widget>
+			<widget pos="8,8" size="20x20" type="*widget.validationStatus">
+			</widget>
+		</widget>
+	</content>
+</canvas>


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Implements a way to show errors without user interaction as described in the issue mentioned below. The main goal was to implement this change without modifying existing tests, ensuring that current behavior remains intact. The default functionality continues to work as expected without setting `AlwaysShowValidationError`.

All the tests create their testbed from the ground up instead of expanding a single test and doing `SetText()` for example. This way the tests test the behaviour when the entry is rendered instead of relying on user interaction to tigger a `Refresh()`.

Fixes #5590 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
