### PR TITLE
Remove incorrect early return from Rectangle.Resize

### DIFF
--- a/canvas/bezier_curve.go
+++ b/canvas/bezier_curve.go
@@ -58,9 +58,6 @@ func (r *BezierCurve) Resize(s fyne.Size) {
 	}
 
 	r.baseObject.Resize(s)
-	if r.StrokeWidth == 0 {
-		return
-	}
 
 	Refresh(r)
 }

--- a/canvas/polygon.go
+++ b/canvas/polygon.go
@@ -55,9 +55,6 @@ func (r *Polygon) Resize(s fyne.Size) {
 	}
 
 	r.baseObject.Resize(s)
-	if r.StrokeWidth == 0 {
-		return
-	}
 
 	Refresh(r)
 }

--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -80,7 +80,8 @@ func (r *Rectangle) Resize(s fyne.Size) {
 	}
 
 	r.baseObject.Resize(s)
-	Refresh(r)
+
+	repaint(r)
 }
 
 // NewRectangle returns a new Rectangle instance

--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -81,7 +81,7 @@ func (r *Rectangle) Resize(s fyne.Size) {
 
 	r.baseObject.Resize(s)
 
-	repaint(r)
+	Refresh(r)
 }
 
 // NewRectangle returns a new Rectangle instance

--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -80,10 +80,6 @@ func (r *Rectangle) Resize(s fyne.Size) {
 	}
 
 	r.baseObject.Resize(s)
-	if r.StrokeWidth == 0 {
-		return
-	}
-
 	Refresh(r)
 }
 


### PR DESCRIPTION
### Description:

Fixes #6040 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.