### PR TITLE
Set StartupWMClass in Unix/Linux .desktop files

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -23,6 +23,7 @@ type unixData struct {
 	ExecParams       string
 
 	SourceRepo, SourceDir string
+	StartupWMClass        string
 }
 
 func (p *Packager) packageUNIX() error {
@@ -67,15 +68,16 @@ func (p *Packager) packageUNIX() error {
 		linuxBSD = *p.linuxAndBSDMetadata
 	}
 	tplData := unixData{
-		Name:        p.Name,
-		Exec:        filepath.Base(p.exe),
-		Icon:        p.Name + filepath.Ext(p.icon),
-		Local:       local,
-		GenericName: linuxBSD.GenericName,
-		Keywords:    formatDesktopFileList(linuxBSD.Keywords),
-		Comment:     linuxBSD.Comment,
-		Categories:  formatDesktopFileList(linuxBSD.Categories),
-		ExecParams:  linuxBSD.ExecParams,
+		Name:           p.Name,
+		Exec:           filepath.Base(p.exe),
+		Icon:           p.Name + filepath.Ext(p.icon),
+		Local:          local,
+		GenericName:    linuxBSD.GenericName,
+		Keywords:       formatDesktopFileList(linuxBSD.Keywords),
+		Comment:        linuxBSD.Comment,
+		Categories:     formatDesktopFileList(linuxBSD.Categories),
+		ExecParams:     linuxBSD.ExecParams,
+		StartupWMClass: p.Name,
 	}
 
 	if p.sourceMetadata != nil {

--- a/cmd/fyne/internal/commands/package-unix_test.go
+++ b/cmd/fyne/internal/commands/package-unix_test.go
@@ -33,4 +33,9 @@ func TestDesktopFileSource(t *testing.T) {
 	assert.True(t, strings.Contains(buf.String(), "[X-Fyne"))
 	assert.True(t, strings.Contains(buf.String(), "Repo=https://example.com"))
 	assert.True(t, strings.Contains(buf.String(), "Dir=cmd/name"))
+
+	tplData.StartupWMClass = "Testing"
+	err = templates.DesktopFileUNIX.Execute(buf, tplData)
+	assert.Nil(t, err)
+	assert.True(t, strings.Contains(buf.String(), "StartupWMClass=Testing"))
 }

--- a/cmd/fyne/internal/templates/bundled.go
+++ b/cmd/fyne/internal/templates/bundled.go
@@ -23,7 +23,7 @@ var resourceMakefile = &fyne.StaticResource{
 var resourceAppDesktop = &fyne.StaticResource{
 	StaticName: "app.desktop",
 	StaticContent: []byte(
-		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}} {{- .ExecParams}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\nKeywords={{if ne .Keywords \"\"}}{{.Keywords}}{{else}}fyne;{{end}}\n\n{{if or (ne .SourceRepo \"\") (ne .SourceDir \"\") -}}\n[X-Fyne Source]\nRepo={{.SourceRepo}}\nDir={{.SourceDir}}\n\n{{end -}}\n"),
+		"[Desktop Entry]\nType=Application\nName={{.Name}}\n{{- if ne .GenericName \"\"}}\nGenericName={{.GenericName}}{{end}}\nExec={{.Exec}} {{- .ExecParams}}\nIcon={{.Name}}\n{{- if ne .Comment \"\"}}\nComment={{.Comment}}{{end}}\n{{- if ne .Categories \"\"}}\nCategories={{.Categories}}{{end}}\nKeywords={{if ne .Keywords \"\"}}{{.Keywords}}{{else}}fyne;{{end}}\n\n{{if or (ne .SourceRepo \"\") (ne .SourceDir \"\") -}}\n[X-Fyne Source]\nRepo={{.SourceRepo}}\nDir={{.SourceDir}}\n\n{{end -}}\n{{- if ne .StartupWMClass \"\"}}\nStartupWMClass={{.StartupWMClass}}{{end}}\n"),
 }
 var resourceAppManifest = &fyne.StaticResource{
 	StaticName: "app.manifest",

--- a/cmd/fyne/internal/templates/data/app.desktop
+++ b/cmd/fyne/internal/templates/data/app.desktop
@@ -17,3 +17,4 @@ Repo={{.SourceRepo}}
 Dir={{.SourceDir}}
 
 {{end -}}
+StartupWMClass=Testing


### PR DESCRIPTION
### Description:
This change adds StartupWMClass to the Unix/Linux  .desktop file, which links the running application to the installed shortcut.
This change fixes this on Ubuntu 24.04 for me

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [?] Tests all pass.  (waiting for GH run as some tests fail locally with a fresh checkout)
