### PR TITLE
Add support for IPv6 addresses in ParseURI

### DIFF
--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -83,6 +83,7 @@ func ParseURI(s string) (fyne.URI, error) {
 
 	authority := l.Authority()
 	authBuilder := strings.Builder{}
+	authBuilder.Grow(len(authority.UserInfo()) + len(authority.Host()) + len(authority.Port()) + len("@[]:"))
 
 	if userInfo := authority.UserInfo(); userInfo != "" {
 		authBuilder.WriteString(userInfo)

--- a/storage/repository/parse_test.go
+++ b/storage/repository/parse_test.go
@@ -23,6 +23,16 @@ func TestParseURI(t *testing.T) {
 	uri, err = ParseURI("file://C:/tmp/foo.txt")
 	assert.NoError(t, err)
 	assert.Equal(t, "file://C:/tmp/foo.txt", uri.String())
+
+	IPv6url := "http://[2001:db8:4006:812::200e]:8080/path/page.html"
+	uri, err = ParseURI(IPv6url)
+	assert.NoError(t, err)
+	assert.Equal(t, IPv6url, uri.String())
+
+	IPv6url = "http://[2001:db8:4006:812::200e]/path/page.html"
+	uri, err = ParseURI(IPv6url)
+	assert.NoError(t, err)
+	assert.Equal(t, IPv6url, uri.String())
 }
 
 func TestParseInvalidURI(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Noticed this when working on other stuff. You can't just blindly do host + ":" + port any more. It is recommended to use net.JoinHostPort but we don't always have a port so we avoid dealing with the colon this way.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

