### PR TITLE
RichText: Let ratioSearch accept an initial width to space ratio

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -845,33 +845,37 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	return xPos - initialX, height
 }
 
-// ratioSearch accepts a function that, given a start and end rune index, returns
-// the ratio of the text width to the maximum allowed width. The low and maxHigh
-// parameters are the start and end rune indices to search between. ratioSearch
-// returns the index of the rune located as close as possible to the maximum line width.
-func ratioSearch(widthToMaxWidthRatio func(int, int) float32, low int, maxHigh int) int {
+// ratioSearch accepts a function that, given a start and end rune index and a
+// precalculated ratio, returns the ratio of the text width to the maximum
+// allowed width. The low and maxHigh parameters are the start and end rune
+// indices to search between. ratioSearch returns the index of the rune located
+// as close as possible to the maximum line width.
+func ratioSearch(widthToMaxWidthRatio func(int, int) float32, low int, maxHigh int, ratio float32) int {
 	if low >= maxHigh {
 		return low
 	}
-	ratio := widthToMaxWidthRatio(low, maxHigh)
-	if ratio <= 1.0 {
-		return maxHigh
+	if ratio == 0.0 {
+		ratio = widthToMaxWidthRatio(low, maxHigh)
+		if ratio <= 1.0 {
+			return maxHigh
+		}
 	}
+	tooHigh := maxHigh + 1
 	high := low
 	nextHigh := low + int(float32(maxHigh-low)/ratio)
 	if nextHigh <= high {
 		nextHigh = high + 1
 	}
-	for nextHigh < maxHigh {
+	for nextHigh < tooHigh {
 		ratio = widthToMaxWidthRatio(low, nextHigh)
 		if ratio <= 1.0 {
 			high = nextHigh
 		} else {
-			maxHigh = nextHigh
+			tooHigh = nextHigh
 		}
 		nextHigh = low + int(float32(nextHigh-low)/ratio)
-		if nextHigh >= maxHigh {
-			nextHigh = maxHigh - 1
+		if nextHigh >= tooHigh {
+			nextHigh = tooHigh - 1
 		}
 		if nextHigh <= high {
 			nextHigh = high + 1
@@ -902,7 +906,7 @@ func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width f
 		return measurer([]rune(seg.Text)[low:high]).Width / (width - ellipsisSize.Width)
 	}
 
-	limit := ratioSearch(widthChecker, prior.begin, prior.end)
+	limit := ratioSearch(widthChecker, prior.begin, prior.end, 0.0)
 	prior.end = limit
 
 	prior.ellipsis = true
@@ -983,7 +987,8 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 
 					yPos += measured.Height
 				} else {
-					newHigh := ratioSearch(widthChecker, low, high)
+					ratio := measured.Width / measureWidth
+					newHigh := ratioSearch(widthChecker, low, high, ratio)
 					if newHigh <= low {
 						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
 						reuse++
@@ -1018,7 +1023,8 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 				} else {
 					oldHigh := high
 					last := low + len(sub) - 1
-					fallback := ratioSearch(widthChecker, low, last) - low
+					ratio := measured.Width / measureWidth
+					fallback := ratioSearch(widthChecker, low, last, ratio) - low
 
 					if fallback < 1 { // even a character won't fit
 						include := 1
@@ -1063,7 +1069,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 				reuse++
 			} else if trunc == fyne.TextTruncateClip {
-				high = ratioSearch(widthChecker, low, high)
+				high = ratioSearch(widthChecker, low, high, 0.0)
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
 			}

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -72,6 +72,6 @@ func BenchmarkText_ratioSearch(b *testing.B) {
 		return measurer([]rune(text[low:high])) / maxWidth
 	}
 	for n := 0; n < b.N; n++ {
-		ratioSearch(checker, 0, len(text))
+		ratioSearch(checker, 0, len(text), 0.0)
 	}
 }

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1206,7 +1206,7 @@ func TestText_ratioSearch(t *testing.T) {
 			return measurer([]rune(tt.text[low:high])) / maxWidth
 		}
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, ratioSearch(checker, 0, len(tt.text)))
+			assert.Equal(t, tt.want, ratioSearch(checker, 0, len(tt.text), 0.0))
 		})
 	}
 }


### PR DESCRIPTION
### Description:

The `lineBounds` function (`richtext.go`) measures the sizes of substrings in a nested loop and in many cases it calls `ratioSearch` which then measures the size for the same substring minus the last char.

For long substrings this difference doesn't matter. For short substrings, this function is fast anyway.

This PR changes `ratioSearch` to accept an initial width to space ratio as additional parameter. If this is set to a value greater than 0, this `ratio` is used for the first iteration. This saves one `measurer` call (the most expensive one) per `ratioSearch`.

### Performance:

In the example app from #5297, the time for `w.SetContent(e)` shrinks from about 1.25s to 0.68s. A resize improves from about 0.74s to about 0.40 ms.

#### Benchmark

**develop branch**:

```sh
$ go test -v -test.bench BenchmarkText_lineBounds_WrapWord -test.benchtime 1x -test.run xxx ./widget
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_lineBounds_WrapWord
BenchmarkText_lineBounds_WrapWord-4   	       1	1539452502 ns/op
PASS
ok  	fyne.io/fyne/v2/widget	1.597s
```

**this PR**:

```sh
$ go test -v -test.bench BenchmarkText_lineBounds_WrapWord -test.benchtime 1x -test.run xxx ./widget
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_lineBounds_WrapWord
BenchmarkText_lineBounds_WrapWord-4   	       1	 818989825 ns/op
PASS
ok  	fyne.io/fyne/v2/widget	0.880s
```
Improves  #5297.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass (except `data/binding` with `-tags-mobile` but these fail on `develop`, too)
