### PR TITLE
Fixing icon failure when `currentColor` is at the root node (i.e. no current color)

### DIFF
--- a/internal/svg/svg.go
+++ b/internal/svg/svg.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 func NewDecoder(stream io.Reader) (*Decoder, error) {
-	icon, err := oksvg.ReadIconStream(stream)
+	icon, err := oksvg.ReadReplacingCurrentColor(stream, "#000000")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/svg/svg_test.go
+++ b/internal/svg/svg_test.go
@@ -151,6 +151,17 @@ func TestColorize(t *testing.T) {
 	}
 }
 
+func TestSVG_CurrentColor(t *testing.T) {
+	src := []byte("<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"ionicon\" viewBox=\"0 0 512 512\" width=\"42\" height=\"42\"><rect x=\"32\" y=\"128\" width=\"448\" height=\"320\" rx=\"48\" ry=\"48\" fill=\"none\" stroke=\"currentColor\" stroke-linejoin=\"round\" stroke-width=\"32\"/><path d=\"M144 128V96a32 32 0 0132-32h160a32 32 0 0132 32v32M480 240H32M320 240v24a8 8 0 01-8 8H200a8 8 0 01-8-8v-24\" fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"32\"/></svg>")
+	rdr := bytes.NewReader(src)
+	d, err := NewDecoder(rdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotNil(t, d)
+}
+
 func TestSVG_ReplaceFillColor(t *testing.T) {
 	src, err := os.ReadFile("testdata/cancel_Paths.svg")
 	if err != nil {


### PR DESCRIPTION
In the "image parse" context we cannot figure out what the color should be...
Using black for now. Is this a suitable fix? We apply theming in different ways, so I don't think it is required that the image is parsed with the theme colour present.

Fixes #6102

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
