### PR TITLE
Use single threaded canvas object queue when migrated

### DIFF
--- a/internal/async/queue.go
+++ b/internal/async/queue.go
@@ -1,3 +1,5 @@
+//go:build !migrated_fynedo
+
 package async
 
 import (

--- a/internal/async/queue_migratedfynedo.go
+++ b/internal/async/queue_migratedfynedo.go
@@ -1,0 +1,38 @@
+//go:build migrated_fynedo
+
+package async
+
+import "fyne.io/fyne/v2"
+
+// CanvasObjectQueue represents a simple single threaded queue for managing canvas objects.
+type CanvasObjectQueue struct {
+	items []fyne.CanvasObject
+}
+
+// NewCanvasObjectQueue returns a queue for caching values.
+func NewCanvasObjectQueue() *CanvasObjectQueue {
+	return &CanvasObjectQueue{items: make([]fyne.CanvasObject, 0, 32)}
+}
+
+// In puts the given value at the tail of the queue.
+func (q *CanvasObjectQueue) In(v fyne.CanvasObject) {
+	q.items = append(q.items, v)
+}
+
+// Out removes and returns the value at the head of the queue.
+// It returns nil if the queue is empty.
+func (q *CanvasObjectQueue) Out() fyne.CanvasObject {
+	if len(q.items) == 0 {
+		return nil
+	}
+
+	head := q.items[0]
+	q.items[0] = nil
+	q.items = q.items[1:]
+	return head
+}
+
+// Len returns the number of items in the queue.
+func (q *CanvasObjectQueue) Len() uint64 {
+	return uint64(len(q.items))
+}

--- a/internal/async/queue_migratedfynedo.go
+++ b/internal/async/queue_migratedfynedo.go
@@ -2,7 +2,9 @@
 
 package async
 
-import "fyne.io/fyne/v2"
+import (
+	"fyne.io/fyne/v2"
+)
 
 // CanvasObjectQueue represents a single-threaded queue for managing canvas objects using a ring buffer.
 type CanvasObjectQueue struct {
@@ -13,7 +15,7 @@ type CanvasObjectQueue struct {
 
 // NewCanvasObjectQueue returns a queue for caching values with an initial capacity.
 func NewCanvasObjectQueue() *CanvasObjectQueue {
-	return &CanvasObjectQueue{buffer: make([]fyne.CanvasObject, 32)}
+	return &CanvasObjectQueue{buffer: make([]fyne.CanvasObject, 64)}
 }
 
 // In adds the given value to the tail of the queue.

--- a/internal/async/queue_migratedfynedo.go
+++ b/internal/async/queue_migratedfynedo.go
@@ -2,9 +2,9 @@
 
 package async
 
-import (
-	"fyne.io/fyne/v2"
-)
+import "fyne.io/fyne/v2"
+
+const defaultQueueCapacity = 64
 
 // CanvasObjectQueue represents a single-threaded queue for managing canvas objects using a ring buffer.
 type CanvasObjectQueue struct {
@@ -15,7 +15,7 @@ type CanvasObjectQueue struct {
 
 // NewCanvasObjectQueue returns a queue for caching values with an initial capacity.
 func NewCanvasObjectQueue() *CanvasObjectQueue {
-	return &CanvasObjectQueue{buffer: make([]fyne.CanvasObject, 64)}
+	return &CanvasObjectQueue{buffer: make([]fyne.CanvasObject, defaultQueueCapacity)}
 }
 
 // In adds the given value to the tail of the queue.
@@ -45,6 +45,11 @@ func (q *CanvasObjectQueue) Out() fyne.CanvasObject {
 	q.buffer[q.head] = nil
 	q.head = (q.head + 1) % len(q.buffer)
 	q.size--
+
+	if q.size == 0 && len(q.buffer) > 4*defaultQueueCapacity {
+		q.buffer = make([]fyne.CanvasObject, defaultQueueCapacity)
+	}
+
 	return first
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This feels, and is, significantly faster. It is only used for the refresh queue
so when we no longer have migrations, we can likely remove the async
version entirely.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

