### PR TITLE
Don't scroll on FocusGained For Collections

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -114,7 +114,6 @@ func (l *GridWrap) CreateRenderer() fyne.WidgetRenderer {
 // Implements: fyne.Focusable
 func (l *GridWrap) FocusGained() {
 	l.focused = true
-	l.scrollTo(l.currentFocus)
 	l.RefreshItem(l.currentFocus)
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -119,7 +119,6 @@ func (l *List) CreateRenderer() fyne.WidgetRenderer {
 // Implements: fyne.Focusable
 func (l *List) FocusGained() {
 	l.focused = true
-	l.scrollTo(l.currentFocus)
 	l.RefreshItem(l.currentFocus)
 }
 
@@ -178,6 +177,7 @@ func (l *List) scrollTo(id ListItemID) {
 	separatorThickness := l.Theme().Size(theme.SizeNamePadding)
 	y := float32(0)
 	lastItemHeight := l.itemMin.Height
+
 	if len(l.itemHeights) == 0 {
 		y = (float32(id) * l.itemMin.Height) + (float32(id) * separatorThickness)
 	} else {
@@ -195,7 +195,6 @@ func (l *List) scrollTo(id ListItemID) {
 			lastItemHeight = h
 		}
 	}
-
 	if y < l.scroller.Offset.Y {
 		l.scroller.Offset.Y = y
 	} else if y+l.itemMin.Height > l.scroller.Offset.Y+l.scroller.Size().Height {

--- a/widget/table.go
+++ b/widget/table.go
@@ -216,7 +216,6 @@ func (t *Table) DragEnd() {
 // Implements: fyne.Focusable
 func (t *Table) FocusGained() {
 	t.focused = true
-	t.ScrollTo(t.currentFocus)
 	t.RefreshItem(t.currentFocus)
 }
 

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -176,7 +176,6 @@ func (t *Tree) FocusGained() {
 	}
 
 	t.focused = true
-	t.ScrollTo(t.currentFocus)
 	t.RefreshItem(t.currentFocus)
 }
 


### PR DESCRIPTION
Fixes #5605

### Description:
Collections widgets already scroll to items when they are selected via clicking, keys, or by calling the API.  They also scroll via normal scroll means such as clicking scrollbars and scrolling.  There is no need to scroll on FocusGained as it is duplicative of other scrolls that are happening/will happen.

Fixes #5605 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
