### PR TITLE
go test: Skip printing diff of image files

### DIFF
--- a/internal/test/util_helper.go
+++ b/internal/test/util_helper.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	"os"
@@ -47,15 +48,17 @@ func AssertImageMatches(t *testing.T, masterFilename string, img image.Image, ms
 		return true
 	}
 
+	if bytes.Equal(masterPix, capturePix) {
+		return true
+	}
+
 	var msg string
 	if len(msgAndArgs) > 0 {
 		msg = fmt.Sprintf(msgAndArgs[0].(string)+"\n", msgAndArgs[1:]...)
 	}
-	if !assert.Equal(t, masterPix, capturePix, "%sImage did not match master. Actual image written to file://%s.", msg, failedPath) {
-		require.NoError(t, writeImage(failedPath, img))
-		return false
-	}
-	return true
+
+	require.NoError(t, writeImage(failedPath, img))
+	return assert.Fail(t, "Images not equal.", "%sImage did not match master. Actual image written to file://%s.", msg, failedPath)
 }
 
 func pixelsForImage(t *testing.T, img image.Image) []uint8 {


### PR DESCRIPTION
Actually, this skips printing:

- the expected byte array
- the actual byte array
- the byte array diff

(only when images are compared)

### Description:

This is a proposal for keeping the the `go test` output readable.

Fixes #6139, question 2.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.