### PR TITLE
Always repaint all windows even when refreshed is already true

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -89,7 +89,9 @@ func (d *gLDriver) drawSingleFrame() {
 		}
 
 		w.RunWithContext(func() {
-			refreshed = refreshed || w.driver.repaintWindow(w)
+			if w.driver.repaintWindow(w) {
+				refreshed = true
+			}
 		})
 	}
 	cache.Clean(refreshed)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #5782

`w.driver.repaintWindow(w)` was not called on every windows is refresh was set to true previously

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

