### PR TITLE
fix(cache): update lastClean on early return to prevent per-frame calls

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -40,6 +40,10 @@ func Clean(canvasRefreshed bool) {
 		canvasRefreshed = true
 	}
 	if !canvasRefreshed && now.Sub(lastClean) < cleanTaskInterval {
+		// Even though we're not doing full cleanup, update lastClean to prevent
+		// this check from running every frame (which would cause log spam if logging
+		// were enabled and unnecessary CPU usage from the time comparisons).
+		lastClean = now
 		return
 	}
 	destroyExpiredSvgs(now)

--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -77,6 +77,21 @@ func TestCacheClean(t *testing.T) {
 		assert.Zero(t, destroyedRenderersCnt)
 	})
 
+	t.Run("early_return_updates_lastClean", func(t *testing.T) {
+		// Regression test: when canvasRefreshed=false and we're between
+		// 10s and 30s since lastClean, we hit an early return. This early
+		// return must still update lastClean, otherwise Clean() will be
+		// called every frame (causing unnecessary CPU usage).
+		testClearAll()
+		tm.setTime(10, 25)
+		lastClean = tm.createTime(10, 10) // 15 seconds ago (past 10s, before 30s)
+
+		Clean(false)
+
+		// lastClean should be updated to now, not stuck at the old value
+		assert.Equal(t, tm.now, lastClean)
+	})
+
 	t.Run("clean_no_canvas_refresh", func(t *testing.T) {
 		lastClean = tm.createTime(10, 11)
 		tm.setTime(11, 12)


### PR DESCRIPTION
When canvasRefreshed=false and we're between 10s and 30s since lastClean, Clean() returns early without updating lastClean. This causes Clean() to be called every frame (~60Hz) instead of once every 10 seconds, resulting in unnecessary CPU usage.

Adds regression test to verify lastClean is updated on the early return path.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #6088

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [*] Tests included.
- [*] Lint and formatter run with no errors.
- [*] Tests all pass.
