### PR TITLE
Add strikethrough TextStyle for TextGrid

### DIFF
--- a/text.go
+++ b/text.go
@@ -64,6 +64,8 @@ type TextStyle struct {
 	// Since: 2.5
 	// Currently only supported by [fyne.io/fyne/v2/widget.TextGrid].
 	Underline bool // Should text be underlined.
+	// Since: 2.8
+	Strikethrough bool // Should text be struck through.
 }
 
 // MeasureText uses the current driver to calculate the size of text when rendered.

--- a/widget/testdata/textgrid/basic.xml
+++ b/widget/testdata/textgrid/basic.xml
@@ -6,88 +6,115 @@
 					<rectangle size="8x16"/>
 					<text monospace size="0x0">S</text>
 					<line pos="0,16" size="8x0"/>
+					<line pos="0,9" size="8x0"/>
 					<rectangle pos="8,0" size="8x16"/>
 					<text monospace pos="8,0" size="0x0">o</text>
 					<line pos="8,16" size="8x0"/>
+					<line pos="8,9" size="8x0"/>
 					<rectangle pos="16,0" size="8x16"/>
 					<text monospace pos="16,0" size="0x0">m</text>
 					<line pos="16,16" size="8x0"/>
+					<line pos="16,9" size="8x0"/>
 					<rectangle pos="24,0" size="8x16"/>
 					<text monospace pos="24,0" size="0x0">e</text>
 					<line pos="24,16" size="8x0"/>
+					<line pos="24,9" size="8x0"/>
 					<rectangle pos="32,0" size="8x16"/>
 					<text monospace pos="32,0" size="0x0">t</text>
 					<line pos="32,16" size="8x0"/>
+					<line pos="32,9" size="8x0"/>
 					<rectangle pos="40,0" size="8x16"/>
 					<text monospace pos="40,0" size="0x0">h</text>
 					<line pos="40,16" size="8x0"/>
+					<line pos="40,9" size="8x0"/>
 					<rectangle pos="48,0" size="8x16"/>
 					<text monospace pos="48,0" size="0x0">i</text>
 					<line pos="48,16" size="8x0"/>
+					<line pos="48,9" size="8x0"/>
 					<rectangle pos="56,0" size="8x16"/>
 					<text monospace pos="56,0" size="0x0">n</text>
 					<line pos="56,16" size="8x0"/>
+					<line pos="56,9" size="8x0"/>
 					<rectangle pos="64,0" size="8x16"/>
 					<text monospace pos="64,0" size="0x0">g</text>
 					<line pos="64,16" size="8x0"/>
+					<line pos="64,9" size="8x0"/>
 				</widget>
 				<widget pos="0,16" size="72x16" type="*widget.textGridRow">
 					<rectangle size="8x16"/>
 					<text monospace size="0x0">E</text>
 					<line pos="0,16" size="8x0"/>
+					<line pos="0,9" size="8x0"/>
 					<rectangle pos="8,0" size="8x16"/>
 					<text monospace pos="8,0" size="0x0">l</text>
 					<line pos="8,16" size="8x0"/>
+					<line pos="8,9" size="8x0"/>
 					<rectangle pos="16,0" size="8x16"/>
 					<text monospace pos="16,0" size="0x0">s</text>
 					<line pos="16,16" size="8x0"/>
+					<line pos="16,9" size="8x0"/>
 					<rectangle pos="24,0" size="8x16"/>
 					<text monospace pos="24,0" size="0x0">e</text>
 					<line pos="24,16" size="8x0"/>
+					<line pos="24,9" size="8x0"/>
 					<rectangle pos="32,0" size="8x16"/>
 					<text monospace pos="32,0" size="0x0"> </text>
 					<line pos="32,16" size="8x0"/>
+					<line pos="32,9" size="8x0"/>
 					<rectangle pos="40,0" size="8x16"/>
 					<text monospace pos="40,0" size="0x0"> </text>
 					<line pos="40,16" size="8x0"/>
+					<line pos="40,9" size="8x0"/>
 					<rectangle pos="48,0" size="8x16"/>
 					<text monospace pos="48,0" size="0x0"> </text>
 					<line pos="48,16" size="8x0"/>
+					<line pos="48,9" size="8x0"/>
 					<rectangle pos="56,0" size="8x16"/>
 					<text monospace pos="56,0" size="0x0"> </text>
 					<line pos="56,16" size="8x0"/>
+					<line pos="56,9" size="8x0"/>
 					<rectangle pos="64,0" size="8x16"/>
 					<text monospace pos="64,0" size="0x0"> </text>
 					<line pos="64,16" size="8x0"/>
+					<line pos="64,9" size="8x0"/>
 				</widget>
 				<widget pos="0,32" size="72x16" type="*widget.textGridRow">
 					<rectangle size="8x16"/>
 					<text monospace size="0x0"> </text>
 					<line pos="0,16" size="8x0"/>
+					<line pos="0,9" size="8x0"/>
 					<rectangle pos="8,0" size="8x16"/>
 					<text monospace pos="8,0" size="0x0"> </text>
 					<line pos="8,16" size="8x0"/>
+					<line pos="8,9" size="8x0"/>
 					<rectangle pos="16,0" size="8x16"/>
 					<text monospace pos="16,0" size="0x0"> </text>
 					<line pos="16,16" size="8x0"/>
+					<line pos="16,9" size="8x0"/>
 					<rectangle pos="24,0" size="8x16"/>
 					<text monospace pos="24,0" size="0x0"> </text>
 					<line pos="24,16" size="8x0"/>
+					<line pos="24,9" size="8x0"/>
 					<rectangle pos="32,0" size="8x16"/>
 					<text monospace pos="32,0" size="0x0"> </text>
 					<line pos="32,16" size="8x0"/>
+					<line pos="32,9" size="8x0"/>
 					<rectangle pos="40,0" size="8x16"/>
 					<text monospace pos="40,0" size="0x0"> </text>
 					<line pos="40,16" size="8x0"/>
+					<line pos="40,9" size="8x0"/>
 					<rectangle pos="48,0" size="8x16"/>
 					<text monospace pos="48,0" size="0x0"> </text>
 					<line pos="48,16" size="8x0"/>
+					<line pos="48,9" size="8x0"/>
 					<rectangle pos="56,0" size="8x16"/>
 					<text monospace pos="56,0" size="0x0"> </text>
 					<line pos="56,16" size="8x0"/>
+					<line pos="56,9" size="8x0"/>
 					<rectangle pos="64,0" size="8x16"/>
 					<text monospace pos="64,0" size="0x0"> </text>
 					<line pos="64,16" size="8x0"/>
+					<line pos="64,9" size="8x0"/>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/textgrid/scroll.xml
+++ b/widget/testdata/textgrid/scroll.xml
@@ -7,88 +7,115 @@
 						<rectangle size="8x16"/>
 						<text monospace size="0x0">S</text>
 						<line pos="0,16" size="8x0"/>
+						<line pos="0,9" size="8x0"/>
 						<rectangle pos="8,0" size="8x16"/>
 						<text monospace pos="8,0" size="0x0">o</text>
 						<line pos="8,16" size="8x0"/>
+						<line pos="8,9" size="8x0"/>
 						<rectangle pos="16,0" size="8x16"/>
 						<text monospace pos="16,0" size="0x0">m</text>
 						<line pos="16,16" size="8x0"/>
+						<line pos="16,9" size="8x0"/>
 						<rectangle pos="24,0" size="8x16"/>
 						<text monospace pos="24,0" size="0x0">e</text>
 						<line pos="24,16" size="8x0"/>
+						<line pos="24,9" size="8x0"/>
 						<rectangle pos="32,0" size="8x16"/>
 						<text monospace pos="32,0" size="0x0">t</text>
 						<line pos="32,16" size="8x0"/>
+						<line pos="32,9" size="8x0"/>
 						<rectangle pos="40,0" size="8x16"/>
 						<text monospace pos="40,0" size="0x0">h</text>
 						<line pos="40,16" size="8x0"/>
+						<line pos="40,9" size="8x0"/>
 						<rectangle pos="48,0" size="8x16"/>
 						<text monospace pos="48,0" size="0x0">i</text>
 						<line pos="48,16" size="8x0"/>
+						<line pos="48,9" size="8x0"/>
 						<rectangle pos="56,0" size="8x16"/>
 						<text monospace pos="56,0" size="0x0">n</text>
 						<line pos="56,16" size="8x0"/>
+						<line pos="56,9" size="8x0"/>
 						<rectangle pos="64,0" size="8x16"/>
 						<text monospace pos="64,0" size="0x0">g</text>
 						<line pos="64,16" size="8x0"/>
+						<line pos="64,9" size="8x0"/>
 					</widget>
 					<widget pos="0,16" size="72x16" type="*widget.textGridRow">
 						<rectangle size="8x16"/>
 						<text monospace size="0x0">E</text>
 						<line pos="0,16" size="8x0"/>
+						<line pos="0,9" size="8x0"/>
 						<rectangle pos="8,0" size="8x16"/>
 						<text monospace pos="8,0" size="0x0">l</text>
 						<line pos="8,16" size="8x0"/>
+						<line pos="8,9" size="8x0"/>
 						<rectangle pos="16,0" size="8x16"/>
 						<text monospace pos="16,0" size="0x0">s</text>
 						<line pos="16,16" size="8x0"/>
+						<line pos="16,9" size="8x0"/>
 						<rectangle pos="24,0" size="8x16"/>
 						<text monospace pos="24,0" size="0x0">e</text>
 						<line pos="24,16" size="8x0"/>
+						<line pos="24,9" size="8x0"/>
 						<rectangle pos="32,0" size="8x16"/>
 						<text monospace pos="32,0" size="0x0"> </text>
 						<line pos="32,16" size="8x0"/>
+						<line pos="32,9" size="8x0"/>
 						<rectangle pos="40,0" size="8x16"/>
 						<text monospace pos="40,0" size="0x0"> </text>
 						<line pos="40,16" size="8x0"/>
+						<line pos="40,9" size="8x0"/>
 						<rectangle pos="48,0" size="8x16"/>
 						<text monospace pos="48,0" size="0x0"> </text>
 						<line pos="48,16" size="8x0"/>
+						<line pos="48,9" size="8x0"/>
 						<rectangle pos="56,0" size="8x16"/>
 						<text monospace pos="56,0" size="0x0"> </text>
 						<line pos="56,16" size="8x0"/>
+						<line pos="56,9" size="8x0"/>
 						<rectangle pos="64,0" size="8x16"/>
 						<text monospace pos="64,0" size="0x0"> </text>
 						<line pos="64,16" size="8x0"/>
+						<line pos="64,9" size="8x0"/>
 					</widget>
 					<widget pos="0,32" size="72x16" type="*widget.textGridRow">
 						<rectangle size="8x16"/>
 						<text monospace size="0x0"> </text>
 						<line pos="0,16" size="8x0"/>
+						<line pos="0,9" size="8x0"/>
 						<rectangle pos="8,0" size="8x16"/>
 						<text monospace pos="8,0" size="0x0"> </text>
 						<line pos="8,16" size="8x0"/>
+						<line pos="8,9" size="8x0"/>
 						<rectangle pos="16,0" size="8x16"/>
 						<text monospace pos="16,0" size="0x0"> </text>
 						<line pos="16,16" size="8x0"/>
+						<line pos="16,9" size="8x0"/>
 						<rectangle pos="24,0" size="8x16"/>
 						<text monospace pos="24,0" size="0x0"> </text>
 						<line pos="24,16" size="8x0"/>
+						<line pos="24,9" size="8x0"/>
 						<rectangle pos="32,0" size="8x16"/>
 						<text monospace pos="32,0" size="0x0"> </text>
 						<line pos="32,16" size="8x0"/>
+						<line pos="32,9" size="8x0"/>
 						<rectangle pos="40,0" size="8x16"/>
 						<text monospace pos="40,0" size="0x0"> </text>
 						<line pos="40,16" size="8x0"/>
+						<line pos="40,9" size="8x0"/>
 						<rectangle pos="48,0" size="8x16"/>
 						<text monospace pos="48,0" size="0x0"> </text>
 						<line pos="48,16" size="8x0"/>
+						<line pos="48,9" size="8x0"/>
 						<rectangle pos="56,0" size="8x16"/>
 						<text monospace pos="56,0" size="0x0"> </text>
 						<line pos="56,16" size="8x0"/>
+						<line pos="56,9" size="8x0"/>
 						<rectangle pos="64,0" size="8x16"/>
 						<text monospace pos="64,0" size="0x0"> </text>
 						<line pos="64,16" size="8x0"/>
+						<line pos="64,9" size="8x0"/>
 					</widget>
 				</widget>
 				<widget pos="50,0" size="0x32" type="*widget.Shadow">

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -677,12 +677,14 @@ func (t *textGridRow) appendTextCell(str rune) {
 
 	ul := canvas.NewLine(color.Transparent)
 
-	t.objects = append(t.objects, bg, text, ul)
+	st := canvas.NewLine(color.Transparent)
+
+	t.objects = append(t.objects, bg, text, ul, st)
 }
 
 func (t *textGridRow) refreshCell(col int) {
 	pos := t.cols + col
-	if pos*3+1 >= len(t.objects) {
+	if pos*4+1 >= len(t.objects) {
 		return
 	}
 
@@ -698,15 +700,18 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 	if str == 0 {
 		str = ' '
 	}
-	rect := t.objects[pos*3].(*canvas.Rectangle)
-	text := t.objects[pos*3+1].(*canvas.Text)
-	underline := t.objects[pos*3+2].(*canvas.Line)
+	rect := t.objects[pos*4].(*canvas.Rectangle)
+	text := t.objects[pos*4+1].(*canvas.Text)
+	underline := t.objects[pos*4+2].(*canvas.Line)
+	strikethrough := t.objects[pos*4+3].(*canvas.Line)
 
 	fg := t.cachedFGColor
 	text.TextSize = t.cachedTextSize
 
 	var underlineStrokeWidth float32 = 1
 	var underlineStrokeColor color.Color = color.Transparent
+	var strikethroughStrokeWidth float32 = 1
+	var strikethroughStrokeColor color.Color = color.Transparent
 	textStyle := fyne.TextStyle{}
 	if style != nil {
 		textStyle = style.Style()
@@ -715,9 +720,13 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 	}
 	if textStyle.Bold {
 		underlineStrokeWidth = 2
+		strikethroughStrokeWidth = 2
 	}
 	if textStyle.Underline {
 		underlineStrokeColor = fg
+	}
+	if textStyle.Strikethrough {
+		strikethroughStrokeColor = fg
 	}
 	textStyle.Monospace = true
 
@@ -740,6 +749,11 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 		underline.Refresh()
 	}
 
+	if strikethroughStrokeWidth != strikethrough.StrokeWidth || strikethroughStrokeColor != strikethrough.StrokeColor {
+		strikethrough.StrokeWidth, strikethrough.StrokeColor = strikethroughStrokeWidth, strikethroughStrokeColor
+		strikethrough.Refresh()
+	}
+
 	bg := color.Color(color.Transparent)
 	if style != nil && style.BackgroundColor() != nil {
 		bg = style.BackgroundColor()
@@ -754,10 +768,10 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 
 func (t *textGridRow) addCellsIfRequired() {
 	cellCount := t.cols
-	if len(t.objects) == cellCount*3 {
+	if len(t.objects) == cellCount*4 {
 		return
 	}
-	for i := len(t.objects); i < cellCount*3; i += 3 {
+	for i := len(t.objects); i < cellCount*4; i += 4 {
 		t.appendTextCell(' ')
 	}
 }
@@ -765,7 +779,7 @@ func (t *textGridRow) addCellsIfRequired() {
 func (t *textGridRow) refreshCells() {
 	x := 0
 	if t.row >= len(t.text.text.Rows) {
-		for ; x < len(t.objects)/3; x++ {
+		for ; x < len(t.objects)/4; x++ {
 			t.setCellRune(' ', x, TextGridStyleDefault, nil) // blank rows no longer needed
 		}
 
@@ -827,7 +841,7 @@ func (t *textGridRow) refreshCells() {
 		x++
 	}
 
-	for ; x < len(t.objects)/3; x++ {
+	for ; x < len(t.objects)/4; x++ {
 		t.setCellRune(' ', x, TextGridStyleDefault, nil) // trailing cells and blank lines
 	}
 }
@@ -885,8 +899,12 @@ func (t *textGridRowRenderer) Layout(size fyne.Size) {
 		t.obj.objects[off+2].Move(cellPos.Add(fyne.Position{X: 0, Y: t.obj.text.cellSize.Height}))
 		t.obj.objects[off+2].Resize(fyne.Size{Width: t.obj.text.cellSize.Width})
 
+		// strikethrough
+		t.obj.objects[off+3].Move(cellPos.Add(fyne.Position{X: 0, Y: t.obj.text.cellSize.Height * 0.6}))
+		t.obj.objects[off+3].Resize(fyne.Size{Width: t.obj.text.cellSize.Width})
+
 		cellPos.X += t.obj.text.cellSize.Width
-		off += 3
+		off += 4
 	}
 }
 

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -145,7 +145,7 @@ func TestTextGrid_CreateRendererRows(t *testing.T) {
 	grid.Resize(fyne.NewSize(52, 22))
 	wrap := test.TempWidgetRenderer(t, grid).(*textGridRenderer).text
 	row := wrap.visible[0].(*textGridRow)
-	assert.Len(t, row.objects, 18)
+	assert.Len(t, row.objects, 24)
 }
 
 func TestTextGrid_Row(t *testing.T) {
@@ -196,7 +196,7 @@ func TestTextGrid_SetText_Overflow(t *testing.T) {
 	row1 := content.visible[1].(*textGridRow)
 	row2 := content.visible[2].(*textGridRow)
 	assert.Equal(t, "H", row0.objects[1].(*canvas.Text).Text)
-	assert.Equal(t, "g", row0.objects[28].(*canvas.Text).Text)
+	assert.Equal(t, "g", row0.objects[37].(*canvas.Text).Text)
 	assert.Equal(t, "t", row1.objects[1].(*canvas.Text).Text)
 	assert.Equal(t, " ", row2.objects[1].(*canvas.Text).Text)
 
@@ -207,7 +207,7 @@ func TestTextGrid_SetText_Overflow(t *testing.T) {
 	assert.Len(t, grid.Rows[0].Cells, 7)
 
 	assert.Equal(t, "R", row0.objects[1].(*canvas.Text).Text)
-	assert.Equal(t, " ", row0.objects[28].(*canvas.Text).Text)
+	assert.Equal(t, " ", row0.objects[37].(*canvas.Text).Text)
 	assert.Equal(t, " ", row1.objects[1].(*canvas.Text).Text)
 }
 
@@ -451,6 +451,6 @@ func assertGridStyle(t *testing.T, g *TextGrid, content string, expectedStyles m
 }
 
 func rendererCell(r *textGridRowRenderer, col int) (*canvas.Rectangle, *canvas.Text) {
-	i := col * 3
+	i := col * 4
 	return r.obj.objects[i].(*canvas.Rectangle), r.obj.objects[i+1].(*canvas.Text)
 }


### PR DESCRIPTION
### Description:

Add `TextStyle.Strikethrough` and add support for it to `TextGrid`.

#### Demo program:

```go
package main

import (
	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.New()
	w := a.NewWindow("Strikethrough demo")

	grid := widget.NewTextGridFromString("Regular\nUnderline\nStrikethrough\nBoth")
	grid.SetRowStyle(1, &widget.CustomTextGridStyle{TextStyle: fyne.TextStyle{Underline: true}})
	grid.SetRowStyle(2, &widget.CustomTextGridStyle{TextStyle: fyne.TextStyle{Strikethrough: true}})
	grid.SetRowStyle(3, &widget.CustomTextGridStyle{TextStyle: fyne.TextStyle{Underline: true, Strikethrough: true}})

	w.SetContent(grid)
	w.ShowAndRun()
}
```

#### Screenshot:

<img width="268" height="168" alt="2026-02-25 14 15 51 268x168 Window" src="https://github.com/user-attachments/assets/d631fe5a-ed27-43bf-b3ae-b49db2516df2" />

Fixes #1084 partially. (Support for other widgets is still missing.)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
