### PR TITLE
TextGrid: Expose internal scrolls ScrollToTop()

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -125,6 +125,7 @@ func (t *TextGrid) CursorLocationForPosition(p fyne.Position) (row, col int) {
 // Since: 2.7
 func (t *TextGrid) ScrollToTop() {
 	t.scroll.ScrollToTop()
+	t.Refresh()
 }
 
 // ScrollToBottom will scroll content to container bottom - to show latest info which end user just added
@@ -132,6 +133,7 @@ func (t *TextGrid) ScrollToTop() {
 // Since: 2.7
 func (t *TextGrid) ScrollToBottom() {
 	t.scroll.ScrollToBottom()
+	t.Refresh()
 }
 
 // PositionForCursorLocation returns the relative position in this TextGrid for the cell at position row, col.

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -122,7 +122,7 @@ func (t *TextGrid) CursorLocationForPosition(p fyne.Position) (row, col int) {
 
 // ScrollToTop will scroll content to container top
 //
-// Since: 2.6
+// Since: 2.7
 func (t *TextGrid) ScrollToTop() {
 	t.scroll.ScrollToTop()
 }

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -120,6 +120,13 @@ func (t *TextGrid) CursorLocationForPosition(p fyne.Position) (row, col int) {
 	return
 }
 
+// ScrollToTop will scroll content to container top
+//
+// Since: 2.6
+func (t *TextGrid) ScrollToTop() {
+	t.scroll.ScrollToTop()
+}
+
 // PositionForCursorLocation returns the relative position in this TextGrid for the cell at position row, col.
 // If the grid has been scrolled this will be taken into account so that the position compared to top left will
 // refer to the requested location.

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -127,6 +127,13 @@ func (t *TextGrid) ScrollToTop() {
 	t.scroll.ScrollToTop()
 }
 
+// ScrollToBottom will scroll content to container bottom - to show latest info which end user just added
+//
+// Since: 2.7
+func (t *TextGrid) ScrollToBottom() {
+	t.scroll.ScrollToBottom()
+}
+
 // PositionForCursorLocation returns the relative position in this TextGrid for the cell at position row, col.
 // If the grid has been scrolled this will be taken into account so that the position compared to top left will
 // refer to the requested location.

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -118,6 +118,27 @@ func TestTextGrid_ScrollToTop(t *testing.T) {
 	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
 }
 
+func TestTextGrid_ScrollToBottom(t *testing.T) {
+	grid := NewTextGridFromString("Something\nElse")
+	grid.Resize(fyne.NewSize(50, 20))
+	test.AssertObjectRendersToMarkup(t, "textgrid/basic.xml", grid)
+
+	scrolling := NewTextGridFromString("Something\nElse")
+	scrolling.Scroll = widget.ScrollBoth
+	scrolling.Resize(fyne.NewSize(50, 20))
+	scrolling.Refresh()
+	scrolling.ScrollToBottom()
+	scrolling.scroll.ScrollToTop()
+	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
+
+	scrolling = NewTextGrid()
+	scrolling.Scroll = widget.ScrollBoth
+	scrolling.Resize(fyne.NewSize(50, 20))
+	scrolling.SetText("Something\nElse")
+	scrolling.ScrollToBottom()
+	scrolling.scroll.ScrollToTop()
+	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
+}
 func TestTextGrid_CreateRendererRows(t *testing.T) {
 	grid := NewTextGrid()
 	grid.Resize(fyne.NewSize(52, 22))

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -96,6 +96,28 @@ func TestTextGrid_Scroll(t *testing.T) {
 	test.AssertObjectRendersToMarkup(t, "textgrid/basic.xml", grid)
 }
 
+func TestTextGrid_ScrollToTop(t *testing.T) {
+	grid := NewTextGridFromString("Something\nElse")
+	grid.Resize(fyne.NewSize(50, 20))
+	test.AssertObjectRendersToMarkup(t, "textgrid/basic.xml", grid)
+
+	scrolling := NewTextGridFromString("Something\nElse")
+	scrolling.Scroll = widget.ScrollBoth
+	scrolling.Resize(fyne.NewSize(50, 20))
+	scrolling.Refresh()
+	scrolling.scroll.ScrollToBottom()
+	scrolling.ScrollToTop()
+	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
+
+	scrolling = NewTextGrid()
+	scrolling.Scroll = widget.ScrollBoth
+	scrolling.Resize(fyne.NewSize(50, 20))
+	scrolling.SetText("Something\nElse")
+	scrolling.scroll.ScrollToBottom()
+	scrolling.ScrollToTop()
+	test.AssertObjectRendersToMarkup(t, "textgrid/scroll.xml", scrolling)
+}
+
 func TestTextGrid_CreateRendererRows(t *testing.T) {
 	grid := NewTextGrid()
 	grid.Resize(fyne.NewSize(52, 22))


### PR DESCRIPTION
### Description:
Expose TextGrids internal scroll's `ScrollToTop()`.

I wasn't sure if an additional test was needed here given the simplicity of the change, but I added one anyway just in case. Let me know if it isn't necessary, and I can remove :)

Fixes #5758

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [X] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
