### PR TITLE
Remove atomic.Pointer from fyne.CurrentApp()

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,9 +1,6 @@
 package fyne
 
-import (
-	"net/url"
-	"sync/atomic"
-)
+import "net/url"
 
 // An App is the definition of a graphical application.
 // Apps can have multiple windows, by default they will exit when all windows
@@ -88,21 +85,19 @@ type App interface {
 	Clipboard() Clipboard
 }
 
-var app atomic.Pointer[App]
+var app App
 
 // SetCurrentApp is an internal function to set the app instance currently running.
 func SetCurrentApp(current App) {
-	app.Store(&current)
+	app = current
 }
 
 // CurrentApp returns the current application, for which there is only 1 per process.
 func CurrentApp() App {
-	val := app.Load()
-	if val == nil {
+	if app == nil {
 		LogError("Attempt to access current Fyne app when none is started", nil)
-		return nil
 	}
-	return *val
+	return app
 }
 
 // AppMetadata captures the build metadata for an application.


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The main benefit here is that someone using the race detector will know that they are using fyne.CurrentApp() from the wrong goroutine in a migrated app and it should be safe for non migrations given the fact that the app is set once only. Another benefit is of course that frequest app lookups should be much faster (not only are we avoiding the atomic lookup but fyne.CurrentApp() is now also inlineable).

I would argue that this would be good to add for v2.6.0 mainly due to the fact that it will make the race detector trigger on using the API from the wrong place.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

