### PR TITLE
Fix canonicalizes the system language string

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -60,7 +60,7 @@ func lookupLangFont(family string, aspect font.Aspect) *font.Face {
 	}
 
 	fm.SetQuery(fontscan.Query{Families: []string{family}, Aspect: aspect})
-	l, _ := language.NewLangID(language.Language(lang.SystemLocale().LanguageString()))
+	l, _ := language.NewLangID(language.NewLanguage(lang.SystemLocale().LanguageString()))
 	return fm.ResolveFaceForLang(l)
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

The language.NewLangID does not work here before. This is a small change to use the right API to instantiate the `language.Language` and make sure it's canonicalized.

See https://github.com/go-text/typesetting/issues/239 for more details

Evidence:
```go
package main

import (
	"fmt"

	"fyne.io/fyne/v2/lang"
	"github.com/go-text/typesetting/language"
)

func main() {
	locale := lang.SystemLocale().LanguageString() // zh-CN
	_, ok := language.NewLangID(language.Language(locale))
	fmt.Println(ok) // false
	_, ok = language.NewLangID(language.NewLanguage(locale))
	fmt.Println(ok) // true
}
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
