### PR TITLE
wasm: Fix memory leaks in uses of js.FuncOf

### DIFF
--- a/app/app_wasm.go
+++ b/app/app_wasm.go
@@ -22,14 +22,16 @@ func (a *fyneApp) SendNotification(n *fyne.Notification) {
 
 	permission := notification.Get("permission")
 	if permission.Type() != js.TypeString || permission.String() != "granted" {
-		notification.Call("requestPermission", js.FuncOf(func(this js.Value, args []js.Value) any {
+		request := js.FuncOf(func(this js.Value, args []js.Value) any {
 			if len(args) > 0 && args[0].Type() == js.TypeString && args[0].String() == "granted" {
 				a.showNotification(n, &notification)
 			} else {
 				fyne.LogError("User rejected the request for notifications.", nil)
 			}
 			return nil
-		}))
+		})
+		defer request.Release()
+		notification.Call("requestPermission", request)
 		return
 	}
 
@@ -45,7 +47,6 @@ func (a *fyneApp) showNotification(data *fyne.Notification, notification *js.Val
 		"body": data.Content,
 		"icon": base64Img,
 	})
-	fyne.LogError("done show...", nil)
 }
 
 var themeChanged = js.FuncOf(func(this js.Value, args []js.Value) any {

--- a/app/app_wasm.go
+++ b/app/app_wasm.go
@@ -14,42 +14,38 @@ import (
 )
 
 func (a *fyneApp) SendNotification(n *fyne.Notification) {
-	window := js.Global().Get("window")
-	if window.IsUndefined() {
+	notification := js.Global().Get("window").Get("Notification")
+	if notification.IsUndefined() {
 		fyne.LogError("Current browser does not support notifications.", nil)
 		return
 	}
-	notification := window.Get("Notification")
-	if window.IsUndefined() {
-		fyne.LogError("Current browser does not support notifications.", nil)
-		return
-	}
-	// check permission
+
 	permission := notification.Get("permission")
-	showNotification := func() {
-		icon := a.icon.Content()
-		base64Str := base64.StdEncoding.EncodeToString(icon)
-		mimeType := http.DetectContentType(icon)
-		base64Img := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Str)
-		notification.New(n.Title, map[string]any{
-			"body": n.Content,
-			"icon": base64Img,
-		})
-		fyne.LogError("done show...", nil)
-	}
 	if permission.Type() != js.TypeString || permission.String() != "granted" {
-		// need to request for permission
 		notification.Call("requestPermission", js.FuncOf(func(this js.Value, args []js.Value) any {
 			if len(args) > 0 && args[0].Type() == js.TypeString && args[0].String() == "granted" {
-				showNotification()
+				a.showNotification(n, &notification)
 			} else {
 				fyne.LogError("User rejected the request for notifications.", nil)
 			}
 			return nil
 		}))
-	} else {
-		showNotification()
+		return
 	}
+
+	a.showNotification(n, &notification)
+}
+
+func (a *fyneApp) showNotification(data *fyne.Notification, notification *js.Value) {
+	icon := a.icon.Content()
+	base64Str := base64.StdEncoding.EncodeToString(icon)
+	mimeType := http.DetectContentType(icon)
+	base64Img := fmt.Sprintf("data:%s;base64,%s", mimeType, base64Str)
+	notification.New(data.Title, map[string]any{
+		"body": data.Content,
+		"icon": base64Img,
+	})
+	fyne.LogError("done show...", nil)
 }
 
 var themeChanged = js.FuncOf(func(this js.Value, args []js.Value) any {


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The documentation for `js.FuncOf` notes that you need to call `.Release()` on the function to release the value from the internal map. I noticed that there was two places in our code where this memory leak may happen. I removed the two leaks and refactored the notification code to be more readable (plus removed the fyne.LogError on success). The only remaining `js.FuncOf` is the theme watcher but that lives the entirety of the program so it should need to be cleaned up.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

