### PR TITLE
Add compile of fyne_demo to mobile tests

### DIFF
--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -28,3 +28,7 @@ jobs:
 
     - name: Tests
       run: go test -race -tags mobile,ci,migrated_fynedo ./...
+
+    - name: Compile
+      working-directory: cmd/fyne_demo
+      run: go build -tags mobile


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This avoids having to do fixes like https://github.com/fyne-io/fyne/pull/5633 in the future. The problem came about because of tests running with the ci tag so the compile error in the other code path was missed.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included. <- Well, kind of?
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

