### PR TITLE
Fix text blurring by using explicit size rounding instead of position…

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -430,7 +430,8 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 	}
 
 	// text size is sensitive to position on screen
-	size, _ = roundToPixelCoords(size, text.Position(), p.pixScale)
+	size.Width = roundToPixel(size.Width, p.pixScale)
+	size.Height = roundToPixel(size.Height, p.pixScale)
 	size.Width += roundToPixel(paint.VectorPad(text), p.pixScale)
 	p.drawTextureWithDetails(text, p.newGlTextTexture, pos, size, frame, canvas.ImageFillStretch, 1.0, 0)
 }


### PR DESCRIPTION
…-derived bounds

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Fix text blurring caused by sub-pixel texture stretching
The previous implementation used roundToPixelCoords to derive the text
quad size from the difference of rounded positions. Due to rounding
inconsistencies (round(pos+size) - round(pos) ≠ round(size)), this could
result in the quad being 1px larger than the texture, causing GL_LINEAR
filtering to blur the fonts.
This change explicitly rounds the text dimensions, ensuring 1:1 pixel
mapping between the texture and the rendering quad.

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
