### PR TITLE
Multiple performance improvements for TextGrid

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -496,13 +496,13 @@ func (t *textGridContent) refreshCell(row, col int) {
 
 func (t *textGridContentRenderer) updateGridSize(size fyne.Size) {
 	bufRows := len(t.text.text.Rows)
-	bufCols := 0
-	for _, row := range t.text.text.Rows {
-		bufCols = int(math.Max(float64(bufCols), float64(len(row.Cells))))
-	}
-	sizeRows := math.Floor(float64(size.Height) / float64(t.text.cellSize.Height))
+	sizeRows := int(size.Height / t.text.cellSize.Height)
 
-	t.text.rows = int(math.Max(sizeRows, float64(bufRows)))
+	if sizeRows > bufRows {
+		t.text.rows = sizeRows
+	} else {
+		t.text.rows = bufRows
+	}
 	t.addRowsIfRequired()
 }
 
@@ -818,11 +818,13 @@ func (t *textGridRowRenderer) lineNumberWidth() int {
 }
 
 func (t *textGridRowRenderer) updateGridSize(size fyne.Size) {
-	bufCols := 0
+	bufCols := int(size.Width / t.obj.text.cellSize.Width)
 	for _, row := range t.obj.text.text.Rows {
-		bufCols = int(math.Max(float64(bufCols), float64(len(row.Cells))))
+		lenCells := len(row.Cells)
+		if lenCells > bufCols {
+			bufCols = lenCells	
+		}
 	}
-	sizeCols := math.Floor(float64(size.Width) / float64(t.obj.text.cellSize.Width))
 
 	if t.obj.text.text.ShowWhitespace {
 		bufCols++
@@ -831,7 +833,7 @@ func (t *textGridRowRenderer) updateGridSize(size fyne.Size) {
 		bufCols += t.lineNumberWidth()
 	}
 
-	t.cols = int(math.Max(sizeCols, float64(bufCols)))
+	t.cols = bufCols
 	t.addCellsIfRequired()
 }
 

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -822,7 +822,7 @@ func (t *textGridRowRenderer) updateGridSize(size fyne.Size) {
 	for _, row := range t.obj.text.text.Rows {
 		lenCells := len(row.Cells)
 		if lenCells > bufCols {
-			bufCols = lenCells	
+			bufCols = lenCells
 		}
 	}
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
While profiling an application I am writing that uses TextGrid, I noticed that the largest amount of time was being spent inside 
`updateGridSize`, not any render specific code. This led me down the path of trying to optimize it.

Optimizations:
1. Remove dead code from `textGridContentRenderer.updateGridSize`
    I noticed that bufCols is computed, but then never used, so I removed it.
2. Use direct comparisons and integer division instead of `math.Max` and `math.Floor` respectively.
    Max and Floor are general purpose utilities, and as such have to do a lot of extra work that we don't need. For example, they must properly handle `Infinity`, as well as negative numbers. This introduces a lot of overhead. Since we are checking lengths of rows and columns, we can guarantee that the numbers involved are positive, we can beat the performance of Max and Floor by doing the computation ourselves directly.

With these two performance improvements, I see a noticeable difference in performance. 

Take a look at this recording, with optimizations on the left, without optimizations on the right:
https://github.com/user-attachments/assets/e3f8ab9f-cd59-4b72-81c7-59413a9decf8

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
