### PR TITLE
Simplify Parent() and fix bug for empty path

### DIFF
--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/storage"
@@ -155,18 +156,13 @@ func (r *FileRepository) DeleteAll(u fyne.URI) error {
 // Since: 2.0
 func (r *FileRepository) Parent(u fyne.URI) (fyne.URI, error) {
 	p := path.Clean(u.Path())
-	if p == "" || p == "/" || (len(p) == 2 && p[1] == ':') {
+	if p == "." || strings.HasSuffix(p, "/") {
 		return nil, repository.ErrURIRoot
 	}
 
 	parent := path.Dir(p)
 	if parent != "/" {
 		parent += "/"
-	}
-
-	// only root is its own parent
-	if parent == p {
-		return nil, repository.ErrURIRoot
 	}
 
 	return storage.NewFileURI(parent), nil

--- a/internal/repository/file_test.go
+++ b/internal/repository/file_test.go
@@ -317,6 +317,10 @@ func TestFileRepositoryParent(t *testing.T) {
 	_, err = storage.Parent(storage.NewFileURI("/"))
 	assert.Equal(t, repository.ErrURIRoot, err)
 
+	// Test with URI returning empty path (as storage.NewFileURI("") returns PWD):
+	_, err = storage.Parent(repository.NewFileURI(""))
+	assert.Equal(t, repository.ErrURIRoot, err)
+
 	if runtime.GOOS == "windows" {
 		// This is only an error under Windows, on *NIX this is a
 		// relative path to a directory named "C:", which is completely


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This is a small change to simplify the code further from my previous rework of the `.Parent()` mwthod for the `file://` repository. The docs for `path.Clean()` say "`The returned path ends in a slash only if it is the root “/”.`" so we can safely do a check for trailing `/`. Also, handle the case were the given URI returns an empty path (or equivalent) as `path.Clean()` will return `.` in those cases. While at it, remove no longer relevant check for parent and child being the same, it can never happen given the suffix check mentioned above.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
