### PR TITLE
Correctly reset an image when resource goes to nil

### DIFF
--- a/canvas/image.go
+++ b/canvas/image.go
@@ -133,8 +133,9 @@ func (i *Image) Refresh() {
 			return
 		}
 		rc = io.NopCloser(r)
-	} else if !i.previousRender {
+	} else if i.previousRender {
 		i.previousRender = false
+	} else {
 		return
 	}
 

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -135,6 +135,9 @@ func (i *Image) Refresh() {
 		rc = io.NopCloser(r)
 	} else if i.previousRender {
 		i.previousRender = false
+
+		Refresh(i)
+		return
 	} else {
 		return
 	}

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -70,6 +70,8 @@ type Image struct {
 	Translucency float64    // Set a translucency value > 0.0 to fade the image
 	FillMode     ImageFill  // Specify how the image should expand to fill or fit the available space
 	ScaleMode    ImageScale // Specify the type of scaling interpolation applied to the image
+
+	previousRender bool // did we successfully draw before? if so a nil content will need a reset
 }
 
 // Alpha is a convenience function that returns the alpha value for an image
@@ -131,7 +133,8 @@ func (i *Image) Refresh() {
 			return
 		}
 		rc = io.NopCloser(r)
-	} else {
+	} else if !i.previousRender {
+		i.previousRender = false
 		return
 	}
 
@@ -165,6 +168,7 @@ func (i *Image) Refresh() {
 		}
 	}
 
+	i.previousRender = true
 	Refresh(i)
 }
 

--- a/canvas/image_test.go
+++ b/canvas/image_test.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/storage"
 	_ "fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -26,6 +28,22 @@ func TestImage_TranslucencyDefault(t *testing.T) {
 	img := &canvas.Image{}
 
 	assert.Equal(t, 0.0, img.Translucency)
+}
+
+func TestImage_RefreshBlank(t *testing.T) {
+	img := &canvas.Image{}
+	img.Resize(fyne.NewSize(64, 64))
+	img.Refresh()
+	assert.Nil(t, img.Image)
+
+	img.Resource = theme.HomeIcon()
+	img.Refresh()
+	assert.NotNil(t, img.Image)
+
+	img.Image = nil
+	img.Resource = nil
+	img.Refresh()
+	assert.Nil(t, img.Image)
 }
 
 func TestNewImageFromFile(t *testing.T) {


### PR DESCRIPTION
An image optimisation triggered a bug where it could not be reset to nil after a resource was used

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

