### PR TITLE
Fix theme watch not being set up if custom theme is specified before app run

### DIFF
--- a/app/settings_desktop.go
+++ b/app/settings_desktop.go
@@ -60,9 +60,6 @@ func watchFile(path string, callback func()) *fsnotify.Watcher {
 }
 
 func (s *settings) watchSettings() {
-	if s.themeSpecified {
-		return // we only watch for theme changes at this time so don't bother
-	}
 	s.watcher = watchFile(s.schema.StoragePath(), s.fileChanged)
 
 	a := fyne.CurrentApp()


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #6056

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
