### PR TITLE
glfw: Skip first resize in glCanvas.SetContent

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -137,9 +137,6 @@ func (c *glCanvas) Scale() float32 {
 }
 
 func (c *glCanvas) SetContent(content fyne.CanvasObject) {
-	content.Resize(content.MinSize()) // give it the space it wants then calculate the real min
-
-	// the pass above makes some layouts wide enough to wrap, so we ask again what the true min is.
 	newSize := c.size.Max(c.canvasSize(content.MinSize()))
 
 	c.setContent(content)


### PR DESCRIPTION
### Description:

The example code from issue #5297 runs really slow. The main reason seems to be that `MeasureText` is called about 250.000 times.

The interesting part: 95% of these `MeasureText` calls are used to fit the text into a temporary container of 20.7 pixels width.

A quick fix for this: Simply skip the initial `content.Resize(content.MinSize())` call in `glCanvas.SetContent`.

So far, I couldn't find any drawbacks. At least, this change doesn't break any tests.

#### Results (measured on Linux)

##### Example code from #5297 (8000 chars):

||~~develop~~|~~#6177~~ develop|~~this PR~~|~~#6177 +~~ this PR|
|--|--|--|--|--|
|time to set content|35.0s|21.9s|2.0s|1.3s|
|`measurer` calls in `lineBounds`|249.924|80.876|12080|4428|

Fixes/improves #5297.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass except `TestMenuBar`.