### PR TITLE
fix: inconsistent and too wide borders of non-round rectangle

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -210,6 +210,10 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		radiusUniform := p.ctx.GetUniformLocation(program, "radius")
 		radiusScaled := roundToPixel(radius*p.pixScale, 1.0)
 		p.ctx.Uniform1f(radiusUniform, radiusScaled)
+
+		edgeSoftnessUniform := p.ctx.GetUniformLocation(program, "edge_softness")
+		edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
+		p.ctx.Uniform1f(edgeSoftnessUniform, edgeSoftnessScaled)
 	} else {
 		strokeUniform := p.ctx.GetUniformLocation(program, "stroke_width")
 		p.ctx.Uniform1f(strokeUniform, strokeWidthScaled)
@@ -227,10 +231,6 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
 	p.ctx.Uniform4f(strokeColorUniform, r, g, b, a)
-
-	edgeSoftnessUniform := p.ctx.GetUniformLocation(program, "edge_softness")
-	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.ctx.Uniform1f(edgeSoftnessUniform, edgeSoftnessScaled)
 	p.logError()
 	// Fragment: END
 

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -11,6 +11,11 @@ uniform vec4 stroke_color;
 
 void main() {
 
+    // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
+    if (gl_FragCoord.x < rect_coords[0] || gl_FragCoord.x > rect_coords[1] || gl_FragCoord.y < frame_size.y - rect_coords[3] || gl_FragCoord.y > frame_size.y - rect_coords[2]) {
+        discard;
+    }
+
     vec4 color = fill_color;
     
     if (gl_FragCoord.x >= rect_coords[1] - stroke_width ){

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -21,6 +21,11 @@ uniform vec4 stroke_color;
 
 void main() {
 
+    // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
+    if (gl_FragCoord.x < rect_coords[0] || gl_FragCoord.x > rect_coords[1] || gl_FragCoord.y < frame_size.y - rect_coords[3] || gl_FragCoord.y > frame_size.y - rect_coords[2]) {
+        discard;
+    }
+
     vec4 color = fill_color;
     
     if (gl_FragCoord.x >= rect_coords[1] - stroke_width ){


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Unfortunately, the recently merged PR #5838 has broken the ability to render thin borders (StrokeWidth=1) on non-round rectangles.

Additionally, this pull request is intended to fix the issue of inconsistent borders #3573 on non-round rectangles.

This PR also includes a minor adjustment to the `drawOblong` method: the `edge_softness` parameter is now applied only to the shader for rounded rectangle. In PR #5838, this parameter was unnecessarily applied to all rectangle shaders.

#### Before
![before](https://github.com/user-attachments/assets/a77834d9-f314-4bdd-a454-66f6b1df5b43)
#### After
![after](https://github.com/user-attachments/assets/9924f8aa-1866-449c-8732-c203f70d75ed)
#### Master branch
![master](https://github.com/user-attachments/assets/228d2835-08b4-4516-9121-0121ba9a0979)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
