### PR TITLE
Properly handle when a rich text line ends not in a text segment

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -417,6 +417,11 @@ func (t *RichText) updateRowBounds() {
 				itemMin := t.cachedSegmentVisual(seg, 0).MinSize()
 				if seg.Inline() {
 					wrapWidth -= itemMin.Width
+					if wrapWidth < 0 {
+						wrapWidth = maxWidth
+						currentBound = nil
+						fitSize.Height -= itemMin.Height + th.Size(theme.SizeNameLineSpacing)
+					}
 				} else {
 					wrapWidth = maxWidth
 					currentBound = nil


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Fix for incorrect wrap of text segments after a hyperlink segment that ends outside the current window

When a line ends with not a TextSegment, the `wrapWidth` becomes negative. This is because the segment takes all the space left but nothing detects this so that the next segment is in a new line

The solution implemented was to advance the internal state to continue laying out segments in the next line, mimicking what the code does for non-inline segments

Fixes #4303 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.
