### PR TITLE
Generalise Form Validation

### DIFF
--- a/cmd/fyne_demo/tutorials/dialog.go
+++ b/cmd/fyne_demo/tutorials/dialog.go
@@ -120,9 +120,9 @@ func dialogScreen(win fyne.Window) fyne.CanvasObject {
 		}),
 		widget.NewButton("Form Dialog (Login Form)", func() {
 			username := widget.NewEntry()
-			username.Validator = validation.NewRegexp(`^[A-Za-z0-9_-]+$`, "username can only contain letters, numbers, '_', and '-'")
+			username.SetValidator(validation.NewRegexp(`^[A-Za-z0-9_-]+$`, "username can only contain letters, numbers, '_', and '-'"))
 			password := widget.NewPasswordEntry()
-			password.Validator = validation.NewRegexp(`^[A-Za-z0-9_-]+$`, "password can only contain letters, numbers, '_', and '-'")
+			password.SetValidator(validation.NewRegexp(`^[A-Za-z0-9_-]+$`, "password can only contain letters, numbers, '_', and '-'"))
 			remember := false
 			items := []*widget.FormItem{
 				widget.NewFormItem("Username", username),

--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -432,7 +432,7 @@ func makeFormTab(_ fyne.Window) fyne.CanvasObject {
 
 	email := widget.NewEntry()
 	email.SetPlaceHolder("test@example.com")
-	email.Validator = validation.NewRegexp(`\w{1,}@\w{1,}\.\w{1,4}`, "not a valid email")
+	email.SetValidator(validation.NewRegexp(`\w{1,}@\w{1,}\.\w{1,4}`, "not a valid email"))
 
 	password := widget.NewPasswordEntry()
 	password.SetPlaceHolder("Password")
@@ -513,6 +513,6 @@ func (n *numEntry) Keyboard() mobile.KeyboardType {
 func newNumEntry() *numEntry {
 	e := &numEntry{}
 	e.ExtendBaseWidget(e)
-	e.Validator = validation.NewRegexp(`\d`, "Must contain a number")
+	e.SetValidator(validation.NewRegexp(`\d`, "Must contain a number"))
 	return e
 }

--- a/dialog/form_test.go
+++ b/dialog/form_test.go
@@ -119,7 +119,7 @@ func TestFormDialog_Hints(t *testing.T) {
 
 func TestFormDialog_Submit(t *testing.T) {
 	validatingEntry := widget.NewEntry()
-	validatingEntry.SetValidator (func(input string) error {
+	validatingEntry.SetValidator(func(input string) error {
 		if input != "abc" {
 			return errors.New("only accepts 'abc'")
 		}

--- a/dialog/form_test.go
+++ b/dialog/form_test.go
@@ -119,12 +119,12 @@ func TestFormDialog_Hints(t *testing.T) {
 
 func TestFormDialog_Submit(t *testing.T) {
 	validatingEntry := widget.NewEntry()
-	validatingEntry.Validator = func(input string) error {
+	validatingEntry.SetValidator (func(input string) error {
 		if input != "abc" {
 			return errors.New("only accepts 'abc'")
 		}
 		return nil
-	}
+	})
 	validatingItem := &widget.FormItem{Widget: validatingEntry}
 
 	confirmed := false
@@ -150,12 +150,12 @@ func TestFormDialog_Submit(t *testing.T) {
 
 func validatingFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {
 	validatingEntry := widget.NewEntry()
-	validatingEntry.Validator = func(input string) error {
+	validatingEntry.SetValidator(func(input string) error {
 		if input != "abc" {
 			return errors.New("only accepts 'abc'")
 		}
 		return nil
-	}
+	})
 	validatingItem := &widget.FormItem{
 		Text:   "Only accepts 'abc'",
 		Widget: validatingEntry,
@@ -199,12 +199,12 @@ func controlFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog
 
 func hintsFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {
 	validatingEntry := widget.NewEntry()
-	validatingEntry.Validator = func(input string) error {
+	validatingEntry.SetValidator(func(input string) error {
 		if input != "abc" {
 			return errors.New("only accepts 'abc'")
 		}
 		return nil
-	}
+	})
 	validatingItem := &widget.FormItem{
 		Text:     "Only accepts 'abc'",
 		Widget:   validatingEntry,

--- a/lang/translations/base.ru.json
+++ b/lang/translations/base.ru.json
@@ -43,4 +43,4 @@
     "wednesday": "Среда",
     "wednesday.short": "Ср"
 }
-{}
+

--- a/lang/translations/base.ru.json
+++ b/lang/translations/base.ru.json
@@ -43,3 +43,4 @@
     "wednesday": "Среда",
     "wednesday.short": "Ср"
 }
+{}

--- a/validation.go
+++ b/validation.go
@@ -24,6 +24,12 @@ type FormValidatable interface {
 	// GetValidator retrieves the validator function.
 	GetValidator() StringValidator
 
+	// IsFocused indicates that the widget has focus.
+	HasFocus() bool
+
+	// IsDirty indicates that the widget's contents have changed.
+	IsDirty() bool
+
 	// SetValidator sets the validator function. This function should be called from within the Validate function.
 	SetValidator(StringValidator)
 

--- a/validation.go
+++ b/validation.go
@@ -1,6 +1,7 @@
 package fyne
 
-// Validatable is an interface for specifying if a widget is validatable.
+// Validatable is an interface for specifying if a widget is validatable. Implementation of this interface
+// is not sufficient to validate a widget within a Form widget.
 //
 // Since: 1.4
 type Validatable interface {
@@ -9,6 +10,29 @@ type Validatable interface {
 	// SetOnValidationChanged is used to set the callback that will be triggered when the validation state changes.
 	// The function might be overwritten by a parent that cares about child validation (e.g. widget.Form).
 	SetOnValidationChanged(func(error))
+}
+
+// FormValidatable is an interface for specifying if a widget can be validated within a Form widget.
+//
+// Since: 2.7
+type FormValidatable interface {
+	Validatable
+
+	// GetValidationError retrieves the widget's validation error. This will be null if validation passes.
+	GetValidationError() error
+
+	// GetValidator retrieves the validator function.
+	GetValidator() StringValidator
+
+	// SetValidator sets the validator function. This function should be called from within the Validate function.
+	SetValidator(StringValidator)
+
+	// SetOnFocusChanged sets the function that should be called from within the widget's FocusGained and FocusLost
+	// methods.
+	SetOnFocusChanged(func(bool))
+
+	// SetValidation error sets the widget's validation error.
+	SetValidationError(error)
 }
 
 // StringValidator is a function signature for validating string inputs.

--- a/widget/date_entry.go
+++ b/widget/date_entry.go
@@ -36,10 +36,10 @@ func (e *DateEntry) CreateRenderer() fyne.WidgetRenderer {
 	e.ExtendBaseWidget(e)
 
 	dateFormat := getLocaleDateFormat()
-	e.Validator = func(in string) error {
+	e.SetValidator(func(in string) error {
 		_, err := time.Parse(dateFormat, in)
 		return err
-	}
+	})
 	e.Entry.OnChanged = func(in string) {
 		if in == "" {
 			e.Date = nil

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -62,9 +62,8 @@ type Entry struct {
 	onValidationChanged func(error)
 	validationError     error
 
-	// If true, the Validator runs automatically on render without user interaction.
-	// It will reflect any validation errors found or those explicitly set via SetValidationError().
-	// Since: 2.7
+	// When true, the entry will always display an error (if there is any) without user interaction.
+	// Validator is called when rendered
 	AlwaysShowValidationError bool
 
 	CursorRow, CursorColumn int

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -296,6 +296,15 @@ func (e *Entry) FocusLost() {
 	}
 }
 
+// HasFocus indicates if the widget has focus.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
+func (e *Entry) HasFocus() bool {
+	return e.focused
+}
+
 // Hide hides the entry.
 //
 // Implements: fyne.Widget
@@ -305,6 +314,15 @@ func (e *Entry) Hide() {
 		e.popUp = nil
 	}
 	e.DisableableWidget.Hide()
+}
+
+// IsDirty indicates if the widget's text has changed.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
+func (e *Entry) IsDirty() bool {
+	return e.dirty
 }
 
 // Keyboard implements the Keyboardable interface

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -461,6 +461,11 @@ func (e *Entry) SetMinRowsVisible(count int) {
 	e.Refresh()
 }
 
+// SetOnFocusChanged sets the function that is called when focus is gained or lost.
+func (e *Entry) SetOnFocusChanged(f func(bool)) {
+	e.onFocusChanged = f
+}
+
 // SetPlaceHolder sets the text that will be displayed if the entry is otherwise empty
 func (e *Entry) SetPlaceHolder(text string) {
 	e.Theme() // setup theme cache before locking

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -63,7 +63,7 @@ type Entry struct {
 	validationError     error
 
 	// When true, the entry will always display an validation error (if there is any) without user interaction.
-	// Since: 2.5
+	// Since: 2.6
 	AlwaysShowValidationError bool
 
 	CursorRow, CursorColumn int

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -462,6 +462,10 @@ func (e *Entry) SetMinRowsVisible(count int) {
 }
 
 // SetOnFocusChanged sets the function that is called when focus is gained or lost.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
 func (e *Entry) SetOnFocusChanged(f func(bool)) {
 	e.onFocusChanged = f
 }

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -62,8 +62,9 @@ type Entry struct {
 	onValidationChanged func(error)
 	validationError     error
 
-	// When true, the entry will always display an validation error (if there is any) without user interaction.
-	// Since: 2.6
+	// If true, the Validator runs automatically on render without user interaction.
+	// It will reflect any validation errors found or those explicitly set via SetValidationError().
+	// Since: 2.7
 	AlwaysShowValidationError bool
 
 	CursorRow, CursorColumn int

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -62,8 +62,8 @@ type Entry struct {
 	onValidationChanged func(error)
 	validationError     error
 
-	// When true, the entry will always display an error (if there is any) without user interaction.
-	// Validator is called when rendered
+	// When true, the entry will always display an validation error (if there is any) without user interaction.
+	// Since: 2.5
 	AlwaysShowValidationError bool
 
 	CursorRow, CursorColumn int

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -383,10 +383,10 @@ func TestEntry_PasteFromClipboard_MultilineWrapping(t *testing.T) {
 func TestEntry_PasteFromClipboardValidation(t *testing.T) {
 	entry := NewEntry()
 	var triggered int
-	entry.Validator = func(s string) error {
+	entry.SetValidator(func(s string) error {
 		triggered++
 		return nil
-	}
+	})
 
 	testContent := "test"
 	clipboard := test.NewTempApp(t).Clipboard()

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -8,7 +8,23 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-var _ fyne.Validatable = (*Entry)(nil)
+var _ fyne.FormValidatable = (*Entry)(nil)
+
+// GetValidationError retrieves the Entry widget's validation error.
+func (e *Entry) GetValidationError() error {
+	return e.validationError
+}
+
+// GetValidator returns the Validator function, or nil if there is none.
+func (e *Entry) GetValidator() fyne.StringValidator {
+	return e.Validator
+}
+
+// SetValidator sets the function that validates Entry text. This function should be called
+// by the Validate method.
+func (e *Entry) SetValidator(f fyne.StringValidator) {
+	e.Validator = f
+}
 
 // Validate validates the current text in the widget.
 func (e *Entry) Validate() error {
@@ -48,6 +64,11 @@ func (e *Entry) SetValidationError(err error) {
 	}
 
 	e.Refresh()
+}
+
+// ValidationError returns the Entry widget's validation error.
+func (e *Entry) ValidationError() error {
+	return e.validationError
 }
 
 // setValidationError sets the validation error and returns a bool to indicate if it changes.

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -11,17 +11,29 @@ import (
 var _ fyne.FormValidatable = (*Entry)(nil)
 
 // GetValidationError retrieves the Entry widget's validation error.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
 func (e *Entry) GetValidationError() error {
 	return e.validationError
 }
 
 // GetValidator returns the Validator function, or nil if there is none.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
 func (e *Entry) GetValidator() fyne.StringValidator {
 	return e.Validator
 }
 
 // SetValidator sets the function that validates Entry text. This function should be called
 // by the Validate method.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
 func (e *Entry) SetValidator(f fyne.StringValidator) {
 	e.Validator = f
 }
@@ -54,6 +66,10 @@ func (e *Entry) SetOnValidationChanged(callback func(error)) {
 }
 
 // SetValidationError manually updates the validation status until the next input change.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
 func (e *Entry) SetValidationError(err error) {
 	if e.Validator == nil && !e.AlwaysShowValidationError {
 		return

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -82,11 +82,6 @@ func (e *Entry) SetValidationError(err error) {
 	e.Refresh()
 }
 
-// ValidationError returns the Entry widget's validation error.
-func (e *Entry) ValidationError() error {
-	return e.validationError
-}
-
 // setValidationError sets the validation error and returns a bool to indicate if it changes.
 // It assumes that the widget has a validator.
 func (e *Entry) setValidationError(err error) bool {

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -17,7 +17,7 @@ func TestEntry_DisabledHideValidation(t *testing.T) {
 	entry, window := setupImageTest(t, false)
 	c := window.Canvas()
 
-	entry.Validator = validator
+	entry.SetValidator(validator)
 	entry.SetText("invalid text")
 	entry.Disable()
 
@@ -29,7 +29,7 @@ func TestEntry_ValidatedEntry(t *testing.T) {
 	c := window.Canvas()
 
 	r := validation.NewRegexp(`^\d{4}-\d{2}-\d{2}`, "Input is not a valid date")
-	entry.Validator = r
+	entry.SetValidator(r)
 	test.AssertRendersToMarkup(t, "entry/validate_initial.xml", c)
 
 	test.Type(entry, "2020-02")
@@ -44,30 +44,30 @@ func TestEntry_ValidatedEntry(t *testing.T) {
 
 func TestEntry_Validate(t *testing.T) {
 	entry := widget.NewEntry()
-	entry.Validator = validator
+	entry.SetValidator(validator)
 
 	test.Type(entry, "2020-02")
 	assert.Error(t, entry.Validate())
-	assert.Equal(t, entry.Validate(), entry.Validator(entry.Text))
+	assert.Equal(t, entry.Validate(), entry.GetValidator()(entry.Text))
 
 	test.Type(entry, "-12")
 	assert.NoError(t, entry.Validate())
-	assert.Equal(t, entry.Validate(), entry.Validator(entry.Text))
+	assert.Equal(t, entry.Validate(), entry.GetValidator()(entry.Text))
 
 	entry.SetText("incorrect")
 	assert.Error(t, entry.Validate())
-	assert.Equal(t, entry.Validate(), entry.Validator(entry.Text))
+	assert.Equal(t, entry.Validate(), entry.GetValidator()(entry.Text))
 }
 
 func TestEntry_NotEmptyValidator(t *testing.T) {
 	test.NewTempApp(t)
 	entry := widget.NewEntry()
-	entry.Validator = func(s string) error {
+	entry.SetValidator(func(s string) error {
 		if s == "" {
 			return errors.New("should not be empty")
 		}
 		return nil
-	}
+	})
 	w := test.NewTempWindow(t, entry)
 
 	test.AssertRendersToMarkup(t, "entry/validator_not_empty_initial.xml", w.Canvas())
@@ -86,7 +86,7 @@ func TestEntry_SetValidationError(t *testing.T) {
 	test.ApplyTheme(t, test.Theme())
 	c := window.Canvas()
 
-	entry.Validator = validator
+	entry.SetValidator(validator)
 
 	entry.SetText("2020-30-30")
 	entry.SetValidationError(errors.New("set invalid"))
@@ -99,11 +99,11 @@ func TestEntry_SetValidationError(t *testing.T) {
 
 func TestEntry_SetOnValidationChanged(t *testing.T) {
 	entry := widget.NewEntry()
-	entry.Validator = validator
+	entry.SetValidator(validator)
 
 	modified := false
 	entry.SetOnValidationChanged(func(err error) {
-		assert.Equal(t, err, entry.Validator(entry.Text))
+		assert.Equal(t, err, entry.GetValidator()(entry.Text))
 		modified = true
 	})
 
@@ -125,13 +125,13 @@ func TestEntry_AlwaysShowValidationError_WithValidator_Error(t *testing.T) {
 
 	entry := widget.NewEntry()
 	entry.AlwaysShowValidationError = true
-	entry.Validator = func(s string) error {
+	entry.SetValidator(func(s string) error {
 		if s == "success" {
 			return nil
 		}
 
 		return errors.New("mocking failed validation")
-	}
+	})
 
 	w := test.NewTempWindow(t, entry)
 	test.AssertRendersToMarkup(t, "entry/always_on_with_validator_error.xml", w.Canvas())
@@ -142,13 +142,13 @@ func TestEntry_AlwaysShowValidationError_WithValidator_Success(t *testing.T) {
 
 	entry := widget.NewEntry()
 	entry.AlwaysShowValidationError = true
-	entry.Validator = func(s string) error {
+	entry.SetValidator(func(s string) error {
 		if s == "success" {
 			return nil
 		}
 
 		return errors.New("error")
-	}
+	})
 
 	entry.SetText("success")
 

--- a/widget/form.go
+++ b/widget/form.go
@@ -344,11 +344,11 @@ func (f *Form) updateHelperText(item *FormItem) {
 		return // testing probably, either way not rendered yet
 	}
 	showHintIfError := false
-	if e, ok := item.Widget.(*Entry); ok {
-		if !e.dirty || (e.focused && !item.wasFocused) {
+	if w, ok := item.Widget.(fyne.FormValidatable); ok {
+		if !w.IsDirty() || (w.HasFocus() && !item.wasFocused) {
 			showHintIfError = true
 		}
-		if e.dirty && !e.focused {
+		if w.IsDirty() && !w.HasFocus() {
 			item.wasFocused = true
 		}
 	}

--- a/widget/form.go
+++ b/widget/form.go
@@ -2,7 +2,6 @@ package widget
 
 import (
 	"errors"
-	"reflect"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -181,16 +180,10 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 }
 
 func (f *Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
-	value := reflect.ValueOf(w).Elem()
-	validatorField := value.FieldByName("Validator")
-	if validatorField == (reflect.Value{}) {
-		return false
+	if v, ok := w.(fyne.FormValidatable); ok {
+		return v.GetValidator() != nil
 	}
-	validator, ok := validatorField.Interface().(fyne.StringValidator)
-	if !ok {
-		return false
-	}
-	return validator != nil
+	return false
 }
 
 func (f *Form) createLabel(text string) fyne.CanvasObject {

--- a/widget/form.go
+++ b/widget/form.go
@@ -307,17 +307,16 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 		f.checkValidation(err)
 		f.updateHelperText(f.Items[i])
 	}
-	if w, ok := widget.(fyne.Validatable); ok {
+	if w, ok := widget.(fyne.FormValidatable); ok {
 		f.Items[i].invalid = w.Validate() != nil
-		if e, ok := w.(*Entry); ok {
-			e.onFocusChanged = func(bool) {
-				updateValidation(e.validationError)
-			}
-			if e.Validator != nil && f.Items[i].invalid {
-				// set initial state error to guarantee next error (if triggers) is always different
-				e.SetValidationError(errFormItemInitialState)
-			}
+		w.SetOnFocusChanged(func(bool) {
+			updateValidation(w.GetValidationError())
+		})
+		if w.GetValidator() != nil && f.Items[i].invalid {
+			// set initial state error to guarantee next error (if triggers) is always different
+			w.SetValidationError(errFormItemInitialState)
 		}
+
 		w.SetOnValidationChanged(updateValidation)
 	}
 }

--- a/widget/testdata/entry/always_on_with_validator_error.xml
+++ b/widget/testdata/entry/always_on_with_validator_error.xml
@@ -3,12 +3,12 @@
 		<widget pos="4,4" size="60x35" type="*widget.Entry">
 			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
 			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="error" strokeWidth="2"/>
-			<widget pos="0,2" size="28x31" type="*widget.Scroll">
-				<widget size="28x31" type="*widget.entryContent">
-					<widget size="28x31" type="*widget.RichText">
+			<widget pos="0,2" size="36x31" type="*widget.Scroll">
+				<widget size="36x31" type="*widget.entryContent">
+					<widget size="36x31" type="*widget.RichText">
 						<text color="placeholder" pos="8,6" size="0x19"></text>
 					</widget>
-					<widget size="28x31" type="*widget.RichText">
+					<widget size="36x31" type="*widget.RichText">
 						<text pos="8,6" size="0x19"></text>
 					</widget>
 				</widget>

--- a/widget/testdata/entry/always_on_with_validator_error.xml
+++ b/widget/testdata/entry/always_on_with_validator_error.xml
@@ -3,12 +3,12 @@
 		<widget pos="4,4" size="60x35" type="*widget.Entry">
 			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
 			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="error" strokeWidth="2"/>
-			<widget pos="0,2" size="36x31" type="*widget.Scroll">
-				<widget size="36x31" type="*widget.entryContent">
-					<widget size="36x31" type="*widget.RichText">
+			<widget pos="0,2" size="28x31" type="*widget.Scroll">
+				<widget size="28x31" type="*widget.entryContent">
+					<widget size="28x31" type="*widget.RichText">
 						<text color="placeholder" pos="8,6" size="0x19"></text>
 					</widget>
-					<widget size="36x31" type="*widget.RichText">
+					<widget size="28x31" type="*widget.RichText">
 						<text pos="8,6" size="0x19"></text>
 					</widget>
 				</widget>

--- a/widget/testdata/entry/always_on_with_validator_success.xml
+++ b/widget/testdata/entry/always_on_with_validator_success.xml
@@ -3,18 +3,18 @@
 		<widget pos="4,4" size="60x35" type="*widget.Entry">
 			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
 			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="inputBorder" strokeWidth="2"/>
-			<widget pos="0,2" size="36x31" type="*widget.Scroll">
+			<widget pos="0,2" size="28x31" type="*widget.Scroll">
 				<widget size="66x31" type="*widget.entryContent">
 					<widget size="66x31" type="*widget.RichText">
 						<text pos="8,6" size="50x19">success</text>
 					</widget>
 				</widget>
-				<widget pos="36,0" size="0x31" type="*widget.Shadow">
+				<widget pos="28,0" size="0x31" type="*widget.Shadow">
 					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x31"/>
 				</widget>
-				<widget pos="0,25" size="36x6" type="*widget.scrollBarArea">
-					<widget pos="0,3" size="19x3" type="*widget.scrollBar">
-						<rectangle fillColor="scrollbar" radius="3" size="19x3"/>
+				<widget pos="0,25" size="28x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="16x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" radius="3" size="16x3"/>
 					</widget>
 				</widget>
 			</widget>

--- a/widget/testdata/entry/always_on_with_validator_success.xml
+++ b/widget/testdata/entry/always_on_with_validator_success.xml
@@ -3,18 +3,18 @@
 		<widget pos="4,4" size="60x35" type="*widget.Entry">
 			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>
 			<rectangle pos="1,1" radius="4" size="58x32" strokeColor="inputBorder" strokeWidth="2"/>
-			<widget pos="0,2" size="28x31" type="*widget.Scroll">
+			<widget pos="0,2" size="36x31" type="*widget.Scroll">
 				<widget size="66x31" type="*widget.entryContent">
 					<widget size="66x31" type="*widget.RichText">
 						<text pos="8,6" size="50x19">success</text>
 					</widget>
 				</widget>
-				<widget pos="28,0" size="0x31" type="*widget.Shadow">
+				<widget pos="36,0" size="0x31" type="*widget.Shadow">
 					<linearGradient angle="270" endColor="shadow" pos="-8,0" size="8x31"/>
 				</widget>
-				<widget pos="0,25" size="28x6" type="*widget.scrollBarArea">
-					<widget pos="0,3" size="16x3" type="*widget.scrollBar">
-						<rectangle fillColor="scrollbar" radius="3" size="16x3"/>
+				<widget pos="0,25" size="36x6" type="*widget.scrollBarArea">
+					<widget pos="0,3" size="19x3" type="*widget.scrollBar">
+						<rectangle fillColor="scrollbar" radius="3" size="19x3"/>
 					</widget>
 				</widget>
 			</widget>


### PR DESCRIPTION
### Description:
The Form widget only handles validation of Entry widget. These changes generalise validation handling by:
1. Creating a new FormValidatable interface that encapsulates Entry functionality that the Form widget was referencing directly. For example: instead of referencing Entry.dirty directly, the interface defines a new IsDirty() method.
2. Modifying the Entry widget to implement the FormValidatable interface.
3. Modifying the Form widget to interact with the Entry widget only using the methods in the FormValidatable interface.
4. Remove all Entry specific references from Form.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.