### PR TITLE
Add NewMenuItemWithIcon constructor

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -64,6 +64,13 @@ func NewMenuItem(label string, action func()) *MenuItem {
 	return &MenuItem{Label: label, Action: action}
 }
 
+// NewMenuItemWithIcon creates a new menu item from the passed label, icon, and action parameters.
+//
+// Since: 2.7
+func NewMenuItemWithIcon(label string, icon Resource, action func()) *MenuItem {
+	return &MenuItem{Label: label, Icon: icon, Action: action}
+}
+
 // NewMenuItemSeparator creates a menu item that is to be used as a separator.
 func NewMenuItemSeparator() *MenuItem {
 	return &MenuItem{IsSeparator: true, Action: func() {}}


### PR DESCRIPTION
### Description:
In my app (and probably many others), most or all menu items have icons. This is a useful shorthand, similar to existing APIs like `NewButtonWithIcon`.

Fixes #(issue)

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
