### PR TITLE
Fix bug in refreshCell causing multiple renderers to be created

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -663,9 +663,11 @@ func (t *textGridRowRenderer) refreshCell(col int) {
 		return
 	}
 
-	if len(t.obj.text.text.Rows[t.obj.row].Cells) > col {
-		cell := t.obj.text.text.Rows[t.obj.row].Cells[col]
-		t.setCellRune(cell.Rune, pos, cell.Style, t.obj.text.text.Rows[t.obj.row].Style)
+	row := t.obj.text.text.Rows[t.obj.row]
+
+	if len(row.Cells) > col {
+		cell := row.Cells[col]
+		t.setCellRune(cell.Rune, pos, cell.Style, row.Style)
 	}
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #5767

The bug was caused by `cache.Renderer` creating a renderer for TextGrid, even when TextGrid was extended with a custom widget. Instead, we can retrieve textContent directly from TextGrid, without needing to retrieve the renderer at all.

After that was fixed, it also uncovered an out-of-bounds error in `textGridRowRenderer`, which also needed to be fixed. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
