### PR TITLE
Fix selectable label highlight offset when alignment is changed

### DIFF
--- a/widget/label.go
+++ b/widget/label.go
@@ -197,8 +197,24 @@ func (r *labelRenderer) Destroy() {
 }
 
 func (r *labelRenderer) Layout(s fyne.Size) {
-	r.l.selection.Resize(s)
 	r.l.provider.Resize(s)
+
+	if !r.l.Selectable || r.l.selection == nil {
+		return
+	}
+
+	textSize := r.l.provider.MinSize()
+
+	offsetX := float32(0)
+	switch r.l.Alignment {
+	case fyne.TextAlignCenter:
+		offsetX = (s.Width - textSize.Width) / 2
+	case fyne.TextAlignTrailing:
+		offsetX = s.Width - textSize.Width
+	}
+
+	r.l.selection.Move(fyne.NewPos(offsetX, 0))
+	r.l.selection.Resize(fyne.NewSize(textSize.Width, s.Height))
 }
 
 func (r *labelRenderer) MinSize() fyne.Size {

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -344,3 +344,12 @@ func labelTextRenderTexts(p fyne.Widget) []*canvas.Text {
 	rich := cache.Renderer(p).Objects()[0].(*RichText)
 	return richTextRenderTexts(rich)
 }
+
+func TestLabel_SelectableHighlightOffset(t *testing.T) {
+	label := NewLabel("Centered Text")
+	label.Alignment = fyne.TextAlignCenter
+	label.Selectable = true
+	label.Refresh()
+
+	assert.NotNil(t, test.WidgetRenderer(label))
+}


### PR DESCRIPTION
### Description:
Fixes the offset issue with the selectable label highlight when the label text alignment is changed. 

---

### Screenshot of the issue:

![image](https://github.com/user-attachments/assets/61a75b02-2695-408f-8c9a-317818a1f799)

---

### Test application to replicate the issue:

```go
package main

import (
	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.New()
	w := a.NewWindow("Test")
	w.Resize(fyne.NewSize(700, 600))

	test := widget.NewLabel("Test")
	test.Alignment = fyne.TextAlignCenter
	test.Selectable = true

	w.SetContent(test)

	w.ShowAndRun()
}
```
---

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.