### PR TITLE
Remove recover from svg drawing

### DIFF
--- a/internal/svg/svg.go
+++ b/internal/svg/svg.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -83,12 +82,7 @@ func (d *Decoder) Draw(width, height int) (*image.NRGBA, error) {
 	img := image.NewNRGBA(image.Rect(0, 0, imgW, imgH))
 	scanner := rasterx.NewScannerGV(config.Width, config.Height, img, img.Bounds())
 	raster := rasterx.NewDasher(width, height, scanner)
-
-	err := drawSVGSafely(d.icon, raster)
-	if err != nil {
-		err = fmt.Errorf("SVG render error: %w", err)
-		return nil, err
-	}
+	d.icon.Draw(raster, 1)
 	return img, nil
 }
 
@@ -315,16 +309,4 @@ func colorToHexAndOpacity(color color.Color) (hexStr, aStr string) {
 	cBytes := []byte{byte(r), byte(g), byte(b)}
 	hexStr, aStr = "#"+hex.EncodeToString(cBytes), strconv.FormatFloat(float64(a)/0xff, 'f', 6, 64)
 	return hexStr, aStr
-}
-
-func drawSVGSafely(icon *oksvg.SvgIcon, raster *rasterx.Dasher) error {
-	var err error
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("crash when rendering svg")
-		}
-	}()
-	icon.Draw(raster, 1)
-
-	return err
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I ran all `.svg` files I could find on my system through a test application that I wrote and it did not crash once with this change (although there were some other printed errors from the image loading related to  strconv.Atoi used on floating point values among other things). After that, I believe that the recover no longer is relevant. Also, we should fix the crash in the dependency instead of working around the issue there in any case. I anyone has a file which does crash, please provide one.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
