### PR TITLE
Fix JNI crash due to invalid reference when using Android streams

### DIFF
--- a/internal/driver/mobile/android.c
+++ b/internal/driver/mobile/android.c
@@ -170,6 +170,10 @@ void* saveStream(uintptr_t jni_env, uintptr_t ctx, char* uriCstr, bool truncate)
 }
 
 jbyte* readStream(uintptr_t jni_env, uintptr_t ctx, void* stream, int len, int* total) {
+	if (stream == NULL) {
+		*total = -1;
+		return NULL;
+	}
 	JNIEnv *env = (JNIEnv*)jni_env;
 	jclass streamClass = (*env)->GetObjectClass(env, stream);
 	jmethodID read = find_method(env, streamClass, "read", "([BII)I");
@@ -188,6 +192,12 @@ jbyte* readStream(uintptr_t jni_env, uintptr_t ctx, void* stream, int len, int* 
 }
 
 void writeStream(uintptr_t jni_env, uintptr_t ctx, void* stream, jbyte* buf, int len) {
+	if (stream == NULL) {
+		if (buf != NULL) {
+			free(buf);
+		}
+		return;
+	}
 	JNIEnv *env = (JNIEnv*)jni_env;
 	jclass streamClass = (*env)->GetObjectClass(env, stream);
 	jmethodID write = find_method(env, streamClass, "write", "([BII)V");
@@ -201,6 +211,9 @@ void writeStream(uintptr_t jni_env, uintptr_t ctx, void* stream, jbyte* buf, int
 }
 
 void closeStream(uintptr_t jni_env, uintptr_t ctx, void* stream) {
+	if (stream == NULL) {
+		return;
+	}
 	JNIEnv *env = (JNIEnv*)jni_env;
 	jclass streamClass = (*env)->GetObjectClass(env, stream);
 	jmethodID close = find_method(env, streamClass, "close", "()V");


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

On Android, when using file streams (via storage.Reader or storage.Writer), the application can crash with: JNI DETECTED ERROR IN APPLICATION: JNI ERROR (app bug): jobject is an invalid global reference in call to GetObjectClass

This occurs because the javaStream struct wrapping Java InputStream/OutputStream objects was not thread-safe and lacked protection against use-after-close scenarios. When a stream was closed (either explicitly or via garbage collection), subsequent operations could pass an invalid/deleted JNI reference to native code, causing the JVM to abort.

Fix:
1. Added mutex protection and a closed flag to javaStream to make stream operations thread-safe
2. Added NULL pointer checks in the C functions (readStream, writeStream, closeStream) before calling JNI methods
3. The Close() method now sets the stream pointer to nil after closing to prevent reuse
4. Read() and Write() methods now return an error if the stream has been closed

Fixes [6067](https://github.com/fyne-io/fyne/issues/6067)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ x] Tests included.
- [ x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x ] Public APIs match existing style and have Since: line.
- [x ] Any breaking changes have a deprecation path or have been discussed.
- [ x] Check for binary size increases when importing new modules.
