### PR TITLE
Don't make() slices to zero

### DIFF
--- a/internal/repository/memory.go
+++ b/internal/repository/memory.go
@@ -104,31 +104,22 @@ func (n *nodeReaderWriter) Close() error {
 // This implementation automatically creates the path n.path if it does not
 // exist. If it does exist, it is overwritten.
 func (n *nodeReaderWriter) Write(p []byte) (int, error) {
-	// guarantee that the path exists
-	_, ok := n.repo.Data[n.path]
-	if !ok {
-		n.repo.Data[n.path] = []byte{}
-	}
-
 	// overwrite the file if we haven't already started writing to it
 	if !n.writing {
-		n.repo.Data[n.path] = make([]byte, 0)
+		n.repo.Data[n.path] = make([]byte, 0, len(p))
 		n.writing = true
 	}
 
 	// copy the data into the node buffer
-	count := 0
-	start := n.writeCursor
-	for ; n.writeCursor < start+len(p); n.writeCursor++ {
+	for start := n.writeCursor; n.writeCursor < start+len(p); n.writeCursor++ {
 		// extend the file if needed
 		if len(n.repo.Data) < n.writeCursor+len(p) {
 			n.repo.Data[n.path] = append(n.repo.Data[n.path], 0)
 		}
 		n.repo.Data[n.path][n.writeCursor] = p[n.writeCursor-start]
-		count++
 	}
 
-	return count, nil
+	return len(p), nil
 }
 
 // Name implements fyne.URIReadCloser.URI and fyne.URIWriteCloser.URI

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -153,7 +153,7 @@ func renderChildren(source []byte, n ast.Node, blockquote bool) ([]RichTextSegme
 }
 
 func forceIntoText(source []byte, n ast.Node) string {
-	texts := make([]string, 0)
+	texts := []string{}
 	ast.Walk(n, func(n2 ast.Node, entering bool) (ast.WalkStatus, error) {
 		if entering {
 			switch t := n2.(type) {


### PR DESCRIPTION


<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I noted that some old code seemed to be written without the knowledge of nil slices being valid to use as is. Clean up that code and let Go handle the size instead of making to zero size.  Go 1.25 can stack allocate a slice of length 32 automatically.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

