### PR TITLE
Compute json theme colors on load instead of on lookup

### DIFF
--- a/theme/json_test.go
+++ b/theme/json_test.go
@@ -55,26 +55,33 @@ func TestFromTOML_Resource(t *testing.T) {
 }
 
 func TestHexColor(t *testing.T) {
-	c, err := hexColor("#abc").color(nil)
+	c := hexColor{str: "#abc"}
+	err := c.parseColor()
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c)
-	c, err = hexColor("abc").color(nil)
+	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c.color)
+	c = hexColor{str: "abc"}
+	err = c.parseColor()
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c)
-	c, err = hexColor("#abcd").color(nil)
+	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c.color)
+	c = hexColor{str: "#abcd"}
+	err = c.parseColor()
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xdd}, c)
+	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xdd}, c.color)
 
-	c, err = hexColor("#a1b2c3").color(nil)
+	c = hexColor{str: "#a1b2c3"}
+	err = c.parseColor()
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c)
-	c, err = hexColor("a1b2c3").color(nil)
+	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c.color)
+	c = hexColor{str: "a1b2c3"}
+	err = c.parseColor()
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c)
-	c, err = hexColor("#a1b2c3f4").color(nil)
+	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c.color)
+	c = hexColor{str: "#a1b2c3f4"}
+	err = c.parseColor()
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c)
-	c, err = hexColor("a1b2c3f4").color(nil)
+	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c.color)
+	c = hexColor{str: "a1b2c3f4"}
+	err = c.parseColor()
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c)
+	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c.color)
 }


### PR DESCRIPTION
### Description:
Previously, json themes parsed the color string for a color each time it was looked up. This was less bad than it sounds because there was a color cache map. However, this was still much slower than builtin themes because color lookups had to do two map accesses (One for the color string, one for the color for that color string). 

This PR removes a map access on color lookup by computing all theme colors when the theme is loaded, instead of on color access.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
