### PR TITLE
Fix: Hangul (Korean Alpha) wrongly rendered since go-text/typesetting v0.3.0

### DIFF
--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends clang lld libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
+          sudo apt-get install --no-install-recommends clang lld libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev fonts-noto-cjk
 
       - name: Tests
         run: xvfb-run go test -race -tags mobile,ci,migrated_fynedo ./...

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends bc clang lld libgl1-mesa-dev libwayland-dev libx11-dev libxkbcommon-dev xorg-dev xvfb language-pack-en
+          sudo apt-get install --no-install-recommends bc clang lld libgl1-mesa-dev libwayland-dev libx11-dev libxkbcommon-dev xorg-dev xvfb language-pack-en fonts-noto-cjk
           echo "CC=clang" >> "$GITHUB_ENV"
           echo "CGO_LDFLAGS=-fuse-ld=lld" >> "$GITHUB_ENV"
         if: ${{ runner.os == 'Linux' }}

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -74,6 +74,7 @@ func lookupRuneFont(r rune, family string, aspect font.Aspect) *font.Face {
 	}
 
 	fm.SetQuery(fontscan.Query{Families: []string{family}, Aspect: aspect})
+	fm.SetScript(language.LookupScript(r))
 	return fm.ResolveFace(r)
 }
 

--- a/internal/painter/font_test.go
+++ b/internal/painter/font_test.go
@@ -132,3 +132,11 @@ func TestRenderedTextSize(t *testing.T) {
 	assert.Equal(t, size1.Height, size2.Height)
 	assert.Equal(t, baseline1, baseline2)
 }
+
+func TestHangul(t *testing.T) {
+	got := painter.CachedFontFace(fyne.TextStyle{}, nil, nil)
+	f := got.Fonts.ResolveFace('안')
+	gid, ok := f.Cmap.Lookup('안')
+	assert.True(t, ok)
+	assert.NotZero(t, gid)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

After go-text v0.3.0 is released with https://github.com/go-text/typesetting/pull/178 merged, `SetScript` should be called before using `ResolveFace` which is not considered on the current branch.
I added the missing call and added the glyph lookup test for Hungul.
Fixes #6146

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
