### PR TITLE
Support form validation of widgets other than Entry

### DIFF
--- a/dialog/form_test.go
+++ b/dialog/form_test.go
@@ -119,12 +119,12 @@ func TestFormDialog_Hints(t *testing.T) {
 
 func TestFormDialog_Submit(t *testing.T) {
 	validatingEntry := widget.NewEntry()
-	validatingEntry.Validator = func(input string) error {
+	validatingEntry.SetValidator(func(input string) error {
 		if input != "abc" {
 			return errors.New("only accepts 'abc'")
 		}
 		return nil
-	}
+	})
 	validatingItem := &widget.FormItem{Widget: validatingEntry}
 
 	confirmed := false
@@ -150,12 +150,12 @@ func TestFormDialog_Submit(t *testing.T) {
 
 func validatingFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {
 	validatingEntry := widget.NewEntry()
-	validatingEntry.Validator = func(input string) error {
+	validatingEntry.SetValidator(func(input string) error {
 		if input != "abc" {
 			return errors.New("only accepts 'abc'")
 		}
 		return nil
-	}
+	})
 	validatingItem := &widget.FormItem{
 		Text:   "Only accepts 'abc'",
 		Widget: validatingEntry,
@@ -199,12 +199,12 @@ func controlFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog
 
 func hintsFormDialog(result *formDialogResult, parent fyne.Window) *FormDialog {
 	validatingEntry := widget.NewEntry()
-	validatingEntry.Validator = func(input string) error {
+	validatingEntry.SetValidator(func(input string) error {
 		if input != "abc" {
 			return errors.New("only accepts 'abc'")
 		}
 		return nil
-	}
+	})
 	validatingItem := &widget.FormItem{
 		Text:     "Only accepts 'abc'",
 		Widget:   validatingEntry,

--- a/validation.go
+++ b/validation.go
@@ -1,6 +1,7 @@
 package fyne
 
-// Validatable is an interface for specifying if a widget is validatable.
+// Validatable is an interface for specifying if a widget is validatable. Implementation of this interface
+// is not sufficient to validate a widget within a Form widget.
 //
 // Since: 1.4
 type Validatable interface {
@@ -9,6 +10,35 @@ type Validatable interface {
 	// SetOnValidationChanged is used to set the callback that will be triggered when the validation state changes.
 	// The function might be overwritten by a parent that cares about child validation (e.g. widget.Form).
 	SetOnValidationChanged(func(error))
+}
+
+// FormValidatable is an interface for specifying if a widget can be validated within a Form widget.
+//
+// Since: 2.7
+type FormValidatable interface {
+	Validatable
+
+	// GetValidationError retrieves the widget's validation error. This will be null if validation passes.
+	GetValidationError() error
+
+	// GetValidator retrieves the validator function.
+	GetValidator() StringValidator
+
+	// HasFocus indicates that the widget has focus.
+	HasFocus() bool
+
+	// IsDirty indicates that the widget's contents have changed.
+	IsDirty() bool
+
+	// SetValidator sets the validator function. This function should be called from within the Validate function.
+	SetValidator(StringValidator)
+
+	// SetOnFocusChanged sets the function that should be called from within the widget's FocusGained and FocusLost
+	// methods.
+	SetOnFocusChanged(func(bool))
+
+	// SetValidation error sets the widget's validation error.
+	SetValidationError(error)
 }
 
 // StringValidator is a function signature for validating string inputs.

--- a/widget/date_entry.go
+++ b/widget/date_entry.go
@@ -36,10 +36,10 @@ func (e *DateEntry) CreateRenderer() fyne.WidgetRenderer {
 	e.ExtendBaseWidget(e)
 
 	dateFormat := getLocaleDateFormat()
-	e.Validator = func(in string) error {
+	e.SetValidator(func(in string) error {
 		_, err := time.Parse(dateFormat, in)
 		return err
-	}
+	})
 	e.Entry.OnChanged = func(in string) {
 		if in == "" {
 			e.Date = nil

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -296,6 +296,15 @@ func (e *Entry) FocusLost() {
 	}
 }
 
+// HasFocus indicates if the widget has focus.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
+func (e *Entry) HasFocus() bool {
+	return e.focused
+}
+
 // Hide hides the entry.
 //
 // Implements: fyne.Widget
@@ -305,6 +314,15 @@ func (e *Entry) Hide() {
 		e.popUp = nil
 	}
 	e.DisableableWidget.Hide()
+}
+
+// IsDirty indicates if the widget's text has changed.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
+func (e *Entry) IsDirty() bool {
+	return e.dirty
 }
 
 // Keyboard implements the Keyboardable interface
@@ -459,6 +477,15 @@ func (e *Entry) SelectedText() string {
 func (e *Entry) SetMinRowsVisible(count int) {
 	e.multiLineRows = count
 	e.Refresh()
+}
+
+// SetOnFocusChanged sets the function that is called when focus is gained or lost.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
+func (e *Entry) SetOnFocusChanged(f func(bool)) {
+	e.onFocusChanged = f
 }
 
 // SetPlaceHolder sets the text that will be displayed if the entry is otherwise empty

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -383,10 +383,10 @@ func TestEntry_PasteFromClipboard_MultilineWrapping(t *testing.T) {
 func TestEntry_PasteFromClipboardValidation(t *testing.T) {
 	entry := NewEntry()
 	var triggered int
-	entry.Validator = func(s string) error {
+	entry.SetValidator(func(s string) error {
 		triggered++
 		return nil
-	}
+	})
 
 	testContent := "test"
 	clipboard := test.NewTempApp(t).Clipboard()

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -8,7 +8,31 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-var _ fyne.Validatable = (*Entry)(nil)
+var _ fyne.FormValidatable = (*Entry)(nil)
+
+// GetValidationError retrieves the Entry widget's validation error.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
+func (e *Entry) GetValidationError() error {
+	return e.validationError
+}
+
+// GetValidator returns the Validator function, or nil if there is none.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
+func (e *Entry) GetValidator() fyne.StringValidator {
+	return e.Validator
+}
+
+// SetValidator sets the function that validates Entry text. This function should be called
+// by the Validate method.
+func (e *Entry) SetValidator(f fyne.StringValidator) {
+	e.Validator = f
+}
 
 // Validate validates the current text in the widget.
 func (e *Entry) Validate() error {
@@ -38,6 +62,10 @@ func (e *Entry) SetOnValidationChanged(callback func(error)) {
 }
 
 // SetValidationError manually updates the validation status until the next input change.
+//
+// Since: 2.7
+//
+// Implements fyne.FormValidatable
 func (e *Entry) SetValidationError(err error) {
 	if e.Validator == nil && !e.AlwaysShowValidationError {
 		return

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -17,7 +17,7 @@ func TestEntry_DisabledHideValidation(t *testing.T) {
 	entry, window := setupImageTest(t, false)
 	c := window.Canvas()
 
-	entry.Validator = validator
+	entry.SetValidator(validator)
 	entry.SetText("invalid text")
 	entry.Disable()
 
@@ -29,7 +29,7 @@ func TestEntry_ValidatedEntry(t *testing.T) {
 	c := window.Canvas()
 
 	r := validation.NewRegexp(`^\d{4}-\d{2}-\d{2}`, "Input is not a valid date")
-	entry.Validator = r
+	entry.SetValidator(r)
 	test.AssertRendersToMarkup(t, "entry/validate_initial.xml", c)
 
 	test.Type(entry, "2020-02")
@@ -44,30 +44,30 @@ func TestEntry_ValidatedEntry(t *testing.T) {
 
 func TestEntry_Validate(t *testing.T) {
 	entry := widget.NewEntry()
-	entry.Validator = validator
+	entry.SetValidator(validator)
 
 	test.Type(entry, "2020-02")
 	assert.Error(t, entry.Validate())
-	assert.Equal(t, entry.Validate(), entry.Validator(entry.Text))
+	assert.Equal(t, entry.Validate(), entry.GetValidator()(entry.Text))
 
 	test.Type(entry, "-12")
 	assert.NoError(t, entry.Validate())
-	assert.Equal(t, entry.Validate(), entry.Validator(entry.Text))
+	assert.Equal(t, entry.Validate(), entry.GetValidator()(entry.Text))
 
 	entry.SetText("incorrect")
 	assert.Error(t, entry.Validate())
-	assert.Equal(t, entry.Validate(), entry.Validator(entry.Text))
+	assert.Equal(t, entry.Validate(), entry.GetValidator()(entry.Text))
 }
 
 func TestEntry_NotEmptyValidator(t *testing.T) {
 	test.NewTempApp(t)
 	entry := widget.NewEntry()
-	entry.Validator = func(s string) error {
+	entry.SetValidator(func(s string) error {
 		if s == "" {
 			return errors.New("should not be empty")
 		}
 		return nil
-	}
+	})
 	w := test.NewTempWindow(t, entry)
 
 	test.AssertRendersToMarkup(t, "entry/validator_not_empty_initial.xml", w.Canvas())
@@ -86,7 +86,7 @@ func TestEntry_SetValidationError(t *testing.T) {
 	test.ApplyTheme(t, test.Theme())
 	c := window.Canvas()
 
-	entry.Validator = validator
+	entry.SetValidator(validator)
 
 	entry.SetText("2020-30-30")
 	entry.SetValidationError(errors.New("set invalid"))
@@ -99,11 +99,11 @@ func TestEntry_SetValidationError(t *testing.T) {
 
 func TestEntry_SetOnValidationChanged(t *testing.T) {
 	entry := widget.NewEntry()
-	entry.Validator = validator
+	entry.SetValidator(validator)
 
 	modified := false
 	entry.SetOnValidationChanged(func(err error) {
-		assert.Equal(t, err, entry.Validator(entry.Text))
+		assert.Equal(t, err, entry.GetValidator()(entry.Text))
 		modified = true
 	})
 
@@ -125,13 +125,13 @@ func TestEntry_AlwaysShowValidationError_WithValidator_Error(t *testing.T) {
 
 	entry := widget.NewEntry()
 	entry.AlwaysShowValidationError = true
-	entry.Validator = func(s string) error {
+	entry.SetValidator(func(s string) error {
 		if s == "success" {
 			return nil
 		}
 
 		return errors.New("mocking failed validation")
-	}
+	})
 
 	w := test.NewTempWindow(t, entry)
 	test.AssertRendersToMarkup(t, "entry/always_on_with_validator_error.xml", w.Canvas())

--- a/widget/form.go
+++ b/widget/form.go
@@ -2,7 +2,6 @@ package widget
 
 import (
 	"errors"
-	"reflect"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -181,16 +180,10 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 }
 
 func (f *Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
-	value := reflect.ValueOf(w).Elem()
-	validatorField := value.FieldByName("Validator")
-	if validatorField == (reflect.Value{}) {
-		return false
+	if v, ok := w.(fyne.FormValidatable); ok {
+		return v.GetValidator() != nil
 	}
-	validator, ok := validatorField.Interface().(fyne.StringValidator)
-	if !ok {
-		return false
-	}
-	return validator != nil
+	return false
 }
 
 func (f *Form) createLabel(text string) fyne.CanvasObject {
@@ -307,17 +300,16 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 		f.checkValidation(err)
 		f.updateHelperText(f.Items[i])
 	}
-	if w, ok := widget.(fyne.Validatable); ok {
+	if w, ok := widget.(fyne.FormValidatable); ok {
 		f.Items[i].invalid = w.Validate() != nil
-		if e, ok := w.(*Entry); ok {
-			e.onFocusChanged = func(bool) {
-				updateValidation(e.validationError)
-			}
-			if e.Validator != nil && f.Items[i].invalid {
-				// set initial state error to guarantee next error (if triggers) is always different
-				e.SetValidationError(errFormItemInitialState)
-			}
+		w.SetOnFocusChanged(func(bool) {
+			updateValidation(w.GetValidationError())
+		})
+		if w.GetValidator() != nil && f.Items[i].invalid {
+			// set initial state error to guarantee next error (if triggers) is always different
+			w.SetValidationError(errFormItemInitialState)
 		}
+
 		w.SetOnValidationChanged(updateValidation)
 	}
 }
@@ -352,11 +344,11 @@ func (f *Form) updateHelperText(item *FormItem) {
 		return // testing probably, either way not rendered yet
 	}
 	showHintIfError := false
-	if e, ok := item.Widget.(*Entry); ok {
-		if !e.dirty || (e.focused && !item.wasFocused) {
+	if w, ok := item.Widget.(fyne.FormValidatable); ok {
+		if !w.IsDirty() || (w.HasFocus() && !item.wasFocused) {
 			showHintIfError = true
 		}
-		if e.dirty && !e.focused {
+		if w.IsDirty() && !w.HasFocus() {
 			item.wasFocused = true
 		}
 	}


### PR DESCRIPTION
Form and FormDialog currently support validation of Entry widgets. With this PR, validation can be extended to other widgets.
This PR is an alternative to any changes submitted with issue #4250. Issue #4147 is also fixed.

### Description
FormValidatable interface has been added. Entry has been modified to implement this interface. Form has been modified to validate widgets that implement FormValidatable interface. This removes Entry specific code from Form, and also any need for reflection.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [X] Tests included.
- (No additional tests were required)
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.