### PR TITLE
Expose API for Generic Item to String Binding Conversion

### DIFF
--- a/data/binding/convert.go
+++ b/data/binding/convert.go
@@ -91,7 +91,7 @@ func URIToString(v URI) String {
 // ItemToString creates a binding that connects a generic data item to a String.
 //
 // Since: 2.8
-func ItemToString[T any](v Item[T], formatter func(T) (string, error), comparator func(T, T) bool, parser func(string) (T, error)) String {
+func ItemToString[T any](v Item[T], formatter func(T) (string, error), parser func(string) (T, error), comparator func(T, T) bool) String {
 	return toString(v, formatter, comparator, parser)
 }
 

--- a/data/binding/convert_test.go
+++ b/data/binding/convert_test.go
@@ -92,7 +92,7 @@ func BenchmarkIntToString(b *testing.B) {
 func BenchmarkItemtToString(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		i := NewItem(testItemComparator)
-		s := ItemToString(i, testItemFormatter, testItemComparator, testItemParser)
+		s := ItemToString(i, testItemFormatter, testItemParser, testItemComparator)
 		s.Get()
 
 		i.Set(testItem{"test", 2})
@@ -515,7 +515,7 @@ func TestURIToString(t *testing.T) {
 
 func TestItemToString(t *testing.T) {
 	i := NewItem(testItemComparator)
-	s := ItemToString(i, testItemFormatter, testItemComparator, testItemParser)
+	s := ItemToString(i, testItemFormatter, testItemParser, testItemComparator)
 	v, err := s.Get()
 	assert.Nil(t, err)
 	assert.Equal(t, "-0", v)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
2.6 added a generic binding item, and there is associated Item->String code that is currently not visible but extremely helpful for binding generic items to widgets like entries. This change simply exposes that API.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
