### PR TITLE
Markdown renderer: Support ast.AutoLink

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -102,6 +102,10 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		link, _ := url.Parse(string(t.Destination))
 		text := forceIntoText(source, n)
 		return []RichTextSegment{&HyperlinkSegment{Alignment: fyne.TextAlignLeading, Text: decodeText(text), URL: link}}, nil
+	case *ast.AutoLink:
+		link, _ := url.Parse(string(t.URL(source)))
+		text := string(t.Label(source))
+		return []RichTextSegment{&HyperlinkSegment{Alignment: fyne.TextAlignLeading, Text: decodeText(text), URL: link}}, nil
 	case *ast.CodeSpan:
 		text := forceIntoText(source, n)
 		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeInline, Text: text}}, nil

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -140,6 +140,18 @@ func TestRichTextMarkdown_Hyperlink(t *testing.T) {
 	}
 }
 
+func TestRichTextMarkdown_HyperlinkInAngleBrackets(t *testing.T) {
+	r := NewRichTextFromMarkdown("<https://fyne.io/>")
+
+	assert.Len(t, r.Segments, 2)
+	if link, ok := r.Segments[0].(*HyperlinkSegment); ok {
+		assert.Equal(t, "https://fyne.io/", link.Text)
+		assert.Equal(t, "fyne.io", link.URL.Host)
+	} else {
+		t.Error("Segment should be a Hyperlink")
+	}
+}
+
 func TestRichTextMarkdown_Image(t *testing.T) {
 	r := NewRichTextFromMarkdown("![title](../../theme/icons/fyne.png)")
 


### PR DESCRIPTION
Render links in angle brackets (like `<https://fyne.io>`) instead of ignoring them.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

Currently, such links are handled as empty text and thus not visible at all (in the rendered RichText).

This pull request is only about links in angle brackets (like `<https://fyne.io>` or `<mailto:info@fyne.io>`).

"Naked" links (like `https://fyne.io`) are still not treated as links because this feature would require goldmark's "linkify" extension which handles what GFM calls "autolink".

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.