### PR TITLE
Add ScrollToBottom method to Entry

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -528,6 +528,13 @@ func (e *Entry) Append(text string) {
 	e.Refresh()
 }
 
+// ScrollToBottom scrolls the entry's content to the bottom.
+//
+// Since: 2.7
+func (e *Entry) ScrollToBottom() {
+	e.scroll.ScrollToBottom()
+}
+
 // Tapped is called when this entry has been tapped. We update the cursor position in
 // device-specific callbacks (MouseDown() and TouchDown()).
 func (e *Entry) Tapped(ev *fyne.PointEvent) {


### PR DESCRIPTION
Add ScrollToBottom method to Entry widget

### Description:

This PR adds a new `ScrollToBottom()` method to the `Entry` widget, allowing users to programmatically scroll the entry content to the bottom. This is useful for:
- Any multi-line entry where automatic scrolling to the latest content is desired

### Checklist:

- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.

#### Where applicable:

- [X] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.

### Additional Notes:

Although issue #3590 mentions that alternative methods exist to achieve the same functionality, I believe providing a direct `ScrollToBottom` method simplifies development.

This is particularly useful for developers who simply want to use a multi-line `Entry` for basic, low-frequency log output.

However, I am not a professional Go developer. If I have missed any procedural steps or if there are any concerns with this approach, please feel free to point them out. Your understanding and guidance are greatly appreciated.