### PR TITLE
change dialog callback order

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -111,10 +111,10 @@ func (d *dialog) SetOnClosed(closed func()) {
 	originalCallback := d.callback
 
 	d.callback = func(response bool) {
-		closed()
 		if originalCallback != nil {
 			originalCallback(response)
 		}
+		closed()
 	}
 }
 

--- a/dialog/color.go
+++ b/dialog/color.go
@@ -91,7 +91,6 @@ func (p *ColorPickerDialog) createSimplePickers() (contents []fyne.CanvasObject)
 }
 
 func (p *ColorPickerDialog) selectColor(c color.Color) {
-	p.dialog.Hide()
 	writeRecentColor(colorToString(c))
 	if p.picker != nil {
 		p.picker.SetColor(c)
@@ -99,6 +98,7 @@ func (p *ColorPickerDialog) selectColor(c color.Color) {
 	if f := p.callback; f != nil {
 		f(c)
 	}
+	p.dialog.Hide()
 	p.updateUI()
 }
 

--- a/dialog/confirm_test.go
+++ b/dialog/confirm_test.go
@@ -27,8 +27,8 @@ func TestDialog_ConfirmDoubleCallback(t *testing.T) {
 
 	assert.False(t, cnf.win.Hidden)
 	go cnf.Dismiss()
-	assert.EqualValues(t, 43, <-ch)
 	assert.EqualValues(t, 42, <-ch)
+	assert.EqualValues(t, 43, <-ch)
 	assert.True(t, cnf.win.Hidden)
 }
 

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -813,10 +813,10 @@ func (f *FileDialog) SetOnClosed(closed func()) {
 		if f.dialog == nil {
 			return
 		}
-		closed()
 		if originalCallback != nil {
 			originalCallback(response)
 		}
+		closed()
 	}
 }
 


### PR DESCRIPTION
### Description:

This changes the order of callback execution in dialogs so that the original callback is executed before any of the `SetOnClosed` functions.

Marking as a draft until I go through and look for any other dialog inconsistencies.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
