### PR TITLE
Add theme.CurrentVariant() API

### DIFF
--- a/canvas/image.go
+++ b/canvas/image.go
@@ -15,6 +15,7 @@ import (
 	"fyne.io/fyne/v2/internal/scale"
 	"fyne.io/fyne/v2/internal/svg"
 	"fyne.io/fyne/v2/storage"
+	"fyne.io/fyne/v2/theme"
 )
 
 // ImageFill defines the different type of ways an image can stretch to fill its space.
@@ -285,7 +286,7 @@ func (i *Image) updateReader() (io.ReadCloser, error) {
 		if res, ok := i.Resource.(fyne.ThemedResource); i.isSVG && ok {
 			th := cache.WidgetTheme(i)
 			if th != nil {
-				col := th.Color(res.ThemeColorName(), fyne.CurrentApp().Settings().ThemeVariant())
+				col := th.Color(res.ThemeColorName(), theme.CurrentVariant())
 				var err error
 				content, err = svg.Colorize(content, col)
 				if err != nil {

--- a/container/apptabs.go
+++ b/container/apptabs.go
@@ -49,7 +49,7 @@ func NewAppTabs(items ...*TabItem) *AppTabs {
 func (t *AppTabs) CreateRenderer() fyne.WidgetRenderer {
 	t.BaseWidget.ExtendBaseWidget(t)
 	th := t.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	r := &appTabsRenderer{
 		baseTabsRenderer: baseTabsRenderer{

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -57,7 +57,7 @@ func (t *DocTabs) Append(item *TabItem) {
 func (t *DocTabs) CreateRenderer() fyne.WidgetRenderer {
 	t.ExtendBaseWidget(t)
 	th := t.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	r := &docTabsRenderer{
 		baseTabsRenderer: baseTabsRenderer{

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -64,7 +64,7 @@ func (w *InnerWindow) Close() {
 func (w *InnerWindow) CreateRenderer() fyne.WidgetRenderer {
 	w.ExtendBaseWidget(w)
 	th := w.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	min := newBorderButton(theme.WindowMinimizeIcon(), modeMinimize, th, w.OnMinimized)
 	if w.OnMinimized == nil {
@@ -214,7 +214,7 @@ func (i *innerWindowRenderer) MinSize() fyne.Size {
 
 func (i *innerWindowRenderer) Refresh() {
 	th := i.win.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	i.bg.FillColor = th.Color(theme.ColorNameOverlayBackground, v)
 	i.bg.Refresh()
 	i.contentBG.FillColor = th.Color(theme.ColorNameBackground, v)

--- a/container/split.go
+++ b/container/split.go
@@ -253,7 +253,7 @@ func newDivider(split *Split) *divider {
 func (d *divider) CreateRenderer() fyne.WidgetRenderer {
 	d.ExtendBaseWidget(d)
 	th := d.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	background := canvas.NewRectangle(th.Color(theme.ColorNameShadow, v))
 	foreground := canvas.NewRectangle(th.Color(theme.ColorNameForeground, v))
@@ -363,7 +363,7 @@ func (r *dividerRenderer) Objects() []fyne.CanvasObject {
 
 func (r *dividerRenderer) Refresh() {
 	th := r.divider.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	if r.divider.hovered {
 		r.background.FillColor = th.Color(theme.ColorNameHover, v)

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -316,7 +316,7 @@ func (r *baseTabsRenderer) applyTheme(t baseTabs) {
 		r.action.SetIcon(moreIcon(t))
 	}
 	th := theme.CurrentForWidget(t)
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	r.divider.FillColor = th.Color(theme.ColorNameShadow, v)
 	r.indicator.FillColor = th.Color(theme.ColorNamePrimary, v)
@@ -439,7 +439,7 @@ func (r *baseTabsRenderer) moveIndicator(pos fyne.Position, siz fyne.Size, th fy
 		r.sizeAnimation = nil
 	}
 
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	r.indicator.FillColor = th.Color(theme.ColorNamePrimary, v)
 	if r.indicator.Position().IsZero() {
 		r.indicator.Move(pos)
@@ -525,7 +525,7 @@ type tabButton struct {
 func (b *tabButton) CreateRenderer() fyne.WidgetRenderer {
 	b.ExtendBaseWidget(b)
 	th := b.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	background := canvas.NewRectangle(th.Color(theme.ColorNameHover, v))
 	background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
@@ -679,7 +679,7 @@ func (r *tabButtonRenderer) Objects() []fyne.CanvasObject {
 
 func (r *tabButtonRenderer) Refresh() {
 	th := r.button.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	if r.button.hovered && !r.button.Disabled() {
 		r.background.FillColor = th.Color(theme.ColorNameHover, v)
@@ -769,7 +769,7 @@ type tabCloseButton struct {
 func (b *tabCloseButton) CreateRenderer() fyne.WidgetRenderer {
 	b.ExtendBaseWidget(b)
 	th := b.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	background := canvas.NewRectangle(th.Color(theme.ColorNameHover, v))
 	background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
@@ -831,7 +831,7 @@ func (r *tabCloseButtonRenderer) Objects() []fyne.CanvasObject {
 
 func (r *tabCloseButtonRenderer) Refresh() {
 	th := r.button.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	if r.button.hovered {
 		r.background.FillColor = th.Color(theme.ColorNameHover, v)

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -54,7 +54,7 @@ func (r *scrollBarRenderer) MinSize() fyne.Size {
 
 func (r *scrollBarRenderer) Refresh() {
 	th := theme.CurrentForWidget(r.scrollBar)
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	r.background.FillColor = th.Color(theme.ColorNameScrollBar, v)
 	r.background.CornerRadius = th.Size(theme.SizeNameScrollBarRadius)
@@ -76,7 +76,7 @@ type scrollBar struct {
 
 func (b *scrollBar) CreateRenderer() fyne.WidgetRenderer {
 	th := theme.CurrentForWidget(b)
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	background := canvas.NewRectangle(th.Color(theme.ColorNameScrollBar, v))
 	background.CornerRadius = th.Size(theme.SizeNameScrollBarRadius)
@@ -197,7 +197,7 @@ func (r *scrollBarAreaRenderer) MinSize() fyne.Size {
 func (r *scrollBarAreaRenderer) Refresh() {
 	th := theme.CurrentForWidget(r.area)
 	r.bar.Refresh()
-	r.background.FillColor = th.Color(theme.ColorNameScrollBarBackground, fyne.CurrentApp().Settings().ThemeVariant())
+	r.background.FillColor = th.Color(theme.ColorNameScrollBarBackground, theme.CurrentVariant())
 	r.background.Hidden = !r.area.isLarge()
 	r.layoutWithTheme(th, r.area.Size())
 	canvas.Refresh(r.bar)
@@ -247,7 +247,7 @@ type scrollBarArea struct {
 
 func (a *scrollBarArea) CreateRenderer() fyne.WidgetRenderer {
 	th := theme.CurrentForWidget(a)
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	a.bar = newScrollBar(a)
 	background := canvas.NewRectangle(th.Color(theme.ColorNameScrollBarBackground, v))
 	background.Hidden = !a.isLarge()

--- a/internal/widget/shadow.go
+++ b/internal/widget/shadow.go
@@ -122,7 +122,7 @@ func (r *shadowRenderer) Refresh() {
 
 func (r *shadowRenderer) createShadows() {
 	th := theme.CurrentForWidget(r.s)
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	fg := th.Color(theme.ColorNameShadow, v)
 
 	switch r.s.typ {
@@ -161,7 +161,7 @@ func (r *shadowRenderer) createShadows() {
 
 func (r *shadowRenderer) refreshShadows() {
 	th := theme.CurrentForWidget(r.s)
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	fg := th.Color(theme.ColorNameShadow, v)
 
 	updateShadowEnd(r.l, fg)

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -67,6 +67,15 @@ func LightTheme() fyne.Theme {
 	return theme
 }
 
+// CurrentVariant returns the current [fyne.ThemeVariant] which is
+// determined by user and/or system settings.
+// It is a shorthand for `fyne.CurrentApp().Settings().ThemeVariant()`
+//
+// Since: 2.7
+func CurrentVariant() fyne.ThemeVariant {
+	return fyne.CurrentApp().Settings().ThemeVariant()
+}
+
 type builtinTheme struct {
 	variant fyne.ThemeVariant
 

--- a/widget/activity.go
+++ b/widget/activity.go
@@ -59,7 +59,7 @@ func (a *Activity) Stop() {
 
 func (a *Activity) CreateRenderer() fyne.WidgetRenderer {
 	dots := make([]fyne.CanvasObject, 3)
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	for i := range dots {
 		dots[i] = canvas.NewCircle(a.Theme().Color(theme.ColorNameForeground, v))
 	}
@@ -171,7 +171,7 @@ func (a *activityRenderer) stop() {
 }
 
 func (a *activityRenderer) updateColor() {
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	rr, gg, bb, aa := a.parent.Theme().Color(theme.ColorNameForeground, v).RGBA()
 	a.maxCol = color.NRGBA{R: uint8(rr >> 8), G: uint8(gg >> 8), B: uint8(bb >> 8), A: uint8(aa >> 8)}
 }

--- a/widget/button.go
+++ b/widget/button.go
@@ -92,7 +92,7 @@ func NewButtonWithIcon(label string, icon fyne.Resource, tapped func()) *Button 
 func (b *Button) CreateRenderer() fyne.WidgetRenderer {
 	b.ExtendBaseWidget(b)
 	th := b.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	seg := &TextSegment{Text: b.Text, Style: RichTextStyleStrong}
 	seg.Style.Alignment = fyne.TextAlignCenter
@@ -305,7 +305,7 @@ func (r *buttonRenderer) Refresh() {
 // must be called with the button propertyLock RLocked
 func (r *buttonRenderer) applyTheme() {
 	th := r.button.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	fgColorName, bgColorName, bgBlendName := r.buttonColorNames()
 	if bg := r.background; bg != nil {
 		bgColor := color.Color(color.Transparent)

--- a/widget/card.go
+++ b/widget/card.go
@@ -35,7 +35,7 @@ func NewCard(title, subtitle string, content fyne.CanvasObject) *Card {
 func (c *Card) CreateRenderer() fyne.WidgetRenderer {
 	c.ExtendBaseWidget(c)
 	th := c.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	header := canvas.NewText(c.Title, th.Color(theme.ColorNameForeground, v))
 	header.TextStyle.Bold = true
@@ -225,7 +225,7 @@ func (c *cardRenderer) Refresh() {
 // applyTheme updates this button to match the current theme
 func (c *cardRenderer) applyTheme() {
 	th := c.card.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	if c.header != nil {
 		c.header.TextSize = th.Size(theme.SizeNameHeadingText)

--- a/widget/check.go
+++ b/widget/check.go
@@ -163,7 +163,7 @@ func (c *Check) MinSize() fyne.Size {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (c *Check) CreateRenderer() fyne.WidgetRenderer {
 	th := c.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	c.ExtendBaseWidget(c)
 	bg := canvas.NewImageFromResource(th.Icon(theme.IconNameCheckButtonFill))
@@ -329,7 +329,7 @@ func (c *checkRenderer) applyTheme(th fyne.Theme, v fyne.ThemeVariant) {
 
 func (c *checkRenderer) Refresh() {
 	th := c.check.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	c.applyTheme(th, v)
 	c.updateLabel()

--- a/widget/check_internal_test.go
+++ b/widget/check_internal_test.go
@@ -273,7 +273,7 @@ func TestCheck_Disabled(t *testing.T) {
 
 func TestCheckRenderer_ApplyTheme(t *testing.T) {
 	check := &Check{}
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	render := test.TempWidgetRenderer(t, check).(*checkRenderer)
 
 	textSize := render.label.TextSize

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -164,7 +164,7 @@ func (e *Entry) Bind(data binding.String) {
 // Implements: fyne.Widget
 func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 	th := e.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	e.ExtendBaseWidget(e)
 
 	// initialise
@@ -1655,7 +1655,7 @@ func (r *entryRenderer) Refresh() {
 	r.entry.placeholder.Refresh()
 
 	th := r.entry.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	inputBorder := th.Size(theme.SizeNameInputBorder)
 
 	// correct our scroll wrappers if the wrap mode changed
@@ -1829,7 +1829,7 @@ func (r *entryContentRenderer) Refresh() {
 	}
 
 	th := r.content.entry.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	if focusedAppearance {
 		if fyne.CurrentApp().Settings().ShowAnimations() {
 			r.content.entry.cursorAnim.start()

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -64,7 +64,7 @@ func (i *FileIcon) MinSize() fyne.Size {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (i *FileIcon) CreateRenderer() fyne.WidgetRenderer {
 	th := i.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	i.ExtendBaseWidget(i)
 	i.setURI(i.URI)
@@ -173,7 +173,7 @@ func (s *fileIconRenderer) Layout(size fyne.Size) {
 
 func (s *fileIconRenderer) Refresh() {
 	th := s.file.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	s.file.setURI(s.file.URI)
 

--- a/widget/form.go
+++ b/widget/form.go
@@ -170,7 +170,7 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 	}
 
 	th := f.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	text := canvas.NewText(item.HintText, th.Color(theme.ColorNamePlaceHolder, v))
 	text.TextSize = th.Size(theme.SizeNameCaptionText)
@@ -195,7 +195,7 @@ func (f *Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
 
 func (f *Form) createLabel(text string) fyne.CanvasObject {
 	th := f.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	label := &canvas.Text{
 		Text:      text,
 		Alignment: fyne.TextAlignTrailing,
@@ -348,7 +348,7 @@ func (f *Form) setValidationError(err error) {
 
 func (f *Form) updateHelperText(item *FormItem) {
 	th := f.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	if item.helperOutput == nil {
 		return // testing probably, either way not rendered yet
@@ -381,7 +381,7 @@ func (f *Form) updateHelperText(item *FormItem) {
 
 func (f *Form) updateLabels() {
 	th := f.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	for i, item := range f.Items {
 		l := f.itemGrid.Objects[i*2].(*fyne.Container).Objects[0].(*canvas.Text)

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -436,7 +436,7 @@ func newGridWrapItem(child fyne.CanvasObject, tapped func()) *gridWrapItem {
 func (gw *gridWrapItem) CreateRenderer() fyne.WidgetRenderer {
 	gw.ExtendBaseWidget(gw)
 	th := gw.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	gw.background = canvas.NewRectangle(th.Color(theme.ColorNameHover, v))
 	gw.background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
@@ -501,7 +501,7 @@ func (gw *gridWrapItemRenderer) Layout(size fyne.Size) {
 
 func (gw *gridWrapItemRenderer) Refresh() {
 	th := gw.item.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	gw.item.background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
 	if gw.item.selected {

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -70,7 +70,7 @@ func (hl *Hyperlink) CreateRenderer() fyne.WidgetRenderer {
 	hl.syncSegments()
 
 	th := hl.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	focus := canvas.NewRectangle(color.Transparent)
 	focus.StrokeColor = th.Color(theme.ColorNameFocus, v)
 	focus.StrokeWidth = 2
@@ -327,7 +327,7 @@ func (r *hyperlinkRenderer) Objects() []fyne.CanvasObject {
 func (r *hyperlinkRenderer) Refresh() {
 	r.hl.provider.Refresh()
 	th := r.hl.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	r.focus.StrokeColor = th.Color(theme.ColorNameFocus, v)
 	r.focus.Hidden = !r.hl.focused

--- a/widget/list.go
+++ b/widget/list.go
@@ -524,7 +524,7 @@ func newListItem(child fyne.CanvasObject, tapped func()) *listItem {
 func (li *listItem) CreateRenderer() fyne.WidgetRenderer {
 	li.ExtendBaseWidget(li)
 	th := li.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	li.background = canvas.NewRectangle(th.Color(theme.ColorNameHover, v))
 	li.background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
@@ -589,7 +589,7 @@ func (li *listItemRenderer) Layout(size fyne.Size) {
 
 func (li *listItemRenderer) Refresh() {
 	th := li.item.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	li.item.background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
 	if li.item.selected {

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -326,7 +326,7 @@ func newMenuBox(items []fyne.CanvasObject) *menuBox {
 
 func (b *menuBox) CreateRenderer() fyne.WidgetRenderer {
 	th := b.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	background := canvas.NewRectangle(th.Color(theme.ColorNameMenuBackground, v))
 	cont := &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: b.items}
@@ -359,7 +359,7 @@ func (r *menuBoxRenderer) MinSize() fyne.Size {
 
 func (r *menuBoxRenderer) Refresh() {
 	th := r.b.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	r.background.FillColor = th.Color(theme.ColorNameMenuBackground, v)
 	r.background.Refresh()

--- a/widget/menu_item.go
+++ b/widget/menu_item.go
@@ -46,7 +46,7 @@ func (i *menuItem) Child() *Menu {
 // Implements: fyne.Widget
 func (i *menuItem) CreateRenderer() fyne.WidgetRenderer {
 	th := i.parent.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	background := canvas.NewRectangle(th.Color(theme.ColorNameHover, v))
 	background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
@@ -290,7 +290,7 @@ func (r *menuItemRenderer) MinSize() fyne.Size {
 
 func (r *menuItemRenderer) updateVisuals() {
 	th := r.i.parent.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	r.background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
 	if fyne.CurrentDevice().IsMobile() {
 		r.background.Hide()
@@ -351,7 +351,7 @@ func (r *menuItemRenderer) updateIcon(img *canvas.Image, rsc fyne.Resource) {
 
 func (r *menuItemRenderer) refreshText(text *canvas.Text, shortcut bool) {
 	th := r.i.parent.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	text.TextSize = th.Size(theme.SizeNameText)
 	if r.i.Item.Disabled {
@@ -367,7 +367,7 @@ func (r *menuItemRenderer) refreshText(text *canvas.Text, shortcut bool) {
 }
 
 func shortcutColor(th fyne.Theme) color.Color {
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	r, g, b, a := th.Color(theme.ColorNameForeground, v).RGBA()
 	a = uint32(float32(a) * 0.95)
 	return color.NRGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: uint8(a)}

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -101,7 +101,7 @@ func (p *PopUp) MinSize() fyne.Size {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (p *PopUp) CreateRenderer() fyne.WidgetRenderer {
 	th := p.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	p.ExtendBaseWidget(p)
 	background := canvas.NewRectangle(th.Color(theme.ColorNameOverlayBackground, v))
@@ -228,7 +228,7 @@ func (r *popUpRenderer) MinSize() fyne.Size {
 
 func (r *popUpRenderer) Refresh() {
 	th := r.popUp.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	r.background.FillColor = th.Color(theme.ColorNameOverlayBackground, v)
 	expectedContentSize := r.popUp.innerSize.Max(r.popUp.MinSize()).Subtract(r.padding())
 	shouldRelayout := r.popUp.Content.Size() != expectedContentSize
@@ -275,7 +275,7 @@ func (r *modalPopUpRenderer) MinSize() fyne.Size {
 
 func (r *modalPopUpRenderer) Refresh() {
 	th := r.popUp.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	r.underlay.FillColor = th.Color(theme.ColorNameShadow, v)
 	r.background.FillColor = th.Color(theme.ColorNameOverlayBackground, v)
 	expectedContentSize := r.popUp.innerSize.Max(r.popUp.MinSize()).Subtract(r.padding())

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -73,7 +73,7 @@ func (p *progressRenderer) Layout(size fyne.Size) {
 // applyTheme updates the progress bar to match the current theme
 func (p *progressRenderer) applyTheme() {
 	th := p.progress.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	primaryColor := th.Color(theme.ColorNamePrimary, v)
 	inputRadius := th.Size(theme.SizeNameInputRadius)

--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -75,7 +75,7 @@ func (p *infProgressRenderer) Refresh() {
 	}
 
 	th := p.progress.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	cornerRadius := th.Size(theme.SizeNameInputRadius)
 	primaryColor := th.Color(theme.ColorNamePrimary, v)
 
@@ -168,7 +168,7 @@ func (p *ProgressBarInfinite) MinSize() fyne.Size {
 func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 	p.ExtendBaseWidget(p)
 	th := p.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	primaryColor := th.Color(theme.ColorNamePrimary, v)
 	cornerRadius := th.Size(theme.SizeNameInputRadius)

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -182,7 +182,7 @@ func (r *radioItemRenderer) Refresh() {
 
 func (r *radioItemRenderer) update() {
 	th := r.item.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	r.label.Text = r.item.Label
 	r.label.TextSize = th.Size(theme.SizeNameText)

--- a/widget/select.go
+++ b/widget/select.go
@@ -88,7 +88,7 @@ func (s *Select) ClearSelected() {
 func (s *Select) CreateRenderer() fyne.WidgetRenderer {
 	s.ExtendBaseWidget(s)
 	th := s.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	icon := NewIcon(th.Icon(theme.IconNameArrowDropDown))
 	if s.PlaceHolder == "" {
@@ -411,7 +411,7 @@ func (s *selectRenderer) MinSize() fyne.Size {
 
 func (s *selectRenderer) Refresh() {
 	th := s.combo.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	s.updateLabel()
 	s.updateIcon(th)

--- a/widget/selectable.go
+++ b/widget/selectable.go
@@ -301,7 +301,7 @@ func (r *selectableRenderer) Objects() []fyne.CanvasObject {
 func (r *selectableRenderer) Refresh() {
 	r.buildSelection()
 	selections := r.selections
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	selectionColor := r.sel.theme.Color(theme.ColorNameSelection, v)
 	for _, selection := range selections {
@@ -327,7 +327,7 @@ func (r *selectableRenderer) Refresh() {
 // all rectangles to comply with the occurrence order as stated above.
 func (r *selectableRenderer) buildSelection() {
 	th := r.sel.theme
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	textSize := th.Size(r.sel.getSizeName())
 
 	cursorRow, cursorCol := r.sel.cursorRow, r.sel.cursorColumn

--- a/widget/separator.go
+++ b/widget/separator.go
@@ -34,7 +34,7 @@ func NewSeparator() *Separator {
 func (s *Separator) CreateRenderer() fyne.WidgetRenderer {
 	s.ExtendBaseWidget(s)
 	th := s.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	var col color.Color
 	if s.invert {
 		col = th.Color(theme.ColorNameForeground, v)
@@ -72,7 +72,7 @@ func (r *separatorRenderer) MinSize() fyne.Size {
 
 func (r *separatorRenderer) Refresh() {
 	th := r.d.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	if r.d.invert {
 		r.bar.FillColor = th.Color(theme.ColorNameForeground, v)

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -350,7 +350,7 @@ func (s *Slider) Disabled() bool {
 func (s *Slider) CreateRenderer() fyne.WidgetRenderer {
 	s.ExtendBaseWidget(s)
 	th := s.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	track := canvas.NewRectangle(th.Color(theme.ColorNameInputBackground, v))
 	active := canvas.NewRectangle(th.Color(theme.ColorNameForeground, v))
@@ -429,7 +429,7 @@ type sliderRenderer struct {
 // Refresh updates the widget state for drawing.
 func (s *sliderRenderer) Refresh() {
 	th := s.slider.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	s.track.FillColor = th.Color(theme.ColorNameInputBackground, v)
 	if s.slider.disabled {

--- a/widget/table.go
+++ b/widget/table.go
@@ -1165,7 +1165,7 @@ func newTableCells(t *Table) *tableCells {
 
 func (c *tableCells) CreateRenderer() fyne.WidgetRenderer {
 	th := c.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	marker := canvas.NewRectangle(th.Color(theme.ColorNameSelection, v))
 	marker.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
 	hover := canvas.NewRectangle(th.Color(theme.ColorNameHover, v))
@@ -1268,7 +1268,7 @@ func (r *tableCellsRenderer) Refresh() {
 
 func (r *tableCellsRenderer) refreshForID(toDraw TableCellID) {
 	th := r.cells.t.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	separatorThickness := th.Size(theme.SizeNamePadding)
 	dataRows, dataCols := 0, 0

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -360,7 +360,7 @@ func (t *TextGrid) CreateRenderer() fyne.WidgetRenderer {
 	t.ExtendBaseWidget(t)
 
 	th := t.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	TextGridStyleDefault = &CustomTextGridStyle{}
 	TextGridStyleWhitespace = &CustomTextGridStyle{FGColor: th.Color(theme.ColorNameDisabled, v)}
 
@@ -664,7 +664,7 @@ func (t *textGridRow) setRow(row int) {
 
 func (t *textGridRow) appendTextCell(str rune) {
 	th := t.text.text.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	text := canvas.NewText(string(str), th.Color(theme.ColorNameForeground, v))
 	text.TextStyle.Monospace = true
@@ -699,7 +699,7 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 	underline := t.objects[pos*3+2].(*canvas.Line)
 
 	th := t.text.text.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	fg := th.Color(theme.ColorNameForeground, v)
 	text.TextSize = th.Size(theme.SizeNameText)
 
@@ -898,7 +898,7 @@ func (t *textGridRowRenderer) MinSize() fyne.Size {
 
 func (t *textGridRowRenderer) Refresh() {
 	th := t.obj.text.text.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 	TextGridStyleWhitespace = &CustomTextGridStyle{FGColor: th.Color(theme.ColorNameDisabled, v)}
 	t.obj.updateGridSize(t.obj.text.text.Size())
 	t.obj.refreshCells()

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -858,7 +858,7 @@ func (n *treeNode) Content() fyne.CanvasObject {
 
 func (n *treeNode) CreateRenderer() fyne.WidgetRenderer {
 	th := n.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	background := canvas.NewRectangle(th.Color(theme.ColorNameHover, v))
 	background.CornerRadius = th.Size(theme.SizeNameSelectionRadius)
@@ -981,7 +981,7 @@ func (r *treeNodeRenderer) Refresh() {
 
 func (r *treeNodeRenderer) partialRefresh() {
 	th := r.treeNode.Theme()
-	v := fyne.CurrentApp().Settings().ThemeVariant()
+	v := theme.CurrentVariant()
 
 	if r.treeNode.icon != nil {
 		r.treeNode.icon.Refresh()


### PR DESCRIPTION
### Description:
Adding a new shorthand for `fyne.CurrentApp().Settings().ThemeVariant()`. Makes writing custom widgets and applying theming in the CreateRenderer / Refresh calls easier to read, write, and more discoverable for how to get the current variant to pass to the widget theme when calling the `.Color` API.

Fixes #5891 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
