### PR TITLE
RFC: Drag and Drop API

### DIFF
--- a/canvasobject.go
+++ b/canvasobject.go
@@ -121,6 +121,8 @@ type DragItemCursor interface {
 	Image() (image.Image, int, int)
 }
 
+// DragSource is implemented by CanvasObjects to indicate that they can be dragged and dropped
+// onto another CanvasObject which implements DropTarget.
 type DragSource interface {
 	// DragSourceBegin is invoked when a drag and drop is initiated on this DragSource.
 	// It should return the DragItems it is sourcing, and optionally a non-nil DragItemCursor
@@ -161,6 +163,8 @@ type DragSource interface {
 	DropAccepted([]DragItem)
 }
 
+// DropTarget is implemented by CanvasObjects to signify that they can accept items dropped
+// from another CanvasObject implementing DragSource.
 type DropTarget interface {
 	// DropBegin is invoked when a drag and drop beginning from a DragSource
 	// enters over this DropTarget. Implementations should return the (sub)-set of items that


### PR DESCRIPTION
### Description:
RfC / Draft of API to allow drag and drop between CanvasObjects

For #142 

## Example use cases

### Dragging to reorder items in a list (with possible multi-selection)

* The list item widget (each individual row) implements DragSource
* When a selected list item row is dragged, it returns one DragItem for each selected row
* The list itself (extended) implements DropTarget, and as DropDragged is invoked, it draws a horizontal line to indicate where the items would be inserted if they were to be dropped
* Custom mime types and URI schemes can be defined by the app to represent to itself the different types of content it supports drag-and-drop for

### Dragging DocTabs items from one DocTabs widget to another (eg multi-pane text editor)

* The tab itself can implement DragSource
* When dragged over a potential DropTarget (e.g. another DocTabs) the tab item can gray itself out in response to DropPending
* The DocTabs implements DropTarget and communicates with the tabitems renderer to render a horizontal line in between adjacent tabs where the new document would be inserted.

### Dragging items from one top-level Fyne window to another window in the same app (process)

* The API should support this, just need to handle it in the driver

## Open questions

* Should DropPending also pass the DropTarget as a parameter? I can see that it may be useful, for example, in a multi pane text editor app to know if a tab would be dropped in the same DocTabs (e.g. simply reordering the tabs) or a different DocTabs (moving from one pane to another)
* How to handle drop from outside of the Fyne app onto a widget
* How to handle drag from within a Fyne window and drop outside the window? (e.g. for browsers or text editors where dragging a tab outside the window opens a new window

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
