### PR TITLE
Calendar_additions

### DIFF
--- a/widget/calendar_test.go
+++ b/widget/calendar_test.go
@@ -14,9 +14,9 @@ import (
 func TestNewCalendar(t *testing.T) {
 	now := time.Now()
 	c := NewCalendar(now, func(time.Time) {})
-	assert.Equal(t, now.Day(), c.currentTime.Day())
-	assert.Equal(t, int(now.Month()), int(c.currentTime.Month()))
-	assert.Equal(t, now.Year(), c.currentTime.Year())
+	assert.Equal(t, now.Day(), c.displayedMonth.Day())
+	assert.Equal(t, int(now.Month()), int(c.displayedMonth.Month()))
+	assert.Equal(t, now.Year(), c.displayedMonth.Year())
 
 	_ = test.WidgetRenderer(c) // and render
 	assert.Equal(t, now.Format("January 2006"), c.monthLabel.Text)

--- a/widget/date_entry.go
+++ b/widget/date_entry.go
@@ -12,7 +12,7 @@ import (
 // Since: 2.6
 type DateEntry struct {
 	Entry
-	Date      *time.Time
+	Date      *time.Time // TODO discuss: why not just use time.Time{} (Zero-time) ?
 	OnChanged func(*time.Time) `json:"-"`
 
 	dropDown *Calendar
@@ -117,9 +117,9 @@ func (e *DateEntry) Move(pos fyne.Position) {
 // Implements: fyne.Widget
 func (e *DateEntry) Resize(size fyne.Size) {
 	e.Entry.Resize(size)
-	if e.popUp != nil {
+	/*if e.popUp != nil {
 		e.popUp.Resize(fyne.NewSize(size.Width, e.popUp.Size().Height))
-	}
+	}*/
 }
 
 // SetDate will update the widget to a specific date.
@@ -141,7 +141,11 @@ func (e *DateEntry) popUpPos() fyne.Position {
 }
 
 func (e *DateEntry) setDate(d time.Time) {
-	e.Date = &d
+	if !d.IsZero() {
+		e.Date = &d
+	} else {
+		e.Date = nil
+	}
 	if e.popUp != nil {
 		e.popUp.Hide()
 	}
@@ -154,11 +158,19 @@ func (e *DateEntry) setupDropDown() *Button {
 		e.dropDown = NewCalendar(time.Now(), e.setDate)
 	}
 	dropDownButton := NewButton("", func() {
+		if e.Date != nil && !e.Date.IsZero() {
+			e.dropDown.SetSelectedDate(*e.Date)
+			e.dropDown.SetDisplayedDate(*e.Date)
+		} else {
+			e.dropDown.SetSelectedDate(time.Time{})
+			e.dropDown.SetDisplayedDate(time.Time{})
+		}
+
 		c := fyne.CurrentApp().Driver().CanvasForObject(e.super())
 
 		e.popUp = NewPopUp(e.dropDown, c)
 		e.popUp.ShowAtPosition(e.popUpPos())
-		e.popUp.Resize(fyne.NewSize(e.Size().Width, e.popUp.MinSize().Height))
+		//e.popUp.Resize(fyne.NewSize(e.Size().Width, e.popUp.MinSize().Height))
 	})
 	dropDownButton.Importance = LowImportance
 	dropDownButton.SetIcon(e.Theme().Icon(theme.IconNameCalendar))


### PR DESCRIPTION
### Description:

Some enhancements to Calendar widget and DateEntry

- added localized month name
- added a function to programmatically change the currently displayed date
- added the ability to select a date, and a function to programmatically change the selected date
- fixed crash when OnChanged callback in not set
- calendar of DateEntry will now open with currently entered date selected
- corrected Calendar popup positioning (do not resize the popup, keep it always at its minSize)

What to discuss next:

- adding a localized button under the Calendar in DateEntry to select today's date
- adding a config variable WeekStart to Calendar to override configured first Week day
- adding something similar for date format to DateEntry (did not do it, will have to study it)
- discussing is it judicious and idiomatic that tapping the selected date in the calendar will unselect it (setting SelectedDate = time.Time{})

Another one I just want to understand:
- Why using in DateEntry a *time.Time and not a time.Time ??? We can just set Date = time.Time{} (Zero-date) instead on nil

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
