### PR TITLE
Fix/svgiconlinux

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/driver/software"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/svg"
 	"fyne.io/fyne/v2/lang"
@@ -167,6 +168,23 @@ func (d *gLDriver) refreshSystrayMenu(m *fyne.Menu, parent *systray.MenuItem) {
 
 func (d *gLDriver) SetSystemTrayIcon(resource fyne.Resource) {
 	systrayIcon = resource // in case we need it later
+
+	// only macOS supports SVG system tray
+	if runtime.GOOS != "darwin" && svg.IsResourceSVG(resource) {
+		img := canvas.NewImageFromResource(resource)
+		c := software.NewTransparentCanvas()
+		c.SetContent(img)
+		c.SetPadded(false)
+		c.Resize(fyne.NewSquareSize(systrayIconSize))
+
+		buf := &bytes.Buffer{}
+		err := png.Encode(buf, c.Capture())
+		if err != nil {
+			fyne.LogError("Failed to encode SVG icon for system tray icon", err)
+			return
+		}
+		resource = fyne.NewStaticResource(resource.Name()+".png", buf.Bytes())
+	}
 
 	img, err := toOSIcon(resource.Content())
 	if err != nil {

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -20,6 +20,8 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
+const systrayIconSize = 64
+
 var (
 	systrayIcon    fyne.Resource
 	systrayRunning bool
@@ -106,7 +108,7 @@ func itemForMenuItem(i *fyne.MenuItem, parent *systray.MenuItem) *systray.MenuIt
 			if runtime.GOOS == "windows" && isDark() { // windows menus don't match dark mode so invert icons
 				res = theme.NewInvertedThemedResource(i.Icon)
 			}
-			img := painter.PaintImage(canvas.NewImageFromResource(res), nil, 64, 64)
+			img := painter.PaintImage(canvas.NewImageFromResource(res), nil, systrayIconSize, systrayIconSize)
 			err := png.Encode(b, img)
 			if err != nil {
 				fyne.LogError("Failed to encode SVG icon for menu", err)


### PR DESCRIPTION
Many system tray spec does not accept SVG

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- set your system tray icon to be an svg and use a linux system tray - it will be blank
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
