### PR TITLE
Fix fyne.Do error

### DIFF
--- a/internal/async/goroutine_desktop.go
+++ b/internal/async/goroutine_desktop.go
@@ -1,4 +1,4 @@
-//go:build !mobile
+//go:build !mobile && !android && !ios
 
 package async
 

--- a/internal/async/goroutine_mobile.go
+++ b/internal/async/goroutine_mobile.go
@@ -1,4 +1,4 @@
-//go:build mobile
+//go:build mobile || android || ios
 
 package async
 


### PR DESCRIPTION
Use `goroutine_mobile.go` for Android and iOS builds.

### Description:

When I tried to understand the "fyne.Do" error messages in my Android log and added some debug output, I noticed that `func IsMainGoroutine()` from `goroutine_desktop.go` is being used and not that version from `goroutine_mobile.go`.

It looks like the `mobile` tag isn't used/set when `fyne package --os android --release` is run.

(Maybe the actual fix is using different flags for `fyne package` or maybe the `mobile` tag should be set automatically but isn't for some reason.)

Fixes #5664 (and the related #5868, I guess).

(Btw, this fix helps a lot regarding my issue #6124: It reduces the app start duration from about 18-20 to 6-8 seconds and the time for running `createRichText()` from 6-8 to 0.3-0.4 seconds.)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.