### PR TITLE
Try to use CC=clang for faster CI build on Linux

### DIFF
--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -2,6 +2,8 @@ name: Mobile Tests
 on: [push, pull_request]
 permissions:
   contents: read
+env:
+  CC: "clang"
 
 jobs:
   mobile_tests:
@@ -24,7 +26,7 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Get dependencies
-      run: sudo apt-get update && sudo apt-get install gcc libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
+      run: sudo apt-get update && sudo apt-get install clang libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
 
     - name: Tests
       run: go test -race -tags mobile,ci,migrated_fynedo ./...

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -28,18 +28,10 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Get dependencies
-      run: >-
-        sudo apt-get update &&
-        sudo apt-get install
-        bc
-        gcc
-        libgl1-mesa-dev
-        libwayland-dev
-        libx11-dev
-        libxkbcommon-dev
-        xorg-dev
-        xvfb
-        language-pack-en
+      run: |
+        sudo apt-get update
+        sudo apt-get install bc clang libgl1-mesa-dev libwayland-dev libx11-dev libxkbcommon-dev xorg-dev xvfb language-pack-en
+        echo "CC=clang" >> "$GITHUB_ENV"
       if: ${{ runner.os == 'Linux' }}
 
     - name: Set environment variable LANG

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -20,17 +20,9 @@ jobs:
         go-version: 'stable'
 
     - name: Get dependencies
-      run: >-
-        sudo apt-get update &&
-        sudo apt-get install
-        gcc
-        libegl1-mesa-dev
-        libgl1-mesa-dev
-        libgles2-mesa-dev
-        libx11-dev
-        xorg-dev
-        xvfb
-        language-pack-en
+      run: |
+        sudo apt-get update
+        sudo apt-get install clang libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev xvfb language-pack-en
 
     - name: Set environment variable LANG
       run: export LANG=en_EN.UTF-8

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -2,6 +2,8 @@ name: Static Analysis
 on: [push, pull_request]
 permissions:
   contents: read
+env:
+  CC: "clang"
 
 jobs:
   static_analysis:

--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -17,9 +17,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    - name: Get dependencies
-      run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
-
     - name: Build WebAssembly binary
       env:
         GOOS: js


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Windows is the slowest building system in CI but that doesn't stop us from trying to make Linux compiles faster. I have been seeing clang get much faster compiles locally so let's see if it can work its magic in CI as well. I also removed the apt package installation from the web tests given that the WASM port doesn't use CGO so it runs blazingly fast now.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
