### PR TITLE
Simplify breadcrumbs

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -471,24 +471,30 @@ func (f *fileDialog) refreshDir(dir fyne.ListableURI) {
 }
 
 func (f *fileDialog) setLocation(dir fyne.URI) error {
-	if f.selectedID > -1 {
-		f.files.Unselect(f.selectedID)
-	}
 	if dir == nil {
 		return errors.New("failed to open nil directory")
 	}
+
+	if f.selectedID > -1 {
+		f.files.Unselect(f.selectedID)
+	}
+
 	list, err := storage.ListerForURI(dir)
 	if err != nil {
 		return err
 	}
 
+	isDir, err := storage.CanList(dir)
+	if err != nil {
+		return err
+	} else if !isDir {
+		return errors.New("location was not a listable URI")
+	}
+
 	fyne.CurrentApp().Preferences().SetString(lastFolderKey, dir.String())
 	isFav := false
 	for i, fav := range f.favorites {
-		if fav.loc == nil {
-			continue
-		}
-		if fav.loc.Path() == dir.Path() {
+		if storage.EqualURI(fav.loc, dir) {
 			f.favoritesList.Select(i)
 			isFav = true
 			break
@@ -502,40 +508,22 @@ func (f *fileDialog) setLocation(dir fyne.URI) error {
 	f.dir = list
 
 	f.breadcrumb.Objects = nil
-
-	localdir := dir.Path()
-	buildDir := filepath.VolumeName(localdir)
-	for i, d := range strings.Split(localdir, "/") {
-		if d == "" {
-			if i > 0 { // what we get if we split "/"
-				break
-			}
-			buildDir = "/"
-			d = "/"
-		} else if i > 0 {
-			buildDir = filepath.Join(buildDir, d)
-		} else {
-			d = buildDir
-			buildDir = d + string(os.PathSeparator)
-		}
-
-		newDir := storage.NewFileURI(buildDir)
-		isDir, err := storage.CanList(newDir)
-		if err != nil {
-			return err
-		}
-
-		if !isDir {
-			return errors.New("location was not a listable URI")
-		}
+	for parent := dir; parent != nil && err == nil; parent, err = storage.Parent(parent) {
+		currentParent := parent
 		f.breadcrumb.Add(
-			widget.NewButton(d, func() {
-				err := f.setLocation(newDir)
+			widget.NewButton(currentParent.Name(), func() {
+				err := f.setLocation(currentParent)
 				if err != nil {
 					fyne.LogError("Failed to set directory", err)
 				}
 			}),
 		)
+	}
+
+	// Use slices.Reverse with Go 1.21:
+	objects := f.breadcrumb.Objects
+	for i, j := 0, len(objects)-1; i < j; i, j = i+1, j-1 {
+		objects[i], objects[j] = objects[j], objects[i]
 	}
 
 	f.breadcrumbScroll.Refresh()

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -274,10 +274,6 @@ func (f *fileDialog) makeOpenButton(label string) *widget.Button {
 			location, _ := storage.Child(f.dir, name)
 
 			exists, _ := storage.Exists(location)
-
-			// check if a directory is selected
-			listable, err := storage.CanList(location)
-
 			if !exists {
 				f.win.Hide()
 				if f.file.onClosedCallback != nil {
@@ -285,8 +281,10 @@ func (f *fileDialog) makeOpenButton(label string) *widget.Button {
 				}
 				callback(storage.Writer(location))
 				return
-			} else if err == nil && listable {
-				// a directory has been selected
+			}
+
+			listable, err := storage.CanList(location)
+			if err == nil && listable {
 				ShowInformation("Cannot overwrite",
 					"Files cannot replace a directory,\ncheck the file name and try again", f.file.parent)
 				return


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

This simplifies the logic for creating breadcrumbs a lot. Instead of doing a big allocation when splitting the path and then building the path again for each location, we can just go backwards and get the parent URI until we reach the root. Lastly, we just reverse the slice and boom, bob's your uncle. Also, move some logic around so we exit early.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

