### PR TITLE
Disregard a fake "Alt key up" event sent by glfw after unfocusing

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -743,6 +743,10 @@ func (w *window) processFocused(focus bool) {
 	} else {
 		w.canvas.FocusLost()
 		w.mousePos = fyne.Position{}
+		// Avoid triggering menu on Alt+Tab: glfw sends a fake "alt key released" event immediately after
+		// unfocusing the window, and it should be ignored.
+		w.menuTogglePending = desktop.KeyNone
+		w.menuDeactivationPending = desktop.KeyNone
 
 		// check whether another window was focused or not
 		if curWindow != w {


### PR DESCRIPTION
Keyboard handling code in `internal/driver/glfw/window.go` uses private fields `window.menuTogglePending` and `window.menuDeactivationPending` to handle some keyboard input properly, notably to expand the main menu of a window on the press+release of Alt. However, at least on linux X11 systems, after pressing Alt+Tab for some reason `glfw` sends a fake "alt key released" event to the window right after unfocusing. This is interpreted as user pressing and releasing Alt and thus triggered main menu.

For example, if you press (and release) Alt+Tab to switch to another window, then press Alt+Tab again, you return to your application window with a main menu expanded, which is a bug. The fix is to reset the values of the `menu ... Pending` private fields when the window goes out of focus.

### Description:
This used to trigger the main menu of the application after user pressed Alt+Tab: the application receives an "alt key pressed" event (as it should), then it receives a "window focused" event, and then glfw immediately manufactures a fake "alt key released" event (even if the user continues to hold the Alt key). Previously the unfocusing callback did not update the internal variables used to keep track of key presses, so this sequence of events got interpreted as "user pressed and then released the Alt key", thus opening the main menu.

Fixes #2998 (and maybe #5960 ?)

### Checklist:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

### Additional information

On my laptop some glfw tests are broken now, but I couldn't figure out whether the tests are bad or if I'm actually breaking something...