### PR TITLE
Underline and strikethrough support for labels

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -25,7 +25,9 @@ import (
 
 const (
 	// DefaultTabWidth is the default width in spaces
-	DefaultTabWidth = 4
+	DefaultTabWidth               = 4
+	UnderlineOffsetFromBaseline   = 2
+	StrikethroughToBaselineFactor = 0.75
 
 	fontTabSpaceSize = 10
 )

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -413,7 +413,11 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 }
 
 func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
-	if text.Text == "" || text.Text == " " {
+	if text.Text == "" {
+		return
+	}
+	decorated := text.TextStyle.Underline || text.TextStyle.Strikethrough
+	if text.Text == " " && !decorated {
 		return
 	}
 
@@ -448,23 +452,20 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 	size.Width += roundToPixel(paint.VectorPad(text), p.pixScale)
 	p.drawTextureWithDetails(text, p.newGlTextTexture, pos, size, frame, canvas.ImageFillStretch, 1.0, 0)
 
-	if text.TextStyle.Underline {
+	if decorated {
 		line := canvas.NewLine(text.Color)
 		if text.TextStyle.Bold {
 			line.StrokeWidth = 2
 		}
 		line.Resize(fyne.NewSize(size.Width, 0))
-		underlinePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.9)
-		p.drawLine(line, underlinePos, frame)
-	}
-	if text.TextStyle.Strikethrough {
-		line := canvas.NewLine(text.Color)
-		if text.TextStyle.Bold {
-			line.StrokeWidth = 2
+		if text.TextStyle.Underline {
+			underlinePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.9)
+			p.drawLine(line, underlinePos, frame)
 		}
-		line.Resize(fyne.NewSize(size.Width, 0))
-		strikePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.6)
-		p.drawLine(line, strikePos, frame)
+		if text.TextStyle.Strikethrough {
+			strikePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.6)
+			p.drawLine(line, strikePos, frame)
+		}
 	}
 }
 

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -457,6 +457,15 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 		underlinePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.9)
 		p.drawLine(line, underlinePos, frame)
 	}
+	if text.TextStyle.Strikethrough {
+		line := canvas.NewLine(text.Color)
+		if text.TextStyle.Bold {
+			line.StrokeWidth = 2
+		}
+		line.Resize(fyne.NewSize(size.Width, 0))
+		strikePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.6)
+		p.drawLine(line, strikePos, frame)
+	}
 }
 
 func (p *painter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canvasObject fyne.CanvasObject) Texture,

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -447,6 +447,16 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 	size.Height = roundToPixel(size.Height, p.pixScale)
 	size.Width += roundToPixel(paint.VectorPad(text), p.pixScale)
 	p.drawTextureWithDetails(text, p.newGlTextTexture, pos, size, frame, canvas.ImageFillStretch, 1.0, 0)
+
+	if text.TextStyle.Underline {
+		line := canvas.NewLine(text.Color)
+		if text.TextStyle.Bold {
+			line.StrokeWidth = 2
+		}
+		line.Resize(fyne.NewSize(size.Width, 0))
+		underlinePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.9)
+		p.drawLine(line, underlinePos, frame)
+	}
 }
 
 func (p *painter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canvasObject fyne.CanvasObject) Texture,

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal"
+	"fyne.io/fyne/v2/internal/cache"
 	paint "fyne.io/fyne/v2/internal/painter"
 )
 
@@ -453,17 +454,15 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 	p.drawTextureWithDetails(text, p.newGlTextTexture, pos, size, frame, canvas.ImageFillStretch, 1.0, 0)
 
 	if decorated {
+		_, baseline := cache.GetFontMetrics(text.Text, text.TextSize, text.TextStyle, text.FontSource)
 		line := canvas.NewLine(text.Color)
-		if text.TextStyle.Bold {
-			line.StrokeWidth = 2
-		}
 		line.Resize(fyne.NewSize(size.Width, 0))
 		if text.TextStyle.Underline {
-			underlinePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.9)
+			underlinePos := fyne.NewPos(pos.X, pos.Y+baseline+paint.UnderlineOffsetFromBaseline)
 			p.drawLine(line, underlinePos, frame)
 		}
 		if text.TextStyle.Strikethrough {
-			strikePos := fyne.NewPos(pos.X, pos.Y+size.Height*0.6)
+			strikePos := fyne.NewPos(pos.X, pos.Y+baseline*paint.StrikethroughToBaselineFactor)
 			p.drawLine(line, strikePos, frame)
 		}
 	}

--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -243,6 +243,25 @@ func drawText(c fyne.Canvas, text *canvas.Text, pos fyne.Position, base *image.N
 	clippedBounds := clip.Intersect(imgBounds)
 	srcPt := image.Point{X: clippedBounds.Min.X - imgBounds.Min.X, Y: clippedBounds.Min.Y - imgBounds.Min.Y}
 	draw.Draw(base, clippedBounds, txtImg, srcPt, draw.Over)
+
+	if text.TextStyle.Underline {
+		line := canvas.NewLine(color)
+		if text.TextStyle.Bold {
+			line.StrokeWidth = 2
+		}
+		line.Resize(fyne.NewSize(bounds.Width, 0))
+		underlinePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.9)
+		drawLine(c, line, underlinePos, base, clip)
+	}
+	if text.TextStyle.Strikethrough {
+		line := canvas.NewLine(color)
+		if text.TextStyle.Bold {
+			line.StrokeWidth = 2
+		}
+		line.Resize(fyne.NewSize(bounds.Width, 0))
+		strikePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.6)
+		drawLine(c, line, strikePos, base, clip)
+	}
 }
 
 func drawRaster(c fyne.Canvas, rast *canvas.Raster, pos fyne.Position, base *image.NRGBA, clip image.Rectangle) {

--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -8,6 +8,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/scale"
 	"fyne.io/fyne/v2/theme"
@@ -245,17 +246,15 @@ func drawText(c fyne.Canvas, text *canvas.Text, pos fyne.Position, base *image.N
 	draw.Draw(base, clippedBounds, txtImg, srcPt, draw.Over)
 
 	if text.TextStyle.Underline || text.TextStyle.Strikethrough {
+		_, baseline := cache.GetFontMetrics(text.Text, text.TextSize, text.TextStyle, text.FontSource)
 		line := canvas.NewLine(color)
-		if text.TextStyle.Bold {
-			line.StrokeWidth = 2
-		}
 		line.Resize(fyne.NewSize(bounds.Width, 0))
 		if text.TextStyle.Underline {
-			underlinePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.9)
+			underlinePos := fyne.NewPos(pos.X, pos.Y+baseline+painter.UnderlineOffsetFromBaseline)
 			drawLine(c, line, underlinePos, base, clip)
 		}
 		if text.TextStyle.Strikethrough {
-			strikePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.6)
+			strikePos := fyne.NewPos(pos.X, pos.Y+baseline*painter.StrikethroughToBaselineFactor)
 			drawLine(c, line, strikePos, base, clip)
 		}
 	}

--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -244,23 +244,20 @@ func drawText(c fyne.Canvas, text *canvas.Text, pos fyne.Position, base *image.N
 	srcPt := image.Point{X: clippedBounds.Min.X - imgBounds.Min.X, Y: clippedBounds.Min.Y - imgBounds.Min.Y}
 	draw.Draw(base, clippedBounds, txtImg, srcPt, draw.Over)
 
-	if text.TextStyle.Underline {
+	if text.TextStyle.Underline || text.TextStyle.Strikethrough {
 		line := canvas.NewLine(color)
 		if text.TextStyle.Bold {
 			line.StrokeWidth = 2
 		}
 		line.Resize(fyne.NewSize(bounds.Width, 0))
-		underlinePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.9)
-		drawLine(c, line, underlinePos, base, clip)
-	}
-	if text.TextStyle.Strikethrough {
-		line := canvas.NewLine(color)
-		if text.TextStyle.Bold {
-			line.StrokeWidth = 2
+		if text.TextStyle.Underline {
+			underlinePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.9)
+			drawLine(c, line, underlinePos, base, clip)
 		}
-		line.Resize(fyne.NewSize(bounds.Width, 0))
-		strikePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.6)
-		drawLine(c, line, strikePos, base, clip)
+		if text.TextStyle.Strikethrough {
+			strikePos := fyne.NewPos(pos.X, pos.Y+bounds.Height*0.6)
+			drawLine(c, line, strikePos, base, clip)
+		}
 	}
 }
 

--- a/text.go
+++ b/text.go
@@ -62,7 +62,6 @@ type TextStyle struct {
 	// Since: 2.1
 	TabWidth int // Width of tabs in spaces
 	// Since: 2.5
-	// Currently only supported by [fyne.io/fyne/v2/widget.TextGrid].
 	Underline bool // Should text be underlined.
 	// Since: 2.8
 	Strikethrough bool // Should text be struck through.

--- a/text.go
+++ b/text.go
@@ -64,6 +64,8 @@ type TextStyle struct {
 	// Since: 2.5
 	// Currently only supported by [fyne.io/fyne/v2/widget.TextGrid].
 	Underline bool // Should text be underlined.
+	// Since: 2.8
+	Strikethrough bool // Should text be struck through.
 }
 
 // MeasureText uses the current driver to calculate the size of text when rendered.

--- a/widget/testdata/textgrid/basic.xml
+++ b/widget/testdata/textgrid/basic.xml
@@ -5,89 +5,62 @@
 				<widget size="72x16" type="*widget.textGridRow">
 					<rectangle size="8x16"/>
 					<text monospace size="0x0">S</text>
-					<line pos="0,16" size="8x0"/>
 					<rectangle pos="8,0" size="8x16"/>
 					<text monospace pos="8,0" size="0x0">o</text>
-					<line pos="8,16" size="8x0"/>
 					<rectangle pos="16,0" size="8x16"/>
 					<text monospace pos="16,0" size="0x0">m</text>
-					<line pos="16,16" size="8x0"/>
 					<rectangle pos="24,0" size="8x16"/>
 					<text monospace pos="24,0" size="0x0">e</text>
-					<line pos="24,16" size="8x0"/>
 					<rectangle pos="32,0" size="8x16"/>
 					<text monospace pos="32,0" size="0x0">t</text>
-					<line pos="32,16" size="8x0"/>
 					<rectangle pos="40,0" size="8x16"/>
 					<text monospace pos="40,0" size="0x0">h</text>
-					<line pos="40,16" size="8x0"/>
 					<rectangle pos="48,0" size="8x16"/>
 					<text monospace pos="48,0" size="0x0">i</text>
-					<line pos="48,16" size="8x0"/>
 					<rectangle pos="56,0" size="8x16"/>
 					<text monospace pos="56,0" size="0x0">n</text>
-					<line pos="56,16" size="8x0"/>
 					<rectangle pos="64,0" size="8x16"/>
 					<text monospace pos="64,0" size="0x0">g</text>
-					<line pos="64,16" size="8x0"/>
 				</widget>
 				<widget pos="0,16" size="72x16" type="*widget.textGridRow">
 					<rectangle size="8x16"/>
 					<text monospace size="0x0">E</text>
-					<line pos="0,16" size="8x0"/>
 					<rectangle pos="8,0" size="8x16"/>
 					<text monospace pos="8,0" size="0x0">l</text>
-					<line pos="8,16" size="8x0"/>
 					<rectangle pos="16,0" size="8x16"/>
 					<text monospace pos="16,0" size="0x0">s</text>
-					<line pos="16,16" size="8x0"/>
 					<rectangle pos="24,0" size="8x16"/>
 					<text monospace pos="24,0" size="0x0">e</text>
-					<line pos="24,16" size="8x0"/>
 					<rectangle pos="32,0" size="8x16"/>
 					<text monospace pos="32,0" size="0x0"> </text>
-					<line pos="32,16" size="8x0"/>
 					<rectangle pos="40,0" size="8x16"/>
 					<text monospace pos="40,0" size="0x0"> </text>
-					<line pos="40,16" size="8x0"/>
 					<rectangle pos="48,0" size="8x16"/>
 					<text monospace pos="48,0" size="0x0"> </text>
-					<line pos="48,16" size="8x0"/>
 					<rectangle pos="56,0" size="8x16"/>
 					<text monospace pos="56,0" size="0x0"> </text>
-					<line pos="56,16" size="8x0"/>
 					<rectangle pos="64,0" size="8x16"/>
 					<text monospace pos="64,0" size="0x0"> </text>
-					<line pos="64,16" size="8x0"/>
 				</widget>
 				<widget pos="0,32" size="72x16" type="*widget.textGridRow">
 					<rectangle size="8x16"/>
 					<text monospace size="0x0"> </text>
-					<line pos="0,16" size="8x0"/>
 					<rectangle pos="8,0" size="8x16"/>
 					<text monospace pos="8,0" size="0x0"> </text>
-					<line pos="8,16" size="8x0"/>
 					<rectangle pos="16,0" size="8x16"/>
 					<text monospace pos="16,0" size="0x0"> </text>
-					<line pos="16,16" size="8x0"/>
 					<rectangle pos="24,0" size="8x16"/>
 					<text monospace pos="24,0" size="0x0"> </text>
-					<line pos="24,16" size="8x0"/>
 					<rectangle pos="32,0" size="8x16"/>
 					<text monospace pos="32,0" size="0x0"> </text>
-					<line pos="32,16" size="8x0"/>
 					<rectangle pos="40,0" size="8x16"/>
 					<text monospace pos="40,0" size="0x0"> </text>
-					<line pos="40,16" size="8x0"/>
 					<rectangle pos="48,0" size="8x16"/>
 					<text monospace pos="48,0" size="0x0"> </text>
-					<line pos="48,16" size="8x0"/>
 					<rectangle pos="56,0" size="8x16"/>
 					<text monospace pos="56,0" size="0x0"> </text>
-					<line pos="56,16" size="8x0"/>
 					<rectangle pos="64,0" size="8x16"/>
 					<text monospace pos="64,0" size="0x0"> </text>
-					<line pos="64,16" size="8x0"/>
 				</widget>
 			</widget>
 		</widget>

--- a/widget/testdata/textgrid/scroll.xml
+++ b/widget/testdata/textgrid/scroll.xml
@@ -6,89 +6,62 @@
 					<widget size="72x16" type="*widget.textGridRow">
 						<rectangle size="8x16"/>
 						<text monospace size="0x0">S</text>
-						<line pos="0,16" size="8x0"/>
 						<rectangle pos="8,0" size="8x16"/>
 						<text monospace pos="8,0" size="0x0">o</text>
-						<line pos="8,16" size="8x0"/>
 						<rectangle pos="16,0" size="8x16"/>
 						<text monospace pos="16,0" size="0x0">m</text>
-						<line pos="16,16" size="8x0"/>
 						<rectangle pos="24,0" size="8x16"/>
 						<text monospace pos="24,0" size="0x0">e</text>
-						<line pos="24,16" size="8x0"/>
 						<rectangle pos="32,0" size="8x16"/>
 						<text monospace pos="32,0" size="0x0">t</text>
-						<line pos="32,16" size="8x0"/>
 						<rectangle pos="40,0" size="8x16"/>
 						<text monospace pos="40,0" size="0x0">h</text>
-						<line pos="40,16" size="8x0"/>
 						<rectangle pos="48,0" size="8x16"/>
 						<text monospace pos="48,0" size="0x0">i</text>
-						<line pos="48,16" size="8x0"/>
 						<rectangle pos="56,0" size="8x16"/>
 						<text monospace pos="56,0" size="0x0">n</text>
-						<line pos="56,16" size="8x0"/>
 						<rectangle pos="64,0" size="8x16"/>
 						<text monospace pos="64,0" size="0x0">g</text>
-						<line pos="64,16" size="8x0"/>
 					</widget>
 					<widget pos="0,16" size="72x16" type="*widget.textGridRow">
 						<rectangle size="8x16"/>
 						<text monospace size="0x0">E</text>
-						<line pos="0,16" size="8x0"/>
 						<rectangle pos="8,0" size="8x16"/>
 						<text monospace pos="8,0" size="0x0">l</text>
-						<line pos="8,16" size="8x0"/>
 						<rectangle pos="16,0" size="8x16"/>
 						<text monospace pos="16,0" size="0x0">s</text>
-						<line pos="16,16" size="8x0"/>
 						<rectangle pos="24,0" size="8x16"/>
 						<text monospace pos="24,0" size="0x0">e</text>
-						<line pos="24,16" size="8x0"/>
 						<rectangle pos="32,0" size="8x16"/>
 						<text monospace pos="32,0" size="0x0"> </text>
-						<line pos="32,16" size="8x0"/>
 						<rectangle pos="40,0" size="8x16"/>
 						<text monospace pos="40,0" size="0x0"> </text>
-						<line pos="40,16" size="8x0"/>
 						<rectangle pos="48,0" size="8x16"/>
 						<text monospace pos="48,0" size="0x0"> </text>
-						<line pos="48,16" size="8x0"/>
 						<rectangle pos="56,0" size="8x16"/>
 						<text monospace pos="56,0" size="0x0"> </text>
-						<line pos="56,16" size="8x0"/>
 						<rectangle pos="64,0" size="8x16"/>
 						<text monospace pos="64,0" size="0x0"> </text>
-						<line pos="64,16" size="8x0"/>
 					</widget>
 					<widget pos="0,32" size="72x16" type="*widget.textGridRow">
 						<rectangle size="8x16"/>
 						<text monospace size="0x0"> </text>
-						<line pos="0,16" size="8x0"/>
 						<rectangle pos="8,0" size="8x16"/>
 						<text monospace pos="8,0" size="0x0"> </text>
-						<line pos="8,16" size="8x0"/>
 						<rectangle pos="16,0" size="8x16"/>
 						<text monospace pos="16,0" size="0x0"> </text>
-						<line pos="16,16" size="8x0"/>
 						<rectangle pos="24,0" size="8x16"/>
 						<text monospace pos="24,0" size="0x0"> </text>
-						<line pos="24,16" size="8x0"/>
 						<rectangle pos="32,0" size="8x16"/>
 						<text monospace pos="32,0" size="0x0"> </text>
-						<line pos="32,16" size="8x0"/>
 						<rectangle pos="40,0" size="8x16"/>
 						<text monospace pos="40,0" size="0x0"> </text>
-						<line pos="40,16" size="8x0"/>
 						<rectangle pos="48,0" size="8x16"/>
 						<text monospace pos="48,0" size="0x0"> </text>
-						<line pos="48,16" size="8x0"/>
 						<rectangle pos="56,0" size="8x16"/>
 						<text monospace pos="56,0" size="0x0"> </text>
-						<line pos="56,16" size="8x0"/>
 						<rectangle pos="64,0" size="8x16"/>
 						<text monospace pos="64,0" size="0x0"> </text>
-						<line pos="64,16" size="8x0"/>
 					</widget>
 				</widget>
 				<widget pos="50,0" size="0x32" type="*widget.Shadow">

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -675,14 +675,12 @@ func (t *textGridRow) appendTextCell(str rune) {
 
 	bg := canvas.NewRectangle(color.Transparent)
 
-	ul := canvas.NewLine(color.Transparent)
-
-	t.objects = append(t.objects, bg, text, ul)
+	t.objects = append(t.objects, bg, text)
 }
 
 func (t *textGridRow) refreshCell(col int) {
 	pos := t.cols + col
-	if pos*3+1 >= len(t.objects) {
+	if pos*2+1 >= len(t.objects) {
 		return
 	}
 
@@ -698,26 +696,17 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 	if str == 0 {
 		str = ' '
 	}
-	rect := t.objects[pos*3].(*canvas.Rectangle)
-	text := t.objects[pos*3+1].(*canvas.Text)
-	underline := t.objects[pos*3+2].(*canvas.Line)
+	rect := t.objects[pos*2].(*canvas.Rectangle)
+	text := t.objects[pos*2+1].(*canvas.Text)
 
 	fg := t.cachedFGColor
 	text.TextSize = t.cachedTextSize
 
-	var underlineStrokeWidth float32 = 1
-	var underlineStrokeColor color.Color = color.Transparent
 	textStyle := fyne.TextStyle{}
 	if style != nil {
 		textStyle = style.Style()
 	} else if rowStyle != nil {
 		textStyle = rowStyle.Style()
-	}
-	if textStyle.Bold {
-		underlineStrokeWidth = 2
-	}
-	if textStyle.Underline {
-		underlineStrokeColor = fg
 	}
 	textStyle.Monospace = true
 
@@ -735,11 +724,6 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 		text.Refresh()
 	}
 
-	if underlineStrokeWidth != underline.StrokeWidth || underlineStrokeColor != underline.StrokeColor {
-		underline.StrokeWidth, underline.StrokeColor = underlineStrokeWidth, underlineStrokeColor
-		underline.Refresh()
-	}
-
 	bg := color.Color(color.Transparent)
 	if style != nil && style.BackgroundColor() != nil {
 		bg = style.BackgroundColor()
@@ -754,10 +738,10 @@ func (t *textGridRow) setCellRune(str rune, pos int, style, rowStyle TextGridSty
 
 func (t *textGridRow) addCellsIfRequired() {
 	cellCount := t.cols
-	if len(t.objects) == cellCount*3 {
+	if len(t.objects) == cellCount*2 {
 		return
 	}
-	for i := len(t.objects); i < cellCount*3; i += 3 {
+	for i := len(t.objects); i < cellCount*2; i += 2 {
 		t.appendTextCell(' ')
 	}
 }
@@ -765,7 +749,7 @@ func (t *textGridRow) addCellsIfRequired() {
 func (t *textGridRow) refreshCells() {
 	x := 0
 	if t.row >= len(t.text.text.Rows) {
-		for ; x < len(t.objects)/3; x++ {
+		for ; x < len(t.objects)/2; x++ {
 			t.setCellRune(' ', x, TextGridStyleDefault, nil) // blank rows no longer needed
 		}
 
@@ -827,7 +811,7 @@ func (t *textGridRow) refreshCells() {
 		x++
 	}
 
-	for ; x < len(t.objects)/3; x++ {
+	for ; x < len(t.objects)/2; x++ {
 		t.setCellRune(' ', x, TextGridStyleDefault, nil) // trailing cells and blank lines
 	}
 }
@@ -881,12 +865,8 @@ func (t *textGridRowRenderer) Layout(size fyne.Size) {
 		// text
 		t.obj.objects[off+1].Move(cellPos)
 
-		// underline
-		t.obj.objects[off+2].Move(cellPos.Add(fyne.Position{X: 0, Y: t.obj.text.cellSize.Height}))
-		t.obj.objects[off+2].Resize(fyne.Size{Width: t.obj.text.cellSize.Width})
-
 		cellPos.X += t.obj.text.cellSize.Width
-		off += 3
+		off += 2
 	}
 }
 

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -145,7 +145,7 @@ func TestTextGrid_CreateRendererRows(t *testing.T) {
 	grid.Resize(fyne.NewSize(52, 22))
 	wrap := test.TempWidgetRenderer(t, grid).(*textGridRenderer).text
 	row := wrap.visible[0].(*textGridRow)
-	assert.Len(t, row.objects, 18)
+	assert.Len(t, row.objects, 12)
 }
 
 func TestTextGrid_Row(t *testing.T) {
@@ -196,7 +196,7 @@ func TestTextGrid_SetText_Overflow(t *testing.T) {
 	row1 := content.visible[1].(*textGridRow)
 	row2 := content.visible[2].(*textGridRow)
 	assert.Equal(t, "H", row0.objects[1].(*canvas.Text).Text)
-	assert.Equal(t, "g", row0.objects[28].(*canvas.Text).Text)
+	assert.Equal(t, "g", row0.objects[19].(*canvas.Text).Text)
 	assert.Equal(t, "t", row1.objects[1].(*canvas.Text).Text)
 	assert.Equal(t, " ", row2.objects[1].(*canvas.Text).Text)
 
@@ -207,7 +207,7 @@ func TestTextGrid_SetText_Overflow(t *testing.T) {
 	assert.Len(t, grid.Rows[0].Cells, 7)
 
 	assert.Equal(t, "R", row0.objects[1].(*canvas.Text).Text)
-	assert.Equal(t, " ", row0.objects[28].(*canvas.Text).Text)
+	assert.Equal(t, " ", row0.objects[19].(*canvas.Text).Text)
 	assert.Equal(t, " ", row1.objects[1].(*canvas.Text).Text)
 }
 
@@ -451,6 +451,6 @@ func assertGridStyle(t *testing.T, g *TextGrid, content string, expectedStyles m
 }
 
 func rendererCell(r *textGridRowRenderer, col int) (*canvas.Rectangle, *canvas.Text) {
-	i := col * 3
+	i := col * 2
 	return r.obj.objects[i].(*canvas.Rectangle), r.obj.objects[i+1].(*canvas.Text)
 }


### PR DESCRIPTION
### Description:

This adds underline and strikethrough support for labels and removes the old underline support that was limited to `TextGrid`s.

#### Before (develop branch)

(Underline for labels not supported. No strikethrough.)

**gl driver:**

<img width="128" height="276" alt="gl develop" src="https://github.com/user-attachments/assets/629052a1-aed8-499f-9f55-801564a7f001" />

**software driver:**

<img width="144" height="248" alt="software develop" src="https://github.com/user-attachments/assets/60a7a6f9-0e9a-4d49-badd-b0712a0a0c1f" />

#### After (this PR)

**gl driver:**

<img width="124" height="333" alt="gl PR #6138" src="https://github.com/user-attachments/assets/292309ec-4c9b-4e04-bc91-df50fe56449c" />

(Underline in TextGrid might be too close to text.)

**software driver:**

<img width="144" height="326" alt="software PR #6138" src="https://github.com/user-attachments/assets/72e416b2-91fb-406c-8f1f-fb1207fac86b" />

#### To do:

- [x] TextGrid already supports underline style. With this PR, text in TextGrids is underlined twice. Underlines shouldn't be drawn in `widget/textgrid.go: func (t *textGridRow) setCellRune` if this PR gets accepted.
- [x] Draw underlines and strikethrough in `software/draw.go: func drawText`. (How to test this? → [Found it](https://github.com/fyne-io/fyne/wiki/Drivers#software).)
- [x] Make sure, underline and strikethrough work in TextGrids with the software driver.
- [x] Compare performance for underline in TextGrid
   - Performance of this PR is better. Tested on Linux with TextGrid with 1000 rows of underlined text.
   - develop: `w.SetContent` takes 37-40 ms
   - this PR: `w.SetContent` takes 22-28 ms
   - about the same results when no row is underlined

Fixes #4321 and #1084.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
