### PR TITLE
Fix compilation with mobile simulator on XDG

### DIFF
--- a/app/app_mobile_xdg.go
+++ b/app/app_mobile_xdg.go
@@ -1,0 +1,22 @@
+//go:build !ci && mobile && !android && !ios
+
+package app
+
+import (
+	"errors"
+	"net/url"
+
+	"fyne.io/fyne/v2"
+)
+
+func (a *fyneApp) OpenURL(_ *url.URL) error {
+	return errors.New("mobile simulator does not support open URLs yet")
+}
+
+func (a *fyneApp) SendNotification(_ *fyne.Notification) {
+	fyne.LogError("Notifications are not supported in the mobile simulator yet", nil)
+}
+
+func watchTheme(_ *settings) {
+	// not implemented yet
+}

--- a/app/app_other.go
+++ b/app/app_other.go
@@ -1,4 +1,4 @@
-//go:build ci || (mobile && !android && !ios) || (!linux && !darwin && !windows && !freebsd && !openbsd && !netbsd && !wasm && !test_web_driver)
+//go:build ci || (!ios && !android && !linux && !darwin && !windows && !freebsd && !openbsd && !netbsd && !wasm && !test_web_driver)
 
 package app
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Compiling mobile simulator on develop gave a compile error about duplicate function definitions.
This fixes that issue also prepares for being able to add missing support for OpenURL and SendNotification in v2.7.0 instead of using the unsupported operating system error.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
