### PR TITLE
Fix TestMenuBar (glfw)

### DIFF
--- a/internal/driver/glfw/menu_bar_test.go
+++ b/internal/driver/glfw/menu_bar_test.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"strconv"
 	"testing"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -322,6 +323,7 @@ func TestMenuBar(t *testing.T) {
 							}
 							var capture2 image.Image
 							runOnMain(func() {
+								time.Sleep(time.Millisecond * 20)
 								capture2 = c.Capture()
 							})
 							test.AssertImageMatches(t, s.wantImage, capture2)


### PR DESCRIPTION
Sleep for 20 ms because otherwise it might happen that the screen is not yet fully redrawn when the screenshot is taken.

### Description:

`TestMenuBar` fails every time (on my laptop). The screenshot taken looks like the latest redraw isn't finished yet:

<img width="300" height="300" alt="menu_bar_hovered_content_test_theme" src="https://github.com/user-attachments/assets/be0f11f5-7965-4f16-9177-70f2994a20b2" />

A little delay before taking the screenshot fixes this test for me.

Fixes #6139 (partially).

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
