### PR TITLE
fix comments (OnHighlighted)

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -50,7 +50,7 @@ type GridWrap struct {
 	// in the GridWrap has been selected.
 	OnSelected func(id GridWrapItemID) `json:"-"`
 
-	// OnSelected is a callback to be notified when a given item
+	// OnUnselected is a callback to be notified when a given item
 	// in the GridWrap has been unselected.
 	OnUnselected func(id GridWrapItemID) `json:"-"`
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -50,7 +50,7 @@ type List struct {
 	// in the list has been selected.
 	OnSelected func(id ListItemID) `json:"-"`
 
-	// OnSelected is a callback to be notified when a given item
+	// OnUnselected is a callback to be notified when a given item
 	// in the list has been unselected.
 	OnUnselected func(id ListItemID) `json:"-"`
 
@@ -60,7 +60,7 @@ type List struct {
 	HideSeparators bool
 
 	// OnHighlighted is a callback to be notified when a given item
-	// in the GridWrap has been highlighted by keyboard navigation and mouse hover
+	// in the list has been highlighted by keyboard navigation and mouse hover
 	//
 	// Since: 2.8
 	OnHighlighted func(id ListItemID) `json:"-"`

--- a/widget/table.go
+++ b/widget/table.go
@@ -95,7 +95,7 @@ type Table struct {
 	HideSeparators bool
 
 	// OnHighlighted is a callback to be notified when a given item
-	// in the GridWrap has been highlighted by keyboard navigation and mouse hover
+	// in the table has been highlighted by keyboard navigation and mouse hover
 	//
 	// Since: 2.8
 	OnHighlighted func(id TableCellID) `json:"-"`

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -51,7 +51,7 @@ type Tree struct {
 	UpdateNode     func(uid TreeNodeID, branch bool, node fyne.CanvasObject) `json:"-"` // Called to update the given CanvasObject to represent the data at the given TreeNodeID
 
 	// OnHighlighted is a callback to be notified when a given item
-	// in the GridWrap has been highlighted by keyboard navigation and mouse hover
+	// in the tree has been highlighted by keyboard navigation and mouse hover
 	//
 	// Since: 2.8
 	OnHighlighted func(id TreeNodeID) `json:"-"`


### PR DESCRIPTION
### Description:

PR #5961 added `OnHighlighted`, first to `GridWrap` only, then also to `List`, `Table`, and `Tree`.

When extending to the other widgets, the doc comment for `OnHighlighted` kept referring to `GridWrap`.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

N/A: comment change only:

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.


