### PR TITLE
Rework map binding to avoid recover() and reduce duplication

### DIFF
--- a/data/binding/maps.go
+++ b/data/binding/maps.go
@@ -289,13 +289,13 @@ func (b *boundStruct) Reload() (retErr error) {
 		var err error
 		switch kind {
 		case reflect.Bool:
-			err = b.items[key].set(f.Bool())
+			err = b.items[key].(*boundReflect[bool]).Set(f.Bool())
 		case reflect.Float32, reflect.Float64:
-			err = b.items[key].set(f.Float())
+			err = b.items[key].(*boundReflect[float64]).Set(f.Float())
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			err = b.items[key].set(int(f.Int()))
+			err = b.items[key].(*boundReflect[int]).Set(int(f.Int()))
 		case reflect.String:
-			err = b.items[key].set(f.String())
+			err = b.items[key].(*boundReflect[string]).Set(f.String())
 		}
 		if err != nil {
 			retErr = err
@@ -403,7 +403,7 @@ func bindReflect(field reflect.Value) reflectUntyped {
 	case reflect.Float32, reflect.Float64:
 		return &boundReflect[float64]{val: field}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return &boundReflect[int64]{val: field}
+		return &boundReflect[int]{val: field}
 	case reflect.String:
 		return &boundReflect[string]{val: field}
 	}

--- a/data/binding/maps.go
+++ b/data/binding/maps.go
@@ -289,13 +289,13 @@ func (b *boundStruct) Reload() (retErr error) {
 		var err error
 		switch kind {
 		case reflect.Bool:
-			err = b.items[key].(*reflectBool).Set(f.Bool())
+			err = b.items[key].set(f.Bool())
 		case reflect.Float32, reflect.Float64:
-			err = b.items[key].(*reflectFloat).Set(f.Float())
+			err = b.items[key].set(f.Float())
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			err = b.items[key].(*reflectInt).Set(int(f.Int()))
+			err = b.items[key].set(int(f.Int()))
 		case reflect.String:
-			err = b.items[key].(*reflectString).Set(f.String())
+			err = b.items[key].set(f.String())
 		}
 		if err != nil {
 			retErr = err
@@ -353,170 +353,59 @@ func (b *boundExternalMapValue) setIfChanged(val any) error {
 	return b.set(val)
 }
 
-type boundReflect struct {
+type boundReflect[T any] struct {
 	base
 
 	val reflect.Value
 }
 
-func (b *boundReflect) get() (any, error) {
+func (b *boundReflect[T]) Get() (T, error) {
+	var zero T
+	val, err := b.get()
+	if err != nil {
+		return zero, err
+	}
+
+	casted, ok := val.(T)
+	if !ok {
+		return zero, errors.New("unable to convert value to type")
+	}
+
+	return casted, nil
+}
+
+func (b *boundReflect[T]) Set(val T) error {
+	return b.set(val)
+}
+
+func (b *boundReflect[T]) get() (any, error) {
+	if !b.val.CanInterface() {
+		return nil, errors.New("unable to get value from data binding")
+	}
+
 	return b.val.Interface(), nil
 }
 
-func (b *boundReflect) set(val any) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("unable to set bool in data binding")
-		}
-	}()
-	b.val.Set(reflect.ValueOf(val))
+func (b *boundReflect[T]) set(val any) error {
+	if !b.val.CanSet() {
+		return errors.New("unable to set value in data binding")
+	}
 
+	b.val.Set(reflect.ValueOf(val))
 	b.trigger()
 	return nil
-}
-
-type reflectBool struct {
-	boundReflect
-}
-
-func (r *reflectBool) Get() (val bool, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("invalid bool value in data binding")
-		}
-	}()
-
-	val = r.val.Bool()
-	return val, err
-}
-
-func (r *reflectBool) Set(b bool) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("unable to set bool in data binding")
-		}
-	}()
-
-	r.val.SetBool(b)
-	r.trigger()
-	return err
-}
-
-func bindReflectBool(f reflect.Value) reflectUntyped {
-	r := &reflectBool{}
-	r.val = f
-	return r
-}
-
-type reflectFloat struct {
-	boundReflect
-}
-
-func (r *reflectFloat) Get() (val float64, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("invalid float64 value in data binding")
-		}
-	}()
-
-	val = r.val.Float()
-	return val, err
-}
-
-func (r *reflectFloat) Set(f float64) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("unable to set float64 in data binding")
-		}
-	}()
-
-	r.val.SetFloat(f)
-	r.trigger()
-	return err
-}
-
-func bindReflectFloat(f reflect.Value) reflectUntyped {
-	r := &reflectFloat{}
-	r.val = f
-	return r
-}
-
-type reflectInt struct {
-	boundReflect
-}
-
-func (r *reflectInt) Get() (val int, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("invalid int value in data binding")
-		}
-	}()
-
-	val = int(r.val.Int())
-	return val, err
-}
-
-func (r *reflectInt) Set(i int) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("unable to set int in data binding")
-		}
-	}()
-
-	r.val.SetInt(int64(i))
-	r.trigger()
-	return err
-}
-
-func bindReflectInt(f reflect.Value) reflectUntyped {
-	r := &reflectInt{}
-	r.val = f
-	return r
-}
-
-type reflectString struct {
-	boundReflect
-}
-
-func (r *reflectString) Get() (val string, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("invalid string value in data binding")
-		}
-	}()
-
-	val = r.val.String()
-	return val, err
-}
-
-func (r *reflectString) Set(s string) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("unable to set string in data binding")
-		}
-	}()
-
-	r.val.SetString(s)
-	r.trigger()
-	return err
-}
-
-func bindReflectString(f reflect.Value) reflectUntyped {
-	r := &reflectString{}
-	r.val = f
-	return r
 }
 
 func bindReflect(field reflect.Value) reflectUntyped {
 	switch field.Kind() {
 	case reflect.Bool:
-		return bindReflectBool(field)
+		return &boundReflect[bool]{val: field}
 	case reflect.Float32, reflect.Float64:
-		return bindReflectFloat(field)
+		return &boundReflect[float64]{val: field}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return bindReflectInt(field)
+		return &boundReflect[int64]{val: field}
 	case reflect.String:
-		return bindReflectString(field)
+		return &boundReflect[string]{val: field}
 	}
-	return &boundReflect{val: field}
+	return &boundReflect[any]{val: field}
 }

--- a/data/binding/maps_test.go
+++ b/data/binding/maps_test.go
@@ -9,29 +9,29 @@ import (
 
 func TestBindReflectInt(t *testing.T) {
 	i := 5
-	b := bindReflectInt(reflect.ValueOf(&i).Elem())
-	v, err := b.(Int).Get()
+	b := &boundReflect[int]{val: reflect.ValueOf(&i).Elem()}
+	v, err := b.Get()
 	assert.Nil(t, err)
 	assert.Equal(t, 5, v)
 
-	err = b.(Int).Set(4)
+	err = b.Set(4)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, i)
 
 	s := "hi"
-	b = bindReflectInt(reflect.ValueOf(&s).Elem())
-	_, err = b.(Int).Get()
+	b.val = reflect.ValueOf(&s).Elem()
+	_, err = b.Get()
 	assert.NotNil(t, err) // don't crash
 }
 
 func TestBindReflectString(t *testing.T) {
 	s := "Hi"
-	b := bindReflectString(reflect.ValueOf(&s).Elem())
-	v, err := b.(String).Get()
+	b := &boundReflect[string]{val: reflect.ValueOf(&s).Elem()}
+	v, err := b.Get()
 	assert.Nil(t, err)
 	assert.Equal(t, "Hi", v)
 
-	err = b.(String).Set("New")
+	err = b.Set("New")
 	assert.Nil(t, err)
 	assert.Equal(t, "New", s)
 }

--- a/data/binding/preference.go
+++ b/data/binding/preference.go
@@ -200,9 +200,6 @@ func (b *prefBoundList[T]) checkForChange() {
 		b.Set(updated)
 		return
 	}
-	if val == nil {
-		return
-	}
 
 	// incoming changes to a preference list are not at the child level
 	for i, v := range val {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This cleans up some code duplication in the map binding and uses one of the new `reflect.Value.CanXYZ` methods from Go 1.18 to allow us to stop using `recover()`.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

