### PR TITLE
TextGrid.SetText update scroll if new text is shorter

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -175,8 +175,9 @@ func (t *TextGrid) SetText(text string) {
 	oldRowsLen := len(t.Rows)
 	t.Rows = rows
 
-	// Update scroll position if new text is shorter than previous text
-	if t.Scroll != fyne.ScrollNone && len(rows) < oldRowsLen {
+	// If we don't update the scroll offset when the text is shorter,
+	// we may end up with no text displayed or text appearing partially cut off
+	if t.Scroll != fyne.ScrollNone && len(rows) < oldRowsLen && t.scroll.Content != nil {
 		offset := t.PositionForCursorLocation(len(rows), 0)
 		t.scroll.ScrollToOffset(fyne.NewPos(offset.X, t.scroll.Offset.Y))
 		t.scroll.Refresh()

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -177,7 +177,7 @@ func (t *TextGrid) SetText(text string) {
 
 	// If we don't update the scroll offset when the text is shorter,
 	// we may end up with no text displayed or text appearing partially cut off
-	if t.Scroll != fyne.ScrollNone && len(rows) < oldRowsLen && t.scroll.Content != nil {
+	if t.scroll != nil && t.Scroll != fyne.ScrollNone && len(rows) < oldRowsLen && t.scroll.Content != nil {
 		offset := t.PositionForCursorLocation(len(rows), 0)
 		t.scroll.ScrollToOffset(fyne.NewPos(offset.X, t.scroll.Offset.Y))
 		t.scroll.Refresh()

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -172,7 +172,16 @@ func (t *TextGrid) Resize(size fyne.Size) {
 func (t *TextGrid) SetText(text string) {
 	rows := t.parseRows(text)
 
+	oldRowsLen := len(t.Rows)
 	t.Rows = rows
+
+	// Update scroll position if new text is shorter than previous text
+	if t.Scroll != fyne.ScrollNone && len(rows) < oldRowsLen {
+		offset := t.PositionForCursorLocation(len(rows), 0)
+		t.scroll.ScrollToOffset(fyne.NewPos(offset.X, t.scroll.Offset.Y))
+		t.scroll.Refresh()
+	}
+
 	t.Refresh()
 }
 

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -44,7 +44,6 @@ func TestTextGrid_CursorLocationForPosition(t *testing.T) {
 	assert.Equal(t, 2, col)
 
 	grid.Scroll = widget.ScrollBoth
-	grid.Refresh()
 	grid.SetText("Really Long Really Long Really Long Really Long Really Long")
 	row, col = grid.CursorLocationForPosition(fyne.NewPos(20, 20))
 	assert.Equal(t, 1, row)

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -44,6 +44,7 @@ func TestTextGrid_CursorLocationForPosition(t *testing.T) {
 	assert.Equal(t, 2, col)
 
 	grid.Scroll = widget.ScrollBoth
+	grid.Refresh()
 	grid.SetText("Really Long Really Long Really Long Really Long Really Long")
 	row, col = grid.CursorLocationForPosition(fyne.NewPos(20, 20))
 	assert.Equal(t, 1, row)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #5762

_Note: I had to add an explicit refresh in one of the unit tests, otherwise I was getting a crash related to 
`t.scroll.Content` being nil in `Scroll.updateOffset`._

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
