### PR TITLE
Fix possible crash on app boot if window is closing or not shown

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -347,11 +347,13 @@ func (w *window) processMouseMoved(xpos float64, ypos float64) {
 		rawCursor, isCustomCursor := fyneToNativeCursor(cursor)
 		w.cursor = cursor
 
-		if rawCursor == nil {
-			w.view().SetInputMode(CursorMode, CursorHidden)
-		} else {
-			w.view().SetInputMode(CursorMode, CursorNormal)
-			w.SetCursor(rawCursor)
+		if view := w.view(); view != nil { // not yet visible? linux weirdness
+			if rawCursor == nil {
+				view.SetInputMode(CursorMode, CursorHidden)
+			} else {
+				view.SetInputMode(CursorMode, CursorNormal)
+				w.SetCursor(rawCursor)
+			}
 		}
 		w.setCustomCursor(rawCursor, isCustomCursor)
 	}


### PR DESCRIPTION
Fixes #5981

Not certain of the reproduction but lauching an app with a window that is hidden, in some Linux desktops, could crash like this.
Perhaps only when system tray is also enabled (from my testing).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
