### PR TITLE
Use Scaled Monitor Size For Monitor Detection

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -272,13 +272,13 @@ func getMonitorScale(monitor *glfw.Monitor) float32 {
 }
 
 // getScaledMonitorSize returns the monitor dimensions adjusted for scaling
-func getScaledMonitorSize(monitor *glfw.Monitor) (int, int) {
+func getScaledMonitorSize(monitor *glfw.Monitor) fyne.Size {
 	videoMode := monitor.GetVideoMode()
 	scale := getMonitorScale(monitor)
 
-	scaledWidth := int(float32(videoMode.Width) / scale)
-	scaledHeight := int(float32(videoMode.Height) / scale)
-	return scaledWidth, scaledHeight
+	scaledWidth := float32(videoMode.Width) / scale
+	scaledHeight := float32(videoMode.Height) / scale
+	return fyne.NewSize(scaledWidth, scaledHeight)
 }
 
 func (w *window) getMonitorForWindow() *glfw.Monitor {
@@ -297,8 +297,8 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 				continue
 			}
 
-			scaledWidth, scaledHeight := getScaledMonitorSize(monitor)
-			if x+scaledWidth <= xOff || y+scaledHeight <= yOff {
+			scaledSize := getScaledMonitorSize(monitor)
+			if x+int(scaledSize.Width) <= xOff || y+int(scaledSize.Height) <= yOff {
 				continue
 			}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -261,6 +261,21 @@ func (w *window) fitContent() {
 	}
 }
 
+// getScaledMonitorSize returns the monitor dimensions adjusted for scaling
+func getScaledMonitorSize(monitor *glfw.Monitor) (int, int) {
+	videoMode := monitor.GetVideoMode()
+	widthMm, heightMm := monitor.GetPhysicalSize()
+
+	var scale float32 = 1.0
+	if runtime.GOOS != "linux" || widthMm != 60 || heightMm != 60 { // Steam Deck incorrectly reports 6cm square!
+		scale = calculateDetectedScale(widthMm, videoMode.Width)
+	}
+
+	scaledWidth := int(float32(videoMode.Width) / scale)
+	scaledHeight := int(float32(videoMode.Height) / scale)
+	return scaledWidth, scaledHeight
+}
+
 func (w *window) getMonitorForWindow() *glfw.Monitor {
 	if !build.IsWayland {
 		x, y := w.xpos, w.ypos
@@ -276,7 +291,9 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 			if x > xOff || y > yOff {
 				continue
 			}
-			if videoMode := monitor.GetVideoMode(); x+videoMode.Width <= xOff || y+videoMode.Height <= yOff {
+
+			scaledWidth, scaledHeight := getScaledMonitorSize(monitor)
+			if x+scaledWidth <= xOff || y+scaledHeight <= yOff {
 				continue
 			}
 


### PR DESCRIPTION
Fix monitor detection by using the candidate monitor's scaled
dimensions.

Fixes bug in which scale changes prematurely as window gets near monitor with a different scale.