### PR TITLE
Remove uses of renderer cache in textgrid

### DIFF
--- a/widget/testdata/textgrid/basic.xml
+++ b/widget/testdata/textgrid/basic.xml
@@ -3,91 +3,91 @@
 		<widget size="72x32" type="*widget.TextGrid">
 			<widget size="72x32" type="*widget.textGridContent">
 				<widget size="72x16" type="*widget.textGridRow">
-					<rectangle size="0x0"/>
+					<rectangle size="8x16"/>
 					<text monospace size="0x0">S</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">o</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">m</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">e</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">t</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">h</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">i</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">n</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">g</text>
-					<line size="0x0"/>
+					<line pos="0,16" size="8x0"/>
+					<rectangle pos="8,0" size="8x16"/>
+					<text monospace pos="8,0" size="0x0">o</text>
+					<line pos="8,16" size="8x0"/>
+					<rectangle pos="16,0" size="8x16"/>
+					<text monospace pos="16,0" size="0x0">m</text>
+					<line pos="16,16" size="8x0"/>
+					<rectangle pos="24,0" size="8x16"/>
+					<text monospace pos="24,0" size="0x0">e</text>
+					<line pos="24,16" size="8x0"/>
+					<rectangle pos="32,0" size="8x16"/>
+					<text monospace pos="32,0" size="0x0">t</text>
+					<line pos="32,16" size="8x0"/>
+					<rectangle pos="40,0" size="8x16"/>
+					<text monospace pos="40,0" size="0x0">h</text>
+					<line pos="40,16" size="8x0"/>
+					<rectangle pos="48,0" size="8x16"/>
+					<text monospace pos="48,0" size="0x0">i</text>
+					<line pos="48,16" size="8x0"/>
+					<rectangle pos="56,0" size="8x16"/>
+					<text monospace pos="56,0" size="0x0">n</text>
+					<line pos="56,16" size="8x0"/>
+					<rectangle pos="64,0" size="8x16"/>
+					<text monospace pos="64,0" size="0x0">g</text>
+					<line pos="64,16" size="8x0"/>
 				</widget>
 				<widget pos="0,16" size="72x16" type="*widget.textGridRow">
-					<rectangle size="0x0"/>
+					<rectangle size="8x16"/>
 					<text monospace size="0x0">E</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">l</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">s</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0">e</text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
+					<line pos="0,16" size="8x0"/>
+					<rectangle pos="8,0" size="8x16"/>
+					<text monospace pos="8,0" size="0x0">l</text>
+					<line pos="8,16" size="8x0"/>
+					<rectangle pos="16,0" size="8x16"/>
+					<text monospace pos="16,0" size="0x0">s</text>
+					<line pos="16,16" size="8x0"/>
+					<rectangle pos="24,0" size="8x16"/>
+					<text monospace pos="24,0" size="0x0">e</text>
+					<line pos="24,16" size="8x0"/>
+					<rectangle pos="32,0" size="8x16"/>
+					<text monospace pos="32,0" size="0x0"> </text>
+					<line pos="32,16" size="8x0"/>
+					<rectangle pos="40,0" size="8x16"/>
+					<text monospace pos="40,0" size="0x0"> </text>
+					<line pos="40,16" size="8x0"/>
+					<rectangle pos="48,0" size="8x16"/>
+					<text monospace pos="48,0" size="0x0"> </text>
+					<line pos="48,16" size="8x0"/>
+					<rectangle pos="56,0" size="8x16"/>
+					<text monospace pos="56,0" size="0x0"> </text>
+					<line pos="56,16" size="8x0"/>
+					<rectangle pos="64,0" size="8x16"/>
+					<text monospace pos="64,0" size="0x0"> </text>
+					<line pos="64,16" size="8x0"/>
 				</widget>
 				<widget pos="0,32" size="72x16" type="*widget.textGridRow">
-					<rectangle size="0x0"/>
+					<rectangle size="8x16"/>
 					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
-					<rectangle size="0x0"/>
-					<text monospace size="0x0"> </text>
-					<line size="0x0"/>
+					<line pos="0,16" size="8x0"/>
+					<rectangle pos="8,0" size="8x16"/>
+					<text monospace pos="8,0" size="0x0"> </text>
+					<line pos="8,16" size="8x0"/>
+					<rectangle pos="16,0" size="8x16"/>
+					<text monospace pos="16,0" size="0x0"> </text>
+					<line pos="16,16" size="8x0"/>
+					<rectangle pos="24,0" size="8x16"/>
+					<text monospace pos="24,0" size="0x0"> </text>
+					<line pos="24,16" size="8x0"/>
+					<rectangle pos="32,0" size="8x16"/>
+					<text monospace pos="32,0" size="0x0"> </text>
+					<line pos="32,16" size="8x0"/>
+					<rectangle pos="40,0" size="8x16"/>
+					<text monospace pos="40,0" size="0x0"> </text>
+					<line pos="40,16" size="8x0"/>
+					<rectangle pos="48,0" size="8x16"/>
+					<text monospace pos="48,0" size="0x0"> </text>
+					<line pos="48,16" size="8x0"/>
+					<rectangle pos="56,0" size="8x16"/>
+					<text monospace pos="56,0" size="0x0"> </text>
+					<line pos="56,16" size="8x0"/>
+					<rectangle pos="64,0" size="8x16"/>
+					<text monospace pos="64,0" size="0x0"> </text>
+					<line pos="64,16" size="8x0"/>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/textgrid/scroll.xml
+++ b/widget/testdata/textgrid/scroll.xml
@@ -4,91 +4,91 @@
 			<widget size="50x32" type="*widget.Scroll">
 				<widget size="72x32" type="*widget.textGridContent">
 					<widget size="72x16" type="*widget.textGridRow">
-						<rectangle size="0x0"/>
+						<rectangle size="8x16"/>
 						<text monospace size="0x0">S</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">o</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">m</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">e</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">t</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">h</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">i</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">n</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">g</text>
-						<line size="0x0"/>
+						<line pos="0,16" size="8x0"/>
+						<rectangle pos="8,0" size="8x16"/>
+						<text monospace pos="8,0" size="0x0">o</text>
+						<line pos="8,16" size="8x0"/>
+						<rectangle pos="16,0" size="8x16"/>
+						<text monospace pos="16,0" size="0x0">m</text>
+						<line pos="16,16" size="8x0"/>
+						<rectangle pos="24,0" size="8x16"/>
+						<text monospace pos="24,0" size="0x0">e</text>
+						<line pos="24,16" size="8x0"/>
+						<rectangle pos="32,0" size="8x16"/>
+						<text monospace pos="32,0" size="0x0">t</text>
+						<line pos="32,16" size="8x0"/>
+						<rectangle pos="40,0" size="8x16"/>
+						<text monospace pos="40,0" size="0x0">h</text>
+						<line pos="40,16" size="8x0"/>
+						<rectangle pos="48,0" size="8x16"/>
+						<text monospace pos="48,0" size="0x0">i</text>
+						<line pos="48,16" size="8x0"/>
+						<rectangle pos="56,0" size="8x16"/>
+						<text monospace pos="56,0" size="0x0">n</text>
+						<line pos="56,16" size="8x0"/>
+						<rectangle pos="64,0" size="8x16"/>
+						<text monospace pos="64,0" size="0x0">g</text>
+						<line pos="64,16" size="8x0"/>
 					</widget>
 					<widget pos="0,16" size="72x16" type="*widget.textGridRow">
-						<rectangle size="0x0"/>
+						<rectangle size="8x16"/>
 						<text monospace size="0x0">E</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">l</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">s</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0">e</text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
+						<line pos="0,16" size="8x0"/>
+						<rectangle pos="8,0" size="8x16"/>
+						<text monospace pos="8,0" size="0x0">l</text>
+						<line pos="8,16" size="8x0"/>
+						<rectangle pos="16,0" size="8x16"/>
+						<text monospace pos="16,0" size="0x0">s</text>
+						<line pos="16,16" size="8x0"/>
+						<rectangle pos="24,0" size="8x16"/>
+						<text monospace pos="24,0" size="0x0">e</text>
+						<line pos="24,16" size="8x0"/>
+						<rectangle pos="32,0" size="8x16"/>
+						<text monospace pos="32,0" size="0x0"> </text>
+						<line pos="32,16" size="8x0"/>
+						<rectangle pos="40,0" size="8x16"/>
+						<text monospace pos="40,0" size="0x0"> </text>
+						<line pos="40,16" size="8x0"/>
+						<rectangle pos="48,0" size="8x16"/>
+						<text monospace pos="48,0" size="0x0"> </text>
+						<line pos="48,16" size="8x0"/>
+						<rectangle pos="56,0" size="8x16"/>
+						<text monospace pos="56,0" size="0x0"> </text>
+						<line pos="56,16" size="8x0"/>
+						<rectangle pos="64,0" size="8x16"/>
+						<text monospace pos="64,0" size="0x0"> </text>
+						<line pos="64,16" size="8x0"/>
 					</widget>
 					<widget pos="0,32" size="72x16" type="*widget.textGridRow">
-						<rectangle size="0x0"/>
+						<rectangle size="8x16"/>
 						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
-						<rectangle size="0x0"/>
-						<text monospace size="0x0"> </text>
-						<line size="0x0"/>
+						<line pos="0,16" size="8x0"/>
+						<rectangle pos="8,0" size="8x16"/>
+						<text monospace pos="8,0" size="0x0"> </text>
+						<line pos="8,16" size="8x0"/>
+						<rectangle pos="16,0" size="8x16"/>
+						<text monospace pos="16,0" size="0x0"> </text>
+						<line pos="16,16" size="8x0"/>
+						<rectangle pos="24,0" size="8x16"/>
+						<text monospace pos="24,0" size="0x0"> </text>
+						<line pos="24,16" size="8x0"/>
+						<rectangle pos="32,0" size="8x16"/>
+						<text monospace pos="32,0" size="0x0"> </text>
+						<line pos="32,16" size="8x0"/>
+						<rectangle pos="40,0" size="8x16"/>
+						<text monospace pos="40,0" size="0x0"> </text>
+						<line pos="40,16" size="8x0"/>
+						<rectangle pos="48,0" size="8x16"/>
+						<text monospace pos="48,0" size="0x0"> </text>
+						<line pos="48,16" size="8x0"/>
+						<rectangle pos="56,0" size="8x16"/>
+						<text monospace pos="56,0" size="0x0"> </text>
+						<line pos="56,16" size="8x0"/>
+						<rectangle pos="64,0" size="8x16"/>
+						<text monospace pos="64,0" size="0x0"> </text>
+						<line pos="64,16" size="8x0"/>
 					</widget>
 				</widget>
 				<widget pos="50,0" size="0x32" type="*widget.Shadow">

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -9,7 +9,6 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/async"
-	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -490,6 +489,8 @@ type textGridContent struct {
 
 	rows     int
 	cellSize fyne.Size
+
+	visible []fyne.CanvasObject
 }
 
 func newTextGridContent(t *TextGrid) *textGridContent {
@@ -511,13 +512,11 @@ func (t *textGridContent) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func (t *textGridContent) refreshCell(row, col int) {
-	rows := cache.Renderer(t).Objects()
-	if row >= len(rows)-1 {
+	if row >= len(t.visible)-1 {
 		return
 	}
-	wid := rows[row].(*textGridRow)
-	r := cache.Renderer(wid).(*textGridRowRenderer)
-	r.refreshCell(col)
+	wid := t.visible[row].(*textGridRow)
+	wid.refreshCell(col)
 }
 
 func (t *textGridContentRenderer) updateGridSize(size fyne.Size) {
@@ -533,9 +532,7 @@ func (t *textGridContentRenderer) updateGridSize(size fyne.Size) {
 }
 
 type textGridContentRenderer struct {
-	text *textGridContent
-
-	visible  []fyne.CanvasObject
+	text     *textGridContent
 	itemPool async.Pool[*textGridRow]
 }
 
@@ -546,7 +543,7 @@ func (t *textGridContentRenderer) Layout(s fyne.Size) {
 	size := fyne.NewSize(s.Width, t.text.cellSize.Height)
 	t.updateGridSize(s)
 
-	for _, o := range t.visible {
+	for _, o := range t.text.visible {
 		o.Move(fyne.NewPos(0, float32(o.(*textGridRow).row)*t.text.cellSize.Height))
 		o.Resize(size)
 	}
@@ -562,7 +559,7 @@ func (t *textGridContentRenderer) MinSize() fyne.Size {
 }
 
 func (t *textGridContentRenderer) Objects() []fyne.CanvasObject {
-	return t.visible
+	return t.text.visible
 }
 
 func (t *textGridContentRenderer) Refresh() {
@@ -570,7 +567,7 @@ func (t *textGridContentRenderer) Refresh() {
 	t.updateCellSize()
 	t.updateGridSize(t.text.text.Size())
 
-	for _, o := range t.visible {
+	for _, o := range t.text.visible {
 		o.Refresh()
 	}
 }
@@ -586,8 +583,8 @@ func (t *textGridContentRenderer) addRowsIfRequired() {
 		end = int(math.Ceil(float64(off / t.text.cellSize.Height)))
 	}
 
-	remain := t.visible[:0]
-	for _, row := range t.visible {
+	remain := t.text.visible[:0]
+	for _, row := range t.text.visible {
 		if row.(*textGridRow).row < start || row.(*textGridRow).row > end {
 			t.itemPool.Put(row.(*textGridRow))
 			continue
@@ -595,12 +592,12 @@ func (t *textGridContentRenderer) addRowsIfRequired() {
 
 		remain = append(remain, row.(*textGridRow))
 	}
-	t.visible = remain
+	t.text.visible = remain
 
 	var newItems []fyne.CanvasObject
 	for i := start; i <= end; i++ {
 		found := false
-		for _, row := range t.visible {
+		for _, row := range t.text.visible {
 			if i == row.(*textGridRow).row {
 				found = true
 				break
@@ -621,7 +618,7 @@ func (t *textGridContentRenderer) addRowsIfRequired() {
 	}
 
 	if len(newItems) > 0 {
-		t.visible = append(t.visible, newItems...)
+		t.text.visible = append(t.text.visible, newItems...)
 	}
 }
 
@@ -640,16 +637,20 @@ type textGridRow struct {
 	BaseWidget
 	text *textGridContent
 
-	row int
+	objects []fyne.CanvasObject
+	row     int
+	cols    int
 }
 
 func newTextGridRow(t *textGridContent, row int) *textGridRow {
-	return &textGridRow{text: t, row: row}
+	newRow := &textGridRow{text: t, row: row}
+	newRow.ExtendBaseWidget(newRow)
+
+	return newRow
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *textGridRow) CreateRenderer() fyne.WidgetRenderer {
-	t.ExtendBaseWidget(t)
 	render := &textGridRowRenderer{obj: t}
 
 	render.Refresh() // populate
@@ -663,14 +664,10 @@ func (t *textGridRow) setRow(row int) {
 
 type textGridRowRenderer struct {
 	obj *textGridRow
-
-	cols int
-
-	objects []fyne.CanvasObject
 }
 
-func (t *textGridRowRenderer) appendTextCell(str rune) {
-	th := t.obj.text.text.Theme()
+func (t *textGridRow) appendTextCell(str rune) {
+	th := t.text.text.Theme()
 	v := fyne.CurrentApp().Settings().ThemeVariant()
 
 	text := canvas.NewText(string(str), th.Color(theme.ColorNameForeground, v))
@@ -683,13 +680,13 @@ func (t *textGridRowRenderer) appendTextCell(str rune) {
 	t.objects = append(t.objects, bg, text, ul)
 }
 
-func (t *textGridRowRenderer) refreshCell(col int) {
+func (t *textGridRow) refreshCell(col int) {
 	pos := t.cols + col
 	if pos*3+1 >= len(t.objects) {
 		return
 	}
 
-	row := t.obj.text.text.Rows[t.obj.row]
+	row := t.text.text.Rows[t.row]
 
 	if len(row.Cells) > col {
 		cell := row.Cells[col]
@@ -697,7 +694,7 @@ func (t *textGridRowRenderer) refreshCell(col int) {
 	}
 }
 
-func (t *textGridRowRenderer) setCellRune(str rune, pos int, style, rowStyle TextGridStyle) {
+func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridStyle) {
 	if str == 0 {
 		str = ' '
 	}
@@ -705,7 +702,7 @@ func (t *textGridRowRenderer) setCellRune(str rune, pos int, style, rowStyle Tex
 	text := t.objects[pos*3+1].(*canvas.Text)
 	underline := t.objects[pos*3+2].(*canvas.Line)
 
-	th := t.obj.text.text.Theme()
+	th := t.text.text.Theme()
 	v := fyne.CurrentApp().Settings().ThemeVariant()
 	fg := th.Color(theme.ColorNameForeground, v)
 	text.TextSize = th.Size(theme.SizeNameText)
@@ -757,7 +754,7 @@ func (t *textGridRowRenderer) setCellRune(str rune, pos int, style, rowStyle Tex
 	}
 }
 
-func (t *textGridRowRenderer) addCellsIfRequired() {
+func (t *textGridRow) addCellsIfRequired() {
 	cellCount := t.cols
 	if len(t.objects) == cellCount*3 {
 		return
@@ -767,9 +764,9 @@ func (t *textGridRowRenderer) addCellsIfRequired() {
 	}
 }
 
-func (t *textGridRowRenderer) refreshCells() {
+func (t *textGridRow) refreshCells() {
 	x := 0
-	if t.obj.row >= len(t.obj.text.text.Rows) {
+	if t.row >= len(t.text.text.Rows) {
 		for ; x < len(t.objects)/3; x++ {
 			t.setCellRune(' ', x, TextGridStyleDefault, nil) // blank rows no longer needed
 		}
@@ -777,11 +774,11 @@ func (t *textGridRowRenderer) refreshCells() {
 		return // we can have more rows than content rows (filling space)
 	}
 
-	row := t.obj.text.text.Rows[t.obj.row]
+	row := t.text.text.Rows[t.row]
 	rowStyle := row.Style
 	i := 0
-	if t.obj.text.text.ShowLineNumbers {
-		lineStr := []rune(strconv.Itoa(t.obj.row + 1))
+	if t.text.text.ShowLineNumbers {
+		lineStr := []rune(strconv.Itoa(t.row + 1))
 		pad := t.lineNumberWidth() - len(lineStr)
 		for ; i < pad; i++ {
 			t.setCellRune(' ', x, TextGridStyleWhitespace, rowStyle) // padding space
@@ -801,7 +798,7 @@ func (t *textGridRowRenderer) refreshCells() {
 		if i >= t.cols { // would be an overflow - bad
 			continue
 		}
-		if t.obj.text.text.ShowWhitespace && (r.Rune == ' ' || r.Rune == '\t') {
+		if t.text.text.ShowWhitespace && (r.Rune == ' ' || r.Rune == '\t') {
 			sym := textAreaSpaceSymbol
 			if r.Rune == '\t' {
 				sym = textAreaTabSymbol
@@ -822,7 +819,7 @@ func (t *textGridRowRenderer) refreshCells() {
 		i++
 		x++
 	}
-	if t.obj.text.text.ShowWhitespace && i < t.cols && t.obj.row < len(t.obj.text.text.Rows)-1 {
+	if t.text.text.ShowWhitespace && i < t.cols && t.row < len(t.text.text.Rows)-1 {
 		t.setCellRune(textAreaNewLineSymbol, x, TextGridStyleWhitespace, rowStyle) // newline
 		i++
 		x++
@@ -845,23 +842,23 @@ func (t *TextGrid) tabWidth() int {
 	return t.TabWidth
 }
 
-func (t *textGridRowRenderer) lineNumberWidth() int {
-	return len(strconv.Itoa(t.obj.text.rows + 1))
+func (t *textGridRow) lineNumberWidth() int {
+	return len(strconv.Itoa(t.text.rows + 1))
 }
 
-func (t *textGridRowRenderer) updateGridSize(size fyne.Size) {
-	bufCols := int(size.Width / t.obj.text.cellSize.Width)
-	for _, row := range t.obj.text.text.Rows {
+func (t *textGridRow) updateGridSize(size fyne.Size) {
+	bufCols := int(size.Width / t.text.cellSize.Width)
+	for _, row := range t.text.text.Rows {
 		lenCells := len(row.Cells)
 		if lenCells > bufCols {
 			bufCols = lenCells
 		}
 	}
 
-	if t.obj.text.text.ShowWhitespace {
+	if t.text.text.ShowWhitespace {
 		bufCols++
 	}
-	if t.obj.text.text.ShowLineNumbers {
+	if t.text.text.ShowLineNumbers {
 		bufCols += t.lineNumberWidth()
 	}
 
@@ -870,21 +867,21 @@ func (t *textGridRowRenderer) updateGridSize(size fyne.Size) {
 }
 
 func (t *textGridRowRenderer) Layout(size fyne.Size) {
-	t.updateGridSize(size)
+	t.obj.updateGridSize(size)
 
 	cellPos := fyne.NewPos(0, 0)
 	off := 0
-	for x := 0; x < t.cols; x++ {
+	for x := 0; x < t.obj.cols; x++ {
 		// rect
-		t.objects[off].Resize(t.obj.text.cellSize)
-		t.objects[off].Move(cellPos)
+		t.obj.objects[off].Resize(t.obj.text.cellSize)
+		t.obj.objects[off].Move(cellPos)
 
 		// text
-		t.objects[off+1].Move(cellPos)
+		t.obj.objects[off+1].Move(cellPos)
 
 		// underline
-		t.objects[off+2].Move(cellPos.Add(fyne.Position{X: 0, Y: t.obj.text.cellSize.Height}))
-		t.objects[off+2].Resize(fyne.Size{Width: t.obj.text.cellSize.Width})
+		t.obj.objects[off+2].Move(cellPos.Add(fyne.Position{X: 0, Y: t.obj.text.cellSize.Height}))
+		t.obj.objects[off+2].Resize(fyne.Size{Width: t.obj.text.cellSize.Width})
 
 		cellPos.X += t.obj.text.cellSize.Width
 		off += 3
@@ -903,15 +900,15 @@ func (t *textGridRowRenderer) Refresh() {
 	th := t.obj.text.text.Theme()
 	v := fyne.CurrentApp().Settings().ThemeVariant()
 	TextGridStyleWhitespace = &CustomTextGridStyle{FGColor: th.Color(theme.ColorNameDisabled, v)}
-	t.updateGridSize(t.obj.text.text.Size())
-	t.refreshCells()
+	t.obj.updateGridSize(t.obj.text.text.Size())
+	t.obj.refreshCells()
 }
 
 func (t *textGridRowRenderer) ApplyTheme() {
 }
 
 func (t *textGridRowRenderer) Objects() []fyne.CanvasObject {
-	return t.objects
+	return t.obj.objects
 }
 
 func (t *textGridRowRenderer) Destroy() {

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -144,12 +144,8 @@ func TestTextGrid_CreateRendererRows(t *testing.T) {
 	grid := NewTextGrid()
 	grid.Resize(fyne.NewSize(52, 22))
 	wrap := test.TempWidgetRenderer(t, grid).(*textGridRenderer).text
-	rend := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
-	rend.Refresh()
-
-	row := rend.visible[0].(fyne.Widget)
-	rr := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
-	assert.Len(t, rr.objects, 18)
+	row := wrap.visible[0].(*textGridRow)
+	assert.Len(t, row.objects, 18)
 }
 
 func TestTextGrid_Row(t *testing.T) {
@@ -194,11 +190,11 @@ func TestTextGrid_SetText_Overflow(t *testing.T) {
 
 	assert.Len(t, grid.Rows, 2)
 	assert.Len(t, grid.Rows[1].Cells, 5)
-	render := test.WidgetRenderer(test.WidgetRenderer(grid).(*textGridRenderer).text).(*textGridContentRenderer)
-	assert.Equal(t, 3, len(render.visible))
-	row0 := test.WidgetRenderer(render.visible[0].(*textGridRow)).(*textGridRowRenderer)
-	row1 := test.WidgetRenderer(render.visible[1].(*textGridRow)).(*textGridRowRenderer)
-	row2 := test.WidgetRenderer(render.visible[2].(*textGridRow)).(*textGridRowRenderer)
+	content := test.WidgetRenderer(grid).(*textGridRenderer).text
+	assert.Equal(t, 3, len(content.visible))
+	row0 := content.visible[0].(*textGridRow)
+	row1 := content.visible[1].(*textGridRow)
+	row2 := content.visible[2].(*textGridRow)
 	assert.Equal(t, "H", row0.objects[1].(*canvas.Text).Text)
 	assert.Equal(t, "g", row0.objects[28].(*canvas.Text).Text)
 	assert.Equal(t, "t", row1.objects[1].(*canvas.Text).Text)
@@ -207,7 +203,7 @@ func TestTextGrid_SetText_Overflow(t *testing.T) {
 	grid.SetText("Replace")
 
 	assert.Len(t, grid.Rows, 1)
-	assert.Equal(t, 2, len(render.visible))
+	assert.Equal(t, 2, len(content.visible))
 	assert.Len(t, grid.Rows[0].Cells, 7)
 
 	assert.Equal(t, "R", row0.objects[1].(*canvas.Text).Text)
@@ -315,9 +311,8 @@ func TestTextGridRender_Size(t *testing.T) {
 
 	assert.Equal(t, 2, rend.text.rows)
 
-	row := rend.visible[0].(fyne.Widget)
-	rend2 := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
-	assert.Equal(t, 3, rend2.cols)
+	row := wrap.visible[0].(*textGridRow)
+	assert.Equal(t, 3, row.cols)
 }
 
 func TestTextGridRender_Whitespace(t *testing.T) {
@@ -383,12 +378,11 @@ func TestTextGridRender_TextColor(t *testing.T) {
 func assertGridContent(t *testing.T, g *TextGrid, expected string) {
 	lines := strings.Split(expected, "\n")
 	wrap := test.TempWidgetRenderer(t, g).(*textGridRenderer).text
-	renderer := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
 
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes
 		for _, r := range line {
-			row := renderer.visible[y].(fyne.Widget)
+			row := wrap.visible[y].(fyne.Widget)
 			rend2 := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
 
 			_, fg := rendererCell(rend2, x)
@@ -401,12 +395,11 @@ func assertGridContent(t *testing.T, g *TextGrid, expected string) {
 func assertGridStyle(t *testing.T, g *TextGrid, content string, expectedStyles map[string]TextGridStyle) {
 	lines := strings.Split(content, "\n")
 	wrap := test.TempWidgetRenderer(t, g).(*textGridRenderer).text
-	renderer := test.TempWidgetRenderer(t, wrap).(*textGridContentRenderer)
 
 	for y, line := range lines {
 		x := 0 // rune count - using index below would be offset into string bytes
 
-		row := renderer.visible[y].(fyne.Widget)
+		row := wrap.visible[y].(fyne.Widget)
 		rend2 := test.TempWidgetRenderer(t, row).(*textGridRowRenderer)
 
 		for _, r := range line {
@@ -443,5 +436,5 @@ func assertGridStyle(t *testing.T, g *TextGrid, content string, expectedStyles m
 
 func rendererCell(r *textGridRowRenderer, col int) (*canvas.Rectangle, *canvas.Text) {
 	i := col * 3
-	return r.objects[i].(*canvas.Rectangle), r.objects[i+1].(*canvas.Text)
+	return r.obj.objects[i].(*canvas.Rectangle), r.obj.objects[i+1].(*canvas.Text)
 }


### PR DESCRIPTION
### Description:
Remove usage of renderer cache in TextGrid, per https://github.com/fyne-io/fyne/issues/5827

I also fixed a bug where `textGridRow` was only calling `ExtendBaseWidget` once its renderer was created. This was causing a couple of tests to fail, because with the `cache.Renderer` calls removed, we were no longer creating the renderer during unit test setup.

Because we are now extending BaseWidget on creation of rows, a lot of snapshots needed updating. I took a look at the changes, and I think they were actually wrong before. LMK if I'm wrong about that :)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
