### PR TITLE
Fix regression in GL draw performance on desktop

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -21,13 +21,6 @@ func (p *painter) createBuffer(size int) Buffer {
 	return vbo
 }
 
-func (p *painter) updateBuffer(vbo Buffer, points []float32) {
-	p.ctx.BindBuffer(arrayBuffer, vbo)
-	p.logError()
-	p.ctx.BufferSubData(arrayBuffer, points)
-	p.logError()
-}
-
 func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyne.Size) {
 	radius := paint.GetMaximumRadius(circle.Size())
 	program := p.roundRectangleProgram

--- a/internal/painter/gl/draw_desktop.go
+++ b/internal/painter/gl/draw_desktop.go
@@ -1,0 +1,12 @@
+//go:build windows || darwin || linux || openbsd || freebsd
+
+package gl
+
+func (p *painter) updateBuffer(vbo Buffer, points []float32) {
+	p.ctx.BindBuffer(arrayBuffer, vbo)
+	p.logError()
+	// BufferSubData seems significantly less performant on desktop
+	// so use BufferData instead
+	p.ctx.BufferData(arrayBuffer, points, staticDraw)
+	p.logError()
+}

--- a/internal/painter/gl/draw_notdesktop.go
+++ b/internal/painter/gl/draw_notdesktop.go
@@ -1,0 +1,10 @@
+//go:build !(windows || darwin || linux || openbsd || freebsd)
+
+package gl
+
+func (p *painter) updateBuffer(vbo Buffer, points []float32) {
+	p.ctx.BindBuffer(arrayBuffer, vbo)
+	p.logError()
+	p.ctx.BufferSubData(arrayBuffer, points)
+	p.logError()
+}


### PR DESCRIPTION
### Description:
Revert back to using BufferData rather than BufferSubData

Fixes #6010 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
