### PR TITLE
Add new uniforms to es, mobile, and wasm drivers as well

### DIFF
--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -78,7 +78,7 @@ func (p *painter) Init() {
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
-	p.getUniformLocations(p.program, "text", "alpha")
+	p.getUniformLocations(p.program, "text", "alpha", "cornerRadius", "size")
 	p.enableAttribArrays(p.program, "vert", "vertTexCoord")
 
 	p.lineProgram = ProgramState{

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -74,7 +74,7 @@ func (p *painter) Init() {
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
-		p.getUniformLocations(p.program, "text", "alpha")
+		p.getUniformLocations(p.program, "text", "alpha", "cornerRadius", "size")
 		p.enableAttribArrays(p.program, "vert", "vertTexCoord")
 
 		p.lineProgram = ProgramState{

--- a/internal/painter/gl/gl_wasm.go
+++ b/internal/painter/gl/gl_wasm.go
@@ -69,7 +69,7 @@ func (p *painter) Init() {
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
-	p.getUniformLocations(p.program, "text", "alpha")
+	p.getUniformLocations(p.program, "text", "alpha", "cornerRadius", "size")
 	p.enableAttribArrays(p.program, "vert", "vertTexCoord")
 
 	p.lineProgram = ProgramState{


### PR DESCRIPTION
### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Recent changes to the gl_core driver were not ported to the other drivers. This was causing es, mobile, and wasm drivers to crash. 

I noticed this when starting up a mobile application on the latest develop. 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
