### PR TITLE
Single threaded pool buffer

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -7,7 +7,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/internal/app"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"fyne.io/fyne/v2/internal/build"
 	"fyne.io/fyne/v2/theme"
 )
@@ -37,7 +37,7 @@ type settings struct {
 	variant        fyne.ThemeVariant
 
 	listeners       []func(fyne.Settings)
-	changeListeners async.Map[chan fyne.Settings, bool]
+	changeListeners migrated.Map[chan fyne.Settings, bool]
 	watcher         any // normally *fsnotify.Watcher or nil - avoid import in this file
 
 	schema SettingsSchema

--- a/data/binding/pref_helper.go
+++ b/data/binding/pref_helper.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 )
 
 type preferenceItem interface {
@@ -12,7 +12,7 @@ type preferenceItem interface {
 }
 
 type preferenceBindings struct {
-	async.Map[string, preferenceItem]
+	migrated.Map[string, preferenceItem]
 }
 
 func (b *preferenceBindings) list() []preferenceItem {
@@ -25,7 +25,7 @@ func (b *preferenceBindings) list() []preferenceItem {
 }
 
 type preferencesMap struct {
-	prefs async.Map[fyne.Preferences, *preferenceBindings]
+	prefs migrated.Map[fyne.Preferences, *preferenceBindings]
 
 	appPrefs fyne.Preferences // the main application prefs, to check if it changed...
 	appLock  sync.Mutex

--- a/internal/async/map.go
+++ b/internal/async/map.go
@@ -1,5 +1,3 @@
-//go:build !migrated_fynedo
-
 package async
 
 import "sync"

--- a/internal/async/map_clear.go
+++ b/internal/async/map_clear.go
@@ -1,4 +1,4 @@
-//go:build !go1.23 && !migrated_fynedo
+//go:build !go1.23
 
 package async
 

--- a/internal/async/map_clear_go1.23.go
+++ b/internal/async/map_clear_go1.23.go
@@ -1,4 +1,4 @@
-//go:build go1.23 && !migrated_fynedo
+//go:build go1.23
 
 package async
 

--- a/internal/async/migrated/map.go
+++ b/internal/async/migrated/map.go
@@ -1,0 +1,10 @@
+//go:build !migrated_fynedo
+
+package migrated
+
+import "fyne.io/fyne/v2/internal/async"
+
+// Map is a generic wrapper around [sync.Map].
+type Map[K, V any] struct {
+	async.Map[K, V]
+}

--- a/internal/async/migrated/map_migratedfynedo.go
+++ b/internal/async/migrated/map_migratedfynedo.go
@@ -1,6 +1,6 @@
 //go:build migrated_fynedo
 
-package async
+package migrated
 
 // Map is a generic wrapper around [sync.Map].
 type Map[K any, V any] struct {

--- a/internal/async/migrated/map_test.go
+++ b/internal/async/migrated/map_test.go
@@ -1,4 +1,4 @@
-package async_test
+package migrated_test
 
 import (
 	"testing"

--- a/internal/async/migrated/pool.go
+++ b/internal/async/migrated/pool.go
@@ -1,0 +1,10 @@
+//go:build !migrated_fynedo
+
+package migrated
+
+import "fyne.io/fyne/v2/internal/async"
+
+// Pool is the generic version of sync.Pool.
+type Pool[T any] struct {
+	async.Pool[T]
+}

--- a/internal/async/migrated/pool_migratedfynedo.go
+++ b/internal/async/migrated/pool_migratedfynedo.go
@@ -1,6 +1,6 @@
 //go:build migrated_fynedo
 
-package async
+package migrated
 
 // Pool (when migrated) is just a simple single threaded data buffer.
 type Pool[T any] struct {

--- a/internal/async/migrated/pool_test.go
+++ b/internal/async/migrated/pool_test.go
@@ -1,13 +1,14 @@
-package migrated
+package migrated_test
 
 import (
 	"testing"
 
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPool(t *testing.T) {
-	pool := Pool[int]{}
+	pool := migrated.Pool[int]{}
 
 	item := pool.Get()
 	assert.Equal(t, 0, item)
@@ -22,7 +23,7 @@ func TestPool(t *testing.T) {
 var sink int
 
 func BenchmarkPool(b *testing.B) {
-	p := &Pool[int]{}
+	p := &migrated.Pool[int]{}
 	p.New = func() int {
 		return 0
 	}

--- a/internal/async/migrated/pool_test.go
+++ b/internal/async/migrated/pool_test.go
@@ -1,4 +1,4 @@
-package async
+package migrated
 
 import (
 	"testing"
@@ -22,10 +22,9 @@ func TestPool(t *testing.T) {
 var sink int
 
 func BenchmarkPool(b *testing.B) {
-	p := &Pool[int]{
-		New: func() int {
-			return 0
-		},
+	p := &Pool[int]{}
+	p.New = func() int {
+		return 0
 	}
 
 	b.Run("GetOnly", func(b *testing.B) {

--- a/internal/async/pool.go
+++ b/internal/async/pool.go
@@ -1,5 +1,3 @@
-//go:build !migrated_fynedo
-
 package async
 
 import "sync"

--- a/internal/async/pool.go
+++ b/internal/async/pool.go
@@ -1,3 +1,5 @@
+//go:build !migrated_fynedo
+
 package async
 
 import "sync"

--- a/internal/async/pool_migratedfynedo.go
+++ b/internal/async/pool_migratedfynedo.go
@@ -1,0 +1,32 @@
+//go:build migrated_fynedo
+
+package async
+
+// Pool (when migrated) is just a simple single threaded data buffer.
+type Pool[T any] struct {
+	buffer *T
+
+	// New specifies a function to generate
+	// a value when Get would otherwise return the zero value of T.
+	New func() T
+}
+
+// Get get the saved item from the Pool, removes it from the Pool,
+// and returns it to the caller.
+func (p *Pool[T]) Get() T {
+	if p.buffer == nil {
+		if p.New != nil {
+			return p.New()
+		}
+		return *new(T)
+	}
+
+	x := *p.buffer
+	p.buffer = nil
+	return x
+}
+
+// Put adds x to the pool.
+func (p *Pool[T]) Put(x T) {
+	p.buffer = &x
+}

--- a/internal/async/pool_test.go
+++ b/internal/async/pool_test.go
@@ -18,3 +18,29 @@ func TestPool(t *testing.T) {
 
 	assert.Equal(t, -1, pool.Get())
 }
+
+var sink int
+
+func BenchmarkPool(b *testing.B) {
+	p := &Pool[int]{
+		New: func() int {
+			return 0
+		},
+	}
+
+	b.Run("GetOnly", func(b *testing.B) {
+		b.ReportAllocs()
+		local := 0
+		for i := 0; i < b.N; i++ {
+			local = p.Get()
+		}
+		sink = local
+	})
+
+	b.Run("PutOnly", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			p.Put(i)
+		}
+	})
+}

--- a/internal/cache/canvases.go
+++ b/internal/cache/canvases.go
@@ -2,10 +2,10 @@ package cache
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 )
 
-var canvases async.Map[fyne.CanvasObject, *canvasInfo]
+var canvases migrated.Map[fyne.CanvasObject, *canvasInfo]
 
 // GetCanvasForObject returns the canvas for the specified object.
 func GetCanvasForObject(obj fyne.CanvasObject) fyne.Canvas {

--- a/internal/cache/svg.go
+++ b/internal/cache/svg.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 )
 
-var svgs async.Map[string, *svgInfo]
+var svgs migrated.Map[string, *svgInfo]
 
 // GetSvg gets svg image from cache if it exists.
 func GetSvg(name string, o fyne.CanvasObject, w int, h int) *image.NRGBA {

--- a/internal/cache/text.go
+++ b/internal/cache/text.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 )
 
-var fontSizeCache async.Map[fontSizeEntry, *fontMetric]
+var fontSizeCache migrated.Map[fontSizeEntry, *fontMetric]
 
 type fontMetric struct {
 	expiringCache

--- a/internal/cache/texture_common.go
+++ b/internal/cache/texture_common.go
@@ -2,12 +2,12 @@ package cache
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 )
 
 var (
-	textTextures   async.Map[FontCacheEntry, *textureInfo]
-	objectTextures async.Map[fyne.CanvasObject, *textureInfo]
+	textTextures   migrated.Map[FontCacheEntry, *textureInfo]
+	objectTextures migrated.Map[fyne.CanvasObject, *textureInfo]
 )
 
 // DeleteTexture deletes the texture from the cache map.

--- a/internal/cache/theme.go
+++ b/internal/cache/theme.go
@@ -5,11 +5,11 @@ import (
 	"sync/atomic"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 )
 
 var (
-	overrides     async.Map[fyne.CanvasObject, *overrideScope]
+	overrides     migrated.Map[fyne.CanvasObject, *overrideScope]
 	overrideCount atomic.Uint32
 )
 

--- a/internal/cache/widget.go
+++ b/internal/cache/widget.go
@@ -2,10 +2,10 @@ package cache
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 )
 
-var renderers async.Map[fyne.Widget, *rendererInfo]
+var renderers migrated.Map[fyne.Widget, *rendererInfo]
 
 type isBaseWidget interface {
 	ExtendBaseWidget(fyne.Widget)

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/image/math/fixed"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/theme"
@@ -355,8 +355,8 @@ type cacheID struct {
 }
 
 var (
-	fontCache       async.Map[cacheID, *FontCacheItem]
-	fontCustomCache async.Map[fyne.Resource, *FontCacheItem] // for custom resources
+	fontCache       migrated.Map[cacheID, *FontCacheItem]
+	fontCustomCache migrated.Map[fyne.Resource, *FontCacheItem] // for custom resources
 )
 
 type noopLogger struct{}

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -9,7 +9,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 )
@@ -528,7 +528,7 @@ type gridItemAndID struct {
 type gridWrapLayout struct {
 	gw *GridWrap
 
-	itemPool   async.Pool[fyne.CanvasObject]
+	itemPool   migrated.Pool[fyne.CanvasObject]
 	visible    []gridItemAndID
 	wasVisible []gridItemAndID
 }

--- a/widget/list.go
+++ b/widget/list.go
@@ -9,7 +9,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -618,7 +618,7 @@ type listLayout struct {
 	separators []fyne.CanvasObject
 	children   []fyne.CanvasObject
 
-	itemPool          async.Pool[fyne.CanvasObject]
+	itemPool          migrated.Pool[fyne.CanvasObject]
 	visible           []listItemAndID
 	wasVisible        []listItemAndID
 	visibleRowHeights []float32

--- a/widget/table.go
+++ b/widget/table.go
@@ -8,7 +8,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/driver/mobile"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 )
@@ -1205,7 +1205,7 @@ type tableCellsRenderer struct {
 	widget.BaseRenderer
 
 	cells            *tableCells
-	pool, headerPool async.Pool[fyne.CanvasObject]
+	pool, headerPool migrated.Pool[fyne.CanvasObject]
 	visible, headers map[TableCellID]fyne.CanvasObject
 	hover, marker    *canvas.Rectangle
 	dividers         []fyne.CanvasObject

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -8,7 +8,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -521,7 +521,7 @@ func (t *textGridContent) refreshCell(row, col int) {
 
 type textGridContentRenderer struct {
 	text     *textGridContent
-	itemPool async.Pool[*textGridRow]
+	itemPool migrated.Pool[*textGridRow]
 }
 
 func (t *textGridContentRenderer) updateGridSize(size fyne.Size) {

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -7,7 +7,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
-	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/internal/async/migrated"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -600,8 +600,8 @@ type treeContentRenderer struct {
 	objects     []fyne.CanvasObject
 	branches    map[string]*branch
 	leaves      map[string]*leaf
-	branchPool  async.Pool[fyne.CanvasObject]
-	leafPool    async.Pool[fyne.CanvasObject]
+	branchPool  migrated.Pool[fyne.CanvasObject]
+	leafPool    migrated.Pool[fyne.CanvasObject]
 
 	wasVisible []TreeNodeID
 	visible    []TreeNodeID


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The pool was used in places where concurrency actually was important. I solved this by introducing a new `internal/async/migrated` package which has all of the async data structures but with build tags to become single threaded when migrated. This has the added benefit of avoid issues where we accidentally uses the single threaded version although we need safety.

Benchmark results are promising:

Before:
```
BenchmarkPool/GetOnly-22      	11466109	        90.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkPool/PutOnly-22      	28852821	        38.67 ns/op	      35 B/op	       1 allocs/op
```

After:
```
BenchmarkPool/GetOnly-22      	370900233	         3.386 ns/op	       0 B/op	       0 allocs/op
BenchmarkPool/PutOnly-22      	59720872	        16.87 ns/op	       8 B/op	       1 allocs/op
```


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

