### PR TITLE
TextGrid: Ensure we are refreshing the correct row

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -512,11 +512,12 @@ func (t *textGridContent) CreateRenderer() fyne.WidgetRenderer {
 }
 
 func (t *textGridContent) refreshCell(row, col int) {
-	if row >= len(t.visible)-1 {
-		return
+	for _, v := range t.visible {
+		if tr := v.(*textGridRow); tr.row == row {
+			tr.refreshCell(col)
+			return
+		}
 	}
-	wid := t.visible[row].(*textGridRow)
-	wid.refreshCell(col)
 }
 
 type textGridContentRenderer struct {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
I was not able to reproduce this with a minimal example, but I am able to reliably reproduce a crash with this as a root cause in `https://github.com/redawl/gitm`

The previous code assumes that `t.visible` is ordered by row, which is not a valid assumption in some cases. Take a look at `addRowsIfRequired` to see why. 

This code finds the correct row to update, regardless of the order of `t.visible`.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
