### PR TITLE
Markdown: Support links in headings

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -85,17 +85,7 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 	case *ast.TextBlock:
 		return renderChildren(source, n, blockquote, listDepth)
 	case *ast.Heading:
-		text := forceIntoHeadingText(source, n)
-		switch t.Level {
-		case 1:
-			return []RichTextSegment{&TextSegment{Style: RichTextStyleHeading, Text: decodeText(text)}}, nil
-		case 2:
-			return []RichTextSegment{&TextSegment{Style: RichTextStyleSubHeading, Text: decodeText(text)}}, nil
-		default:
-			textSegment := TextSegment{Style: RichTextStyleParagraph, Text: decodeText(text)}
-			textSegment.Style.TextStyle.Bold = true
-			return []RichTextSegment{&textSegment}, nil
-		}
+		return renderHeading(source, n, blockquote, listDepth)
 	case *ast.ThematicBreak:
 		return []RichTextSegment{&SeparatorSegment{}}, nil
 	case *ast.Link:
@@ -165,6 +155,56 @@ func renderChildren(source []byte, n ast.Node, blockquote bool, listDepth int) (
 	return children, nil
 }
 
+func renderHeading(source []byte, n ast.Node, blockquote bool, listDepth int) ([]RichTextSegment, error) {
+	var style RichTextStyle
+	switch n.(*ast.Heading).Level {
+	case 1:
+		style = RichTextStyleHeading
+	case 2:
+		style = RichTextStyleSubHeading
+	default:
+		style = RichTextStyleStrong
+	}
+
+	children := make([]RichTextSegment, 0, n.ChildCount())
+	lastIsText := false
+	for childCount, child := n.ChildCount(), n.FirstChild(); childCount > 0; childCount-- {
+		switch t := child.(type) {
+		case *ast.Text:
+			text := string(t.Value(source))
+			if lastIsText {
+				children[len(children)-1].(*TextSegment).Text += decodeText(text)
+				lastIsText = true
+				continue
+			}
+			children = append(children, &TextSegment{Style: style, Text: decodeText(text)})
+			lastIsText = true
+		default:
+			segs, err := renderNode(source, child, blockquote, listDepth)
+			if err != nil {
+				return children, err
+			}
+			children = append(children, segs...)
+			lastIsText = false
+		}
+		child = child.NextSibling()
+	}
+	if len(children) == 0 {
+		children = append(children, &TextSegment{Style: style, Text: ""})
+	}
+
+	for _, child := range children {
+		switch t := child.(type) {
+		case *HyperlinkSegment:
+			t.TextStyle = style.TextStyle
+			t.SizeName = style.SizeName
+		}
+	}
+	linebreak := &TextSegment{Style: RichTextStyleParagraph}
+	children = append(children, linebreak)
+	return children, nil
+}
+
 func renderEmphasis(source []byte, n ast.Node, blockquote bool, listDepth int) ([]RichTextSegment, error) {
 	style := RichTextStyleEmphasis
 	if n.(*ast.Emphasis).Level == 2 {
@@ -195,20 +235,6 @@ func forceIntoText(source []byte, n ast.Node) string {
 		return ast.WalkContinue, nil
 	})
 	return strings.TrimSuffix(text.String(), " ")
-}
-
-func forceIntoHeadingText(source []byte, n ast.Node) string {
-	text := strings.Builder{}
-	ast.Walk(n, func(n2 ast.Node, entering bool) (ast.WalkStatus, error) {
-		if entering {
-			switch t := n2.(type) {
-			case *ast.Text:
-				text.Write(t.Value(source))
-			}
-		}
-		return ast.WalkContinue, nil
-	})
-	return text.String()
 }
 
 func parseMarkdown(content string) []RichTextSegment {

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -128,6 +128,42 @@ func TestRichTextMarkdown_Heading_Blank(t *testing.T) {
 	}
 }
 
+func TestRichTextMarkdown_HeadingWithHyperlink(t *testing.T) {
+	r := NewRichTextFromMarkdown("# Head1 [link](https://fyne.io/)\n\n## Head2 <https://fyne.io>\n### [Head3](https://fyne.io/)\n")
+
+	assert.Len(t, r.Segments, 8)
+	if text, ok := r.Segments[0].(*TextSegment); ok {
+		assert.Equal(t, "Head1 ", text.Text)
+		assert.Equal(t, RichTextStyleHeading, text.Style)
+	} else {
+		t.Error("Segment should be Heading text")
+	}
+	if link, ok := r.Segments[1].(*HyperlinkSegment); ok {
+		assert.Equal(t, "link", link.Text)
+		assert.Equal(t, RichTextStyleHeading.TextStyle, link.TextStyle)
+	} else {
+		t.Error("Segment should be Heading hyperlink")
+	}
+	if text, ok := r.Segments[2].(*TextSegment); ok {
+		assert.Equal(t, "", text.Text)
+		assert.Equal(t, RichTextStyleParagraph, text.Style)
+	} else {
+		t.Error("Segment should be Paragraph (linebreak)")
+	}
+	if link, ok := r.Segments[4].(*HyperlinkSegment); ok {
+		assert.Equal(t, "https://fyne.io", link.Text)
+		assert.Equal(t, RichTextStyleSubHeading.TextStyle, link.TextStyle)
+	} else {
+		t.Error("Segment should be SubHeading hyperlink")
+	}
+	if link, ok := r.Segments[6].(*HyperlinkSegment); ok {
+		assert.Equal(t, "Head3", link.Text)
+		assert.Equal(t, RichTextStyleStrong.TextStyle, link.TextStyle) // we don't have 6 levels of heading so just bold others
+	} else {
+		t.Error("Segment should be Strong hyperlink")
+	}
+}
+
 func TestRichTextMarkdown_Hyperlink(t *testing.T) {
 	r := NewRichTextFromMarkdown("[title](https://fyne.io/)")
 

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -84,21 +84,21 @@ func TestRichTextMarkdown_Emphasis(t *testing.T) {
 func TestRichTextMarkdown_Heading(t *testing.T) {
 	r := NewRichTextFromMarkdown("# Head1\n\n## Head2!\n### Head3\n")
 
-	assert.Len(t, r.Segments, 3)
+	assert.Len(t, r.Segments, 6)
 	if text, ok := r.Segments[0].(*TextSegment); ok {
 		assert.Equal(t, "Head1", text.Text)
 		assert.Equal(t, RichTextStyleHeading, text.Style)
 	} else {
 		t.Error("Segment should be Heading")
 	}
-	if text, ok := r.Segments[1].(*TextSegment); ok {
+	if text, ok := r.Segments[2].(*TextSegment); ok {
 		assert.Equal(t, "Head2!", text.Text)
 		assert.Equal(t, RichTextStyleSubHeading, text.Style)
 	} else {
 		t.Error("Segment should be SubHeading")
 	}
 
-	if text, ok := r.Segments[2].(*TextSegment); ok {
+	if text, ok := r.Segments[4].(*TextSegment); ok {
 		assert.Equal(t, "Head3", text.Text)
 		assert.True(t, text.Style.TextStyle.Bold) // we don't have 6 levels of heading so just bold others
 	} else {
@@ -109,7 +109,7 @@ func TestRichTextMarkdown_Heading(t *testing.T) {
 func TestRichTextMarkdown_Heading_Blank(t *testing.T) {
 	r := NewRichTextFromMarkdown("#")
 
-	assert.Len(t, r.Segments, 1)
+	assert.Len(t, r.Segments, 2)
 	if text, ok := r.Segments[0].(*TextSegment); ok {
 		assert.Equal(t, "", text.Text)
 		assert.Equal(t, RichTextStyleHeading, text.Style)
@@ -119,7 +119,7 @@ func TestRichTextMarkdown_Heading_Blank(t *testing.T) {
 
 	r = NewRichTextFromMarkdown("# ")
 
-	assert.Len(t, r.Segments, 1)
+	assert.Len(t, r.Segments, 2)
 	if text, ok := r.Segments[0].(*TextSegment); ok {
 		assert.Equal(t, "", text.Text)
 		assert.Equal(t, RichTextStyleHeading, text.Style)

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -760,9 +760,6 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	realign := false
 	baselines := make([]float32, len(texts))
 
-	// Access to theme is slow, so we cache the text size
-	textSize := theme.SizeForWidget(theme.SizeNameText, r.obj)
-
 	driver := fyne.CurrentApp().Driver()
 	for i, text := range texts {
 		var size fyne.Size
@@ -779,6 +776,7 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 		} else if c, ok := text.(*fyne.Container); ok {
 			wid := c.Objects[0]
 			if link, ok := wid.(*Hyperlink); ok {
+				textSize := theme.SizeForWidget(link.SizeName, r.obj)
 				s, base := driver.RenderedTextSize(link.Text, textSize, link.TextStyle, nil)
 				if base > tallestBaseline {
 					if tallestBaseline > 0 {

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -117,7 +117,8 @@ type HyperlinkSegment struct {
 	OnTapped func() `json:"-"`
 
 	// Since 2.8
-	SizeName  fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
+	SizeName fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
+	// Since 2.8
 	TextStyle fyne.TextStyle
 }
 

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -117,9 +117,9 @@ type HyperlinkSegment struct {
 	OnTapped func() `json:"-"`
 
 	// Since 2.8
-	SizeName fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
-	// Since 2.8
 	TextStyle fyne.TextStyle
+	// Since 2.8
+	SizeName fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
 }
 
 // Inline returns true as hyperlinks are inside other elements.

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -54,7 +54,7 @@ var (
 	// Since: 2.1
 	RichTextStyleHeading = RichTextStyle{
 		ColorName: theme.ColorNameForeground,
-		Inline:    false,
+		Inline:    true,
 		SizeName:  theme.SizeNameHeadingText,
 		TextStyle: fyne.TextStyle{Bold: true},
 	}
@@ -97,7 +97,7 @@ var (
 	// Since: 2.1
 	RichTextStyleSubHeading = RichTextStyle{
 		ColorName: theme.ColorNameForeground,
-		Inline:    false,
+		Inline:    true,
 		SizeName:  theme.SizeNameSubHeadingText,
 		TextStyle: fyne.TextStyle{Bold: true},
 	}
@@ -117,6 +117,7 @@ type HyperlinkSegment struct {
 	OnTapped func() `json:"-"`
 
 	// Since 2.8
+	SizeName  fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
 	TextStyle fyne.TextStyle
 }
 
@@ -144,6 +145,7 @@ func (h *HyperlinkSegment) Update(o fyne.CanvasObject) {
 	link.Text = h.Text
 	link.URL = h.URL
 	link.Alignment = h.Alignment
+	link.SizeName = h.SizeName
 	link.TextStyle = h.TextStyle
 	link.OnTapped = h.OnTapped
 	link.Refresh()


### PR DESCRIPTION
### Description:

<img width="456" height="113" alt="image" src="https://github.com/user-attachments/assets/410e77a4-e341-4ec6-943d-c203329ba2dd" />

#### Changes in this PR:

- `*ast.Heading` must be checked for `*ast.Text` and `*ast.Link` child nodes.
- Adjacent `*ast.Text` nodes need to be merged.
- `textRenderer.layoutRow`: `textSize` must be checked for every `Hyperlink`.
- HyperlinkSegments become inline and consist of at least two elements: header text + newline/paragraph.


Fixes #5576 (together with #6127, already merged)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass (except data/binding for `-tags mobile`).

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
