### PR TITLE
suppress LogError for menu_test.go

### DIFF
--- a/internal/driver/glfw/menu_test.go
+++ b/internal/driver/glfw/menu_test.go
@@ -3,6 +3,9 @@
 package glfw
 
 import (
+	"io"
+	"log"
+	"os"
 	"reflect"
 	"testing"
 
@@ -13,6 +16,11 @@ import (
 )
 
 func Test_Menu_Empty(t *testing.T) {
+	// Discarding log output for tests
+	// The following method logs an error:
+	// bar := buildMenuOverlay(fyne.NewMainMenu(), w.window)
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
 	w := createWindow("Menu Test")
 	bar := buildMenuOverlay(fyne.NewMainMenu(), w.window)
 	assert.Nil(t, bar) // no bar but does not crash

--- a/internal/driver/mobile/canvas_test.go
+++ b/internal/driver/mobile/canvas_test.go
@@ -4,6 +4,8 @@ package mobile
 
 import (
 	"image/color"
+	"io"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -131,6 +133,13 @@ func Test_canvas_DraggingOutOfWidget(t *testing.T) {
 }
 
 func Test_canvas_Focusable(t *testing.T) {
+	// Discarding log output for tests
+	// The following method logs an error:
+	// wid.Tapped(ev) on lines 148 and 159
+	// c.Focus(content) on line 168
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
 	c := newCanvas(fyne.CurrentDevice()).(*canvas)
 	content := newFocusableEntry(c)
 	c.SetContent(content)
@@ -143,7 +152,6 @@ func Test_canvas_Focusable(t *testing.T) {
 			wid.Tapped(ev)
 		}, nil, nil, nil)
 	}, true)
-
 	waitAndCheck(tapDoubleDelay/time.Millisecond+150, func() {
 		assert.Equal(t, 1, content.focusedTimes)
 		assert.Equal(t, 0, content.unfocusedTimes)

--- a/internal/driver/mobile/keyboard_test.go
+++ b/internal/driver/mobile/keyboard_test.go
@@ -1,11 +1,19 @@
 package mobile
 
 import (
+	"io"
+	"log"
+	"os"
 	"testing"
 
 	_ "fyne.io/fyne/v2/test"
 )
 
 func TestDevice_HideVirtualKeyboard_BeforeRun(t *testing.T) {
+	// Discarding log output for tests
+	// The following method logs an error:
+	// (&device{}).hideVirtualKeyboard() // should not crash!
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
 	(&device{}).hideVirtualKeyboard() // should not crash!
 }


### PR DESCRIPTION
this line causes the LogError
bar := buildMenuOverlay(fyne.NewMainMenu(), w.window)

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
