### PR TITLE
Fix build tags for some wasm files

### DIFF
--- a/app/app_wasm.go
+++ b/app/app_wasm.go
@@ -1,4 +1,4 @@
-//go:build !ci && (!android || !ios || !mobile) && (wasm || test_web_driver)
+//go:build !ci && !android && !ios && !mobile && (wasm || test_web_driver)
 
 package app
 

--- a/internal/app/config_wasm.go
+++ b/internal/app/config_wasm.go
@@ -1,4 +1,4 @@
-//go:build !ci && (!android || !ios || !mobile) && (wasm || test_web_driver) && !noos && !tinygo
+//go:build !ci && !android && !ios && !mobile && (wasm || test_web_driver) && !noos && !tinygo
 
 package app
 

--- a/widget/markdown_image_wasm.go
+++ b/widget/markdown_image_wasm.go
@@ -1,4 +1,4 @@
-//go:build !ci && (!android || !ios || !mobile) && (wasm || test_web_driver)
+//go:build !ci && !android && !ios && !mobile && (wasm || test_web_driver)
 
 package widget
 


### PR DESCRIPTION
`(!android || !ios || !mobile)` is logically the same as `!(android && ios && mobile)`. It's not necessary to exclude builds with `-tags android,ios,mobile`. These fail anyway.

I suppose these build tags were set by mistake with the intention to exclude all android or ios or mobile builds.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.