### PR TITLE
Remove two unnecessary uses of strings.Join

### DIFF
--- a/driver/desktop/shortcut.go
+++ b/driver/desktop/shortcut.go
@@ -31,33 +31,30 @@ func (cs *CustomShortcut) Mod() fyne.KeyModifier {
 	return cs.Modifier
 }
 
-// ShortcutName returns the shortcut name associated to the event
+// ShortcutName returns the shortcut name associated to the event.
 func (cs *CustomShortcut) ShortcutName() string {
 	id := &strings.Builder{}
 	id.WriteString("CustomDesktop:")
-	id.WriteString(modifierToString(cs.Modifier))
-	id.WriteString("+")
+	writeModifiers(id, cs.Modifier)
 	id.WriteString(string(cs.KeyName))
 	return id.String()
 }
 
-func modifierToString(mods fyne.KeyModifier) string {
-	s := []string{}
+func writeModifiers(w *strings.Builder, mods fyne.KeyModifier) {
 	if (mods & fyne.KeyModifierShift) != 0 {
-		s = append(s, string("Shift"))
+		w.WriteString("Shift+")
 	}
 	if (mods & fyne.KeyModifierControl) != 0 {
-		s = append(s, string("Control"))
+		w.WriteString("Control+")
 	}
 	if (mods & fyne.KeyModifierAlt) != 0 {
-		s = append(s, string("Alt"))
+		w.WriteString("Alt+")
 	}
 	if (mods & fyne.KeyModifierSuper) != 0 {
 		if runtime.GOOS == "darwin" {
-			s = append(s, string("Command"))
+			w.WriteString("Command+")
 		} else {
-			s = append(s, string("Super"))
+			w.WriteString("Super+")
 		}
 	}
-	return strings.Join(s, "+")
 }

--- a/driver/desktop/shortcut_test.go
+++ b/driver/desktop/shortcut_test.go
@@ -33,6 +33,13 @@ func TestCustomShortcut_Shortcut(t *testing.T) {
 			},
 			want: "CustomDesktop:Control+Alt+Escape",
 		},
+		{
+			name: "Ctrl+Alt+Shift+Esc",
+			fields: fields{
+				KeyName: fyne.KeyEscape,
+			},
+			want: "CustomDesktop:Escape",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/driver/desktop/shortcut_test.go
+++ b/driver/desktop/shortcut_test.go
@@ -1,6 +1,7 @@
 package desktop
 
 import (
+	"strings"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -70,7 +71,14 @@ func Test_modifierToString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := modifierToString(tt.mods); got != tt.want {
+			w := &strings.Builder{}
+			writeModifiers(w, tt.mods)
+			str := w.String()
+			if str != "" {
+				str = str[:len(str)-1] // Slice off extra plus symbol.
+			}
+
+			if got := str; got != tt.want {
 				t.Errorf("modifierToString() = %v, want %v", got, tt.want)
 			}
 		})

--- a/driver/desktop/shortcut_test.go
+++ b/driver/desktop/shortcut_test.go
@@ -34,7 +34,7 @@ func TestCustomShortcut_Shortcut(t *testing.T) {
 			want: "CustomDesktop:Control+Alt+Escape",
 		},
 		{
-			name: "Ctrl+Alt+Shift+Esc",
+			name: "Esc",
 			fields: fields{
 				KeyName: fyne.KeyEscape,
 			},

--- a/driver/desktop/shortcut_test.go
+++ b/driver/desktop/shortcut_test.go
@@ -61,24 +61,19 @@ func Test_modifierToString(t *testing.T) {
 		{
 			name: "Ctrl",
 			mods: fyne.KeyModifierControl,
-			want: "Control",
+			want: "Control+",
 		},
 		{
 			name: "Shift+Ctrl",
 			mods: fyne.KeyModifierShift + fyne.KeyModifierControl,
-			want: "Shift+Control",
+			want: "Shift+Control+",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &strings.Builder{}
 			writeModifiers(w, tt.mods)
-			str := w.String()
-			if str != "" {
-				str = str[:len(str)-1] // Slice off extra plus symbol.
-			}
-
-			if got := str; got != tt.want {
+			if got := w.String(); got != tt.want {
 				t.Errorf("modifierToString() = %v, want %v", got, tt.want)
 			}
 		})

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -153,21 +153,22 @@ func renderChildren(source []byte, n ast.Node, blockquote bool) ([]RichTextSegme
 }
 
 func forceIntoText(source []byte, n ast.Node) string {
-	texts := []string{}
+	text := strings.Builder{}
 	ast.Walk(n, func(n2 ast.Node, entering bool) (ast.WalkStatus, error) {
 		if entering {
 			switch t := n2.(type) {
 			case *ast.Text:
-				texts = append(texts, string(t.Value(source)))
+				text.Write(t.Value(source))
+				text.WriteByte(' ')
 			}
 		}
 		return ast.WalkContinue, nil
 	})
-	return strings.Join(texts, " ")
+	return strings.TrimSuffix(text.String(), " ")
 }
 
 func forceIntoHeadingText(source []byte, n ast.Node) string {
-	var text strings.Builder
+	text := strings.Builder{}
 	ast.Walk(n, func(n2 ast.Node, entering bool) (ast.WalkStatus, error) {
 		if entering {
 			switch t := n2.(type) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Sometimes we can avoid first allocating a slice of all text segments and then joining them.

In the case of custom shortcuts, there is always a trailing `+` symbol so we can just always write a trailing one and not add an extra one at the end. This also fixes the output to be correct in the case where there is no modifiers (although a custom shortcut with no modifiers is strange).

For markdown, we can write to a string builder and just trim the trailing space at the end if it exists. This has the added benefit of no longer needing to cast the value from `[]byte` to `string` as we can write it directly as `[]byte`.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
