### PR TITLE
OpenGL optimizations

### DIFF
--- a/internal/driver/mobile/gl/fn.go
+++ b/internal/driver/mobile/gl/fn.go
@@ -39,6 +39,7 @@ const (
 	glfnBlendColor
 	glfnBlendFunc
 	glfnBufferData
+	glfnBufferSubData
 	glfnClear
 	glfnClearColor
 	glfnCompileShader

--- a/internal/driver/mobile/gl/gl.go
+++ b/internal/driver/mobile/gl/gl.go
@@ -103,6 +103,23 @@ func (ctx *context) BufferData(target Enum, src []byte, usage Enum) {
 	})
 }
 
+func (ctx *context) BufferSubData(target Enum, src []byte) {
+	parg := unsafe.Pointer(nil)
+	if len(src) > 0 {
+		parg = unsafe.Pointer(&src[0])
+	}
+	ctx.enqueue(call{
+		args: fnargs{
+			fn: glfnBufferSubData,
+			a0: target.c(),
+			a1: 0,
+			a2: uintptr(len(src)),
+		},
+		parg:     parg,
+		blocking: true,
+	})
+}
+
 func (ctx *context) Clear(mask Enum) {
 	ctx.enqueue(call{
 		args: fnargs{

--- a/internal/driver/mobile/gl/interface.go
+++ b/internal/driver/mobile/gl/interface.go
@@ -53,6 +53,12 @@ type Context interface {
 	//
 	// http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferData.xhtml
 	BufferData(target Enum, src []byte, usage Enum)
+
+	// BufferSubData updates the data store for a bound buffer object.
+	//
+	// http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferSubData.xhtml
+	BufferSubData(target Enum, src []byte)
+
 	// Clear clears the window.
 	//
 	// The behavior of Clear is influenced by the pixel ownership test,

--- a/internal/driver/mobile/gl/work.c
+++ b/internal/driver/mobile/gl/work.c
@@ -49,6 +49,9 @@ uintptr_t processFn(struct fnargs* args, char* parg) {
 	case glfnBufferData:
 		glBufferData((GLenum)args->a0, (GLsizeiptr)args->a1, (GLvoid*)parg, (GLenum)args->a2);
 		break;
+	case glfnBufferSubData:
+		glBufferSubData((GLenum)args->a0, (GLsizeiptr)args->a1, (GLenum)args->a2, (GLvoid*)parg);
+		break;
 	case glfnClear:
 		glClear((GLenum)args->a0);
 		break;

--- a/internal/driver/mobile/gl/work.h
+++ b/internal/driver/mobile/gl/work.h
@@ -45,6 +45,7 @@ typedef enum {
 	glfnBlendColor,
 	glfnBlendFunc,
 	glfnBufferData,
+    glfnBufferSubData,
 	glfnClear,
 	glfnClearColor,
 	glfnCompileShader,

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -124,6 +124,10 @@ var glfnMap = map[glfn]func(c call) (ret uintptr){
 		syscall.Syscall6(glBufferData.Addr(), 4, c.args.a0, c.args.a1, uintptr(c.parg), c.args.a2, 0, 0)
 		return
 	},
+	glfnBufferSubData: func(c call) (ret uintptr) {
+		syscall.Syscall6(glBufferSubData.Addr(), 4, c.args.a0, c.args.a1, c.args.a2, uintptr(c.parg), 0, 0)
+		return
+	},
 	glfnClear: func(c call) (ret uintptr) {
 		syscall.Syscall(glClear.Addr(), 1, c.args.a0, 0, 0)
 		return
@@ -303,6 +307,7 @@ var (
 	glBlendColor              = libGLESv2.NewProc("glBlendColor")
 	glBlendFunc               = libGLESv2.NewProc("glBlendFunc")
 	glBufferData              = libGLESv2.NewProc("glBufferData")
+	glBufferSubData           = libGLESv2.NewProc("glBufferSubData")
 	glClear                   = libGLESv2.NewProc("glClear")
 	glClearColor              = libGLESv2.NewProc("glClearColor")
 	glCompileShader           = libGLESv2.NewProc("glCompileShader")

--- a/internal/painter/gl/context.go
+++ b/internal/painter/gl/context.go
@@ -8,6 +8,7 @@ type context interface {
 	BlendColor(r, g, b, a float32)
 	BlendFunc(srcFactor, destFactor uint32)
 	BufferData(target uint32, points []float32, usage uint32)
+	BufferSubData(target uint32, points []float32)
 	Clear(mask uint32)
 	ClearColor(r, g, b, a float32)
 	CompileShader(shader Shader)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -11,20 +11,20 @@ import (
 
 const edgeSoftness = 1.0
 
-func (p *painter) createBuffer(points []float32) Buffer {
+func (p *painter) createBuffer(size int) Buffer {
 	vbo := p.ctx.CreateBuffer()
 	p.logError()
 	p.ctx.BindBuffer(arrayBuffer, vbo)
 	p.logError()
-	p.ctx.BufferData(arrayBuffer, points, staticDraw)
+	p.ctx.BufferData(arrayBuffer, make([]float32, size), staticDraw)
 	p.logError()
 	return vbo
 }
 
-func (p *painter) defineVertexArray(prog Program, name string, size, stride, offset int) {
-	vertAttrib := p.ctx.GetAttribLocation(prog, name)
-	p.ctx.EnableVertexAttribArray(vertAttrib)
-	p.ctx.VertexAttribPointerWithOffset(vertAttrib, size, float, false, stride*floatSize, offset*floatSize)
+func (p *painter) updateBuffer(vbo Buffer, points []float32) {
+	p.ctx.BindBuffer(arrayBuffer, vbo)
+	p.logError()
+	p.ctx.BufferSubData(arrayBuffer, points)
 	p.logError()
 }
 
@@ -38,59 +38,49 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 
 	// Vertex: BEG
 	bounds, points := p.vecSquareCoords(pos, circle, frame)
-	p.ctx.UseProgram(program)
-	vbo := p.createBuffer(points)
-	p.defineVertexArray(program, "vert", 2, 4, 0)
-	p.defineVertexArray(program, "normal", 2, 4, 2)
+	p.ctx.UseProgram(program.ref)
+	p.updateBuffer(program.buff, points)
+	p.UpdateVertexArray(program, "vert", 2, 4, 0)
+	p.UpdateVertexArray(program, "normal", 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
 	// Vertex: END
 
 	// Fragment: BEG
-	frameSizeUniform := p.ctx.GetUniformLocation(program, "frame_size")
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.ctx.Uniform2f(frameSizeUniform, frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
-	rectCoordsUniform := p.ctx.GetUniformLocation(program, "rect_coords")
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.ctx.Uniform4f(rectCoordsUniform, x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(circle.StrokeWidth*p.pixScale, 1.0)
-	strokeUniform := p.ctx.GetUniformLocation(program, "stroke_width_half")
-	p.ctx.Uniform1f(strokeUniform, strokeWidthScaled*0.5)
+	p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)
 
-	rectSizeUniform := p.ctx.GetUniformLocation(program, "rect_size_half")
 	rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 	rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled
-	p.ctx.Uniform2f(rectSizeUniform, rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
+	p.SetUniform2f(program, "rect_size_half", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
 
-	radiusUniform := p.ctx.GetUniformLocation(program, "radius")
 	radiusScaled := roundToPixel(radius*p.pixScale, 1.0)
-	p.ctx.Uniform1f(radiusUniform, radiusScaled)
+	p.SetUniform1f(program, "radius", radiusScaled)
 
-	var r, g, b, a float32
-	fillColorUniform := p.ctx.GetUniformLocation(program, "fill_color")
-	r, g, b, a = getFragmentColor(circle.FillColor)
-	p.ctx.Uniform4f(fillColorUniform, r, g, b, a)
+	r, g, b, a := getFragmentColor(circle.FillColor)
+	p.SetUniform4f(program, "fill_color", r, g, b, a)
 
-	strokeColorUniform := p.ctx.GetUniformLocation(program, "stroke_color")
 	strokeColor := circle.StrokeColor
 	if strokeColor == nil {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.ctx.Uniform4f(strokeColorUniform, r, g, b, a)
+	p.SetUniform4f(program, "stroke_color", r, g, b, a)
 
-	edgeSoftnessUniform := p.ctx.GetUniformLocation(program, "edge_softness")
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.ctx.Uniform1f(edgeSoftnessUniform, edgeSoftnessScaled)
+	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
 	p.logError()
 	// Fragment: END
 
 	p.ctx.DrawArrays(triangleStrip, 0, 4)
 	p.logError()
-	p.freeBuffer(vbo)
 }
 
 func (p *painter) drawGradient(o fyne.CanvasObject, texCreator func(fyne.CanvasObject) Texture, pos fyne.Position, frame fyne.Size) {
@@ -106,27 +96,23 @@ func (p *painter) drawLine(line *canvas.Line, pos fyne.Position, frame fyne.Size
 		return
 	}
 	points, halfWidth, feather := p.lineCoords(pos, line.Position1, line.Position2, line.StrokeWidth, 0.5, frame)
-	p.ctx.UseProgram(p.lineProgram)
-	vbo := p.createBuffer(points)
-	p.defineVertexArray(p.lineProgram, "vert", 2, 4, 0)
-	p.defineVertexArray(p.lineProgram, "normal", 2, 4, 2)
+	p.ctx.UseProgram(p.lineProgram.ref)
+	p.updateBuffer(p.lineProgram.buff, points)
+	p.UpdateVertexArray(p.lineProgram, "vert", 2, 4, 0)
+	p.UpdateVertexArray(p.lineProgram, "normal", 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
 
-	colorUniform := p.ctx.GetUniformLocation(p.lineProgram, "color")
 	r, g, b, a := getFragmentColor(line.StrokeColor)
-	p.ctx.Uniform4f(colorUniform, r, g, b, a)
+	p.SetUniform4f(p.lineProgram, "color", r, g, b, a)
 
-	lineWidthUniform := p.ctx.GetUniformLocation(p.lineProgram, "lineWidth")
-	p.ctx.Uniform1f(lineWidthUniform, halfWidth)
+	p.SetUniform1f(p.lineProgram, "lineWidth", halfWidth)
 
-	featherUniform := p.ctx.GetUniformLocation(p.lineProgram, "feather")
-	p.ctx.Uniform1f(featherUniform, feather)
+	p.SetUniform1f(p.lineProgram, "feather", feather)
 
 	p.ctx.DrawArrays(triangles, 0, 6)
 	p.logError()
-	p.freeBuffer(vbo)
 }
 
 func (p *painter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.Size) {
@@ -170,7 +156,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	}
 
 	roundedCorners := radius != 0
-	var program Program
+	var program ProgramState
 	if roundedCorners {
 		program = p.roundRectangleProgram
 	} else {
@@ -179,64 +165,53 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 
 	// Vertex: BEG
 	bounds, points := p.vecRectCoords(pos, obj, frame, aspect)
-	p.ctx.UseProgram(program)
-	vbo := p.createBuffer(points)
-	p.defineVertexArray(program, "vert", 2, 4, 0)
-	p.defineVertexArray(program, "normal", 2, 4, 2)
+	p.ctx.UseProgram(program.ref)
+	p.updateBuffer(program.buff, points)
+	p.UpdateVertexArray(program, "vert", 2, 4, 0)
+	p.UpdateVertexArray(program, "normal", 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
 	// Vertex: END
 
 	// Fragment: BEG
-	frameSizeUniform := p.ctx.GetUniformLocation(program, "frame_size")
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.ctx.Uniform2f(frameSizeUniform, frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
-	rectCoordsUniform := p.ctx.GetUniformLocation(program, "rect_coords")
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.ctx.Uniform4f(rectCoordsUniform, x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
 	if roundedCorners {
-		strokeUniform := p.ctx.GetUniformLocation(program, "stroke_width_half")
-		p.ctx.Uniform1f(strokeUniform, strokeWidthScaled*0.5)
+		p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)
 
-		rectSizeUniform := p.ctx.GetUniformLocation(program, "rect_size_half")
 		rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 		rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled
-		p.ctx.Uniform2f(rectSizeUniform, rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
+		p.SetUniform2f(program, "rect_size_half", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
 
-		radiusUniform := p.ctx.GetUniformLocation(program, "radius")
 		radiusScaled := roundToPixel(radius*p.pixScale, 1.0)
-		p.ctx.Uniform1f(radiusUniform, radiusScaled)
+		p.SetUniform1f(program, "radius", radiusScaled)
 
-		edgeSoftnessUniform := p.ctx.GetUniformLocation(program, "edge_softness")
 		edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-		p.ctx.Uniform1f(edgeSoftnessUniform, edgeSoftnessScaled)
+		p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
 	} else {
-		strokeUniform := p.ctx.GetUniformLocation(program, "stroke_width")
-		p.ctx.Uniform1f(strokeUniform, strokeWidthScaled)
+		p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
 	}
 
-	var r, g, b, a float32
-	fillColorUniform := p.ctx.GetUniformLocation(program, "fill_color")
-	r, g, b, a = getFragmentColor(fill)
-	p.ctx.Uniform4f(fillColorUniform, r, g, b, a)
+	r, g, b, a := getFragmentColor(fill)
+	p.SetUniform4f(program, "fill_color", r, g, b, a)
 
-	strokeColorUniform := p.ctx.GetUniformLocation(program, "stroke_color")
 	strokeColor := stroke
 	if strokeColor == nil {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.ctx.Uniform4f(strokeColorUniform, r, g, b, a)
+	p.SetUniform4f(program, "stroke_color", r, g, b, a)
 	p.logError()
 	// Fragment: END
 
 	p.ctx.DrawArrays(triangleStrip, 0, 4)
 	p.logError()
-	p.freeBuffer(vbo)
 }
 
 func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size) {
@@ -279,13 +254,12 @@ func (p *painter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canva
 		}
 	}
 	points := p.rectCoords(size, pos, frame, fill, aspect, pad)
-	p.ctx.UseProgram(p.program)
-	vbo := p.createBuffer(points)
-	p.defineVertexArray(p.program, "vert", 3, 5, 0)
-	p.defineVertexArray(p.program, "vertTexCoord", 2, 5, 3)
+	p.ctx.UseProgram(p.program.ref)
+	p.updateBuffer(p.program.buff, points)
+	p.UpdateVertexArray(p.program, "vert", 3, 5, 0)
+	p.UpdateVertexArray(p.program, "vertTexCoord", 2, 5, 3)
 
-	vertAttrib := p.ctx.GetUniformLocation(p.program, "alpha")
-	p.ctx.Uniform1f(vertAttrib, alpha)
+	p.SetUniform1f(p.program, "alpha", alpha)
 
 	p.ctx.BlendFunc(one, oneMinusSrcAlpha)
 	p.logError()
@@ -295,14 +269,6 @@ func (p *painter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canva
 	p.logError()
 
 	p.ctx.DrawArrays(triangleStrip, 0, 4)
-	p.logError()
-	p.freeBuffer(vbo)
-}
-
-func (p *painter) freeBuffer(vbo Buffer) {
-	p.ctx.BindBuffer(arrayBuffer, noBuffer)
-	p.logError()
-	p.ctx.DeleteBuffer(vbo)
 	p.logError()
 }
 

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -72,10 +72,64 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = p.createProgram("simple")
-	p.lineProgram = p.createProgram("line")
-	p.rectangleProgram = p.createProgram("rectangle")
-	p.roundRectangleProgram = p.createProgram("round_rectangle")
+	p.program = ProgramState{
+		ref:        p.createProgram("simple"),
+		buff:       p.createBuffer(20),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(p.program, "text", "alpha")
+	p.enableAttribArrays(p.program, "vert", "vertTexCoord")
+
+	p.lineProgram = ProgramState{
+		ref:        p.createProgram("line"),
+		buff:       p.createBuffer(24),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(p.lineProgram, "feather", "color", "lineWidth")
+	p.enableAttribArrays(p.lineProgram, "vert", "normal")
+
+	p.rectangleProgram = ProgramState{
+		ref:        p.createProgram("rectangle"),
+		buff:       p.createBuffer(16),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(
+		p.rectangleProgram,
+		"frame_size", "rect_coords", "stroke_width", "fill_color", "stroke_color",
+	)
+	p.enableAttribArrays(p.rectangleProgram, "vert", "normal")
+
+	p.roundRectangleProgram = ProgramState{
+		ref:        p.createProgram("round_rectangle"),
+		buff:       p.createBuffer(16),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(p.roundRectangleProgram,
+		"frame_size", "rect_coords",
+		"stroke_width_half", "rect_size_half",
+		"radius", "edge_softness",
+		"fill_color", "stroke_color",
+	)
+	p.enableAttribArrays(p.roundRectangleProgram, "vert", "normal")
+}
+
+func (p *painter) getUniformLocations(pState ProgramState, names ...string) {
+	for _, name := range names {
+		u := p.ctx.GetUniformLocation(pState.ref, name)
+		pState.uniforms[name] = &UniformState{ref: u}
+	}
+}
+
+func (p *painter) enableAttribArrays(pState ProgramState, names ...string) {
+	for _, name := range names {
+		a := p.ctx.GetAttribLocation(pState.ref, name)
+		p.ctx.EnableVertexAttribArray(a)
+		pState.attributes[name] = a
+	}
 }
 
 type coreContext struct{}
@@ -108,6 +162,10 @@ func (c *coreContext) BlendFunc(srcFactor, destFactor uint32) {
 
 func (c *coreContext) BufferData(target uint32, points []float32, usage uint32) {
 	gl.BufferData(target, 4*len(points), gl.Ptr(points), usage)
+}
+
+func (c *coreContext) BufferSubData(target uint32, points []float32) {
+	gl.BufferSubData(target, 0, 4*len(points), gl.Ptr(points))
 }
 
 func (c *coreContext) Clear(mask uint32) {

--- a/internal/painter/gl/gl_wasm.go
+++ b/internal/painter/gl/gl_wasm.go
@@ -63,10 +63,64 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = p.createProgram("simple_es")
-	p.lineProgram = p.createProgram("line_es")
-	p.rectangleProgram = p.createProgram("rectangle_es")
-	p.roundRectangleProgram = p.createProgram("round_rectangle_es")
+	p.program = ProgramState{
+		ref:        p.createProgram("simple_es"),
+		buff:       p.createBuffer(20),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(p.program, "text", "alpha")
+	p.enableAttribArrays(p.program, "vert", "vertTexCoord")
+
+	p.lineProgram = ProgramState{
+		ref:        p.createProgram("line_es"),
+		buff:       p.createBuffer(24),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(p.lineProgram, "color", "feather", "lineWidth")
+	p.enableAttribArrays(p.lineProgram, "vert", "normal")
+
+	p.rectangleProgram = ProgramState{
+		ref:        p.createProgram("rectangle_es"),
+		buff:       p.createBuffer(16),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(
+		p.rectangleProgram,
+		"frame_size", "rect_coords", "stroke_width", "fill_color", "stroke_color",
+	)
+	p.enableAttribArrays(p.rectangleProgram, "vert", "normal")
+
+	p.roundRectangleProgram = ProgramState{
+		ref:        p.createProgram("round_rectangle_es"),
+		buff:       p.createBuffer(16),
+		uniforms:   make(map[string]*UniformState),
+		attributes: make(map[string]Attribute),
+	}
+	p.getUniformLocations(p.roundRectangleProgram,
+		"frame_size", "rect_coords",
+		"stroke_width_half", "rect_size_half",
+		"radius", "edge_softness",
+		"fill_color", "stroke_color",
+	)
+	p.enableAttribArrays(p.roundRectangleProgram, "vert", "normal")
+}
+
+func (p *painter) getUniformLocations(pState ProgramState, names ...string) {
+	for _, name := range names {
+		u := p.ctx.GetUniformLocation(pState.ref, name)
+		pState.uniforms[name] = &UniformState{ref: u}
+	}
+}
+
+func (p *painter) enableAttribArrays(pState ProgramState, names ...string) {
+	for _, name := range names {
+		a := p.ctx.GetAttribLocation(pState.ref, name)
+		p.ctx.EnableVertexAttribArray(a)
+		pState.attributes[name] = a
+	}
 }
 
 type xjsContext struct{}
@@ -99,6 +153,11 @@ func (c *xjsContext) BlendFunc(srcFactor, destFactor uint32) {
 
 func (c *xjsContext) BufferData(target uint32, points []float32, usage uint32) {
 	gl.BufferData(gl.Enum(target), toLEByteOrder(points...), gl.Enum(usage))
+}
+
+func (c *xjsContext) BufferSubData(target uint32, points []float32) {
+	data := toLEByteOrder(points...)
+	gl.BufferSubData(gl.Enum(target), 0, data)
 }
 
 func (c *xjsContext) Clear(mask uint32) {

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -44,12 +44,62 @@ type painter struct {
 	canvas                fyne.Canvas
 	ctx                   context
 	contextProvider       driver.WithContext
-	program               Program
-	lineProgram           Program
-	rectangleProgram      Program
-	roundRectangleProgram Program
+	program               ProgramState
+	lineProgram           ProgramState
+	rectangleProgram      ProgramState
+	roundRectangleProgram ProgramState
 	texScale              float32
 	pixScale              float32 // pre-calculate scale*texScale for each draw
+}
+
+type ProgramState struct {
+	ref        Program
+	buff       Buffer
+	uniforms   map[string]*UniformState
+	attributes map[string]Attribute
+}
+
+type UniformState struct {
+	ref  Uniform
+	prev [4]float32
+}
+
+func (p *painter) SetUniform1f(pState ProgramState, name string, v float32) {
+	u := pState.uniforms[name]
+	if u.prev[0] == v {
+		return
+	}
+	u.prev[0] = v
+	p.ctx.Uniform1f(u.ref, v)
+}
+
+func (p *painter) SetUniform2f(pState ProgramState, name string, v0, v1 float32) {
+	u := pState.uniforms[name]
+	if u.prev[0] == v0 && u.prev[1] == v1 {
+		return
+	}
+	u.prev[0] = v0
+	u.prev[1] = v1
+	p.ctx.Uniform2f(u.ref, v0, v1)
+}
+
+func (p *painter) SetUniform4f(pState ProgramState, name string, v0, v1, v2, v3 float32) {
+	u := pState.uniforms[name]
+	if u.prev[0] == v0 && u.prev[1] == v1 && u.prev[2] == v2 && u.prev[3] == v3 {
+		return
+	}
+	u.prev[0] = v0
+	u.prev[1] = v1
+	u.prev[2] = v2
+	u.prev[3] = v3
+	p.ctx.Uniform4f(u.ref, v0, v1, v2, v3)
+}
+
+func (p *painter) UpdateVertexArray(pState ProgramState, name string, size, stride, offset int) {
+	a := pState.attributes[name]
+
+	p.ctx.VertexAttribPointerWithOffset(a, size, float, false, stride*floatSize, offset*floatSize)
+	p.logError()
 }
 
 // Declare conformity to Painter interface
@@ -156,6 +206,8 @@ func (p *painter) createProgram(shaderFilename string) Program {
 	if glErr := p.ctx.GetError(); glErr != 0 {
 		panic(fmt.Sprintf("failed to link OpenGL program; error code: %x", glErr))
 	}
+
+	p.ctx.UseProgram(prog)
 
 	return prog
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
As an attempt at fixing #1062, this PR significantly reduces the number of OpenGL calls needed during a paint event.
I have tested on android, Linux desktop and WASM, but it still needs testing on IOS, macOS and Windows. Tests are passing on all platforms, however. 

Testing using the example code from #4058.

#### Optimizations
1. Cache uniform locations during initialization, so they don't need to be looked up during every draw.
2. Only set uniforms if the uniform data has changed.
3. Only create buffer objects during initialization, after that use `BufferSubData` to update the buffer.
4. Enable attributes during initialization, and only update them during rendering. 

On a MOTO G 2014:
Without optimizations (develop branch): ~150ms and ~2970 OpenGL calls 
With optimizations: ~50ms and ~1240 OpenGL calls

I also did a quick test on Samsung S24, and paints went from ~50ms to ~18ms.

I also tested https://github.com/fyne-io/demo as well.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
