### PR TITLE
Avoid grabbing renderer twice when setting theme

### DIFF
--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -14,10 +14,11 @@ func ApplyThemeTo(content fyne.CanvasObject, canv fyne.Canvas) {
 
 	switch o := content.(type) {
 	case fyne.Widget:
-		for _, co := range cache.Renderer(o).Objects() {
+		renderer := cache.Renderer(o)
+		for _, co := range renderer.Objects() {
 			ApplyThemeTo(co, canv)
 		}
-		cache.Renderer(o).Layout(content.Size()) // theme can cause sizing changes
+		renderer.Layout(content.Size()) // theme can cause sizing changes
 	case *fyne.Container:
 		for _, co := range o.Objects {
 			ApplyThemeTo(co, canv)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is just a small change to make sure that we are not doing a renderer lookup twice.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
