### PR TITLE
Clean up how app code starts and ends to fix crashes and false warnings

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -36,7 +36,7 @@ func runOnMain(f func()) {
 
 // force a function f to run on the main thread and specify if we should wait for it to return
 func runOnMainWithWait(f func(), wait bool) {
-	// If we are on main during app run just execute - otherwise add it to the main queue and wait.
+	// If we are on main before app run just execute - otherwise add it to the main queue and wait.
 	// We also need to run it as-is if the app is in the process of shutting down as the queue will be stopped.
 	if (!running.Load() && async.IsMainGoroutine()) || drained.Load() {
 		f()

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -36,8 +36,8 @@ func runOnMain(f func()) {
 
 // force a function f to run on the main thread and specify if we should wait for it to return
 func runOnMainWithWait(f func(), wait bool) {
-	// If we are on main just execute - otherwise add it to the main queue and wait.
-	// The "running" variable is normally false when we are on the main thread.
+	// If we are on main during app run just execute - otherwise add it to the main queue and wait.
+	// We also need to run it as-is if the app is in the process of shutting down as the queue will be stopped.
 	if (!running.Load() && async.IsMainGoroutine()) || drained.Load() {
 		f()
 		return
@@ -131,6 +131,7 @@ func (d *gLDriver) runGL() {
 				l.QueueEvent(f)
 			}
 
+			// as we are shutting down make sure we drain the pending funcQueue and close it out.
 			for len(funcQueue.Out()) > 0 {
 				f := <-funcQueue.Out()
 				if f.done != nil {


### PR DESCRIPTION
This fixes a few crashes such as #5639 plus seeing warnings incorrectly during start or end.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
