### PR TITLE
Add RowWrap layout

### DIFF
--- a/layout/rowwrap.go
+++ b/layout/rowwrap.go
@@ -13,7 +13,7 @@ type rowWrapLayout struct {
 
 // NewRowWrapLayout returns a layout that dynamically arranges objects of similar height
 // in rows and wraps them dynamically.
-// Objects are separated with horizontal and vertical inner padding.
+// Objects are separated with horizontal and vertical padding.
 //
 // Since: 2.7
 func NewRowWrapLayout() fyne.Layout {
@@ -25,7 +25,7 @@ func NewRowWrapLayout() fyne.Layout {
 }
 
 // NewRowWrapLayoutWithCustomPadding returns a new RowWrapLayout instance
-// with custom horizontal and vertical inner padding.
+// with custom horizontal and inner padding.
 //
 // Since: 2.7
 func NewRowWrapLayoutWithCustomPadding(horizontal, vertical float32) fyne.Layout {

--- a/layout/rowwrap.go
+++ b/layout/rowwrap.go
@@ -15,7 +15,7 @@ type rowWrapLayout struct {
 // Object visibility is supported.
 //
 // Since: 2.7
-func NewRowWrapLayout() *rowWrapLayout {
+func NewRowWrapLayout() fyne.Layout {
 	return &rowWrapLayout{}
 }
 

--- a/layout/rowwrap.go
+++ b/layout/rowwrap.go
@@ -1,0 +1,67 @@
+package layout
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+type rowWrapLayout struct {
+	rowCount int
+}
+
+// NewRowWrapLayout returns a layout that dynamically arranges objects
+// with the same height in rows and wraps them as necessary.
+//
+// Object visibility is supported.
+//
+// Since: 2.7
+func NewRowWrapLayout() *rowWrapLayout {
+	return &rowWrapLayout{}
+}
+
+var _ fyne.Layout = (*rowWrapLayout)(nil)
+
+func (l *rowWrapLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	if len(objects) == 0 {
+		return fyne.NewSize(0, 0)
+	}
+	rows := l.rowCount
+	if rows == 0 {
+		rows = 1
+	}
+	rowHeight := objects[0].MinSize().Height
+	var w float32
+	for _, o := range objects {
+		size := o.MinSize()
+		if size.Width > w {
+			w = size.Width
+		}
+	}
+	s := fyne.NewSize(w, rowHeight*float32(rows)+theme.Padding()*float32(rows-1))
+	return s
+}
+
+func (l *rowWrapLayout) Layout(objects []fyne.CanvasObject, containerSize fyne.Size) {
+	if len(objects) == 0 {
+		return
+	}
+	padding := theme.Padding()
+	rowHeight := objects[0].MinSize().Height
+	pos := fyne.NewPos(0, 0)
+	rows := 1
+	for _, o := range objects {
+		if !o.Visible() {
+			continue
+		}
+		size := o.MinSize()
+		o.Resize(size)
+		w := size.Width + padding
+		if pos.X+w > containerSize.Width {
+			pos = fyne.NewPos(0, float32(rows)*(rowHeight+padding))
+			rows++
+		}
+		o.Move(pos)
+		pos = pos.Add(fyne.NewPos(w, 0))
+	}
+	l.rowCount = rows
+}

--- a/layout/rowwrap.go
+++ b/layout/rowwrap.go
@@ -64,8 +64,7 @@ func (l *rowWrapLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 }
 
 func (l *rowWrapLayout) minHeight(rowHeight float32, rowCount int) float32 {
-	height := rowHeight*float32(rowCount) + l.verticalPadding*float32(rowCount-1)
-	return height
+	return rowHeight*float32(rowCount) + l.verticalPadding*float32(rowCount-1)
 }
 
 // Layout is called to pack all child objects into a specified size.

--- a/layout/rowwrap_test.go
+++ b/layout/rowwrap_test.go
@@ -82,10 +82,11 @@ func TestRowWrapLayout_MinSize(t *testing.T) {
 		layout := layout.NewRowWrapLayout()
 
 		// when/then
-		minSize := layout.MinSize(container.Objects)
+		got := layout.MinSize(container.Objects)
 
 		// then
-		assert.Equal(t, o.MinSize(), minSize)
+		want := o.MinSize()
+		assert.Equal(t, want, got)
 	})
 	t.Run("should return size 0 when container is empty", func(t *testing.T) {
 		// given
@@ -93,10 +94,11 @@ func TestRowWrapLayout_MinSize(t *testing.T) {
 		layout := layout.NewRowWrapLayout()
 
 		// when/then
-		minSize := layout.MinSize(container.Objects)
+		got := layout.MinSize(container.Objects)
 
 		// then
-		assert.Equal(t, fyne.NewSize(0, 0), minSize)
+		want := fyne.NewSize(0, 0)
+		assert.Equal(t, want, got)
 	})
 	t.Run("should initially return height of first object and width of widest object", func(t *testing.T) {
 		// given
@@ -109,12 +111,13 @@ func TestRowWrapLayout_MinSize(t *testing.T) {
 		layout := layout.NewRowWrapLayout()
 
 		// when/then
-		minSize := layout.MinSize(container.Objects)
+		got := layout.MinSize(container.Objects)
 
 		// then
-		assert.Equal(t, fyne.NewSize(20, h), minSize)
+		want := fyne.NewSize(20, h)
+		assert.Equal(t, want, got)
 	})
-	t.Run("should return height of arranged objects after layout was calculated", func(t *testing.T) {
+	t.Run("should return actual size of arranged objects after layout was calculated", func(t *testing.T) {
 		// given
 		h := float32(10)
 		o1 := canvas.NewRectangle(color.Opaque)
@@ -125,9 +128,10 @@ func TestRowWrapLayout_MinSize(t *testing.T) {
 		container.Resize(fyne.NewSize(15, 50))
 
 		// when/then
-		minSize := container.MinSize()
+		got := container.MinSize()
 
 		// then
-		assert.Equal(t, fyne.NewSize(o2.Size().Width, (o1.Size().Height*2)+theme.Padding()), minSize)
+		want := fyne.NewSize(o2.Size().Width, (o1.Size().Height*2)+theme.Padding())
+		assert.Equal(t, want, got)
 	})
 }

--- a/layout/rowwrap_test.go
+++ b/layout/rowwrap_test.go
@@ -1,0 +1,133 @@
+package layout_test
+
+import (
+	"image/color"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRowWrapLayout_Layout(t *testing.T) {
+	t.Run("should arrange objects in a row and wrap overflow objects into next row", func(t *testing.T) {
+		// given
+		h := float32(10)
+		o1 := canvas.NewRectangle(color.Opaque)
+		o1.SetMinSize(fyne.NewSize(30, h))
+		o2 := canvas.NewRectangle(color.Opaque)
+		o2.SetMinSize(fyne.NewSize(80, h))
+		o3 := canvas.NewRectangle(color.Opaque)
+		o3.SetMinSize(fyne.NewSize(50, h))
+
+		containerSize := fyne.NewSize(125, 125)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{o1, o2, o3},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+
+		// then
+		p := theme.Padding()
+		assert.Equal(t, fyne.NewPos(0, 0), o1.Position())
+		assert.Equal(t, fyne.NewPos(o1.Size().Width+p, 0), o2.Position())
+		assert.Equal(t, fyne.NewPos(0, o1.Size().Height+p), o3.Position())
+	})
+	t.Run("should do nothing when container is empty", func(t *testing.T) {
+		containerSize := fyne.NewSize(125, 125)
+		container := &fyne.Container{}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+	})
+	t.Run("should ignore hidden objects", func(t *testing.T) {
+		// given
+		h := float32(10)
+		o1 := canvas.NewRectangle(color.Opaque)
+		o1.SetMinSize(fyne.NewSize(30, h))
+		o2 := canvas.NewRectangle(color.Opaque)
+		o2.SetMinSize(fyne.NewSize(80, h))
+		o2.Hide()
+		o3 := canvas.NewRectangle(color.Opaque)
+		o3.SetMinSize(fyne.NewSize(50, h))
+
+		containerSize := fyne.NewSize(125, 125)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{o1, o2, o3},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+
+		// then
+		p := theme.Padding()
+		assert.Equal(t, fyne.NewPos(0, 0), o1.Position())
+		assert.Equal(t, fyne.NewPos(o1.Size().Width+p, 0), o3.Position())
+	})
+}
+
+func TestRowWrapLayout_MinSize(t *testing.T) {
+	t.Run("should return min size of single object when container has only one", func(t *testing.T) {
+		// given
+		o := canvas.NewRectangle(color.Opaque)
+		o.SetMinSize(fyne.NewSize(10, 10))
+		container := container.NewWithoutLayout(o)
+		layout := layout.NewRowWrapLayout()
+
+		// when/then
+		minSize := layout.MinSize(container.Objects)
+
+		// then
+		assert.Equal(t, o.MinSize(), minSize)
+	})
+	t.Run("should return size 0 when container is empty", func(t *testing.T) {
+		// given
+		container := container.NewWithoutLayout()
+		layout := layout.NewRowWrapLayout()
+
+		// when/then
+		minSize := layout.MinSize(container.Objects)
+
+		// then
+		assert.Equal(t, fyne.NewSize(0, 0), minSize)
+	})
+	t.Run("should initially return height of first object and width of widest object", func(t *testing.T) {
+		// given
+		h := float32(10)
+		o1 := canvas.NewRectangle(color.Opaque)
+		o1.SetMinSize(fyne.NewSize(10, h))
+		o2 := canvas.NewRectangle(color.Opaque)
+		o2.SetMinSize(fyne.NewSize(20, h))
+		container := container.NewWithoutLayout(o1, o2)
+		layout := layout.NewRowWrapLayout()
+
+		// when/then
+		minSize := layout.MinSize(container.Objects)
+
+		// then
+		assert.Equal(t, fyne.NewSize(20, h), minSize)
+	})
+	t.Run("should return height of arranged objects after layout was calculated", func(t *testing.T) {
+		// given
+		h := float32(10)
+		o1 := canvas.NewRectangle(color.Opaque)
+		o1.SetMinSize(fyne.NewSize(10, h))
+		o2 := canvas.NewRectangle(color.Opaque)
+		o2.SetMinSize(fyne.NewSize(20, h))
+		container := container.New(layout.NewRowWrapLayout(), o1, o2)
+		container.Resize(fyne.NewSize(15, 50))
+
+		// when/then
+		minSize := container.MinSize()
+
+		// then
+		assert.Equal(t, fyne.NewSize(o2.Size().Width, (o1.Size().Height*2)+theme.Padding()), minSize)
+	})
+}

--- a/layout/rowwrap_test.go
+++ b/layout/rowwrap_test.go
@@ -12,80 +12,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRowWrapLayout_Layout(t *testing.T) {
-	t.Run("should arrange objects in a row and wrap overflow objects into next row", func(t *testing.T) {
-		// given
-		h := float32(10)
-		o1 := canvas.NewRectangle(color.Opaque)
-		o1.SetMinSize(fyne.NewSize(30, h))
-		o2 := canvas.NewRectangle(color.Opaque)
-		o2.SetMinSize(fyne.NewSize(80, h))
-		o3 := canvas.NewRectangle(color.Opaque)
-		o3.SetMinSize(fyne.NewSize(50, h))
-
-		containerSize := fyne.NewSize(125, 125)
-		container := &fyne.Container{
-			Objects: []fyne.CanvasObject{o1, o2, o3},
-		}
-		container.Resize(containerSize)
-
-		// when
-		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
-
-		// then
-		p := theme.Padding()
-		assert.Equal(t, fyne.NewPos(0, 0), o1.Position())
-		assert.Equal(t, fyne.NewPos(o1.Size().Width+p, 0), o2.Position())
-		assert.Equal(t, fyne.NewPos(0, o1.Size().Height+p), o3.Position())
-	})
-	t.Run("should do nothing when container is empty", func(t *testing.T) {
-		containerSize := fyne.NewSize(125, 125)
-		container := &fyne.Container{}
-		container.Resize(containerSize)
-
-		// when
-		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
-	})
-	t.Run("should ignore hidden objects", func(t *testing.T) {
-		// given
-		h := float32(10)
-		o1 := canvas.NewRectangle(color.Opaque)
-		o1.SetMinSize(fyne.NewSize(30, h))
-		o2 := canvas.NewRectangle(color.Opaque)
-		o2.SetMinSize(fyne.NewSize(80, h))
-		o2.Hide()
-		o3 := canvas.NewRectangle(color.Opaque)
-		o3.SetMinSize(fyne.NewSize(50, h))
-
-		containerSize := fyne.NewSize(125, 125)
-		container := &fyne.Container{
-			Objects: []fyne.CanvasObject{o1, o2, o3},
-		}
-		container.Resize(containerSize)
-
-		// when
-		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
-
-		// then
-		p := theme.Padding()
-		assert.Equal(t, fyne.NewPos(0, 0), o1.Position())
-		assert.Equal(t, fyne.NewPos(o1.Size().Width+p, 0), o3.Position())
-	})
-}
-
 func TestRowWrapLayout_MinSize(t *testing.T) {
+	p := theme.Padding()
 	t.Run("should return min size of single object when container has only one", func(t *testing.T) {
 		// given
-		o := canvas.NewRectangle(color.Opaque)
-		o.SetMinSize(fyne.NewSize(10, 10))
-		container := container.NewWithoutLayout(o)
+		a := makeObject(10, 10)
+		container := container.NewWithoutLayout(a)
 		layout := layout.NewRowWrapLayout()
 
 		// when/then
 		got := layout.MinSize(container.Objects)
 
 		// then
-		want := o.MinSize()
+		want := a.MinSize()
 		assert.Equal(t, want, got)
 	})
 	t.Run("should return size 0 when container is empty", func(t *testing.T) {
@@ -100,38 +39,191 @@ func TestRowWrapLayout_MinSize(t *testing.T) {
 		want := fyne.NewSize(0, 0)
 		assert.Equal(t, want, got)
 	})
-	t.Run("should initially return height of first object and width of widest object", func(t *testing.T) {
+	t.Run("should estimate min size when layout not yet known", func(t *testing.T) {
 		// given
-		h := float32(10)
-		o1 := canvas.NewRectangle(color.Opaque)
-		o1.SetMinSize(fyne.NewSize(10, h))
-		o2 := canvas.NewRectangle(color.Opaque)
-		o2.SetMinSize(fyne.NewSize(20, h))
-		container := container.NewWithoutLayout(o1, o2)
+		a := makeObject(10, 10)
+		b := makeObject(20, 10)
+		container := container.NewWithoutLayout(a, b)
 		layout := layout.NewRowWrapLayout()
 
 		// when/then
 		got := layout.MinSize(container.Objects)
 
 		// then
-		want := fyne.NewSize(20, h)
+		want := fyne.NewSize(20, 10+p+10)
 		assert.Equal(t, want, got)
 	})
+	t.Run("should use custom padding when estimating min size", func(t *testing.T) {
+		// given
+		a := makeObject(10, 10)
+		b := makeObject(20, 10)
+		container := container.NewWithoutLayout(a, b)
+		layout := layout.NewRowWrapLayoutWithCustomPadding(5, 7)
+
+		// when/then
+		got := layout.MinSize(container.Objects)
+
+		// then
+		want := fyne.NewSize(20, 10+7+10)
+		assert.Equal(t, want, got)
+	})
+	t.Run("should ignore invisible objects when estimating min size", func(t *testing.T) {
+		// given
+		a := makeObject(10, 10)
+		b := makeObject(20, 10)
+		b.Hide()
+		container := container.NewWithoutLayout(a, b)
+		layout := layout.NewRowWrapLayout()
+
+		// when/then
+		got := layout.MinSize(container.Objects)
+
+		// then
+		want := fyne.NewSize(10, 10)
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("should return actual size of arranged objects after layout was calculated", func(t *testing.T) {
 		// given
-		h := float32(10)
-		o1 := canvas.NewRectangle(color.Opaque)
-		o1.SetMinSize(fyne.NewSize(10, h))
-		o2 := canvas.NewRectangle(color.Opaque)
-		o2.SetMinSize(fyne.NewSize(20, h))
-		container := container.New(layout.NewRowWrapLayout(), o1, o2)
-		container.Resize(fyne.NewSize(15, 50))
+		a := makeObject(10, 10)
+		b := makeObject(20, 10)
+		c := makeObject(20, 10)
+		container := container.New(layout.NewRowWrapLayout(), a, b, c)
+		container.Resize(fyne.NewSize(55, 50))
 
 		// when/then
 		got := container.MinSize()
 
 		// then
-		want := fyne.NewSize(o2.Size().Width, (o1.Size().Height*2)+theme.Padding())
+		p := theme.Padding()
+		want := fyne.NewSize(10+p+20, 10+p+10)
 		assert.Equal(t, want, got)
 	})
+}
+
+func TestRowWrapLayout_Layout(t *testing.T) {
+	p := theme.Padding()
+	t.Run("should arrange single object", func(t *testing.T) {
+		// given
+		a := makeObject(30, 10)
+		containerSize := fyne.NewSize(120, 30)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{a},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+
+		// then
+		assert.Equal(t, fyne.NewPos(0, 0), a.Position())
+	})
+
+	t.Run("should arrange objects in single row when they fit", func(t *testing.T) {
+		// given
+		a := makeObject(30, 10)
+		b := makeObject(80, 10)
+		containerSize := fyne.NewSize(120, 30)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{a, b},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+
+		// then
+		assert.Equal(t, fyne.NewPos(0, 0), a.Position())
+		assert.Equal(t, fyne.NewPos(30+p, 0), b.Position())
+	})
+	t.Run("should wrap overflowing object into new row with multiple objects in a row", func(t *testing.T) {
+		// given
+		a := makeObject(30, 10)
+		b := makeObject(80, 10)
+		c := makeObject(50, 10)
+		containerSize := fyne.NewSize(125, 125)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{a, b, c},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+
+		// then
+		assert.Equal(t, fyne.NewPos(0, 0), a.Position())
+		assert.Equal(t, fyne.NewPos(30+p, 0), b.Position())
+		assert.Equal(t, fyne.NewPos(0, 10+p), c.Position())
+	})
+	t.Run("should wrap overflowing object into new row with one object on a row", func(t *testing.T) {
+		// given
+		a := makeObject(80, 10)
+		b := makeObject(30, 10)
+		containerSize := fyne.NewSize(40, 30)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{a, b},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+
+		// then
+		assert.Equal(t, fyne.NewPos(0, 0), a.Position())
+		assert.Equal(t, fyne.NewPos(0, 10+p), b.Position())
+	})
+	t.Run("should do nothing when container is empty", func(t *testing.T) {
+		containerSize := fyne.NewSize(125, 125)
+		container := &fyne.Container{}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+	})
+	t.Run("should ignore hidden objects", func(t *testing.T) {
+		// given
+		a := makeObject(30, 10)
+		b := makeObject(80, 10)
+		b.Hide()
+		c := makeObject(50, 10)
+
+		containerSize := fyne.NewSize(125, 125)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{a, b, c},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayout().Layout(container.Objects, containerSize)
+
+		// then
+		assert.Equal(t, fyne.NewPos(0, 0), a.Position())
+		assert.Equal(t, fyne.NewPos(30+p, 0), c.Position())
+	})
+
+	t.Run("should arrange objects with custom padding", func(t *testing.T) {
+		// given
+		a := makeObject(30, 10)
+		b := makeObject(80, 10)
+		c := makeObject(50, 10)
+		containerSize := fyne.NewSize(125, 125)
+		container := &fyne.Container{
+			Objects: []fyne.CanvasObject{a, b, c},
+		}
+		container.Resize(containerSize)
+
+		// when
+		layout.NewRowWrapLayoutWithCustomPadding(5, 7).Layout(container.Objects, containerSize)
+
+		// then
+		assert.Equal(t, fyne.NewPos(0, 0), a.Position())
+		assert.Equal(t, fyne.NewPos(30+5, 0), b.Position())
+		assert.Equal(t, fyne.NewPos(0, 10+7), c.Position())
+	})
+}
+
+func makeObject(w, h float32) fyne.CanvasObject {
+	a := canvas.NewRectangle(color.Opaque)
+	a.SetMinSize(fyne.NewSize(w, h))
+	return a
 }


### PR DESCRIPTION
### Description:

Adds a new layout for dynamically arranging objects with same height in rows with wrapping. 

In my opinion this layout solves a common layout problem and would be a good addition the Fyne toolkit. For example it would allow to dynamically arranging a set of filter chips in multiple rows:

![image](https://github.com/user-attachments/assets/cee2a4c3-765b-4ed5-9404-28010bc94bb1)

I went with "RowWrap", because it arranges objects in rows and wraps them. This layout is similar to the existing GridWrap layout, so a similar name makes sense (i.e. it arranges in rows instead of a grid). But I am of course open to other suggestions.

### Demo

Here is an example render:

[Screencast from 17.03.2025 15:39:08.webm](https://github.com/user-attachments/assets/3f16b2dc-af1a-47d7-b996-737fdd3889ed)


Code to reproduce the example:

```go
package main

import (
	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/container"
	"fyne.io/fyne/v2/layout"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.New()
	w := a.NewWindow("RowWrap layout")
	c := container.New(
		layout.NewRowWrapLayout(),
		widget.NewButton("Alpha", nil),
		widget.NewButton("Bravo Charlie", nil),
		widget.NewButton("Delta", nil),
		widget.NewButton("Echo Foxtrott Golf Hotel", nil),
		widget.NewButton("India Juliet", nil),
		widget.NewButton("Kilo Limo Mike November", nil),
	)
	w.SetContent(c)
	w.Resize(fyne.NewSize(50, 50))
	w.ShowAndRun()
}

```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.

### Open

- [x] Add tests for custom padding variant
