### PR TITLE
Fix the theme override for padding (and other static values)

### DIFF
--- a/container/theme.go
+++ b/container/theme.go
@@ -53,6 +53,7 @@ func (t *ThemeOverride) Refresh() {
 	}
 
 	cache.OverrideTheme(t.Content, addFeatures(t.Theme, t))
+	t.Content.Refresh()
 	t.BaseWidget.Refresh()
 }
 

--- a/container/theme.go
+++ b/container/theme.go
@@ -43,7 +43,7 @@ func NewThemeOverride(obj fyne.CanvasObject, th fyne.Theme) *ThemeOverride {
 func (t *ThemeOverride) CreateRenderer() fyne.WidgetRenderer {
 	cache.OverrideTheme(t.Content, addFeatures(t.Theme, t))
 
-	return widget.NewSimpleRenderer(t.holder)
+	return &overrideRenderer{parent: t, objs: []fyne.CanvasObject{t.holder}}
 }
 
 func (t *ThemeOverride) Refresh() {
@@ -82,4 +82,34 @@ func (f *featureTheme) Feature(n intTheme.FeatureName) any {
 	}
 
 	return nil
+}
+
+type overrideRenderer struct {
+	parent *ThemeOverride
+
+	objs []fyne.CanvasObject
+}
+
+func (r *overrideRenderer) Destroy() {
+}
+
+func (r *overrideRenderer) Layout(s fyne.Size) {
+	intTheme.PushRenderingTheme(r.parent.Theme)
+	defer intTheme.PopRenderingTheme()
+
+	r.parent.Content.Resize(s)
+}
+
+func (r *overrideRenderer) MinSize() fyne.Size {
+	intTheme.PushRenderingTheme(r.parent.Theme)
+	defer intTheme.PopRenderingTheme()
+
+	return r.parent.Content.MinSize()
+}
+
+func (r *overrideRenderer) Objects() []fyne.CanvasObject {
+	return r.objs
+}
+
+func (r *overrideRenderer) Refresh() {
 }

--- a/container/theme.go
+++ b/container/theme.go
@@ -97,7 +97,7 @@ func (r *overrideRenderer) Layout(s fyne.Size) {
 	intTheme.PushRenderingTheme(r.parent.Theme)
 	defer intTheme.PopRenderingTheme()
 
-	r.parent.Content.Resize(s)
+	r.parent.holder.Resize(s)
 }
 
 func (r *overrideRenderer) MinSize() fyne.Size {

--- a/container/theme_test.go
+++ b/container/theme_test.go
@@ -2,8 +2,10 @@ package container
 
 import (
 	"image"
+	"image/color"
 	"testing"
 
+	"fyne.io/fyne/v2/canvas"
 	"github.com/stretchr/testify/assert"
 
 	"fyne.io/fyne/v2/internal/cache"
@@ -49,4 +51,19 @@ func TestThemeOverride_Refresh(t *testing.T) {
 	o.Refresh()
 	changed := w.Canvas().Capture().(*image.NRGBA)
 	test.AssertImageMatches(t, "theme/text-other-theme.png", changed)
+}
+
+func TestThemeOverride_CurrentTheme(t *testing.T) {
+	custom, err := theme.FromJSON("{\"Colors\": {\"foreground\": \"#000000\"}}")
+	assert.NoError(t, err)
+
+	l := widget.NewLabel("Test")
+	text := test.WidgetRenderer(l).Objects()[0].(*widget.RichText).Segments[0].Visual()
+	assert.Equal(t, color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, text.(*canvas.Text).Color)
+
+	o := NewThemeOverride(l, custom)
+	o.Refresh()
+
+	text = test.WidgetRenderer(l).Objects()[0].(*widget.RichText).Segments[0].Visual()
+	assert.Equal(t, &color.NRGBA{R: 0, G: 0, B: 0, A: 0xff}, text.(*canvas.Text).Color)
 }

--- a/internal/theme/render.go
+++ b/internal/theme/render.go
@@ -1,0 +1,29 @@
+package theme
+
+import (
+	"fyne.io/fyne/v2"
+)
+
+var themeStack []fyne.Theme
+
+// CurrentlyRenderingWithFallback returns the theme that is currently being used during rendering or layout
+// calculations. If there is no override in effect then the fallback is returned.
+func CurrentlyRenderingWithFallback(f fyne.Theme) fyne.Theme {
+	if len(themeStack) == 0 {
+		return f
+	}
+
+	return themeStack[len(themeStack)-1]
+}
+
+// PushRenderingTheme is used by the ThemeOverride container to stack the current theme during rendering
+// and calculations.
+func PushRenderingTheme(th fyne.Theme) {
+	themeStack = append(themeStack, th)
+}
+
+// PopRenderingTheme is used by the ThemeOverride container to remove an overridden theme during rendering
+// and calculations.
+func PopRenderingTheme() {
+	themeStack = themeStack[:len(themeStack)-1]
+}

--- a/internal/theme/render.go
+++ b/internal/theme/render.go
@@ -25,5 +25,6 @@ func PushRenderingTheme(th fyne.Theme) {
 // PopRenderingTheme is used by the ThemeOverride container to remove an overridden theme during rendering
 // and calculations.
 func PopRenderingTheme() {
+	themeStack[len(themeStack)-1] = nil
 	themeStack = themeStack[:len(themeStack)-1]
 }

--- a/internal/theme/render_test.go
+++ b/internal/theme/render_test.go
@@ -1,0 +1,31 @@
+package theme
+
+import (
+	"image/color"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderingTheme(t *testing.T) {
+	current := &simpleTheme{onlyColor: color.Black}
+	assert.Equal(t, current, CurrentlyRenderingWithFallback(current))
+
+	custom := &simpleTheme{onlyColor: color.White}
+	PushRenderingTheme(custom)
+	assert.Equal(t, custom, CurrentlyRenderingWithFallback(current))
+
+	PopRenderingTheme()
+	assert.Equal(t, current, CurrentlyRenderingWithFallback(current))
+}
+
+type simpleTheme struct {
+	fyne.Theme
+
+	onlyColor color.Color
+}
+
+func (s *simpleTheme) Color(fyne.ThemeColorName, fyne.ThemeVariant) color.Color {
+	return s.onlyColor
+}

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -160,7 +160,7 @@ func Current() fyne.Theme {
 		return DarkTheme()
 	}
 
-	return currentTheme
+	return internaltheme.CurrentlyRenderingWithFallback(currentTheme)
 }
 
 // CurrentForWidget returns the theme that is currently used for the specified widget.


### PR DESCRIPTION
In theory some areas of code could be simplified - but that relies on there being no miss-use of the thread/fyne.Do.
So I have left all the widget/theme handling as-is for now and we can simplify it down the road once multiple threads are completely not supported any more.

Fixes #5019

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
