### PR TITLE
Don't refresh in AppTabs and DocTabs constructors

### DIFF
--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -37,9 +37,8 @@ type AppTabs struct {
 //
 // Since: 1.4
 func NewAppTabs(items ...*TabItem) *AppTabs {
-	tabs := &AppTabs{}
+	tabs := &AppTabs{Items: items}
 	tabs.BaseWidget.ExtendBaseWidget(tabs)
-	tabs.SetItems(items)
 	return tabs
 }
 
@@ -89,7 +88,7 @@ func (t *AppTabs) CurrentTab() *TabItem {
 //
 // Deprecated: Use `AppTabs.SelectedIndex() int` instead.
 func (t *AppTabs) CurrentTabIndex() int {
-	return t.current
+	return t.SelectedIndex()
 }
 
 // DisableIndex disables the TabItem at the specified index.
@@ -202,7 +201,7 @@ func (t *AppTabs) Selected() *TabItem {
 
 // SelectedIndex returns the index of the currently selected TabItem.
 func (t *AppTabs) SelectedIndex() int {
-	return t.current
+	return t.selected()
 }
 
 // SetItems sets the containers items and refreshes.
@@ -245,6 +244,9 @@ func (t *AppTabs) items() []*TabItem {
 }
 
 func (t *AppTabs) selected() int {
+	if len(t.Items) == 0 {
+		return -1
+	}
 	return t.current
 }
 
@@ -381,6 +383,9 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 				onTapped: func() { r.appTabs.Select(item) },
 				tabs:     r.tabs,
 			}
+			if item.disabled {
+				item.button.Disable()
+			}
 		}
 		button := item.button
 		button.icon = item.Icon
@@ -399,7 +404,7 @@ func (r *appTabsRenderer) buildTabButtons(count int) *fyne.Container {
 }
 
 func (r *appTabsRenderer) updateIndicator(animate bool) {
-	if r.appTabs.current < 0 {
+	if len(r.appTabs.Items) == 0 || r.appTabs.current < 0 {
 		r.indicator.Hide()
 		return
 	}

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -40,9 +40,8 @@ type DocTabs struct {
 //
 // Since: 2.1
 func NewDocTabs(items ...*TabItem) *DocTabs {
-	tabs := &DocTabs{}
+	tabs := &DocTabs{Items: items}
 	tabs.ExtendBaseWidget(tabs)
-	tabs.SetItems(items)
 	return tabs
 }
 
@@ -161,7 +160,7 @@ func (t *DocTabs) Selected() *TabItem {
 
 // SelectedIndex returns the index of the currently selected TabItem.
 func (t *DocTabs) SelectedIndex() int {
-	return t.current
+	return t.selected()
 }
 
 // SetItems sets the containers items and refreshes.
@@ -208,6 +207,9 @@ func (t *DocTabs) items() []*TabItem {
 }
 
 func (t *DocTabs) selected() int {
+	if len(t.Items) == 0 {
+		return -1
+	}
 	return t.current
 }
 
@@ -338,6 +340,9 @@ func (r *docTabsRenderer) buildTabButtons(count int, buttons *fyne.Container) {
 				onTapped: func() { r.docTabs.Select(item) },
 				onClosed: func() { r.docTabs.close(item) },
 				tabs:     r.tabs,
+			}
+			if item.disabled {
+				item.button.Disable()
 			}
 		}
 		button := item.button

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -21,25 +21,26 @@ type TabItem struct {
 	Content fyne.CanvasObject
 
 	button *tabButton
+
+	disabled bool
 }
 
 // Disabled returns whether or not the TabItem is disabled.
 //
 // Since: 2.3
 func (ti *TabItem) Disabled() bool {
-	if ti.button != nil {
-		return ti.button.Disabled()
-	}
-	return false
+	return ti.disabled
 }
 
 func (ti *TabItem) disable() {
+	ti.disabled = true
 	if ti.button != nil {
 		ti.button.Disable()
 	}
 }
 
 func (ti *TabItem) enable() {
+	ti.disabled = false
 	if ti.button != nil {
 		ti.button.Enable()
 	}


### PR DESCRIPTION
### Description:
Avoids refreshing in the constructor, some code updates to make the zero value for the widget structs valid and to pass tests.

Fixes #5780

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.  <- covered by existing tabs tests
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
