### PR TITLE
Add ability to set framerate on drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file lists the main changes with each version of the Fyne toolkit.
 More detailed release notes can be found on the [releases page](https://github.com/fyne-io/fyne/releases). 
 
+## Next
+
+### Added
+
+* Add the ability to change the internal framerate of the driver at runtime
+
 ## 2.7.1 - 14 Nov 2025
 
 ### Fixed

--- a/driver.go
+++ b/driver.go
@@ -54,4 +54,14 @@ type Driver interface {
 	//
 	// Since: 2.6
 	DoFromGoroutine(fn func(), wait bool)
+
+	// SetFrameRate sets the target frame rate for the application.
+	//
+	// Since: 2.8
+	SetFrameRate(int)
+
+	// GetFrameRate returns the target frame rate for the application.
+	//
+	// Since: 2.8
+	GetFrameRate() int
 }

--- a/internal/driver/embedded/driver.go
+++ b/internal/driver/embedded/driver.go
@@ -24,6 +24,19 @@ type noosDriver struct {
 	wins    []fyne.Window
 	current int
 	device  noosDevice
+
+	frameRate int
+	frameTime time.Duration
+}
+
+func (d *noosDriver) SetFrameRate(rate int) {
+	d.frameRate = rate
+	d.frameTime = time.Second / time.Duration(d.frameRate)
+	// Doesn't appear to actually support frame timing in this driver
+}
+
+func (d *noosDriver) GetFrameRate() int {
+	return d.frameRate
 }
 
 func (n *noosDriver) CreateWindow(_ string) fyne.Window {
@@ -232,6 +245,8 @@ func NewNoOSDriver(render func(img image.Image), run func(func()), events chan e
 	return &noosDriver{
 		events: events, queue: make(chan funcData), size: size,
 		render: render, run: run, wins: make([]fyne.Window, 0),
+		frameRate: 60,
+		frameTime: time.Second / 60,
 	}
 }
 

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -124,11 +124,11 @@ func (d *gLDriver) runGL() {
 		f()
 	}
 
-	eventTick := time.NewTicker(time.Second / 60)
+	d.eventTick = time.NewTicker(d.frameTime)
 	for {
 		select {
 		case <-d.done:
-			eventTick.Stop()
+			d.eventTick.Stop()
 			d.Terminate()
 			l := fyne.CurrentApp().Lifecycle().(*app.Lifecycle)
 			if f := l.OnStopped(); f != nil {
@@ -150,7 +150,7 @@ func (d *gLDriver) runGL() {
 			if f.done != nil {
 				f.done <- struct{}{}
 			}
-		case <-eventTick.C:
+		case <-d.eventTick.C:
 			d.pollEvents()
 			for i := 0; i < len(d.windows); i++ {
 				w := d.windows[i].(*window)

--- a/test/driver.go
+++ b/test/driver.go
@@ -151,3 +151,12 @@ func (d *driver) DoubleTapDelay() time.Duration {
 func (d *driver) SetDisableScreenBlanking(_ bool) {
 	// no-op for test
 }
+
+func (d *driver) SetFrameRate(rate int) {
+	// Nothing
+}
+
+func (d *driver) GetFrameRate() int {
+	// Nothing
+	return 0
+}


### PR DESCRIPTION
Important for devices that are old, slow and can't **comfortably** hit the 60 fps target

### Description:

A desktop application being deployed to some weak/old hardware can struggle to hit the 60 FPS internal frame-rate, or uses excessive resources to do so. This is especially evident when using the TermGrid.

This change allows the changing of the frame-rate at runtime. The default is still 60 FPS.

### Checklist:

- [ ] Tests included. **(There's nothing really to test, it's pretty basic value setting)**
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass. **(I have failing testing, but they fail without my changes. This is on MacOS)**

#### Where applicable:

- [x] Public APIs match existing style and have Since: line. **(I assume 2.8 rather than 2.7.x)**
- [x] Any breaking changes have a deprecation path or have been discussed. **(No breaking changes)**
- [x] Check for binary size increases when importing new modules. (**N/A)**
