### PR TITLE
Fix Test_canvas_Dragged for non-mobile build

### DIFF
--- a/internal/driver/mobile/canvas_test.go
+++ b/internal/driver/mobile/canvas_test.go
@@ -91,15 +91,19 @@ func Test_canvas_Dragged(t *testing.T) {
 		draggedObj = wid
 	})
 
-	assert.True(t, dragged)
-	assert.Equal(t, scroll, draggedObj)
-	dragged = false
-	c.tapMove(fyne.NewPos(32, 5), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
-		wid.Dragged(ev)
-		dragged = true
-	})
-	assert.True(t, dragged)
-	assert.Equal(t, fyne.NewPos(0, 5), scroll.Offset)
+	if _, ok := interface{}(scroll).(fyne.Draggable); ok {
+		assert.True(t, dragged)
+		assert.Equal(t, scroll, draggedObj)
+		dragged = false
+		c.tapMove(fyne.NewPos(32, 5), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+			wid.Dragged(ev)
+			dragged = true
+		})
+		assert.True(t, dragged)
+		assert.Equal(t, fyne.NewPos(0, 5), scroll.Offset)
+	} else {
+		assert.False(t, dragged)
+	}
 }
 
 func Test_canvas_DraggingOutOfWidget(t *testing.T) {


### PR DESCRIPTION
When `go test` is run without `-tags mobile`, there is no `Dragged` implemented for `*container.Scroll` (since ab6b85f). That's why the test fails. This commit checks if `Draggable` is implemented and uses the right assertion for each case.

### Description:

Fixes #6139 (regarding `Test_canvas_Dragged`)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.