### PR TITLE
The system tray lifecycle exits when our app closes

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -70,7 +70,6 @@ func (d *gLDriver) runSystray(m *fyne.Menu) {
 	w := d.CreateWindow("SystrayMonitor")
 	w.(*window).create()
 	w.SetCloseIntercept(d.Quit)
-	w.SetOnClosed(systray.Quit)
 }
 
 func itemForMenuItem(i *fyne.MenuItem, parent *systray.MenuItem) *systray.MenuItem {


### PR DESCRIPTION
Fixes #5724

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
