### PR TITLE
Android: listContentURI: Fix crash caused by permission denial

### DIFF
--- a/internal/driver/mobile/android.c
+++ b/internal/driver/mobile/android.c
@@ -445,6 +445,15 @@ char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 	}
 
 	jobject cursor = (jobject)(*env)->CallObjectMethod(env, resolver, query, childrenUri, project, NULL, NULL);
+	if ((*env)->ExceptionCheck(env)) {
+		(*env)->ExceptionDescribe(env);
+		(*env)->ExceptionClear(env);
+		LOG_FATAL("cannot list content of uri: %s", uriCstr);
+		return "";
+	}
+	if (cursor == NULL) {
+		return "";
+	}
 	jclass cursorClass = (*env)->GetObjectClass(env, cursor);
 	jmethodID next = find_method(env, cursorClass, "moveToNext", "()Z");
 	jmethodID get = find_method(env, cursorClass, "getString", "(I)Ljava/lang/String;");

--- a/internal/driver/mobile/android.c
+++ b/internal/driver/mobile/android.c
@@ -419,16 +419,16 @@ char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 
 	if (loadErr != NULL) {
 		(*env)->ExceptionClear(env);
-		return "";
+		return "ERROR: Cannot parse URI";
 	}
 
 	jclass contractClass = find_class(env, "android/provider/DocumentsContract");
 	if (contractClass == NULL) { // API 19
-		return "";
+		return "ERROR: Cannot list content for URI";
 	}
 	jmethodID getDoc = find_static_method(env, contractClass, "getTreeDocumentId", "(Landroid/net/Uri;)Ljava/lang/String;");
 	if (getDoc == NULL) { // API 21
-		return "";
+		return "ERROR: Cannot list content for URI";
 	}
 	jstring docID = (jobject)(*env)->CallStaticObjectMethod(env, contractClass, getDoc, uri);
 
@@ -441,7 +441,7 @@ char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 	jclass resolverClass = (*env)->GetObjectClass(env, resolver);
 	jmethodID query = find_method(env, resolverClass, "query", "(Landroid/net/Uri;[Ljava/lang/String;Landroid/os/Bundle;Landroid/os/CancellationSignal;)Landroid/database/Cursor;");
 	if (getDoc == NULL) { // API 26
-		return "";
+		return "ERROR: Cannot list content for URI";
 	}
 
 	jobject cursor = (jobject)(*env)->CallObjectMethod(env, resolver, query, childrenUri, project, NULL, NULL);
@@ -449,10 +449,10 @@ char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->ExceptionClear(env);
 		LOG_FATAL("cannot list content of uri: %s", uriCstr);
-		return "";
+		return "ERROR: Cannot list content for URI";
 	}
 	if (cursor == NULL) {
-		return "";
+		return "ERROR: Cannot list content for URI (NULL cursor)";
 	}
 	jclass cursorClass = (*env)->GetObjectClass(env, cursor);
 	jmethodID next = find_method(env, cursorClass, "moveToNext", "()Z");
@@ -546,7 +546,7 @@ char* listURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 		return listContentURI(jni_env, ctx, uriCstr);
 	}
 	LOG_FATAL("Unrecognized scheme: %s", uriCstr);
-	return "";
+	return "ERROR: Unrecognized scheme";
 }
 
 void keepScreenOn(uintptr_t jni_env, uintptr_t ctx, bool disabled) {

--- a/internal/driver/mobile/folder_android.go
+++ b/internal/driver/mobile/folder_android.go
@@ -63,7 +63,12 @@ func listURI(uri fyne.URI) ([]fyne.URI, error) {
 		return nil
 	})
 
-	parts := strings.Split(C.GoString(str), "|")
+	result := C.GoString(str)
+	if strings.HasPrefix(result, "ERROR: ") {
+		return nil, errors.New(result[7:])
+	}
+
+	parts := strings.Split(result, "|")
 	var list []fyne.URI
 	for _, part := range parts {
 		if len(part) == 0 {


### PR DESCRIPTION
### Description:

Fix crash that happens after calling `storage.List(uri)` for a URI whose read permission has expired (on Android).

Fixes #6117.

It would be cool if `storage.List(uri)` would set `err != nil` in such a case. Maybe we can pass a pointer to an int for error codes when calling `char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr)` (and other C functions)!? Or we return `null` instead of `""` if an error happens. Or we set `char *` to an error message?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
