### PR TITLE
Faster text wrapping

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -848,11 +848,11 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 
 // ratioSearch accepts a function that checks if the text width less the maximum width and the start and end rune index
 // ratioSearch returns the index of rune located as close to the maximum line width as possible
-func ratioSearch(lessMaxWidth func(int, int) float32, low int, maxHigh int) int {
+func ratioSearch(widthToMaxWidthRatio func(int, int) float32, low int, maxHigh int) int {
 	if low >= maxHigh {
 		return low
 	}
-	ratio := lessMaxWidth(low, maxHigh)
+	ratio := widthToMaxWidthRatio(low, maxHigh)
 	if ratio <= 1.0 {
 		return maxHigh
 	}
@@ -862,7 +862,7 @@ func ratioSearch(lessMaxWidth func(int, int) float32, low int, maxHigh int) int 
 		nextHigh = high + 1
 	}
 	for nextHigh < maxHigh {
-		ratio = lessMaxWidth(low, nextHigh)
+		ratio = widthToMaxWidthRatio(low, nextHigh)
 		if ratio <= 1.0 {
 			high = nextHigh
 		} else {

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -846,9 +846,10 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	return xPos - initialX, height
 }
 
-// ratioSearch accepts a function that returns the ratio between the text width
-// and the maximum width and the start and end rune index
-// ratioSearch returns the index of rune located as close to the maximum line width as possible
+// ratioSearch accepts a function that, given a start and end rune index, returns
+// the ratio of the text width to the maximum allowed width. The low and maxHigh
+// parameters are the start and end rune indices to search between. ratioSearch
+// returns the index of the rune located as close as possible to the maximum line width.
 func ratioSearch(widthToMaxWidthRatio func(int, int) float32, low int, maxHigh int) int {
 	if low >= maxHigh {
 		return low

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -846,25 +846,35 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	return xPos - initialX, height
 }
 
-// binarySearch accepts a function that checks if the text width less the maximum width and the start and end rune index
-// binarySearch returns the index of rune located as close to the maximum line width as possible
-func binarySearch(lessMaxWidth func(int, int) bool, low int, maxHigh int) int {
+// ratioSearch accepts a function that checks if the text width less the maximum width and the start and end rune index
+// ratioSearch returns the index of rune located as close to the maximum line width as possible
+func ratioSearch(lessMaxWidth func(int, int) float32, low int, maxHigh int) int {
 	if low >= maxHigh {
 		return low
 	}
-	if lessMaxWidth(low, maxHigh) {
+	ratio := lessMaxWidth(low, maxHigh)
+	if ratio <= 1.0 {
 		return maxHigh
 	}
 	high := low
-	delta := maxHigh - low
-	for delta > 0 {
-		delta /= 2
-		if lessMaxWidth(low, high+delta) {
-			high += delta
-		}
+	nextHigh := low + int(float32(maxHigh-low)/ratio)
+	if nextHigh <= high {
+		nextHigh = high + 1
 	}
-	for (high < maxHigh) && lessMaxWidth(low, high+1) {
-		high++
+	for nextHigh < maxHigh {
+		ratio = lessMaxWidth(low, nextHigh)
+		if ratio <= 1.0 {
+			high = nextHigh
+		} else {
+			maxHigh = nextHigh
+		}
+		nextHigh = low + int(float32(nextHigh-low)/ratio)
+		if nextHigh >= maxHigh {
+			nextHigh = maxHigh - 1
+		}
+		if nextHigh <= high {
+			nextHigh = high + 1
+		}
 	}
 	return high
 }
@@ -887,11 +897,11 @@ func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width f
 	seg := prior.segments[0].(*TextSegment)
 	ellipsisSize := fyne.MeasureText("…", seg.size(), seg.Style.TextStyle)
 
-	widthChecker := func(low int, high int) bool {
-		return measurer([]rune(seg.Text)[low:high]).Width <= width-ellipsisSize.Width
+	widthChecker := func(low int, high int) float32 {
+		return measurer([]rune(seg.Text)[low:high]).Width / (width - ellipsisSize.Width)
 	}
 
-	limit := binarySearch(widthChecker, prior.begin, prior.end)
+	limit := ratioSearch(widthChecker, prior.begin, prior.end)
 	prior.end = limit
 
 	prior.ellipsis = true
@@ -938,8 +948,8 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 
 	measureWidth := float32(math.Min(float64(firstWidth), float64(max.Width)))
 	text := []rune(seg.Text)
-	widthChecker := func(low int, high int) bool {
-		return measurer(text[low:high]).Width <= measureWidth
+	widthChecker := func(low int, high int) float32 {
+		return measurer(text[low:high]).Width / measureWidth
 	}
 
 	reuse := 0
@@ -972,7 +982,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 
 					yPos += measured.Height
 				} else {
-					newHigh := binarySearch(widthChecker, low, high)
+					newHigh := ratioSearch(widthChecker, low, high)
 					if newHigh <= low {
 						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
 						reuse++
@@ -1007,7 +1017,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 				} else {
 					oldHigh := high
 					last := low + len(sub) - 1
-					fallback := binarySearch(widthChecker, low, last) - low
+					fallback := ratioSearch(widthChecker, low, last) - low
 
 					if fallback < 1 { // even a character won't fit
 						include := 1
@@ -1052,7 +1062,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 				reuse++
 			} else if trunc == fyne.TextTruncateClip {
-				high = binarySearch(widthChecker, low, high)
+				high = ratioSearch(widthChecker, low, high)
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
 			}

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -846,7 +846,8 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	return xPos - initialX, height
 }
 
-// ratioSearch accepts a function that checks if the text width less the maximum width and the start and end rune index
+// ratioSearch accepts a function that returns the ratio between the text width
+// and the maximum width and the start and end rune index
 // ratioSearch returns the index of rune located as close to the maximum line width as possible
 func ratioSearch(widthToMaxWidthRatio func(int, int) float32, low int, maxHigh int) int {
 	if low >= maxHigh {

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -59,3 +59,19 @@ func BenchmarkText_lineBounds_WrapBreak(b *testing.B) {
 func BenchmarkText_lineBounds_WrapWord(b *testing.B) {
 	benchmarkTextLineBounds(fyne.TextWrapWord, b)
 }
+
+func BenchmarkText_ratioSearch(b *testing.B) {
+	text := loremIpsum
+	maxWidth := float32(200)
+	textSize := float32(10)
+	textStyle := fyne.TextStyle{}
+	measurer := func(text []rune) float32 {
+		return fyne.MeasureText(string(text), textSize, textStyle).Width
+	}
+	checker := func(low int, high int) float32 {
+		return measurer([]rune(text[low:high])) / maxWidth
+	}
+	for n := 0; n < b.N; n++ {
+		ratioSearch(checker, 0, len(text))
+	}
+}

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1158,7 +1158,7 @@ func TestText_lineBounds_variable_char_width(t *testing.T) {
 	}
 }
 
-func TestText_binarySearch(t *testing.T) {
+func TestText_ratioSearch(t *testing.T) {
 	maxWidth := float32(46)
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}
@@ -1202,11 +1202,11 @@ func TestText_binarySearch(t *testing.T) {
 			want: 0,
 		},
 	} {
-		checker := func(low int, high int) bool {
-			return measurer([]rune(tt.text[low:high])) <= maxWidth
+		checker := func(low int, high int) float32 {
+			return measurer([]rune(tt.text[low:high])) / maxWidth
 		}
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, binarySearch(checker, 0, len(tt.text)))
+			assert.Equal(t, tt.want, ratioSearch(checker, 0, len(tt.text)))
 		})
 	}
 }


### PR DESCRIPTION
### Description:

Profiling shows that for windows with a lot of wrapping text much time is spent on `MeasureText` (unsurprisingly).

I noticed that there are many more calls than I expected and I found that the `binarySearch` algorithm could be improved/replaced.

If there is a text line of 2000 px width that needs to be fit in a container of 100 px width, the `binarySearch` calculates the width of 50% of the text (too wide), then 25% (too wide), then 12.5% (too wide), then 6.25% (too wide) and so on.

Under the assumption that 20 times as many runes need approximately 20 times as much space, I have replaced the `binarySearch` by a `ratioSearch`. This one uses a `widthChecker` that retuns a ratio instead of a boolean. This way, `ratioSearch` knows that the example text is 20 times as long as the available width and tries 1/20th as many runes next. If the shortened text is still 10% too wide, it continues with with 1/(110%) as many runes. This converges much faster than the binary search.

#### Results (measured on Linux)

##### Example code from #5297 (8000 chars):

||Before|After|
|--|--|--|
|time to set content|35.0s|21.9s|
|`measurer` calls in `lineBounds`|249.924|80.876|

##### Example code from #6124:

||Before|After|
|--|--|--|
|time for `createRichText`|226ms|149ms|
|`measurer` calls in `lineBounds`|18.085|7.165|

Improves #5297 and #6124 and maybe others.

##### New BenchmarkText_{binary,ratio}Search

Old `binarySearch` (see commit https://github.com/MaxGyver83/fyne/commit/042251045e7c25003089701bcdc52cc7edef2b7c in my fork):

```console
$ go test -v -test.bench BenchmarkText_binarySearch -test.run xxx ./widget
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_binarySearch
BenchmarkText_binarySearch-4   	   13354	     89005 ns/op
PASS
ok  	fyne.io/fyne/v2/widget	2.119s
```

New `ratioSearch`:

```console
$ go test -v -test.bench BenchmarkText_ratioSearch -test.run xxx ./widget
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_ratioSearch
BenchmarkText_ratioSearch-4   	   26258	     42185 ns/op
PASS
ok  	fyne.io/fyne/v2/widget	1.649s
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included (existing test updated).
- [x] Lint and formatter run with no errors.
- [x] Tests all pass (all except `TestMenuBar`)