### PR TITLE
Follow MacOS system setting for scroll bar visibility

### DIFF
--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -1,7 +1,6 @@
 package widget
 
 import (
-	"sync/atomic"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -222,7 +221,7 @@ func (r *scrollBarAreaRenderer) Refresh() {
 	r.bar.Refresh()
 	r.background.FillColor = th.Color(theme.ColorNameScrollBarBackground, fyne.CurrentApp().Settings().ThemeVariant())
 	r.background.Hidden = !r.area.isLarge()
-	if !r.area.isLarge() && !scrollBarAlwaysVisible() && !r.area.scroll.scrolling.Load() {
+	if !r.area.isLarge() && !scrollBarAlwaysVisible() && !r.area.scroll.scrolling {
 		r.bar.Hide()
 	} else {
 		r.bar.Show()
@@ -522,7 +521,7 @@ type Scroll struct {
 	// Since: 2.0
 	OnScrolled func(fyne.Position) `json:"-"`
 
-	scrolling      atomic.Bool
+	scrolling      bool
 	scrollEndTimer *time.Timer
 }
 
@@ -619,13 +618,13 @@ func (s *Scroll) Scrolled(ev *fyne.ScrollEvent) {
 		s.scrollBy(ev.Scrolled.DX, ev.Scrolled.DY)
 	}
 	if !scrollBarAlwaysVisible() {
-		s.scrolling.Store(true)
+		s.scrolling = true
 		if s.scrollEndTimer != nil {
 			s.scrollEndTimer.Reset(scrollEndDelay)
 		} else {
 			s.scrollEndTimer = time.AfterFunc(scrollEndDelay, func() {
 				fyne.Do(func() {
-					s.scrolling.Store(false)
+					s.scrolling = false
 					s.refreshBars()
 				})
 			})

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -1,12 +1,17 @@
 package widget
 
 import (
+	"sync/atomic"
+	"time"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/theme"
 )
+
+const scrollEndDelay = 500 * time.Millisecond
 
 // ScrollDirection represents the directions in which a Scroll can scroll its child content.
 type ScrollDirection = fyne.ScrollDirection
@@ -148,9 +153,27 @@ func (a *scrollBarArea) isLarge() bool {
 
 type scrollBarAreaRenderer struct {
 	BaseRenderer
-	area       *scrollBarArea
-	bar        *scrollBar
-	background *canvas.Rectangle
+	area           *scrollBarArea
+	bar            *scrollBar
+	background     *canvas.Rectangle
+	subscriptionID uint64
+}
+
+func newScrollBarAreaRenderer(area *scrollBarArea, bar *scrollBar, background *canvas.Rectangle) *scrollBarAreaRenderer {
+	r := &scrollBarAreaRenderer{
+		BaseRenderer: NewBaseRenderer([]fyne.CanvasObject{background, bar}),
+		area:         area,
+		bar:          bar,
+		background:   background,
+	}
+	r.subscriptionID = subscribeScrollerStyle(func() {
+		area.Refresh()
+	})
+	return r
+}
+
+func (r *scrollBarAreaRenderer) Destroy() {
+	unsubscribeScrollerStyle(r.subscriptionID)
 }
 
 func (r *scrollBarAreaRenderer) Layout(size fyne.Size) {
@@ -199,6 +222,11 @@ func (r *scrollBarAreaRenderer) Refresh() {
 	r.bar.Refresh()
 	r.background.FillColor = th.Color(theme.ColorNameScrollBarBackground, fyne.CurrentApp().Settings().ThemeVariant())
 	r.background.Hidden = !r.area.isLarge()
+	if !r.area.isLarge() && !scrollBarAlwaysVisible() && !r.area.scroll.scrolling.Load() {
+		r.bar.Hide()
+	} else {
+		r.bar.Show()
+	}
 	r.layoutWithTheme(th, r.area.Size())
 	canvas.Refresh(r.bar)
 	canvas.Refresh(r.background)
@@ -251,7 +279,7 @@ func (a *scrollBarArea) CreateRenderer() fyne.WidgetRenderer {
 	a.bar = newScrollBar(a)
 	background := canvas.NewRectangle(th.Color(theme.ColorNameScrollBarBackground, v))
 	background.Hidden = !a.isLarge()
-	return &scrollBarAreaRenderer{BaseRenderer: NewBaseRenderer([]fyne.CanvasObject{background, a.bar}), area: a, bar: a.bar, background: background}
+	return newScrollBarAreaRenderer(a, a.bar, background)
 }
 
 func (a *scrollBarArea) Tapped(e *fyne.PointEvent) {
@@ -493,6 +521,9 @@ type Scroll struct {
 	//
 	// Since: 2.0
 	OnScrolled func(fyne.Position) `json:"-"`
+
+	scrolling      atomic.Bool
+	scrollEndTimer *time.Timer
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
@@ -586,6 +617,20 @@ func (s *Scroll) refreshWithoutOffsetUpdate() {
 func (s *Scroll) Scrolled(ev *fyne.ScrollEvent) {
 	if s.Direction != ScrollNone {
 		s.scrollBy(ev.Scrolled.DX, ev.Scrolled.DY)
+	}
+	if !scrollBarAlwaysVisible() {
+		s.scrolling.Store(true)
+		if s.scrollEndTimer != nil {
+			s.scrollEndTimer.Reset(scrollEndDelay)
+		} else {
+			s.scrollEndTimer = time.AfterFunc(scrollEndDelay, func() {
+				fyne.Do(func() {
+					s.scrolling.Store(false)
+					s.refreshBars()
+				})
+			})
+		}
+		s.refreshBars()
 	}
 }
 

--- a/internal/widget/scroller_behavior_darwin.go
+++ b/internal/widget/scroller_behavior_darwin.go
@@ -4,9 +4,63 @@ package widget
 
 /*
 int getScrollerPagingBehavior();
+int getScrollerStyle();
+void watchScrollerStyle();
 */
 import "C"
 
+import (
+	"sync"
+
+	"fyne.io/fyne/v2"
+)
+
 func isScrollerPageOnTap() bool {
 	return C.getScrollerPagingBehavior() == 0
+}
+
+// scrollBarAlwaysVisible returns true when the macOS "Show scroll bars" preference
+// is set to "Always" (NSScrollerStyleLegacy = 0).
+// When set to "When scrolling" or "Automatically" (NSScrollerStyleOverlay = 1),
+// scroll bars should only appear on hover or while scrolling.
+func scrollBarAlwaysVisible() bool {
+	return C.getScrollerStyle() == 0
+}
+
+var (
+	scrollerStyleWatchOnce   sync.Once
+	scrollerStyleMu          sync.Mutex
+	scrollerStyleSubscribers = map[uint64]func(){}
+	scrollerStyleNextID      uint64
+)
+
+func subscribeScrollerStyle(fn func()) uint64 {
+	scrollerStyleWatchOnce.Do(func() { C.watchScrollerStyle() })
+	scrollerStyleMu.Lock()
+	defer scrollerStyleMu.Unlock()
+	id := scrollerStyleNextID
+	scrollerStyleNextID++
+	scrollerStyleSubscribers[id] = fn
+	return id
+}
+
+func unsubscribeScrollerStyle(id uint64) {
+	scrollerStyleMu.Lock()
+	defer scrollerStyleMu.Unlock()
+	delete(scrollerStyleSubscribers, id)
+}
+
+//export scrollerStyleChanged
+func scrollerStyleChanged() {
+	scrollerStyleMu.Lock()
+	fns := make([]func(), 0, len(scrollerStyleSubscribers))
+	for _, fn := range scrollerStyleSubscribers {
+		fns = append(fns, fn)
+	}
+	scrollerStyleMu.Unlock()
+	fyne.Do(func() {
+		for _, fn := range fns {
+			fn()
+		}
+	})
 }

--- a/internal/widget/scroller_behavior_darwin.go
+++ b/internal/widget/scroller_behavior_darwin.go
@@ -12,8 +12,6 @@ void watchScrollerStyle();
 import "C"
 
 import (
-	"sync"
-
 	"fyne.io/fyne/v2"
 )
 
@@ -30,16 +28,16 @@ func scrollBarAlwaysVisible() bool {
 }
 
 var (
-	scrollerStyleWatchOnce   sync.Once
-	scrollerStyleMu          sync.Mutex
-	scrollerStyleSubscribers = map[uint64]func(){}
-	scrollerStyleNextID      uint64
+	isWatchingMacScrollerStyle bool
+	scrollerStyleSubscribers   = map[uint64]func(){}
+	scrollerStyleNextID        uint64
 )
 
 func subscribeScrollerStyle(fn func()) uint64 {
-	scrollerStyleWatchOnce.Do(func() { C.watchScrollerStyle() })
-	scrollerStyleMu.Lock()
-	defer scrollerStyleMu.Unlock()
+	if !isWatchingMacScrollerStyle {
+		isWatchingMacScrollerStyle = true
+		C.watchScrollerStyle()
+	}
 	id := scrollerStyleNextID
 	scrollerStyleNextID++
 	scrollerStyleSubscribers[id] = fn
@@ -47,21 +45,13 @@ func subscribeScrollerStyle(fn func()) uint64 {
 }
 
 func unsubscribeScrollerStyle(id uint64) {
-	scrollerStyleMu.Lock()
-	defer scrollerStyleMu.Unlock()
 	delete(scrollerStyleSubscribers, id)
 }
 
 //export scrollerStyleChanged
 func scrollerStyleChanged() {
-	scrollerStyleMu.Lock()
-	fns := make([]func(), 0, len(scrollerStyleSubscribers))
-	for _, fn := range scrollerStyleSubscribers {
-		fns = append(fns, fn)
-	}
-	scrollerStyleMu.Unlock()
 	fyne.Do(func() {
-		for _, fn := range fns {
+		for _, fn := range scrollerStyleSubscribers {
 			fn()
 		}
 	})

--- a/internal/widget/scroller_behavior_darwin.go
+++ b/internal/widget/scroller_behavior_darwin.go
@@ -3,6 +3,8 @@
 package widget
 
 /*
+#cgo LDFLAGS: -framework AppKit
+
 int getScrollerPagingBehavior();
 int getScrollerStyle();
 void watchScrollerStyle();

--- a/internal/widget/scroller_behavior_darwin.go
+++ b/internal/widget/scroller_behavior_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build !ci && darwin
 
 package widget
 

--- a/internal/widget/scroller_behavior_darwin.m
+++ b/internal/widget/scroller_behavior_darwin.m
@@ -1,7 +1,22 @@
 //go:build darwin
 
 #import <Foundation/Foundation.h>
+#import <AppKit/NSScroller.h>
+
+extern void scrollerStyleChanged();
 
 int getScrollerPagingBehavior() {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"AppleScrollerPagingBehavior"];
+}
+
+int getScrollerStyle() {
+    return [NSScroller preferredScrollerStyle];
+}
+
+void watchScrollerStyle() {
+    [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification
+        object:nil queue:nil
+        usingBlock:^(NSNotification *note) {
+            scrollerStyleChanged(); // calls back into Go
+        }];
 }

--- a/internal/widget/scroller_behavior_darwin.m
+++ b/internal/widget/scroller_behavior_darwin.m
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build !ci && darwin
 
 #import <Foundation/Foundation.h>
 #import <AppKit/NSScroller.h>

--- a/internal/widget/scroller_behavior_other.go
+++ b/internal/widget/scroller_behavior_other.go
@@ -10,5 +10,5 @@ func scrollBarAlwaysVisible() bool {
 	return true
 }
 
-func subscribeScrollerStyle(_ func()) int { return 0 }
-func unsubscribeScrollerStyle(_ int)      {}
+func subscribeScrollerStyle(_ func()) uint64 { return 0 }
+func unsubscribeScrollerStyle(_ uint64)      {}

--- a/internal/widget/scroller_behavior_other.go
+++ b/internal/widget/scroller_behavior_other.go
@@ -5,3 +5,10 @@ package widget
 func isScrollerPageOnTap() bool {
 	return false
 }
+
+func scrollBarAlwaysVisible() bool {
+	return true
+}
+
+func subscribeScrollerStyle(_ func()) int { return 0 }
+func unsubscribeScrollerStyle(_ int)      {}

--- a/internal/widget/scroller_behavior_other.go
+++ b/internal/widget/scroller_behavior_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build ci || !darwin
 
 package widget
 


### PR DESCRIPTION
### Description:
Respect the MacOS system settings for scroll bar visibility (always vs when scrolling only). When "show when scrolling only" scroll bars disappear 500 milliseconds after the last scroll event is received, which seems to match the behavior of other apps, at least by eye.

Fixes #5518 

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

