### PR TITLE
More work on generic data bindings

### DIFF
--- a/data/binding/lists.go
+++ b/data/binding/lists.go
@@ -31,6 +31,21 @@ type ExternalList[T any] interface {
 	Reload() error
 }
 
+// NewList returns a bindable list of values with type T.
+//
+// Since: 2.7
+func NewList[T any](comparator func(T, T) bool) List[T] {
+	return newList[T](comparator)
+}
+
+// BindList returns a bound list of values with type T, based on the contents of the passed slice.
+// If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
+//
+// Since: 2.7
+func BindList[T any](v *[]T, comparator func(T, T) bool) ExternalList[T] {
+	return bindList(v, comparator)
+}
+
 // DataList is the base interface for all bindable data lists.
 //
 // Since: 2.0

--- a/data/binding/lists.go
+++ b/data/binding/lists.go
@@ -510,10 +510,6 @@ func bindListItem[T any](v *[]T, i int, external bool, comparator func(T, T) boo
 	return &boundListItem[T]{val: v, index: i, comparator: comparator}
 }
 
-func bindListItemComparable[T bool | float64 | int | rune | string](v *[]T, i int, external bool) Item[T] {
-	return bindListItem(v, i, external, func(t1, t2 T) bool { return t1 == t2 })
-}
-
 type boundListItem[T any] struct {
 	base
 

--- a/data/binding/lists.go
+++ b/data/binding/lists.go
@@ -7,6 +7,30 @@ import (
 	"fyne.io/fyne/v2/storage"
 )
 
+// List supports binding a list of values with type T.
+//
+// Since: 2.7
+type List[T any] interface {
+	DataList
+
+	Append(value T) error
+	Get() ([]T, error)
+	GetValue(index int) (T, error)
+	Prepend(value T) error
+	Remove(value T) error
+	Set(list []T) error
+	SetValue(index int, value T) error
+}
+
+// ExternalList supports binding a list of values, with type T, from an external variable.
+//
+// Since: 2.7
+type ExternalList[T any] interface {
+	List[T]
+
+	Reload() error
+}
+
 // DataList is the base interface for all bindable data lists.
 //
 // Since: 2.0
@@ -19,26 +43,12 @@ type DataList interface {
 // BoolList supports binding a list of bool values.
 //
 // Since: 2.0
-type BoolList interface {
-	DataList
-
-	Append(value bool) error
-	Get() ([]bool, error)
-	GetValue(index int) (bool, error)
-	Prepend(value bool) error
-	Remove(value bool) error
-	Set(list []bool) error
-	SetValue(index int, value bool) error
-}
+type BoolList = List[bool]
 
 // ExternalBoolList supports binding a list of bool values from an external variable.
 //
 // Since: 2.0
-type ExternalBoolList interface {
-	BoolList
-
-	Reload() error
-}
+type ExternalBoolList = ExternalList[bool]
 
 // NewBoolList returns a bindable list of bool values.
 //
@@ -58,26 +68,12 @@ func BindBoolList(v *[]bool) ExternalBoolList {
 // BytesList supports binding a list of []byte values.
 //
 // Since: 2.2
-type BytesList interface {
-	DataList
-
-	Append(value []byte) error
-	Get() ([][]byte, error)
-	GetValue(index int) ([]byte, error)
-	Prepend(value []byte) error
-	Remove(value []byte) error
-	Set(list [][]byte) error
-	SetValue(index int, value []byte) error
-}
+type BytesList = List[[]byte]
 
 // ExternalBytesList supports binding a list of []byte values from an external variable.
 //
 // Since: 2.2
-type ExternalBytesList interface {
-	BytesList
-
-	Reload() error
-}
+type ExternalBytesList = ExternalList[[]byte]
 
 // NewBytesList returns a bindable list of []byte values.
 //
@@ -97,26 +93,12 @@ func BindBytesList(v *[][]byte) ExternalBytesList {
 // FloatList supports binding a list of float64 values.
 //
 // Since: 2.0
-type FloatList interface {
-	DataList
-
-	Append(value float64) error
-	Get() ([]float64, error)
-	GetValue(index int) (float64, error)
-	Prepend(value float64) error
-	Remove(value float64) error
-	Set(list []float64) error
-	SetValue(index int, value float64) error
-}
+type FloatList = List[float64]
 
 // ExternalFloatList supports binding a list of float64 values from an external variable.
 //
 // Since: 2.0
-type ExternalFloatList interface {
-	FloatList
-
-	Reload() error
-}
+type ExternalFloatList = ExternalList[float64]
 
 // NewFloatList returns a bindable list of float64 values.
 //
@@ -136,26 +118,12 @@ func BindFloatList(v *[]float64) ExternalFloatList {
 // IntList supports binding a list of int values.
 //
 // Since: 2.0
-type IntList interface {
-	DataList
-
-	Append(value int) error
-	Get() ([]int, error)
-	GetValue(index int) (int, error)
-	Prepend(value int) error
-	Remove(value int) error
-	Set(list []int) error
-	SetValue(index int, value int) error
-}
+type IntList = List[int]
 
 // ExternalIntList supports binding a list of int values from an external variable.
 //
 // Since: 2.0
-type ExternalIntList interface {
-	IntList
-
-	Reload() error
-}
+type ExternalIntList = ExternalList[int]
 
 // NewIntList returns a bindable list of int values.
 //
@@ -175,26 +143,12 @@ func BindIntList(v *[]int) ExternalIntList {
 // RuneList supports binding a list of rune values.
 //
 // Since: 2.0
-type RuneList interface {
-	DataList
-
-	Append(value rune) error
-	Get() ([]rune, error)
-	GetValue(index int) (rune, error)
-	Prepend(value rune) error
-	Remove(value rune) error
-	Set(list []rune) error
-	SetValue(index int, value rune) error
-}
+type RuneList = List[rune]
 
 // ExternalRuneList supports binding a list of rune values from an external variable.
 //
 // Since: 2.0
-type ExternalRuneList interface {
-	RuneList
-
-	Reload() error
-}
+type ExternalRuneList = ExternalList[rune]
 
 // NewRuneList returns a bindable list of rune values.
 //
@@ -226,26 +180,12 @@ func BindRuneList(v *[]rune) ExternalRuneList {
 // StringList supports binding a list of string values.
 //
 // Since: 2.0
-type StringList interface {
-	DataList
-
-	Append(value string) error
-	Get() ([]string, error)
-	GetValue(index int) (string, error)
-	Prepend(value string) error
-	Remove(value string) error
-	Set(list []string) error
-	SetValue(index int, value string) error
-}
+type StringList = List[string]
 
 // ExternalStringList supports binding a list of string values from an external variable.
 //
 // Since: 2.0
-type ExternalStringList interface {
-	StringList
-
-	Reload() error
-}
+type ExternalStringList = ExternalList[string]
 
 // NewStringList returns a bindable list of string values.
 //
@@ -265,26 +205,12 @@ func BindStringList(v *[]string) ExternalStringList {
 // UntypedList supports binding a list of any values.
 //
 // Since: 2.1
-type UntypedList interface {
-	DataList
-
-	Append(value any) error
-	Get() ([]any, error)
-	GetValue(index int) (any, error)
-	Prepend(value any) error
-	Remove(value any) error
-	Set(list []any) error
-	SetValue(index int, value any) error
-}
+type UntypedList = List[any]
 
 // ExternalUntypedList supports binding a list of any values from an external variable.
 //
 // Since: 2.1
-type ExternalUntypedList interface {
-	UntypedList
-
-	Reload() error
-}
+type ExternalUntypedList = ExternalList[any]
 
 // NewUntypedList returns a bindable list of any values.
 //
@@ -314,26 +240,12 @@ func BindUntypedList(v *[]any) ExternalUntypedList {
 // URIList supports binding a list of fyne.URI values.
 //
 // Since: 2.1
-type URIList interface {
-	DataList
-
-	Append(value fyne.URI) error
-	Get() ([]fyne.URI, error)
-	GetValue(index int) (fyne.URI, error)
-	Prepend(value fyne.URI) error
-	Remove(value fyne.URI) error
-	Set(list []fyne.URI) error
-	SetValue(index int, value fyne.URI) error
-}
+type URIList = List[fyne.URI]
 
 // ExternalURIList supports binding a list of fyne.URI values from an external variable.
 //
 // Since: 2.1
-type ExternalURIList interface {
-	URIList
-
-	Reload() error
-}
+type ExternalURIList = ExternalList[fyne.URI]
 
 // NewURIList returns a bindable list of fyne.URI values.
 //

--- a/data/binding/lists.go
+++ b/data/binding/lists.go
@@ -68,7 +68,7 @@ type ExternalBoolList = ExternalList[bool]
 // NewBoolList returns a bindable list of bool values.
 //
 // Since: 2.0
-func NewBoolList() BoolList {
+func NewBoolList() List[bool] {
 	return newListComparable[bool]()
 }
 
@@ -76,7 +76,7 @@ func NewBoolList() BoolList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0
-func BindBoolList(v *[]bool) ExternalBoolList {
+func BindBoolList(v *[]bool) ExternalList[bool] {
 	return bindListComparable(v)
 }
 
@@ -93,7 +93,7 @@ type ExternalBytesList = ExternalList[[]byte]
 // NewBytesList returns a bindable list of []byte values.
 //
 // Since: 2.2
-func NewBytesList() BytesList {
+func NewBytesList() List[[]byte] {
 	return newList(bytes.Equal)
 }
 
@@ -101,7 +101,7 @@ func NewBytesList() BytesList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.2
-func BindBytesList(v *[][]byte) ExternalBytesList {
+func BindBytesList(v *[][]byte) ExternalList[[]byte] {
 	return bindList(v, bytes.Equal)
 }
 
@@ -118,7 +118,7 @@ type ExternalFloatList = ExternalList[float64]
 // NewFloatList returns a bindable list of float64 values.
 //
 // Since: 2.0
-func NewFloatList() FloatList {
+func NewFloatList() List[float64] {
 	return newListComparable[float64]()
 }
 
@@ -126,7 +126,7 @@ func NewFloatList() FloatList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0
-func BindFloatList(v *[]float64) ExternalFloatList {
+func BindFloatList(v *[]float64) ExternalList[float64] {
 	return bindListComparable(v)
 }
 
@@ -143,7 +143,7 @@ type ExternalIntList = ExternalList[int]
 // NewIntList returns a bindable list of int values.
 //
 // Since: 2.0
-func NewIntList() IntList {
+func NewIntList() List[int] {
 	return newListComparable[int]()
 }
 
@@ -151,7 +151,7 @@ func NewIntList() IntList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0
-func BindIntList(v *[]int) ExternalIntList {
+func BindIntList(v *[]int) ExternalList[int] {
 	return bindListComparable(v)
 }
 
@@ -168,7 +168,7 @@ type ExternalRuneList = ExternalList[rune]
 // NewRuneList returns a bindable list of rune values.
 //
 // Since: 2.0
-func NewRuneList() RuneList {
+func NewRuneList() List[rune] {
 	return newListComparable[rune]()
 }
 
@@ -176,20 +176,8 @@ func NewRuneList() RuneList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0
-func BindRuneList(v *[]rune) ExternalRuneList {
-	if v == nil {
-		return NewRuneList().(ExternalRuneList)
-	}
-
-	b := newListComparable[rune]()
-	b.val = v
-	b.updateExternal = true
-
-	for i := range *v {
-		b.appendItem(bindListItemComparable(v, i, b.updateExternal))
-	}
-
-	return b
+func BindRuneList(v *[]rune) ExternalList[rune] {
+	return bindListComparable(v)
 }
 
 // StringList supports binding a list of string values.
@@ -205,7 +193,7 @@ type ExternalStringList = ExternalList[string]
 // NewStringList returns a bindable list of string values.
 //
 // Since: 2.0
-func NewStringList() StringList {
+func NewStringList() List[string] {
 	return newListComparable[string]()
 }
 
@@ -213,7 +201,7 @@ func NewStringList() StringList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.0
-func BindStringList(v *[]string) ExternalStringList {
+func BindStringList(v *[]string) ExternalList[string] {
 	return bindListComparable(v)
 }
 
@@ -230,7 +218,7 @@ type ExternalUntypedList = ExternalList[any]
 // NewUntypedList returns a bindable list of any values.
 //
 // Since: 2.1
-func NewUntypedList() UntypedList {
+func NewUntypedList() List[any] {
 	return newList(func(t1, t2 any) bool { return t1 == t2 })
 }
 
@@ -238,18 +226,8 @@ func NewUntypedList() UntypedList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.1
-func BindUntypedList(v *[]any) ExternalUntypedList {
-	if v == nil {
-		return NewUntypedList().(ExternalUntypedList)
-	}
-
-	comparator := func(t1, t2 any) bool { return t1 == t2 }
-	b := newExternalList(v, comparator)
-	for i := range *v {
-		b.appendItem(bindListItem(v, i, b.updateExternal, comparator))
-	}
-
-	return b
+func BindUntypedList(v *[]any) ExternalList[any] {
+	return bindList(v, func(t1, t2 any) bool { return t1 == t2 })
 }
 
 // URIList supports binding a list of fyne.URI values.
@@ -265,7 +243,7 @@ type ExternalURIList = ExternalList[fyne.URI]
 // NewURIList returns a bindable list of fyne.URI values.
 //
 // Since: 2.1
-func NewURIList() URIList {
+func NewURIList() List[fyne.URI] {
 	return newList(storage.EqualURI)
 }
 
@@ -273,7 +251,7 @@ func NewURIList() URIList {
 // If your code changes the content of the slice this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.1
-func BindURIList(v *[]fyne.URI) ExternalURIList {
+func BindURIList(v *[]fyne.URI) ExternalList[fyne.URI] {
 	return bindList(v, storage.EqualURI)
 }
 
@@ -314,7 +292,7 @@ func newList[T any](comparator func(T, T) bool) *boundList[T] {
 	return &boundList[T]{val: new([]T), comparator: comparator}
 }
 
-func newListComparable[T bool | float64 | int | rune | string]() *boundList[T] {
+func newListComparable[T comparable]() *boundList[T] {
 	return newList(func(t1, t2 T) bool { return t1 == t2 })
 }
 
@@ -335,7 +313,7 @@ func bindList[T any](v *[]T, comparator func(T, T) bool) *boundList[T] {
 	return l
 }
 
-func bindListComparable[T bool | float64 | int | rune | string](v *[]T) *boundList[T] {
+func bindListComparable[T comparable](v *[]T) *boundList[T] {
 	return bindList(v, func(t1, t2 T) bool { return t1 == t2 })
 }
 

--- a/data/binding/sprintf.go
+++ b/data/binding/sprintf.go
@@ -24,7 +24,7 @@ func NewSprintf(format string, b ...DataItem) String {
 	ret := &sprintfString{
 		String: NewString(),
 		format: format,
-		source: append(make([]DataItem, 0, len(b)), b...),
+		source: b,
 	}
 
 	for _, value := range b {

--- a/data/binding/trees.go
+++ b/data/binding/trees.go
@@ -72,7 +72,7 @@ type ExternalBoolTree = ExternalTree[bool]
 // NewBoolTree returns a bindable tree of bool values.
 //
 // Since: 2.4
-func NewBoolTree() BoolTree {
+func NewBoolTree() Tree[bool] {
 	return newTreeComparable[bool]()
 }
 
@@ -81,7 +81,7 @@ func NewBoolTree() BoolTree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindBoolTree(ids *map[string][]string, v *map[string]bool) ExternalBoolTree {
+func BindBoolTree(ids *map[string][]string, v *map[string]bool) ExternalTree[bool] {
 	return bindTreeComparable(ids, v)
 }
 
@@ -98,7 +98,7 @@ type ExternalBytesTree = ExternalTree[[]byte]
 // NewBytesTree returns a bindable tree of []byte values.
 //
 // Since: 2.4
-func NewBytesTree() BytesTree {
+func NewBytesTree() Tree[[]byte] {
 	return newTree(bytes.Equal)
 }
 
@@ -107,7 +107,7 @@ func NewBytesTree() BytesTree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindBytesTree(ids *map[string][]string, v *map[string][]byte) ExternalBytesTree {
+func BindBytesTree(ids *map[string][]string, v *map[string][]byte) ExternalTree[[]byte] {
 	return bindTree(ids, v, bytes.Equal)
 }
 
@@ -124,7 +124,7 @@ type ExternalFloatTree = ExternalTree[float64]
 // NewFloatTree returns a bindable tree of float64 values.
 //
 // Since: 2.4
-func NewFloatTree() FloatTree {
+func NewFloatTree() Tree[float64] {
 	return newTreeComparable[float64]()
 }
 
@@ -133,7 +133,7 @@ func NewFloatTree() FloatTree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindFloatTree(ids *map[string][]string, v *map[string]float64) ExternalFloatTree {
+func BindFloatTree(ids *map[string][]string, v *map[string]float64) ExternalTree[float64] {
 	return bindTreeComparable(ids, v)
 }
 
@@ -150,7 +150,7 @@ type ExternalIntTree = ExternalTree[int]
 // NewIntTree returns a bindable tree of int values.
 //
 // Since: 2.4
-func NewIntTree() IntTree {
+func NewIntTree() Tree[int] {
 	return newTreeComparable[int]()
 }
 
@@ -159,7 +159,7 @@ func NewIntTree() IntTree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindIntTree(ids *map[string][]string, v *map[string]int) ExternalIntTree {
+func BindIntTree(ids *map[string][]string, v *map[string]int) ExternalTree[int] {
 	return bindTreeComparable(ids, v)
 }
 
@@ -176,7 +176,7 @@ type ExternalRuneTree = ExternalTree[rune]
 // NewRuneTree returns a bindable tree of rune values.
 //
 // Since: 2.4
-func NewRuneTree() RuneTree {
+func NewRuneTree() Tree[rune] {
 	return newTreeComparable[rune]()
 }
 
@@ -185,7 +185,7 @@ func NewRuneTree() RuneTree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindRuneTree(ids *map[string][]string, v *map[string]rune) ExternalRuneTree {
+func BindRuneTree(ids *map[string][]string, v *map[string]rune) ExternalTree[rune] {
 	return bindTreeComparable(ids, v)
 }
 
@@ -202,7 +202,7 @@ type ExternalStringTree = ExternalTree[string]
 // NewStringTree returns a bindable tree of string values.
 //
 // Since: 2.4
-func NewStringTree() StringTree {
+func NewStringTree() Tree[string] {
 	return newTreeComparable[string]()
 }
 
@@ -211,7 +211,7 @@ func NewStringTree() StringTree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindStringTree(ids *map[string][]string, v *map[string]string) ExternalStringTree {
+func BindStringTree(ids *map[string][]string, v *map[string]string) ExternalTree[string] {
 	return bindTreeComparable(ids, v)
 }
 
@@ -228,7 +228,7 @@ type ExternalUntypedTree = ExternalTree[any]
 // NewUntypedTree returns a bindable tree of any values.
 //
 // Since: 2.5
-func NewUntypedTree() UntypedTree {
+func NewUntypedTree() Tree[any] {
 	return newTree(func(a1, a2 any) bool { return a1 == a2 })
 }
 
@@ -237,7 +237,7 @@ func NewUntypedTree() UntypedTree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindUntypedTree(ids *map[string][]string, v *map[string]any) ExternalUntypedTree {
+func BindUntypedTree(ids *map[string][]string, v *map[string]any) ExternalTree[any] {
 	return bindTree(ids, v, func(a1, a2 any) bool { return a1 == a2 })
 }
 
@@ -254,7 +254,7 @@ type ExternalURITree = ExternalTree[fyne.URI]
 // NewURITree returns a bindable tree of fyne.URI values.
 //
 // Since: 2.4
-func NewURITree() URITree {
+func NewURITree() Tree[fyne.URI] {
 	return newTree(storage.EqualURI)
 }
 
@@ -263,7 +263,7 @@ func NewURITree() URITree {
 // If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
 //
 // Since: 2.4
-func BindURITree(ids *map[string][]string, v *map[string]fyne.URI) ExternalURITree {
+func BindURITree(ids *map[string][]string, v *map[string]fyne.URI) ExternalTree[fyne.URI] {
 	return bindTree(ids, v, storage.EqualURI)
 }
 

--- a/data/binding/trees.go
+++ b/data/binding/trees.go
@@ -10,6 +10,30 @@ import (
 // DataTreeRootID const is the value used as ID for the root of any tree binding.
 const DataTreeRootID = ""
 
+// Tree supports binding a tree of values with type T.
+//
+// Since: 2.7
+type Tree[T any] interface {
+	DataTree
+
+	Append(parent, id string, value T) error
+	Get() (map[string][]string, map[string]T, error)
+	GetValue(id string) (T, error)
+	Prepend(parent, id string, value T) error
+	Remove(id string) error
+	Set(ids map[string][]string, values map[string]T) error
+	SetValue(id string, value T) error
+}
+
+// ExternalTree supports binding a tree of values, of type T, from an external variable.
+//
+// Since: 2.7
+type ExternalTree[T any] interface {
+	Tree[T]
+
+	Reload() error
+}
+
 // DataTree is the base interface for all bindable data trees.
 //
 // Since: 2.4
@@ -22,26 +46,12 @@ type DataTree interface {
 // BoolTree supports binding a tree of bool values.
 //
 // Since: 2.4
-type BoolTree interface {
-	DataTree
-
-	Append(parent, id string, value bool) error
-	Get() (map[string][]string, map[string]bool, error)
-	GetValue(id string) (bool, error)
-	Prepend(parent, id string, value bool) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string]bool) error
-	SetValue(id string, value bool) error
-}
+type BoolTree = Tree[bool]
 
 // ExternalBoolTree supports binding a tree of bool values from an external variable.
 //
 // Since: 2.4
-type ExternalBoolTree interface {
-	BoolTree
-
-	Reload() error
-}
+type ExternalBoolTree = ExternalTree[bool]
 
 // NewBoolTree returns a bindable tree of bool values.
 //
@@ -62,26 +72,12 @@ func BindBoolTree(ids *map[string][]string, v *map[string]bool) ExternalBoolTree
 // BytesTree supports binding a tree of []byte values.
 //
 // Since: 2.4
-type BytesTree interface {
-	DataTree
-
-	Append(parent, id string, value []byte) error
-	Get() (map[string][]string, map[string][]byte, error)
-	GetValue(id string) ([]byte, error)
-	Prepend(parent, id string, value []byte) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string][]byte) error
-	SetValue(id string, value []byte) error
-}
+type BytesTree = Tree[[]byte]
 
 // ExternalBytesTree supports binding a tree of []byte values from an external variable.
 //
 // Since: 2.4
-type ExternalBytesTree interface {
-	BytesTree
-
-	Reload() error
-}
+type ExternalBytesTree = ExternalTree[[]byte]
 
 // NewBytesTree returns a bindable tree of []byte values.
 //
@@ -102,26 +98,12 @@ func BindBytesTree(ids *map[string][]string, v *map[string][]byte) ExternalBytes
 // FloatTree supports binding a tree of float64 values.
 //
 // Since: 2.4
-type FloatTree interface {
-	DataTree
-
-	Append(parent, id string, value float64) error
-	Get() (map[string][]string, map[string]float64, error)
-	GetValue(id string) (float64, error)
-	Prepend(parent, id string, value float64) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string]float64) error
-	SetValue(id string, value float64) error
-}
+type FloatTree = Tree[float64]
 
 // ExternalFloatTree supports binding a tree of float64 values from an external variable.
 //
 // Since: 2.4
-type ExternalFloatTree interface {
-	FloatTree
-
-	Reload() error
-}
+type ExternalFloatTree = ExternalTree[float64]
 
 // NewFloatTree returns a bindable tree of float64 values.
 //
@@ -142,26 +124,12 @@ func BindFloatTree(ids *map[string][]string, v *map[string]float64) ExternalFloa
 // IntTree supports binding a tree of int values.
 //
 // Since: 2.4
-type IntTree interface {
-	DataTree
-
-	Append(parent, id string, value int) error
-	Get() (map[string][]string, map[string]int, error)
-	GetValue(id string) (int, error)
-	Prepend(parent, id string, value int) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string]int) error
-	SetValue(id string, value int) error
-}
+type IntTree = Tree[int]
 
 // ExternalIntTree supports binding a tree of int values from an external variable.
 //
 // Since: 2.4
-type ExternalIntTree interface {
-	IntTree
-
-	Reload() error
-}
+type ExternalIntTree = ExternalTree[int]
 
 // NewIntTree returns a bindable tree of int values.
 //
@@ -182,26 +150,12 @@ func BindIntTree(ids *map[string][]string, v *map[string]int) ExternalIntTree {
 // RuneTree supports binding a tree of rune values.
 //
 // Since: 2.4
-type RuneTree interface {
-	DataTree
-
-	Append(parent, id string, value rune) error
-	Get() (map[string][]string, map[string]rune, error)
-	GetValue(id string) (rune, error)
-	Prepend(parent, id string, value rune) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string]rune) error
-	SetValue(id string, value rune) error
-}
+type RuneTree = Tree[rune]
 
 // ExternalRuneTree supports binding a tree of rune values from an external variable.
 //
 // Since: 2.4
-type ExternalRuneTree interface {
-	RuneTree
-
-	Reload() error
-}
+type ExternalRuneTree = ExternalTree[rune]
 
 // NewRuneTree returns a bindable tree of rune values.
 //
@@ -222,26 +176,12 @@ func BindRuneTree(ids *map[string][]string, v *map[string]rune) ExternalRuneTree
 // StringTree supports binding a tree of string values.
 //
 // Since: 2.4
-type StringTree interface {
-	DataTree
-
-	Append(parent, id string, value string) error
-	Get() (map[string][]string, map[string]string, error)
-	GetValue(id string) (string, error)
-	Prepend(parent, id string, value string) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string]string) error
-	SetValue(id string, value string) error
-}
+type StringTree = Tree[string]
 
 // ExternalStringTree supports binding a tree of string values from an external variable.
 //
 // Since: 2.4
-type ExternalStringTree interface {
-	StringTree
-
-	Reload() error
-}
+type ExternalStringTree = ExternalTree[string]
 
 // NewStringTree returns a bindable tree of string values.
 //
@@ -262,26 +202,12 @@ func BindStringTree(ids *map[string][]string, v *map[string]string) ExternalStri
 // UntypedTree supports binding a tree of any values.
 //
 // Since: 2.5
-type UntypedTree interface {
-	DataTree
-
-	Append(parent, id string, value any) error
-	Get() (map[string][]string, map[string]any, error)
-	GetValue(id string) (any, error)
-	Prepend(parent, id string, value any) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string]any) error
-	SetValue(id string, value any) error
-}
+type UntypedTree = Tree[any]
 
 // ExternalUntypedTree supports binding a tree of any values from an external variable.
 //
 // Since: 2.5
-type ExternalUntypedTree interface {
-	UntypedTree
-
-	Reload() error
-}
+type ExternalUntypedTree = ExternalTree[any]
 
 // NewUntypedTree returns a bindable tree of any values.
 //
@@ -302,26 +228,12 @@ func BindUntypedTree(ids *map[string][]string, v *map[string]any) ExternalUntype
 // URITree supports binding a tree of fyne.URI values.
 //
 // Since: 2.4
-type URITree interface {
-	DataTree
-
-	Append(parent, id string, value fyne.URI) error
-	Get() (map[string][]string, map[string]fyne.URI, error)
-	GetValue(id string) (fyne.URI, error)
-	Prepend(parent, id string, value fyne.URI) error
-	Remove(id string) error
-	Set(ids map[string][]string, values map[string]fyne.URI) error
-	SetValue(id string, value fyne.URI) error
-}
+type URITree = Tree[fyne.URI]
 
 // ExternalURITree supports binding a tree of fyne.URI values from an external variable.
 //
 // Since: 2.4
-type ExternalURITree interface {
-	URITree
-
-	Reload() error
-}
+type ExternalURITree = ExternalTree[fyne.URI]
 
 // NewURITree returns a bindable tree of fyne.URI values.
 //

--- a/data/binding/trees.go
+++ b/data/binding/trees.go
@@ -34,6 +34,22 @@ type ExternalTree[T any] interface {
 	Reload() error
 }
 
+// NewTree returns a bindable tree of values with type T.
+//
+// Since: 2.7
+func NewTree[T any](comparator func(T, T) bool) Tree[T] {
+	return newTree[T](comparator)
+}
+
+// BindTree returns a bound tree of values with type T, based on the contents of the passed values.
+// The ids map specifies how each item relates to its parent (with id ""), with the values being in the v map.
+// If your code changes the content of the maps this refers to you should call Reload() to inform the bindings.
+//
+// Since: 2.7
+func BindTree[T any](ids *map[string][]string, v *map[string]T, comparator func(T, T) bool) ExternalTree[T] {
+	return bindTree(ids, v, comparator)
+}
+
 // DataTree is the base interface for all bindable data trees.
 //
 // Since: 2.4
@@ -337,7 +353,7 @@ func newTree[T any](comparator func(T, T) bool) *boundTree[T] {
 	return t
 }
 
-func newTreeComparable[T bool | float64 | int | rune | string]() *boundTree[T] {
+func newTreeComparable[T comparable]() *boundTree[T] {
 	return newTree(func(t1, t2 T) bool { return t1 == t2 })
 }
 
@@ -359,7 +375,7 @@ func bindTree[T any](ids *map[string][]string, v *map[string]T, comparator func(
 	return t
 }
 
-func bindTreeComparable[T bool | float64 | int | rune | string](ids *map[string][]string, v *map[string]T) *boundTree[T] {
+func bindTreeComparable[T comparable](ids *map[string][]string, v *map[string]T) *boundTree[T] {
 	return bindTree(ids, v, func(t1, t2 T) bool { return t1 == t2 })
 }
 

--- a/data/binding/trees.go
+++ b/data/binding/trees.go
@@ -300,11 +300,8 @@ func (t *treeBase) ChildIDs(id string) []string {
 
 func (t *treeBase) appendItem(i DataItem, id, parent string) {
 	t.items[id] = i
-	ids, ok := t.ids[parent]
-	if !ok {
-		ids = make([]string, 0)
-	}
 
+	ids := t.ids[parent]
 	for _, in := range ids {
 		if in == id {
 			return
@@ -389,12 +386,8 @@ type boundTree[T any] struct {
 
 func (t *boundTree[T]) Append(parent, id string, val T) error {
 	t.lock.Lock()
-	ids, ok := t.ids[parent]
-	if !ok {
-		ids = make([]string, 0)
-	}
 
-	t.ids[parent] = append(ids, id)
+	t.ids[parent] = append(t.ids[parent], id)
 	v := *t.val
 	v[id] = val
 
@@ -428,12 +421,8 @@ func (t *boundTree[T]) GetValue(id string) (T, error) {
 
 func (t *boundTree[T]) Prepend(parent, id string, val T) error {
 	t.lock.Lock()
-	ids, ok := t.ids[parent]
-	if !ok {
-		ids = make([]string, 0)
-	}
 
-	t.ids[parent] = append([]string{id}, ids...)
+	t.ids[parent] = append([]string{id}, t.ids[parent]...)
 	v := *t.val
 	v[id] = val
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

With this landed, all of the APIs for data binding have generic versions except for Map and Struct bindings. They are so heavy with reflect uses that I didn't quite feel like digging around in the code.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- covered by existing ones
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
