### PR TITLE
Add leading icon to the entry widget

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -69,13 +69,13 @@ type Entry struct {
 	// Since: 2.7
 	AlwaysShowValidationError bool
 
+	CursorRow, CursorColumn int
+	OnCursorChanged         func() `json:"-"`
+
 	// Icon is displayed at the outer left of the entry.
 	// It is not clickable, but can be used to indicate the purpose of the entry.
 	// Since: 2.7
 	Icon fyne.Resource `json:"-"`
-
-	CursorRow, CursorColumn int
-	OnCursorChanged         func() `json:"-"`
 
 	cursorAnim *entryCursorAnimation
 
@@ -1539,8 +1539,7 @@ func (r *entryRenderer) leadingInset() float32 {
 	xInset := float32(0)
 
 	if r.entry.Icon != nil {
-		iconSpace := th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameLineSpacing) + th.Size(theme.SizeNameInnerPadding)
-		xInset = iconSpace
+		xInset = th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameLineSpacing)
 	}
 
 	return xInset

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -69,6 +69,11 @@ type Entry struct {
 	// Since: 2.7
 	AlwaysShowValidationError bool
 
+	// Icon is displayed at the outer left of the entry.
+	// It is not clickable, but can be used to indicate the purpose of the entry.
+	// Since: 2.7
+	Icon fyne.Resource `json:"-"`
+
 	CursorRow, CursorColumn int
 	OnCursorChanged         func() `json:"-"`
 
@@ -204,8 +209,15 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 		objects = append(objects, e.ActionItem)
 	}
 
+	icon := canvas.NewImageFromResource(e.Icon)
+	icon.FillMode = canvas.ImageFillContain
+	objects = append(objects, icon)
+	if e.Icon == nil {
+		icon.Hide()
+	}
+
 	e.syncSegments()
-	return &entryRenderer{box, border, e.scroll, objects, e}
+	return &entryRenderer{box, border, e.scroll, icon, objects, e}
 }
 
 // Cursor returns the cursor type of this widget
@@ -450,6 +462,16 @@ func (e *Entry) Refresh() {
 // If there is no selection it will return the empty string.
 func (e *Entry) SelectedText() string {
 	return e.sel.SelectedText()
+}
+
+// SetIcon sets the leading icon resource for the entry.
+// The icon will be displayed at the outer left of the entry, but is not clickable.
+// This can be used to indicate the purpose of the entry, such as an email or password field.
+//
+// Since: 2.7
+func (e *Entry) SetIcon(res fyne.Resource) {
+	e.Icon = res
+	e.Refresh()
 }
 
 // SetMinRowsVisible forces a multi-line entry to show `count` number of rows without scrolling.
@@ -1483,6 +1505,7 @@ var _ fyne.WidgetRenderer = (*entryRenderer)(nil)
 type entryRenderer struct {
 	box, border *canvas.Rectangle
 	scroll      *widget.Scroll
+	icon        *canvas.Image
 
 	objects []fyne.CanvasObject
 	entry   *Entry
@@ -1506,6 +1529,18 @@ func (r *entryRenderer) trailingInset() float32 {
 		} else {
 			xInset += iconSpace
 		}
+	}
+
+	return xInset
+}
+
+func (r *entryRenderer) leadingInset() float32 {
+	th := r.entry.Theme()
+	xInset := float32(0)
+
+	if r.entry.Icon != nil {
+		iconSpace := th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameLineSpacing) + th.Size(theme.SizeNameInnerPadding)
+		xInset = iconSpace
 	}
 
 	return xInset
@@ -1547,10 +1582,15 @@ func (r *entryRenderer) Layout(size fyne.Size) {
 		}
 	}
 
+	if r.entry.Icon != nil {
+		r.icon.Resize(fyne.NewSquareSize(iconSize))
+		r.icon.Move(fyne.NewPos(innerPad, innerPad))
+	}
+
 	r.entry.textProvider().inset = fyne.NewSize(0, inputBorder)
 	r.entry.placeholderProvider().inset = fyne.NewSize(0, inputBorder)
-	entrySize := size.Subtract(fyne.NewSize(r.trailingInset(), inputBorder*2))
-	entryPos := fyne.NewPos(0, inputBorder)
+	entrySize := size.Subtract(fyne.NewSize(r.trailingInset()+r.leadingInset(), inputBorder*2))
+	entryPos := fyne.NewPos(r.leadingInset(), inputBorder)
 
 	prov := r.entry.textProvider()
 	textPos := textPosFromRowCol(r.entry.CursorRow, r.entry.CursorColumn, prov)
@@ -1614,6 +1654,9 @@ func (r *entryRenderer) MinSize() fyne.Size {
 	if r.entry.Validator != nil {
 		minSize.Width += iconSpace
 	}
+	if r.entry.Icon != nil {
+		minSize.Width += iconSpace
+	}
 
 	return minSize
 }
@@ -1639,7 +1682,7 @@ func (r *entryRenderer) Refresh() {
 	inputBorder := th.Size(theme.SizeNameInputBorder)
 
 	// correct our scroll wrappers if the wrap mode changed
-	entrySize := r.entry.Size().Subtract(fyne.NewSize(r.trailingInset(), inputBorder*2))
+	entrySize := r.entry.Size().Subtract(fyne.NewSize(r.trailingInset()+r.leadingInset(), inputBorder*2))
 	if wrapping == fyne.TextWrapOff && scroll == widget.ScrollNone && r.scroll.Content != nil {
 		r.scroll.Hide()
 		r.scroll.Content = nil
@@ -1692,6 +1735,14 @@ func (r *entryRenderer) Refresh() {
 		r.entry.validationStatus.Refresh()
 	} else if r.entry.validationStatus != nil {
 		r.entry.validationStatus.Hide()
+	}
+
+	if r.entry.Icon != nil {
+		r.icon.Resource = r.entry.Icon
+		r.icon.Refresh()
+		r.icon.Show()
+	} else {
+		r.icon.Hide()
 	}
 
 	r.entry.sel.Hidden = !r.entry.focused

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -295,31 +295,22 @@ func TestEntry_CallbackLocking(t *testing.T) {
 	assert.Equal(t, 7, called)
 }
 
-func TestEntry_IconContentSizeAndPlacement(t *testing.T) {
+func TestEntry_ContentSizeAndPlacementWithIcon(t *testing.T) {
 	entry := NewEntry()
+	entry.SetIcon(theme.MailComposeIcon())
+	entry.SetText("SomeText")
+	renderer := entry.CreateRenderer()
+	contentPos := fyne.NewPos(theme.InnerPadding()+theme.LineSpacing()+theme.IconInlineSize(), theme.InputBorderSize())
+
+	renderer.Layout(entry.MinSize())
+	// Scrollable content should be positioned after the icon, with correct padding
+	assert.Equal(t, contentPos, entry.scroll.Position())
+
 	entry.Wrapping = fyne.TextWrapOff
 	entry.Scroll = fyne.ScrollNone
-	icon := theme.MailComposeIcon()
-	entry.SetIcon(icon)
-	entry.SetText("SomeText")
-	r := test.TempWidgetRenderer(t, entry)
-	r.Layout(entry.MinSize())
-
-	var iconObj *canvas.Image
-	for _, obj := range r.Objects() {
-		if img, ok := obj.(*canvas.Image); ok && img.Resource == icon {
-			iconObj = img
-			break
-		}
-	}
-
-	// Icon should be at the left, with correct size
-	assert.NotNil(t, iconObj)
-	assert.Equal(t, theme.IconInlineSize(), iconObj.Size().Width)
-	assert.Equal(t, theme.IconInlineSize(), iconObj.Size().Height)
-	assert.Equal(t, fyne.NewPos(theme.InnerPadding(), theme.InnerPadding()), iconObj.Position())
+	renderer.Layout(entry.MinSize())
 	// Content should be positioned after the icon, with correct padding
-	assert.Equal(t, fyne.NewPos(theme.InnerPadding()+theme.LineSpacing()+theme.IconInlineSize(), theme.InputBorderSize()), entry.content.Position())
+	assert.Equal(t, contentPos, entry.content.Position())
 }
 
 func TestEntry_MouseClickAndDragOutsideText(t *testing.T) {

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -295,6 +295,33 @@ func TestEntry_CallbackLocking(t *testing.T) {
 	assert.Equal(t, 7, called)
 }
 
+func TestEntry_IconContentSizeAndPlacement(t *testing.T) {
+	entry := NewEntry()
+	entry.Wrapping = fyne.TextWrapOff
+	entry.Scroll = fyne.ScrollNone
+	icon := theme.MailComposeIcon()
+	entry.SetIcon(icon)
+	entry.SetText("SomeText")
+	r := test.TempWidgetRenderer(t, entry)
+	r.Layout(entry.MinSize())
+
+	var iconObj *canvas.Image
+	for _, obj := range r.Objects() {
+		if img, ok := obj.(*canvas.Image); ok && img.Resource == icon {
+			iconObj = img
+			break
+		}
+	}
+
+	// Icon should be at the left, with correct size
+	assert.NotNil(t, iconObj)
+	assert.Equal(t, theme.IconInlineSize(), iconObj.Size().Width)
+	assert.Equal(t, theme.IconInlineSize(), iconObj.Size().Height)
+	assert.Equal(t, fyne.NewPos(theme.InnerPadding(), theme.InnerPadding()), iconObj.Position())
+	// Content should be positioned after the icon, with correct padding
+	assert.Equal(t, fyne.NewPos(theme.InnerPadding()+theme.LineSpacing()+theme.IconInlineSize(), theme.InputBorderSize()), entry.content.Position())
+}
+
 func TestEntry_MouseClickAndDragOutsideText(t *testing.T) {
 	entry := NewEntry()
 	entry.SetText("A\nB\n")

--- a/widget/entry_internal_test.go
+++ b/widget/entry_internal_test.go
@@ -300,7 +300,7 @@ func TestEntry_ContentSizeAndPlacementWithIcon(t *testing.T) {
 	entry.SetIcon(theme.MailComposeIcon())
 	entry.SetText("SomeText")
 	renderer := entry.CreateRenderer()
-	contentPos := fyne.NewPos(theme.InnerPadding()+theme.LineSpacing()+theme.IconInlineSize(), theme.InputBorderSize())
+	contentPos := fyne.NewPos(theme.LineSpacing()+theme.IconInlineSize(), theme.InputBorderSize())
 
 	renderer.Layout(entry.MinSize())
 	// Scrollable content should be positioned after the icon, with correct padding

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1787,6 +1787,23 @@ func TestEntry_TextWrap_Changed(t *testing.T) {
 	test.AssertRendersToMarkup(t, "entry/wrap_single_line_off.xml", c)
 }
 
+func TestEntry_IconSizeAndPlacement(t *testing.T) {
+	entry := widget.NewEntry()
+	icon := theme.MailComposeIcon()
+	entry.SetIcon(icon)
+	entry.SetText("SomeText")
+	r := test.TempWidgetRenderer(t, entry)
+	r.Layout(entry.MinSize())
+
+	iconObj := r.Objects()[3].(*canvas.Image)
+	// Icon should be at the left, with correct size
+	assert.NotNil(t, iconObj)
+	assert.Equal(t, theme.IconInlineSize(), iconObj.Size().Width)
+	assert.Equal(t, theme.IconInlineSize(), iconObj.Size().Height)
+	assert.Equal(t, fyne.NewPos(theme.InnerPadding(), theme.InnerPadding()), iconObj.Position())
+	assert.Equal(t, icon, iconObj.Resource)
+}
+
 func TestEntry_SetIcon(t *testing.T) {
 	entry := widget.NewEntry()
 	assert.Nil(t, entry.Icon)

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1787,6 +1787,52 @@ func TestEntry_TextWrap_Changed(t *testing.T) {
 	test.AssertRendersToMarkup(t, "entry/wrap_single_line_off.xml", c)
 }
 
+func TestEntry_SetIcon(t *testing.T) {
+	entry := widget.NewEntry()
+	assert.Nil(t, entry.Icon)
+	icon := theme.MailComposeIcon()
+	entry.SetIcon(icon)
+	assert.Equal(t, icon, entry.Icon)
+}
+
+func TestEntry_Icon_MinSize(t *testing.T) {
+	entryWithIcon := widget.NewEntry()
+	entryWithIcon.SetIcon(theme.MailComposeIcon())
+	entryWithIcon.SetText("Test")
+	minSizeWithIcon := entryWithIcon.MinSize()
+
+	entryWithoutIcon := widget.NewEntry()
+	entryWithoutIcon.SetText("Test")
+	minSizeWithoutIcon := entryWithoutIcon.MinSize()
+
+	assert.Greater(t, minSizeWithIcon.Width, minSizeWithoutIcon.Width)
+	assert.Equal(t, minSizeWithIcon.Height, minSizeWithoutIcon.Height)
+}
+
+func TestEntry_Icon_MinSize_IncreasesWidth(t *testing.T) {
+	entry := widget.NewEntry()
+	entry.SetText("Test")
+	minSizeWithoutIcon := entry.MinSize()
+
+	entry.SetIcon(theme.MailComposeIcon())
+	minSizeWithIcon := entry.MinSize()
+
+	assert.Greater(t, minSizeWithIcon.Width, minSizeWithoutIcon.Width)
+	assert.Equal(t, minSizeWithIcon.Height, minSizeWithoutIcon.Height)
+}
+
+func TestEntry_Icon_ReplaceAndRemove(t *testing.T) {
+	entry := widget.NewEntry()
+	icon1 := theme.MailComposeIcon()
+	icon2 := theme.InfoIcon()
+	entry.SetIcon(icon1)
+	assert.Equal(t, icon1, entry.Icon)
+	entry.Icon = icon2
+	assert.Equal(t, icon2, entry.Icon)
+	entry.SetIcon(nil)
+	assert.Nil(t, entry.Icon)
+}
+
 func TestMultiLineEntry_MinSize(t *testing.T) {
 	entry := widget.NewEntry()
 	singleMin := entry.MinSize()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Feature Request [#5789](https://github.com/fyne-io/fyne/issues/5789)

Add `Icon fyne.Resource` to the Entry widget. Icon is displayed at the outer left of the entry.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
