### PR TITLE
canvas: only move if pos is different than previous

### DIFF
--- a/canvas/circle.go
+++ b/canvas/circle.go
@@ -41,6 +41,9 @@ func (c *Circle) MinSize() fyne.Size {
 
 // Move the circle object to a new position, relative to its parent / canvas
 func (c *Circle) Move(pos fyne.Position) {
+	if c.Position1.X == pos.X && c.Position1.Y == pos.Y {
+		return
+	}
 	size := c.Size()
 	c.Position1 = pos
 	c.Position2 = c.Position1.Add(size)

--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -68,6 +68,9 @@ func (g *LinearGradient) Hide() {
 
 // Move the gradient to a new position, relative to its parent / canvas
 func (g *LinearGradient) Move(pos fyne.Position) {
+	if g.Position().X == pos.X && g.Position().Y == pos.Y {
+		return
+	}
 	g.baseObject.Move(pos)
 
 	repaint(g)

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -109,6 +109,9 @@ func (i *Image) MinSize() fyne.Size {
 
 // Move the image object to a new position, relative to its parent top, left corner.
 func (i *Image) Move(pos fyne.Position) {
+	if i.Position().X == pos.X && i.Position().Y == pos.Y {
+		return
+	}
 	i.baseObject.Move(pos)
 
 	repaint(i)

--- a/canvas/line.go
+++ b/canvas/line.go
@@ -57,6 +57,11 @@ func (l *Line) Position() fyne.Position {
 // Move the line object to a new position, relative to its parent / canvas
 func (l *Line) Move(pos fyne.Position) {
 	oldPos := l.Position()
+
+	if oldPos.X == pos.X && oldPos.Y == pos.Y {
+		return
+	}
+
 	deltaX := pos.X - oldPos.X
 	deltaY := pos.Y - oldPos.Y
 

--- a/canvas/raster.go
+++ b/canvas/raster.go
@@ -40,6 +40,9 @@ func (r *Raster) Hide() {
 
 // Move the raster to a new position, relative to its parent / canvas
 func (r *Raster) Move(pos fyne.Position) {
+	if r.Position().X == pos.X && r.Position().Y == pos.Y {
+		return
+	}
 	r.baseObject.Move(pos)
 
 	repaint(r)

--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -37,6 +37,9 @@ func (r *Rectangle) Hide() {
 
 // Move the rectangle to a new position, relative to its parent / canvas
 func (r *Rectangle) Move(pos fyne.Position) {
+	if r.position.X == pos.X && r.position.Y == pos.Y {
+		return
+	}
 	r.baseObject.Move(pos)
 
 	repaint(r)

--- a/canvas/square.go
+++ b/canvas/square.go
@@ -32,6 +32,9 @@ func (s *Square) Hide() {
 
 // Move the square to a new position, relative to its parent / canvas
 func (s *Square) Move(pos fyne.Position) {
+	if s.Position().X == pos.X && s.Position().Y == pos.Y {
+		return
+	}
 	s.baseObject.Move(pos)
 
 	repaint(s)

--- a/canvas/text.go
+++ b/canvas/text.go
@@ -46,6 +46,9 @@ func (t *Text) MinSize() fyne.Size {
 
 // Move the text to a new position, relative to its parent / canvas
 func (t *Text) Move(pos fyne.Position) {
+	if t.Position().X == pos.X && t.Position().Y == pos.Y {
+		return
+	}
 	t.baseObject.Move(pos)
 
 	repaint(t)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Only `Move` the canvas primitive if the passed in pos is different from the previous position.

Since these canvas primitives call `repaint` inside `Move`, there can be a significant performance penalty in some cases without this optimization.

For example, #5815 is helped significantly by this change.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
