### PR TITLE
Include InnerPadding for canvas.Text in MinSize and row height

### DIFF
--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -35,11 +35,16 @@ func (f *formLayout) calculateTableSizes(objects []fyne.CanvasObject, containerW
 		labelSize := labelCell.MinSize()
 		if _, ok := labelCell.(*canvas.Text); ok {
 			labelSize.Width += innerPadding * 2
+			labelSize.Height += innerPadding * 2
 		}
 		labelWidth = fyne.Max(labelWidth, labelSize.Width)
 
 		// Content column width is the maximum of all content items.
 		contentSize := contentCell.MinSize()
+		if _, ok := contentCell.(*canvas.Text); ok {
+			contentSize.Width += innerPadding * 2
+			contentSize.Height += innerPadding * 2
+		}
 		contentWidth = fyne.Max(contentWidth, contentSize.Width)
 
 		rowHeight := fyne.Max(labelSize.Height, contentSize.Height)
@@ -82,7 +87,15 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 		labelMin := labelCell.MinSize()
 		contentMin := contentCell.MinSize()
-		rowHeight := fyne.Max(labelMin.Height, contentMin.Height)
+		labelHeight := labelMin.Height
+		contentHeight := contentMin.Height
+		if _, ok := labelCell.(*canvas.Text); ok {
+			labelHeight += innerPadding * 2
+		}
+		if _, ok := contentCell.(*canvas.Text); ok {
+			contentHeight += innerPadding * 2
+		}
+		rowHeight := fyne.Max(labelHeight, contentHeight)
 
 		pos, size := objectLayout(labelCell, 0, labelWidth, rowHeight, labelMin.Height)
 		labelCell.Move(pos)

--- a/layout/formlayout_test.go
+++ b/layout/formlayout_test.go
@@ -176,3 +176,44 @@ func TestFormLayout_MinSize_Hidden(t *testing.T) {
 	expectedRowHeight := float32(100)
 	assert.Equal(t, fyne.NewSize(expectedRowWidth, expectedRowHeight), layoutMin)
 }
+
+func TestFormLayout_MinSize_CanvasText_SingleRow(t *testing.T) {
+	text1 := canvas.NewText("First text", color.Black)
+	text2 := canvas.NewText("Second text", color.Black)
+
+	l := layout.NewFormLayout()
+	layoutMin := l.MinSize([]fyne.CanvasObject{text1, text2})
+
+	inner := theme.InnerPadding()
+	min1 := text1.MinSize()
+	min2 := text2.MinSize()
+	expectedWidth := (min1.Width + inner*2) + (min2.Width + inner*2) + theme.Padding()
+
+	expectedHeight := fyne.Max(min1.Height, min2.Height) + inner*2
+
+	assert.Equal(t, fyne.NewSize(expectedWidth, expectedHeight), layoutMin)
+}
+
+func TestFormLayout_MinSize_CanvasText_TwoRows(t *testing.T) {
+	label1 := canvas.NewText("First Text", color.Black)
+	value1 := canvas.NewText("First Value", color.Black)
+	label2 := canvas.NewText("Second Text", color.Black)
+	value2 := canvas.NewText("Second Value", color.Black)
+
+	l := layout.NewFormLayout()
+	layoutMin := l.MinSize([]fyne.CanvasObject{label1, value1, label2, value2})
+
+	inner := theme.InnerPadding()
+	l1 := label1.MinSize()
+	l2 := label2.MinSize()
+	v1 := value1.MinSize()
+	v2 := value2.MinSize()
+	labelCol := fyne.Max(l1.Width+inner*2, l2.Width+inner*2)
+	valueCol := fyne.Max(v1.Width+inner*2, v2.Width+inner*2)
+	expectedWidth := labelCol + valueCol + theme.Padding()
+	row1 := fyne.Max(l1.Height+inner*2, v1.Height+inner*2)
+	row2 := fyne.Max(l2.Height+inner*2, v2.Height+inner*2)
+	expectedHeight := row1 + row2 + theme.Padding()
+
+	assert.Equal(t, fyne.NewSize(expectedWidth, expectedHeight), layoutMin)
+}


### PR DESCRIPTION
### Description:
Fix `FormLayout` miscalculations `MinSize()` when cells are `canvas.Text`, which causes text to render outside the container at `MinSize()`, and include inner padding in both width and height calculations for `canvas.Text` in label and content columns.

`canvas.Text.MinSize()` returns the bounds for the string as 'glyph' bounds given the font size, and there is no padding applied to it
```
func (t *Text) MinSize() fyne.Size {
	s, _ := fyne.CurrentApp().Driver().RenderedTextSize(t.Text, t.TextSize, t.TextStyle, t.FontSource)
	return s
}
```

`widget.Label` has its own version of `MinSize()`, which boils down to calling textRenderer's calculateMin(), which accounts for inner padding on both axes via `RichText`
When performing layout (`formLayout.Layout()`) we seem to be treating `canvas.Text` as a special case:
```
		if _, ok := obj.(*canvas.Text); ok {
			pos = pos.AddXY(innerPadding, innerPadding)
			size.Width -= innerPadding * 2
			size.Height = itemHeight
		}
```
so we shrink the width here, but the `MinSize()` logic does not reflect this and only adds inner padding to the label column width only. That is, it does not add inner padding to height and it does not add the padding to the content column width.


Fixes #5163 

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
