### PR TITLE
Fix Ensure GL context is not null when freeing textures

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -727,7 +727,9 @@ func (w *window) RescaleContext() {
 	w.viewport.SetSize(newWidth, newHeight)
 
 	// Ensure textures re-rasterize at the new scale
-	cache.DeleteTextTexturesFor(w.canvas)
+	w.RunWithContext(func() {
+		cache.DeleteTextTexturesFor(w.canvas)
+	})
 	w.canvas.content.Refresh()
 }
 

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -512,7 +512,9 @@ func (w *window) RescaleContext() {
 	w.canvas.Resize(scaledFull)
 
 	// Ensure textures re-rasterize at the new scale
-	cache.DeleteTextTexturesFor(w.canvas)
+	w.RunWithContext(func() {
+		cache.DeleteTextTexturesFor(w.canvas)
+	})
 	w.canvas.content.Refresh()
 }
 

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -51,6 +51,9 @@ func (p *painter) getTexture(object fyne.CanvasObject, creator func(canvasObject
 			texture = cache.TextureType(tex)
 			cache.SetTextTexture(ent, texture, p.canvas, func() {
 				p.ctx.DeleteTexture(tex)
+				if glErr := p.ctx.GetError(); glErr != 0 {
+					panic(fmt.Sprintf("failed to delete the text texture; error code: %x", glErr))
+				}
 			})
 		}
 

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -51,9 +51,7 @@ func (p *painter) getTexture(object fyne.CanvasObject, creator func(canvasObject
 			texture = cache.TextureType(tex)
 			cache.SetTextTexture(ent, texture, p.canvas, func() {
 				p.ctx.DeleteTexture(tex)
-				if glErr := p.ctx.GetError(); glErr != 0 {
-					panic(fmt.Sprintf("failed to delete the text texture; error code: %x", glErr))
-				}
+				p.logError()
 			})
 		}
 


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

I hope this is the right way to ensure the GL context, but I believe the demo's problem is caused by a null WebGL context.

Fixes https://github.com/fyne-io/demo/issues/4

~~I don't really know if I need to apply this change into window_desktop.go
Even without a live GL context, you can still free the text textures correctly on the Desktop.~~
It is indeed necessary, see https://github.com/fyne-io/demo/issues/4#issuecomment-4003073457

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.