### PR TITLE
Move Test_canvas_Dragged to file with mobile build tag

### DIFF
--- a/internal/driver/mobile/canvas_dragged_test.go
+++ b/internal/driver/mobile/canvas_dragged_test.go
@@ -1,0 +1,39 @@
+//go:build mobile && (!windows || !ci)
+
+package mobile
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_canvas_Dragged(t *testing.T) {
+	dragged := false
+	var draggedObj fyne.Draggable
+	scroll := container.NewScroll(widget.NewLabel("Hi\nHi\nHi"))
+	c := newCanvas(fyne.CurrentDevice()).(*canvas)
+	c.SetContent(scroll)
+	c.Resize(fyne.NewSize(40, 24))
+	assert.Equal(t, float32(0), scroll.Offset.Y)
+
+	c.tapDown(fyne.NewPos(32, 3), 0)
+	c.tapMove(fyne.NewPos(32, 10), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+		wid.Dragged(ev)
+		dragged = true
+		draggedObj = wid
+	})
+
+	assert.True(t, dragged)
+	assert.Equal(t, scroll, draggedObj)
+	dragged = false
+	c.tapMove(fyne.NewPos(32, 5), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+		wid.Dragged(ev)
+		dragged = true
+	})
+	assert.True(t, dragged)
+	assert.Equal(t, fyne.NewPos(0, 5), scroll.Offset)
+}

--- a/internal/driver/mobile/canvas_test.go
+++ b/internal/driver/mobile/canvas_test.go
@@ -75,33 +75,6 @@ func Test_canvas_ChildMinSizeChangeAffectsAncestorsUpToRoot(t *testing.T) {
 	assert.Equal(t, expectedContentSize, content.Size())
 }
 
-func Test_canvas_Dragged(t *testing.T) {
-	dragged := false
-	var draggedObj fyne.Draggable
-	scroll := container.NewScroll(widget.NewLabel("Hi\nHi\nHi"))
-	c := newCanvas(fyne.CurrentDevice()).(*canvas)
-	c.SetContent(scroll)
-	c.Resize(fyne.NewSize(40, 24))
-	assert.Equal(t, float32(0), scroll.Offset.Y)
-
-	c.tapDown(fyne.NewPos(32, 3), 0)
-	c.tapMove(fyne.NewPos(32, 10), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
-		wid.Dragged(ev)
-		dragged = true
-		draggedObj = wid
-	})
-
-	assert.True(t, dragged)
-	assert.Equal(t, scroll, draggedObj)
-	dragged = false
-	c.tapMove(fyne.NewPos(32, 5), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
-		wid.Dragged(ev)
-		dragged = true
-	})
-	assert.True(t, dragged)
-	assert.Equal(t, fyne.NewPos(0, 5), scroll.Offset)
-}
-
 func Test_canvas_DraggingOutOfWidget(t *testing.T) {
 	c := newCanvas(fyne.CurrentDevice()).(*canvas)
 	slider := widget.NewSlider(0.0, 100.0)


### PR DESCRIPTION
### Description:

This is a third approach to handle the failing `Test_canvas_Dragged` on non-mobile builds.

#### Overview over alternative fixes:

1. #6149: Handle non-mobile case inside `Test_canvas_Dragged`.
2. #6152: Skip complete `internal/driver/mobile/canvas_test.go‎` on non-mobile builds/test runs.
3. This PR: Exclude only `Test_canvas_Dragged` from non-mobile builds/test runs.

Fixes #6139 (regarding Test_canvas_Dragged by skipping this test for non-mobile)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
