### PR TITLE
Don't block on BufferSubData

### DIFF
--- a/internal/driver/mobile/gl/gl.go
+++ b/internal/driver/mobile/gl/gl.go
@@ -115,8 +115,7 @@ func (ctx *context) BufferSubData(target Enum, src []byte) {
 			a1: 0,
 			a2: uintptr(len(src)),
 		},
-		parg:     parg,
-		blocking: true,
+		parg: parg,
 	})
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Small change with a big impact. 
BufferSubData did not need to be blocking, since there is no return value. 

_Note: there are other methods that have the same issue, but `BufferSubData` is the only one that is used on every draw so I left the others alone._

Paints without this change took ~50ms on my 2014 MOTO G.
Paints with this change take ~35ms.

Another attempt at fully fixing #1062

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
