### PR TITLE
Don't waste time re-parsing colours

### DIFF
--- a/theme/json.go
+++ b/theme/json.go
@@ -39,9 +39,15 @@ func fromJSONWithFallback(r io.Reader, fallback fyne.Theme) (fyne.Theme, error) 
 	return &jsonTheme{data: th, fallback: fallback}, nil
 }
 
+var parsedColors = map[hexColor]color.Color{}
+
 type hexColor string
 
 func (h hexColor) color() (color.Color, error) {
+	if parsed, ok := parsedColors[h]; ok {
+		return parsed, nil
+	}
+
 	data := h
 	switch len([]rune(h)) {
 	case 8, 6:
@@ -77,6 +83,7 @@ func (h hexColor) color() (color.Color, error) {
 		ret.A = 0xff
 	}
 
+	parsedColors[h] = ret
 	return ret, nil
 }
 

--- a/theme/json.go
+++ b/theme/json.go
@@ -36,15 +36,13 @@ func fromJSONWithFallback(r io.Reader, fallback fyne.Theme) (fyne.Theme, error) 
 		return fallback, err
 	}
 
-	return &jsonTheme{data: th, fallback: fallback}, nil
+	return &jsonTheme{data: th, fallback: fallback, parsedColors: map[hexColor]color.Color{}}, nil
 }
-
-var parsedColors = map[hexColor]color.Color{}
 
 type hexColor string
 
-func (h hexColor) color() (color.Color, error) {
-	if parsed, ok := parsedColors[h]; ok {
+func (h hexColor) color(cache map[hexColor]color.Color) (color.Color, error) {
+	if parsed, ok := cache[h]; ok {
 		return parsed, nil
 	}
 
@@ -83,7 +81,9 @@ func (h hexColor) color() (color.Color, error) {
 		ret.A = 0xff
 	}
 
-	parsedColors[h] = ret
+	if cache != nil {
+		cache[h] = ret
+	}
 	return ret, nil
 }
 
@@ -116,13 +116,15 @@ type schema struct {
 type jsonTheme struct {
 	data     *schema
 	fallback fyne.Theme
+
+	parsedColors map[hexColor]color.Color
 }
 
 func (t *jsonTheme) Color(name fyne.ThemeColorName, variant fyne.ThemeVariant) color.Color {
 	switch variant {
 	case VariantLight:
 		if val, ok := t.data.LightColors[string(name)]; ok {
-			c, err := val.color()
+			c, err := val.color(t.parsedColors)
 			if err != nil {
 				fyne.LogError("Failed to parse color", err)
 			} else {
@@ -131,7 +133,7 @@ func (t *jsonTheme) Color(name fyne.ThemeColorName, variant fyne.ThemeVariant) c
 		}
 	case VariantDark:
 		if val, ok := t.data.DarkColors[string(name)]; ok {
-			c, err := val.color()
+			c, err := val.color(t.parsedColors)
 			if err != nil {
 				fyne.LogError("Failed to parse color", err)
 			} else {
@@ -141,7 +143,7 @@ func (t *jsonTheme) Color(name fyne.ThemeColorName, variant fyne.ThemeVariant) c
 	}
 
 	if val, ok := t.data.Colors[string(name)]; ok {
-		c, err := val.color()
+		c, err := val.color(t.parsedColors)
 		if err != nil {
 			fyne.LogError("Failed to parse color", err)
 		} else {

--- a/theme/json_test.go
+++ b/theme/json_test.go
@@ -47,26 +47,26 @@ func TestFromTOML_Resource(t *testing.T) {
 }
 
 func TestHexColor(t *testing.T) {
-	c, err := hexColor("#abc").color()
+	c, err := hexColor("#abc").color(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c)
-	c, err = hexColor("abc").color()
+	c, err = hexColor("abc").color(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c)
-	c, err = hexColor("#abcd").color()
+	c, err = hexColor("#abcd").color(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xdd}, c)
 
-	c, err = hexColor("#a1b2c3").color()
+	c, err = hexColor("#a1b2c3").color(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c)
-	c, err = hexColor("a1b2c3").color()
+	c, err = hexColor("a1b2c3").color(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c)
-	c, err = hexColor("#a1b2c3f4").color()
+	c, err = hexColor("#a1b2c3f4").color(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c)
-	c, err = hexColor("a1b2c3f4").color()
+	c, err = hexColor("a1b2c3f4").color(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c)
 }


### PR DESCRIPTION
Fix issue where custom themes could put CPU usage very high.

Comparing FyneTerm (which is very theme heavy):
* Running "top" at default size: 2% CPU
* Running same with custom theme: 30% CPU

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- not sure how to test core speed comparisons
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
