### PR TITLE
Simplify comparison of positions and sizes

### DIFF
--- a/container/tabs.go
+++ b/container/tabs.go
@@ -424,7 +424,7 @@ func (r *baseTabsRenderer) minSize(t baseTabs) fyne.Size {
 }
 
 func (r *baseTabsRenderer) moveIndicator(pos fyne.Position, siz fyne.Size, th fyne.Theme, animate bool) {
-	isSameState := r.lastIndicatorPos.Subtract(pos).IsZero() && r.lastIndicatorSize.Subtract(siz).IsZero() &&
+	isSameState := r.lastIndicatorPos == pos && r.lastIndicatorSize == siz &&
 		r.lastIndicatorHidden == r.indicator.Hidden
 	if isSameState {
 		return

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -585,7 +585,7 @@ func (s *Scroll) Resize(sz fyne.Size) {
 //
 // Since: 2.6
 func (s *Scroll) ScrollToOffset(p fyne.Position) {
-	if s.Offset.Subtract(p).IsZero() {
+	if s.Offset == p {
 		return
 	}
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -640,8 +640,8 @@ func (r *textRenderer) calculateMin(bounds []rowBoundary, wrap fyne.TextWrap, ob
 
 			min := obj.MinSize()
 			if img, ok := obj.(*richImage); ok {
-				if !img.MinSize().Subtract(img.oldMin).IsZero() {
-					img.oldMin = img.MinSize()
+				if newMin := img.MinSize(); newMin != img.oldMin {
+					img.oldMin = newMin
 
 					min := r.calculateMin(bounds, wrap, objs, charMinSize, th)
 					if r.obj.scr != nil {


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

There is no need to subtract and then check for zero. Just comparing structs directly is cleaner and should generate a lot more efficient code as the two 32 bit comparisons can be combined into a single 64 bit comparison operation. I did a quick check for fun and the generated code is a lot simpler: https://go.godbolt.org/z/Pn6Pj86xq

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

