### PR TITLE
Support referring to a secondary buffer

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -782,9 +782,14 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key fyne.KeyNam
 			shortcut = &fyne.ShortcutPaste{
 				Clipboard: NewClipboard(),
 			}
-		case fyne.KeyC, fyne.KeyInsert: // detect copy shortcut
+		case fyne.KeyC: // detect copy shortcut
 			shortcut = &fyne.ShortcutCopy{
 				Clipboard: NewClipboard(),
+			}
+		case fyne.KeyInsert: // detect copy shortcut (alternative
+			shortcut = &fyne.ShortcutCopy{
+				Clipboard: NewClipboard(),
+				Secondary: true,
 			}
 		case fyne.KeyX: // detect cut shortcut
 			shortcut = &fyne.ShortcutCut{
@@ -797,13 +802,15 @@ func (w *window) triggersShortcut(localizedKeyName fyne.KeyName, key fyne.KeyNam
 
 	if modifier == fyne.KeyModifierShift {
 		switch keyName {
-		case fyne.KeyInsert: // detect paste shortcut
+		case fyne.KeyInsert: // detect paste shortcut (alternative)
 			shortcut = &fyne.ShortcutPaste{
 				Clipboard: NewClipboard(),
+				Secondary: true,
 			}
-		case fyne.KeyDelete: // detect cut shortcut
+		case fyne.KeyDelete: // detect cut shortcut (alternative)
 			shortcut = &fyne.ShortcutCut{
 				Clipboard: NewClipboard(),
+				Secondary: true,
 			}
 		}
 	}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1576,6 +1576,36 @@ func TestWindow_CaptureTypedShortcut(t *testing.T) {
 	assert.Equal(t, "CustomDesktop:Control+F", content.capturedShortcuts[0].ShortcutName())
 }
 
+func TestWindow_CaptureTypedShortcutClipboard(t *testing.T) {
+	w := createWindow("Test")
+	content := &typedShortcutable{}
+	content.SetMinSize(fyne.NewSize(10, 10))
+	w.SetContent(content)
+	repaintWindow(w)
+
+	w.Canvas().Focus(content)
+
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Press, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyV, 0, glfw.Press, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Release, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyV, 0, glfw.Release, glfw.ModControl)
+
+	assert.Equal(t, 1, len(content.capturedShortcuts))
+	paste, ok := content.capturedShortcuts[0].(*fyne.ShortcutPaste)
+	assert.True(t, ok)
+	assert.False(t, paste.Secondary)
+
+	w.keyPressed(nil, glfw.KeyLeftShift, 0, glfw.Press, glfw.ModShift)
+	w.keyPressed(nil, glfw.KeyInsert, 0, glfw.Press, glfw.ModShift)
+	w.keyPressed(nil, glfw.KeyLeftShift, 0, glfw.Press, glfw.ModShift)
+	w.keyPressed(nil, glfw.KeyInsert, 0, glfw.Release, glfw.ModShift)
+
+	assert.Equal(t, 2, len(content.capturedShortcuts))
+	paste, ok = content.capturedShortcuts[1].(*fyne.ShortcutPaste)
+	assert.True(t, ok)
+	assert.True(t, paste.Secondary)
+}
+
 func TestWindow_OnlyTabAndShiftTabToCapturesTab(t *testing.T) {
 	w := createWindow("Test")
 	content := &tabbable{}

--- a/shortcut.go
+++ b/shortcut.go
@@ -46,6 +46,10 @@ var _ KeyboardShortcut = (*ShortcutPaste)(nil)
 // ShortcutPaste describes a shortcut paste action.
 type ShortcutPaste struct {
 	Clipboard Clipboard
+	// Secondary indicates an alternative buffer such as selection, when true
+	//
+	// Since: 2.8
+	Secondary bool
 }
 
 // Key returns the [KeyName] for this shortcut.
@@ -68,6 +72,10 @@ var _ KeyboardShortcut = (*ShortcutCopy)(nil)
 // ShortcutCopy describes a shortcut copy action.
 type ShortcutCopy struct {
 	Clipboard Clipboard
+	// Secondary indicates an alternative buffer such as selection, when true
+	//
+	// Since: 2.8
+	Secondary bool
 }
 
 // Key returns the [KeyName] for this shortcut.
@@ -90,6 +98,10 @@ var _ KeyboardShortcut = (*ShortcutCut)(nil)
 // ShortcutCut describes a shortcut cut action.
 type ShortcutCut struct {
 	Clipboard Clipboard
+	// Secondary indicates an alternative buffer such as selection, when true
+	//
+	// Since: 2.8
+	Secondary bool
 }
 
 // Key returns the [KeyName] for this shortcut.


### PR DESCRIPTION
This is normally ignored but allows terminals etc to have alternative behaviour.

Relates to fyne-io/terminal#134

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
