### PR TITLE
fix entry undo and redo don't trigger OnChanged

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -426,6 +426,10 @@ func (e *Entry) Redo() {
 	e.updateText(newText, false)
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.syncSelectable()
+	cb := e.OnChanged
+	if cb != nil {
+		cb(newText) // We know that the text has changed.
+	}
 	e.Refresh()
 }
 
@@ -720,6 +724,10 @@ func (e *Entry) Undo() {
 	e.updateText(newText, false)
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.syncSelectable()
+	cb := e.OnChanged
+	if cb != nil {
+		cb(newText) // We know that the text has changed.
+	}
 	e.Refresh()
 }
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -426,9 +426,8 @@ func (e *Entry) Redo() {
 	e.updateText(newText, false)
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.syncSelectable()
-	cb := e.OnChanged
-	if cb != nil {
-		cb(newText) // We know that the text has changed.
+	if e.OnChanged != nil {
+		e.OnChanged(newText)
 	}
 	e.Refresh()
 }
@@ -724,9 +723,8 @@ func (e *Entry) Undo() {
 	e.updateText(newText, false)
 	e.CursorRow, e.CursorColumn = e.rowColFromTextPos(pos)
 	e.syncSelectable()
-	cb := e.OnChanged
-	if cb != nil {
-		cb(newText) // We know that the text has changed.
+	if e.OnChanged != nil {
+		e.OnChanged(newText)
 	}
 	e.Refresh()
 }

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -2122,6 +2122,45 @@ func TestEntry_UndoRedoImage(t *testing.T) {
 	test.AssertImageMatches(t, "entry/undo_redo_mistake_corrected.png", window.Canvas().Capture())
 }
 
+func TestEntry_UndoRedo_Callback(t *testing.T) {
+	entry := widget.NewEntry()
+	changed := ""
+	entry.OnChanged = func(s string) {
+		changed = s
+	}
+
+	for _, r := range "abc éàè 123" {
+		entry.TypedRune(r)
+	}
+
+	assert.Equal(t, "abc éàè 123", entry.Text)
+	assert.Equal(t, "abc éàè 123", changed)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "abc éàè", entry.Text)
+	assert.Equal(t, "abc éàè", changed)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "abc", entry.Text)
+	assert.Equal(t, "abc", changed)
+
+	entry.TypedShortcut(&fyne.ShortcutUndo{})
+	assert.Equal(t, "", entry.Text)
+	assert.Equal(t, "", changed)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "abc", entry.Text)
+	assert.Equal(t, "abc", changed)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "abc éàè", entry.Text)
+	assert.Equal(t, "abc éàè", changed)
+
+	entry.TypedShortcut(&fyne.ShortcutRedo{})
+	assert.Equal(t, "abc éàè 123", entry.Text)
+	assert.Equal(t, "abc éàè 123", changed)
+}
+
 const (
 	entryOffset = 10
 


### PR DESCRIPTION
### Description:
using undo and redo on an entry widget didn't trigger OnChanged, so I added a call to the callback in both methods.

Fixes #5710 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
