### PR TITLE
Fix Split container behavior with hidden objects

### DIFF
--- a/container/split.go
+++ b/container/split.go
@@ -100,32 +100,43 @@ func (r *splitContainerRenderer) Layout(size fyne.Size) {
 	var dividerPos, leadingPos, trailingPos fyne.Position
 	var dividerSize, leadingSize, trailingSize fyne.Size
 
-	if r.split.Horizontal {
-		lw, tw := r.computeSplitLengths(size.Width, r.minLeadingWidth(), r.minTrailingWidth())
-		leadingPos.X = 0
-		leadingSize.Width = lw
-		leadingSize.Height = size.Height
-		dividerPos.X = lw
-		dividerSize.Width = dividerThickness(r.divider)
-		dividerSize.Height = size.Height
-		trailingPos.X = lw + dividerSize.Width
-		trailingSize.Width = tw
-		trailingSize.Height = size.Height
-	} else {
-		lh, th := r.computeSplitLengths(size.Height, r.minLeadingHeight(), r.minTrailingHeight())
-		leadingPos.Y = 0
-		leadingSize.Width = size.Width
-		leadingSize.Height = lh
-		dividerPos.Y = lh
-		dividerSize.Width = size.Width
-		dividerSize.Height = dividerThickness(r.divider)
-		trailingPos.Y = lh + dividerSize.Height
-		trailingSize.Width = size.Width
-		trailingSize.Height = th
+	dividerVisible := r.split.Leading.Visible() && r.split.Trailing.Visible()
+	if !r.split.Leading.Visible() {
+		trailingPos = fyne.NewPos(0, 0)
+		trailingSize = size
+	} else if !r.split.Trailing.Visible() {
+		leadingPos = fyne.NewPos(0, 0)
+		leadingSize = size
+	} else if dividerVisible {
+		if r.split.Horizontal {
+			lw, tw := r.computeSplitLengths(size.Width, r.minLeadingWidth(), r.minTrailingWidth())
+			leadingPos.X = 0
+			leadingSize.Width = lw
+			leadingSize.Height = size.Height
+			dividerPos.X = lw
+			dividerSize.Width = dividerThickness(r.divider)
+			dividerSize.Height = size.Height
+			trailingPos.X = lw + dividerSize.Width
+			trailingSize.Width = tw
+			trailingSize.Height = size.Height
+		} else {
+			lh, th := r.computeSplitLengths(size.Height, r.minLeadingHeight(), r.minTrailingHeight())
+			leadingPos.Y = 0
+			leadingSize.Width = size.Width
+			leadingSize.Height = lh
+			dividerPos.Y = lh
+			dividerSize.Width = size.Width
+			dividerSize.Height = dividerThickness(r.divider)
+			trailingPos.Y = lh + dividerSize.Height
+			trailingSize.Width = size.Width
+			trailingSize.Height = th
+		}
 	}
 
 	r.divider.Move(dividerPos)
 	r.divider.Resize(dividerSize)
+	r.divider.Hidden = !dividerVisible
+
 	r.split.Leading.Move(leadingPos)
 	r.split.Leading.Resize(leadingSize)
 	r.split.Trailing.Move(trailingPos)
@@ -135,7 +146,11 @@ func (r *splitContainerRenderer) Layout(size fyne.Size) {
 
 func (r *splitContainerRenderer) MinSize() fyne.Size {
 	s := fyne.NewSize(0, 0)
-	for _, o := range r.objects {
+	dividerVisible := r.split.Leading.Visible() && r.split.Trailing.Visible()
+	for i, o := range r.objects {
+		if (i == 1 /*divider*/ && !dividerVisible) || (i != 1 && !o.Visible()) {
+			continue
+		}
 		min := o.MinSize()
 		if r.split.Horizontal {
 			s.Width += min.Width

--- a/container/split_test.go
+++ b/container/split_test.go
@@ -489,38 +489,50 @@ func TestSplitContainer_Hidden(t *testing.T) {
 	t.Run("Horizontal_Leading", func(t *testing.T) {
 		sc := NewHSplit(objA, objB)
 		sc.Resize(fyne.NewSize(100, 100))
-		assert.Equal(t, 50-(dt/2), sc.Leading.Size().Width)
-
-		objA.Hide()
-		sc.SetOffset(0)
-		assert.Equal(t, float32(0), sc.Leading.Size().Width)
-	})
-	t.Run("Horizontal_Trailing", func(t *testing.T) {
-		sc := NewHSplit(objA, objB)
-		sc.Resize(fyne.NewSize(100, 100))
 		assert.Equal(t, 50-(dt/2), sc.Trailing.Size().Width)
 
+		objA.Hide()
+		sc.Refresh()
+		// sole visible object should take up all space
+		// (none reserved for other obj or divider)
+		assert.Equal(t, float32(100), sc.Trailing.Size().Width)
+	})
+	t.Run("Horizontal_Trailing", func(t *testing.T) {
+		objA.Show()
+		sc := NewHSplit(objA, objB)
+		sc.Resize(fyne.NewSize(100, 100))
+		assert.Equal(t, 50-(dt/2), sc.Leading.Size().Width)
+
 		objB.Hide()
-		sc.SetOffset(1)
-		assert.Equal(t, float32(0), sc.Trailing.Size().Width)
+		sc.Refresh()
+		assert.Equal(t, float32(100), sc.Leading.Size().Width)
 	})
 	t.Run("Vertical_Leading", func(t *testing.T) {
-		sc := NewVSplit(objA, objB)
-		sc.Resize(fyne.NewSize(100, 100))
-		assert.Equal(t, 50-(dt/2), sc.Leading.Size().Height)
-
-		objA.Hide()
-		sc.SetOffset(0)
-		assert.Equal(t, float32(0), sc.Leading.Size().Height)
-	})
-	t.Run("Vertical_Trailing", func(t *testing.T) {
+		objB.Show()
 		sc := NewVSplit(objA, objB)
 		sc.Resize(fyne.NewSize(100, 100))
 		assert.Equal(t, 50-(dt/2), sc.Trailing.Size().Height)
 
+		objA.Hide()
+		sc.Refresh()
+		assert.Equal(t, float32(100), sc.Trailing.Size().Height)
+	})
+	t.Run("Vertical_Trailing", func(t *testing.T) {
+		objA.Show()
+		sc := NewVSplit(objA, objB)
+		sc.Resize(fyne.NewSize(100, 100))
+		assert.Equal(t, 50-(dt/2), sc.Leading.Size().Height)
+
 		objB.Hide()
-		sc.SetOffset(1)
-		assert.Equal(t, float32(0), sc.Trailing.Size().Height)
+		sc.Refresh()
+		assert.Equal(t, float32(100), sc.Leading.Size().Height)
+	})
+	t.Run("MinSize", func(t *testing.T) {
+		objA.Show()
+		objB.Hide()
+		objB.SetMinSize(fyne.NewSize(10, 10))
+		sc := NewVSplit(objA, objB)
+		assert.Equal(t, objA.MinSize(), sc.MinSize())
 	})
 }
 


### PR DESCRIPTION
### Description:
If one object is hidden, the other takes up the entire space and no divider is shown.

Fixes #5900 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
