### PR TITLE
Add OnMouseIn/OnMouseOut callbacks to Button for accessibility

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -60,6 +60,16 @@ type Button struct {
 	IconPlacement ButtonIconPlacement
 
 	OnTapped func() `json:"-"`
+	// OnMouseIn is called when the mouse pointer enters the button.
+	// This can be used for accessibility features like screen reader announcements.
+	//
+	// Since: 2.8
+	OnMouseIn func(*desktop.MouseEvent) `json:"-"`
+	// OnMouseOut is called when the mouse pointer exits the button.
+	// This can be used for accessibility features like screen reader announcements.
+	//
+	// Since: 2.8
+	OnMouseOut func() `json:"-"`
 
 	hovered, focused bool
 	tapAnim          *fyne.Animation
@@ -146,9 +156,13 @@ func (b *Button) MinSize() fyne.Size {
 }
 
 // MouseIn is called when a desktop pointer enters the widget
-func (b *Button) MouseIn(*desktop.MouseEvent) {
+func (b *Button) MouseIn(ev *desktop.MouseEvent) {
 	b.hovered = true
 	b.Refresh()
+
+	if onMouseIn := b.OnMouseIn; onMouseIn != nil {
+		onMouseIn(ev)
+	}
 }
 
 // MouseMoved is called when a desktop pointer hovers over the widget
@@ -159,6 +173,10 @@ func (b *Button) MouseMoved(*desktop.MouseEvent) {
 func (b *Button) MouseOut() {
 	b.hovered = false
 	b.Refresh()
+
+	if onMouseOut := b.OnMouseOut; onMouseOut != nil {
+		onMouseOut()
+	}
 }
 
 // SetIcon updates the icon on a label - pass nil to hide an icon


### PR DESCRIPTION
### Description:

Adds two new callback fields to the Button widget to enable custom hover behavior for accessibility features:
- `OnMouseIn`: Called when mouse enters the button, receives MouseEvent
- `OnMouseOut`: Called when mouse exits the button

**Motivation:**

Currently, `widget.Button.MouseIn` cannot be overridden to add custom hover behavior for accessibility features like screen reader announcements. This change allows developers to add assistive technology features without wrapping every button in a custom widget.

**Example use case:**
```go
button := widget.NewButton("Read More", func() {
    // Handle tap
})

// Add accessibility hover announcements
button.OnMouseIn = func(ev *desktop.MouseEvent) {
    screenReader.Announce(button.Text)
}

button.OnMouseOut = func() {
    screenReader.StopAnnouncement()
}
```

The implementation follows the existing `OnTapped` pattern for consistency and provides an elegant, terse API for end-users.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.

---

**Tests included:**
- OnMouseIn callback verification with event parameter
- OnMouseOut callback verification  
- Sequence testing (in followed by out)
- Nil callback safety testing

All tests follow existing widget test patterns using channels, timeouts, and `test.MoveMouse()` for UI automation.
