### PR TITLE
Avoid scrolling entry to cursor position in unwanted situations

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -1439,6 +1439,7 @@ func (e *Entry) updateTextAndRefresh(text string, fromBinding bool) {
 	if callback != nil {
 		callback(text)
 	}
+	e.requestScrollingToCursor = true
 	e.Refresh()
 }
 

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1790,7 +1790,6 @@ func TestEntry_TextWrap(t *testing.T) {
 			} else {
 				e.SetText("Testing Wrapping")
 			}
-			e.Refresh()
 			test.AssertRendersToMarkup(t, tt.want, c)
 		})
 	}

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -1790,6 +1790,7 @@ func TestEntry_TextWrap(t *testing.T) {
 			} else {
 				e.SetText("Testing Wrapping")
 			}
+			e.Refresh()
 			test.AssertRendersToMarkup(t, tt.want, c)
 		})
 	}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
As currently coded, the `Entry` widget calls `entryContentRenderer.moveCursor()` every time `entryContentRenderer.Refresh()` is invoked. In turn, `moveCursor()` always calls `ensureCursorVisible()`. In other words, whenever the entry content renderer refreshes, the contents of the entry are automatically scrolled to put the current cursor position on screen. This may cause a multiline entry to scroll back to the cursor position even when this is not warranted -- as demonstrated in #6042, unfocusing or focusing an entry may lead to unexpected scroll jumps.

I have changed the code of the `moveCursor` function so that it only calls `ensureCursorVisible` when necessary instead of every time (my superficial understanding is that the `moveCursor` function should probably be renamed to `refreshCursor` or something like that based on how it is used elsewhere). Here "when necessary" is defined "whenever a piece of code (potentially) changes `entry.CursorRow` or `entry.CursorColumn`.

Fixes #6042 .

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

