### PR TITLE
gl: painter.drawText: Return if out of screen

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -429,6 +429,10 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 		pos = fyne.NewPos(pos.X, pos.Y+(containerSize.Height-size.Height)/2)
 	}
 
+	if pos.Y > frame.Height || pos.Y+size.Height < 0 || pos.X > frame.Width || pos.X+size.Width < 0 {
+		return
+	}
+
 	// text size is sensitive to position on screen
 	size.Width = roundToPixel(size.Width, p.pixScale)
 	size.Height = roundToPixel(size.Height, p.pixScale)


### PR DESCRIPTION
### Description:

When I tried to figure out why my Markdown Viewer app is so extremely slow to load and render a (long) Markdown file **on Android**, I found this way to improve loading times a lot!

Without this patch, the app takes about 11 seconds from granting read access to showing the file content. With this patch it's 2-4 seconds.

When I enable `fyne.TextWrapWord`, loading times improve from about 20 to 7 seconds.

Probably, the desktop (Linux) build is faster with this patch as well but this one is fast anyway.

Scrolling should be faster, too, but this is hard to measure.

Fixes possibly multiple issues.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
