### PR TITLE
Fix animation extending outside of button

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -182,7 +182,6 @@ func (b *Button) Tapped(*fyne.PointEvent) {
 	}
 
 	b.tapAnimation()
-	b.Refresh()
 
 	if onTapped := b.OnTapped; onTapped != nil {
 		onTapped()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #5785

This refresh was causing the animation to be reset to the wrong size because it runs during the animation. Removing it fixes the issue and the tests still pass.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
