### PR TITLE
gl: painter.drawText: Return if clipped

### DIFF
--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -57,24 +57,24 @@ func (c *Canvas) AddShortcut(shortcut fyne.Shortcut, handler func(shortcut fyne.
 	c.shortcut.AddShortcut(shortcut, handler)
 }
 
-func (c *Canvas) DrawDebugOverlay(obj fyne.CanvasObject, pos fyne.Position, size fyne.Size) {
+func (c *Canvas) DrawDebugOverlay(obj fyne.CanvasObject, pos fyne.Position, size fyne.Size, clip *internal.ClipItem) {
 	switch obj.(type) {
 	case fyne.Widget:
 		r := canvas.NewRectangle(color.Transparent)
 		r.StrokeColor = color.NRGBA{R: 0xcc, G: 0x33, B: 0x33, A: 0xff}
 		r.StrokeWidth = 1
 		r.Resize(obj.Size())
-		c.Painter().Paint(r, pos, size)
+		c.Painter().Paint(r, pos, size, clip)
 
 		t := canvas.NewText(reflect.ValueOf(obj).Elem().Type().Name(), r.StrokeColor)
 		t.TextSize = 10
-		c.Painter().Paint(t, pos.AddXY(2, 2), size)
+		c.Painter().Paint(t, pos.AddXY(2, 2), size, clip)
 	case *fyne.Container:
 		r := canvas.NewRectangle(color.Transparent)
 		r.StrokeColor = color.NRGBA{R: 0x33, G: 0x33, B: 0xcc, A: 0xff}
 		r.StrokeWidth = 1
 		r.Resize(obj.Size())
-		c.Painter().Paint(r, pos, size)
+		c.Painter().Paint(r, pos, size, clip)
 	}
 }
 

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -258,7 +258,7 @@ func (c *glCanvas) paint(size fyne.Size) {
 		if size.Width <= 0 || size.Height <= 0 { // iconifying on Windows can do bad things
 			return
 		}
-		c.Painter().Paint(obj, pos, size)
+		c.Painter().Paint(obj, pos, size, clips.Top())
 	}
 	afterPaint := func(node *common.RenderCacheNode, pos fyne.Position) {
 		if driver.IsClip(node.Obj()) {
@@ -271,7 +271,7 @@ func (c *glCanvas) paint(size fyne.Size) {
 		}
 
 		if build.Mode == fyne.BuildDebug {
-			c.DrawDebugOverlay(node.Obj(), pos, size)
+			c.DrawDebugOverlay(node.Obj(), pos, size, clips.Top())
 		}
 	}
 	c.WalkTrees(paint, afterPaint)

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -387,7 +387,7 @@ func (d *driver) paintWindow(window fyne.Window, size fyne.Size) {
 		if size.Width <= 0 || size.Height <= 0 { // iconifying on Windows can do bad things
 			return
 		}
-		c.Painter().Paint(obj, pos, size)
+		c.Painter().Paint(obj, pos, size, clips.Top())
 	}
 	afterDraw := func(node *common.RenderCacheNode, pos fyne.Position) {
 		if intdriver.IsClip(node.Obj()) {
@@ -399,7 +399,7 @@ func (d *driver) paintWindow(window fyne.Window, size fyne.Size) {
 		}
 
 		if build.Mode == fyne.BuildDebug {
-			c.DrawDebugOverlay(node.Obj(), pos, size)
+			c.DrawDebugOverlay(node.Obj(), pos, size, clips.Top())
 		}
 	}
 

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal"
 	paint "fyne.io/fyne/v2/internal/painter"
 )
 
@@ -169,7 +170,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.logError()
 }
 
-func (p *painter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.Size) {
+func (p *painter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
 	switch obj := o.(type) {
 	case *canvas.Circle:
 		p.drawCircle(obj, pos, frame)
@@ -182,7 +183,7 @@ func (p *painter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.
 	case *canvas.Rectangle:
 		p.drawRectangle(obj, pos, frame)
 	case *canvas.Text:
-		p.drawText(obj, pos, frame)
+		p.drawText(obj, pos, frame, clip)
 	case *canvas.LinearGradient:
 		p.drawGradient(obj, p.newGlLinearGradientTexture, pos, frame)
 	case *canvas.RadialGradient:
@@ -411,7 +412,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.logError()
 }
 
-func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size) {
+func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
 	if text.Text == "" || text.Text == " " {
 		return
 	}
@@ -427,6 +428,14 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 
 	if containerSize.Height > size.Height {
 		pos = fyne.NewPos(pos.X, pos.Y+(containerSize.Height-size.Height)/2)
+	}
+
+	if clip != nil {
+		clipPos, clipSize := clip.Rect()
+		if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
+			pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
+			return
+		}
 	}
 
 	// text size is sensitive to position on screen

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -430,12 +430,16 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 		pos = fyne.NewPos(pos.X, pos.Y+(containerSize.Height-size.Height)/2)
 	}
 
+	var clipPos fyne.Position
+	var clipSize fyne.Size
 	if clip != nil {
-		clipPos, clipSize := clip.Rect()
-		if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
-			pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
-			return
-		}
+		clipPos, clipSize = clip.Rect()
+	} else {
+		clipSize = frame
+	}
+	if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
+		pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
+		return
 	}
 
 	// text size is sensitive to position on screen

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -6,6 +6,7 @@ import (
 	"image"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/driver"
 	"fyne.io/fyne/v2/theme"
 )
@@ -21,7 +22,7 @@ type Painter interface {
 	// Free is used to indicate that a certain canvas object is no longer needed
 	Free(fyne.CanvasObject)
 	// Paint a single fyne.CanvasObject but not its children.
-	Paint(fyne.CanvasObject, fyne.Position, fyne.Size)
+	Paint(fyne.CanvasObject, fyne.Position, fyne.Size, *internal.ClipItem)
 	// SetFrameBufferScale tells us when we have more than 1 framebuffer pixel for each output pixel
 	SetFrameBufferScale(float32)
 	// SetOutputSize is used to change the resolution of our output viewport
@@ -119,9 +120,9 @@ func (p *painter) Free(obj fyne.CanvasObject) {
 	p.freeTexture(obj)
 }
 
-func (p *painter) Paint(obj fyne.CanvasObject, pos fyne.Position, frame fyne.Size) {
+func (p *painter) Paint(obj fyne.CanvasObject, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
 	if obj.Visible() {
-		p.drawObject(obj, pos, frame)
+		p.drawObject(obj, pos, frame, clip)
 	}
 }
 


### PR DESCRIPTION
### Description:

Return from `painter.drawText` if the text to be rendered is clipped anyway. This has a huge impact for scrollable containers with a lot of text outside the visible area.

This is an alternative to #6121.

`paintWindow` runs even faster with this PR than with #6121 applied (on Android, for my own app):

#### develop branch:

- paintWindow took 14.46767477s
- paintWindow took 11.067228539s

#### With #6121:

- paintWindow took 1.175666462s
- paintWindow took 1.017753923s

#### With this pull request:

- paintWindow took 202.546846ms
- paintWindow took 274.833846ms

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

