### PR TITLE
Markdown renderer: Support links in bold and italic text

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -124,20 +124,7 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		}
 		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeBlock, Text: string(data)}}, nil
 	case *ast.Emphasis:
-		style := RichTextStyleEmphasis
-		if t.Level == 2 {
-			style = RichTextStyleStrong
-		}
-		children, err := renderChildren(source, n, blockquote, listDepth)
-		for _, child := range children {
-			switch t2 := child.(type) {
-			case *TextSegment:
-				t2.Style = style
-			case *HyperlinkSegment:
-				t2.Style = style
-			}
-		}
-		return children, err
+		return renderEmphasis(source, n, blockquote, listDepth)
 	case *ast.Text:
 		text := string(t.Value(source))
 		if text == "" {
@@ -176,6 +163,23 @@ func renderChildren(source []byte, n ast.Node, blockquote bool, listDepth int) (
 		child = child.NextSibling()
 	}
 	return children, nil
+}
+
+func renderEmphasis(source []byte, n ast.Node, blockquote bool, listDepth int) ([]RichTextSegment, error) {
+	style := RichTextStyleEmphasis
+	if n.(*ast.Emphasis).Level == 2 {
+		style = RichTextStyleStrong
+	}
+	children, err := renderChildren(source, n, blockquote, listDepth)
+	for _, child := range children {
+		switch t := child.(type) {
+		case *TextSegment:
+			t.Style = style
+		case *HyperlinkSegment:
+			t.Style = style
+		}
+	}
+	return children, err
 }
 
 func forceIntoText(source []byte, n ast.Node) string {

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -124,13 +124,20 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		}
 		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeBlock, Text: string(data)}}, nil
 	case *ast.Emphasis:
-		text := forceIntoText(source, n)
-		switch t.Level {
-		case 2:
-			return []RichTextSegment{&TextSegment{Style: RichTextStyleStrong, Text: decodeText(text)}}, nil
-		default:
-			return []RichTextSegment{&TextSegment{Style: RichTextStyleEmphasis, Text: decodeText(text)}}, nil
+		style := RichTextStyleEmphasis
+		if t.Level == 2 {
+			style = RichTextStyleStrong
 		}
+		children, err := renderChildren(source, n, blockquote, listDepth)
+		for _, child := range children {
+			switch t2 := child.(type) {
+			case *TextSegment:
+				t2.Style = style
+			case *HyperlinkSegment:
+				t2.Style = style
+			}
+		}
+		return children, err
 	case *ast.Text:
 		text := string(t.Value(source))
 		if text == "" {

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -176,7 +176,7 @@ func renderEmphasis(source []byte, n ast.Node, blockquote bool, listDepth int) (
 		case *TextSegment:
 			t.Style = style
 		case *HyperlinkSegment:
-			t.Style = style
+			t.TextStyle = style.TextStyle
 		}
 	}
 	return children, err

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -117,7 +117,7 @@ type HyperlinkSegment struct {
 	OnTapped func() `json:"-"`
 
 	// Since 2.8
-	Style RichTextStyle
+	TextStyle fyne.TextStyle
 }
 
 // Inline returns true as hyperlinks are inside other elements.
@@ -144,7 +144,7 @@ func (h *HyperlinkSegment) Update(o fyne.CanvasObject) {
 	link.Text = h.Text
 	link.URL = h.URL
 	link.Alignment = h.Alignment
-	link.TextStyle = h.Style.TextStyle
+	link.TextStyle = h.TextStyle
 	link.OnTapped = h.OnTapped
 	link.Refresh()
 }

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -115,6 +115,9 @@ type HyperlinkSegment struct {
 	//
 	// Since: 2.4
 	OnTapped func() `json:"-"`
+
+	// Since 2.8
+	Style RichTextStyle
 }
 
 // Inline returns true as hyperlinks are inside other elements.
@@ -141,6 +144,7 @@ func (h *HyperlinkSegment) Update(o fyne.CanvasObject) {
 	link.Text = h.Text
 	link.URL = h.URL
 	link.Alignment = h.Alignment
+	link.TextStyle = h.Style.TextStyle
 	link.OnTapped = h.OnTapped
 	link.Refresh()
 }


### PR DESCRIPTION
### Description:

In order to support this, a `Style` field is added to the `HyperlinkSegment` struct.

Fixes #5576 partially.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.

### To be discussed

- Some tests fail but they fail without this PR, too.
- Can it harm that `forceIntoText` isn't called anymore?