### PR TITLE
Handle nested lists in Markdown renderer

### DIFF
--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -241,6 +241,46 @@ func TestRichTextMarkdown_ListWithDifferentStartingIndex(t *testing.T) {
 	}
 }
 
+func TestRichTextMarkdown_NestedList(t *testing.T) {
+	r := NewRichTextFromMarkdown("* item 1\n  * item 1.1\n* item 2")
+
+	assert.Len(t, r.Segments, 1)
+	if list, ok := r.Segments[0].(*ListSegment); ok {
+		assert.Len(t, list.Items, 3)
+		assert.Len(t, list.Items[0].(*ParagraphSegment).Texts, 1)
+		assert.Equal(t, "item 1", list.Items[0].(*ParagraphSegment).Texts[0].(*TextSegment).Text)
+		if sublist, ok := list.Items[1].(*ListSegment); ok {
+			assert.Len(t, sublist.Items, 1)
+			assert.False(t, sublist.Ordered)
+			assert.Equal(t, "item 1.1", sublist.Items[0].(*ParagraphSegment).Texts[0].(*TextSegment).Text)
+		} else {
+			t.Error("Segment should be a List")
+		}
+		assert.Len(t, list.Items[1].(*ListSegment).Items, 1)
+	} else {
+		t.Error("Segment should be a List")
+	}
+
+	r.ParseMarkdown("1. item 1\n   - item 1.1\n2. item 2")
+
+	assert.Len(t, r.Segments, 1)
+	if list, ok := r.Segments[0].(*ListSegment); ok {
+		assert.True(t, list.Ordered)
+		assert.Len(t, list.Items, 3)
+		assert.Len(t, list.Items[0].(*ParagraphSegment).Texts, 1)
+		if sublist, ok := list.Items[1].(*ListSegment); ok {
+			assert.Len(t, sublist.Items, 1)
+			assert.False(t, sublist.Ordered)
+			assert.Equal(t, "item 1.1", sublist.Items[0].(*ParagraphSegment).Texts[0].(*TextSegment).Text)
+		} else {
+			t.Error("Segment should be a List")
+		}
+		assert.Equal(t, "item 2", list.Items[2].(*ParagraphSegment).Texts[0].(*TextSegment).Text)
+	} else {
+		t.Error("Segment should be a List")
+	}
+}
+
 func TestRichTextMarkdown_Separator(t *testing.T) {
 	r := NewRichTextFromMarkdown("---\n")
 

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -229,7 +230,8 @@ type ListSegment struct {
 	// startIndex is set to start - 1 to allow the empty value of ListSegment to have a starting
 	// number of 1, while also allowing the caller to override the starting
 	// number to any int, including 0.
-	startIndex int
+	startIndex       int
+	indentationLevel int
 }
 
 // SetStartNumber sets the starting number for an ordered list.
@@ -260,11 +262,14 @@ func (l *ListSegment) Segments() []RichTextSegment {
 		if l.Ordered {
 			txt = strconv.Itoa(i+l.startIndex+1) + "."
 		}
-		bullet := &TextSegment{Text: txt + " ", Style: RichTextStyleStrong}
-		out[i] = &ParagraphSegment{Texts: []RichTextSegment{
-			bullet,
-			in,
-		}}
+		var texts []RichTextSegment
+		if _, ok := in.(*ListSegment); !ok {
+			indentation := strings.Repeat(" ", l.indentationLevel*4)
+			bullet := &TextSegment{Text: indentation + txt + " ", Style: RichTextStyleStrong}
+			texts = append(texts, bullet)
+		}
+		texts = append(texts, in)
+		out[i] = &ParagraphSegment{Texts: texts}
 	}
 	return out
 }

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -257,13 +257,15 @@ func (l *ListSegment) Inline() bool {
 // Segments returns the segments required to draw bullets before each item
 func (l *ListSegment) Segments() []RichTextSegment {
 	out := make([]RichTextSegment, len(l.Items))
+	j := l.StartNumber()
 	for i, in := range l.Items {
-		txt := "• "
-		if l.Ordered {
-			txt = strconv.Itoa(i+l.startIndex+1) + "."
-		}
 		var texts []RichTextSegment
 		if _, ok := in.(*ListSegment); !ok {
+			txt := "• "
+			if l.Ordered {
+				txt = strconv.Itoa(j) + "."
+				j++
+			}
 			indentation := strings.Repeat(" ", l.indentationLevel*4)
 			bullet := &TextSegment{Text: indentation + txt + " ", Style: RichTextStyleStrong}
 			texts = append(texts, bullet)


### PR DESCRIPTION
- Keep track of list indentation level
- Indent sub-lists with 4 spaces per level
- Pull (sub) lists out of `ParagraphSegment`s -> Sub list becomes an additional list item (of the outer list)

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

Fixes #6113 

Example of nested lists created from Markdown:

<img width="252" height="363" alt="image" src="https://github.com/user-attachments/assets/b9d46d4e-d7da-496f-bbfc-d2fb008e5bdd" />

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.