### PR TITLE
Fix crash when form is truncated when an Entry is focused

### DIFF
--- a/widget/form.go
+++ b/widget/form.go
@@ -300,6 +300,9 @@ func (f *Form) isVertical() bool {
 
 func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 	updateValidation := func(err error) {
+		if i >= len(f.Items) {
+			return // called after form has been truncated
+		}
 		if err == errFormItemInitialState {
 			return
 		}

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -222,6 +222,26 @@ func TestForm_Validation(t *testing.T) {
 	test.AssertImageMatches(t, "form/validation_valid.png", w.Canvas().Capture())
 }
 
+func TestForm_Validation_Reset(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	slide := NewSlider(0, 5)
+	entry := &Entry{Validator: validation.NewRegexp(`^\w{3}-\w{5}$`, "Input is not valid"), Text: "wrong"}
+	items := []*FormItem{
+		{Text: "Slide", Widget: slide},
+		{Text: "Input", Widget: entry},
+	}
+
+	form := &Form{Items: items, OnSubmit: func() {}, OnCancel: func() {}}
+	w := test.NewWindow(form)
+	defer w.Close()
+
+	w.Canvas().Focus(entry)
+	form.Items = []*FormItem{}
+	w.Canvas().Focus(slide)
+}
+
 func TestForm_EntryValidation_FirstTypeValid(t *testing.T) {
 	test.NewTempApp(t)
 	test.ApplyTheme(t, test.Theme())


### PR DESCRIPTION

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
