### PR TITLE
RichText.Resize: Skip updateRowBounds call

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -126,7 +126,6 @@ func (t *RichText) Resize(size fyne.Size) {
 			return
 		}
 	}
-	t.updateRowBounds()
 
 	t.Refresh()
 }


### PR DESCRIPTION
`Resize` calls `Refresh` which calls `updateRowBounds` again/anyway.

### Description:

The only difference between the first and the second `updateRowBounds` call is the `t.minCache = fyne.Size{}` in between. I don't see this affecting the result of the row bounds calculation.

This change reduces the `MeasureText` calls by 50%.

Improves #5297.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.