### PR TITLE
Avoid trying to load JSON theme twice

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -131,7 +131,7 @@ func (s *settings) setupTheme() {
 	variant := app.DefaultVariant()
 	effectiveTheme := s.theme
 	if !s.themeSpecified {
-		effectiveTheme = s.loadSystemTheme()
+		effectiveTheme = theme.DefaultTheme()
 	}
 	switch name {
 	case "light":

--- a/app/settings_desktop.go
+++ b/app/settings_desktop.go
@@ -3,13 +3,10 @@
 package app
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/app"
-	"fyne.io/fyne/v2/theme"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -60,26 +57,6 @@ func watchFile(path string, callback func()) *fsnotify.Watcher {
 
 	watchFileAddTarget(watcher, path)
 	return watcher
-}
-
-func (s *settings) loadSystemTheme() fyne.Theme {
-	path := filepath.Join(app.RootConfigDir(), "theme.json")
-	f, err := os.Open(path)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			fyne.LogError("Failed to load user theme file: "+path, err)
-		}
-		return theme.DefaultTheme()
-	}
-	defer f.Close()
-
-	th, err := theme.FromJSONReader(bufio.NewReader(f))
-	if err != nil {
-		fyne.LogError("Failed to parse user theme file: "+path, err)
-		return theme.DefaultTheme()
-	}
-
-	return th
 }
 
 func (s *settings) watchSettings() {

--- a/app/settings_file.go
+++ b/app/settings_file.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"bufio"
 	"encoding/json"
 	"io"
 	"os"
@@ -28,7 +29,5 @@ func (s *settings) loadFromFile(path string) error {
 		return err
 	}
 	defer file.Close()
-	decode := json.NewDecoder(file)
-
-	return decode.Decode(&s.schema)
+	return json.NewDecoder(bufio.NewReader(file)).Decode(&s.schema)
 }

--- a/app/settings_mobile.go
+++ b/app/settings_mobile.go
@@ -2,15 +2,6 @@
 
 package app
 
-import (
-	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
-)
-
-func (s *settings) loadSystemTheme() fyne.Theme {
-	return theme.DefaultTheme()
-}
-
 func (s *settings) watchSettings() {
 	// no-op on mobile
 }

--- a/app/settings_wasm.go
+++ b/app/settings_wasm.go
@@ -2,11 +2,6 @@
 
 package app
 
-import (
-	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
-)
-
 func (s *settings) load() {
 	s.setupTheme()
 	s.schema.Scale = 1
@@ -14,10 +9,6 @@ func (s *settings) load() {
 
 func (s *settings) loadFromFile(path string) error {
 	return nil
-}
-
-func (s *settings) loadSystemTheme() fyne.Theme {
-	return theme.DefaultTheme()
 }
 
 func watchFile(path string, callback func()) {

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -312,7 +312,7 @@ func lightPaletteColorNamed(name fyne.ThemeColorName) color.Color {
 }
 
 func loadCustomFont(env, variant string, fallback fyne.Resource) fyne.Resource {
-	variantPath := strings.Replace(env, "Regular", variant, -1)
+	variantPath := strings.ReplaceAll(env, "Regular", variant)
 
 	res, err := fyne.LoadResourceFromPath(variantPath)
 	if err != nil {

--- a/theme/theme_desktop.go
+++ b/theme/theme_desktop.go
@@ -3,7 +3,7 @@
 package theme
 
 import (
-	"bytes"
+	"bufio"
 	"os"
 	"path/filepath"
 
@@ -12,22 +12,21 @@ import (
 )
 
 func setupSystemTheme(fallback fyne.Theme) fyne.Theme {
-	root := internalApp.RootConfigDir()
-
-	path := filepath.Join(root, "theme.json")
-	data, err := fyne.LoadResourceFromPath(path)
+	path := filepath.Join(internalApp.RootConfigDir(), "theme.json")
+	f, err := os.Open(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			fyne.LogError("Failed to load user theme file: "+path, err)
 		}
 		return nil
 	}
-	if data != nil && data.Content() != nil {
-		th, err := fromJSONWithFallback(bytes.NewReader(data.Content()), fallback)
-		if err == nil {
-			return th
-		}
+	defer f.Close()
+
+	th, err := fromJSONWithFallback(bufio.NewReader(f), fallback)
+	if err != nil {
 		fyne.LogError("Failed to parse user theme file: "+path, err)
+		return nil
 	}
-	return nil
+
+	return th
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is a follow up to #5921. Remove some code duplication around loading the theme and also rewrite the lookup to not read the entire file into memory before parsing the json data. Apply the same buffered reading when reading the settings as well. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

