### PR TITLE
Don't refresh split container content on divider mouse-over

### DIFF
--- a/container/split.go
+++ b/container/split.go
@@ -310,14 +310,14 @@ func (d *divider) Dragged(e *fyne.DragEvent) {
 
 func (d *divider) MouseIn(event *desktop.MouseEvent) {
 	d.hovered = true
-	d.split.Refresh()
+	d.Refresh()
 }
 
 func (d *divider) MouseMoved(event *desktop.MouseEvent) {}
 
 func (d *divider) MouseOut() {
 	d.hovered = false
-	d.split.Refresh()
+	d.Refresh()
 }
 
 var _ fyne.WidgetRenderer = (*dividerRenderer)(nil)

--- a/container/split_test.go
+++ b/container/split_test.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -528,6 +529,21 @@ func TestSplitContainer_UpdateOffsetDoesNotRefreshContent(t *testing.T) {
 	objB := &refreshCountingWidget{}
 	split := NewHSplit(objA, objB)
 	split.SetOffset(0.4)
+	assert.Equal(t, 0, objA.refreshCount)
+	assert.Equal(t, 0, objB.refreshCount)
+
+	split.Refresh()
+	assert.Equal(t, 1, objA.refreshCount)
+	assert.Equal(t, 1, objB.refreshCount)
+}
+
+func TestSplitContainer_HoverDividerDoesNotRefreshContent(t *testing.T) {
+	objA := &refreshCountingWidget{}
+	objB := &refreshCountingWidget{}
+	split := NewHSplit(objA, objB)
+	r := cache.Renderer(split).(*splitContainerRenderer)
+	r.divider.MouseIn(&desktop.MouseEvent{})
+
 	assert.Equal(t, 0, objA.refreshCount)
 	assert.Equal(t, 0, objB.refreshCount)
 


### PR DESCRIPTION
### Description:

Fixes #5877

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

