### PR TITLE
Expand height of the form item widget to fit the available space

### DIFF
--- a/widget/form.go
+++ b/widget/form.go
@@ -477,11 +477,14 @@ type formItemLayout struct {
 
 func (f formItemLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
 	innerPad := f.form.Theme().Size(theme.SizeNameInnerPadding)
-	itemHeight := objs[0].MinSize().Height
+	min0 := objs[0].MinSize()
+	min1 := objs[1].MinSize()
+
+	itemHeight := fyne.Max(min0.Height, size.Height-min1.Height-innerPad)
 	objs[0].Resize(fyne.NewSize(size.Width, itemHeight))
 
 	objs[1].Move(fyne.NewPos(innerPad, itemHeight+innerPad/2))
-	objs[1].Resize(fyne.NewSize(size.Width, objs[1].MinSize().Width))
+	objs[1].Resize(fyne.NewSize(size.Width, min1.Height))
 }
 
 func (f formItemLayout) MinSize(objs []fyne.CanvasObject) fyne.Size {

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -466,29 +466,60 @@ func TestForm_RefreshFromStructInit(t *testing.T) {
 	})
 }
 
-func TestFormItem_Layout_Expansion(t *testing.T) {
+func TestFormItem_Layout_HeightExpansion_Horizontal(t *testing.T) {
 	rect := canvas.NewRectangle(theme.Color(theme.ColorNameForeground))
 	rect.SetMinSize(fyne.NewSize(50, 50))
 	item := NewFormItem("Test", rect)
-	item.HintText = "Hint" // Ensure it is wrapped in formItemLayout
+	item.HintText = "Hint" // ensure it is wrapped in formItemLayout
 	form := NewForm(item)
+	form.Orientation = Horizontal
 
 	test.TempWidgetRenderer(t, form)
 
+	labelContainer := form.itemGrid.Objects[0].(*fyne.Container)
 	inputContainer := form.itemGrid.Objects[1].(*fyne.Container)
-	textContainer := inputContainer.Objects[1].(*fyne.Container)
+	hintTextContainer := inputContainer.Objects[1].(*fyne.Container)
 
-	// Min height of rect is 50. textContainer min height is usually theme dependent.
-	// Let's give the whole inputContainer 100.
-	availableHeight := float32(100)
-	inputContainer.Resize(fyne.NewSize(200, availableHeight))
-	inputContainer.Layout.Layout(inputContainer.Objects, inputContainer.Size())
+	hintTextMinHeight := hintTextContainer.MinSize().Height
+	inputHeight := float32(100)
+	form.itemGrid.Resize(fyne.NewSize(200, inputHeight*2))
+	inputContainer.Resize(fyne.NewSize(200, inputHeight))
 
 	innerPad := form.Theme().Size(theme.SizeNameInnerPadding)
-	min1Height := textContainer.MinSize().Height
-	expectedHeight := availableHeight - min1Height - innerPad
+	expectedRectHeight := inputHeight - hintTextMinHeight - innerPad
 
-	assert.Equal(t, textContainer.Size().Height, min1Height)
-	assert.Equal(t, expectedHeight, rect.Size().Height)
-	assert.Greater(t, rect.Size().Height, float32(50))
+	// label container height equals input container min size height based on the formLayout logic
+	assert.Equal(t, inputContainer.MinSize().Height, labelContainer.Size().Height)
+	assert.Equal(t, rect.MinSize().Height+hintTextMinHeight+innerPad, inputContainer.MinSize().Height)
+	assert.Less(t, inputContainer.MinSize().Height, inputHeight)
+	assert.Equal(t, hintTextMinHeight, hintTextContainer.Size().Height)
+	assert.Equal(t, expectedRectHeight, rect.Size().Height)
+	assert.Greater(t, expectedRectHeight, rect.MinSize().Height)
+}
+
+func TestFormItem_Layout_HeightExpansion_Vertical(t *testing.T) {
+	rect := canvas.NewRectangle(theme.Color(theme.ColorNameForeground))
+	rect.SetMinSize(fyne.NewSize(50, 50))
+	item := NewFormItem("Test", rect)
+	item.HintText = "Hint" // ensure it is wrapped in formItemLayout
+	form := NewForm(item)
+	form.Orientation = Vertical
+
+	test.TempWidgetRenderer(t, form)
+
+	labelContainer := form.itemGrid.Objects[0].(*fyne.Container)
+	inputContainer := form.itemGrid.Objects[1].(*fyne.Container)
+	hintTextContainer := inputContainer.Objects[1].(*fyne.Container)
+
+	labelMinHeight := labelContainer.MinSize().Height
+	hintTextMinHeight := hintTextContainer.MinSize().Height
+
+	inputHeight := float32(100)
+	form.itemGrid.Resize(fyne.NewSize(200, inputHeight*2))
+	innerPad := form.Theme().Size(theme.SizeNameInnerPadding)
+	inputContainer.Resize(fyne.NewSize(200, inputHeight+hintTextMinHeight+innerPad))
+
+	assert.Equal(t, labelMinHeight, labelContainer.Size().Height)
+	assert.Equal(t, hintTextMinHeight, hintTextContainer.Size().Height)
+	assert.Equal(t, inputHeight, rect.Size().Height)
 }

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -465,3 +465,30 @@ func TestForm_RefreshFromStructInit(t *testing.T) {
 		form.Refresh()
 	})
 }
+
+func TestFormItem_Layout_Expansion(t *testing.T) {
+	rect := canvas.NewRectangle(theme.Color(theme.ColorNameForeground))
+	rect.SetMinSize(fyne.NewSize(50, 50))
+	item := NewFormItem("Test", rect)
+	item.HintText = "Hint" // Ensure it is wrapped in formItemLayout
+	form := NewForm(item)
+
+	test.TempWidgetRenderer(t, form)
+
+	inputContainer := form.itemGrid.Objects[1].(*fyne.Container)
+	textContainer := inputContainer.Objects[1].(*fyne.Container)
+
+	// Min height of rect is 50. textContainer min height is usually theme dependent.
+	// Let's give the whole inputContainer 100.
+	availableHeight := float32(100)
+	inputContainer.Resize(fyne.NewSize(200, availableHeight))
+	inputContainer.Layout.Layout(inputContainer.Objects, inputContainer.Size())
+
+	innerPad := form.Theme().Size(theme.SizeNameInnerPadding)
+	min1Height := textContainer.MinSize().Height
+	expectedHeight := availableHeight - min1Height - innerPad
+
+	assert.Equal(t, textContainer.Size().Height, min1Height)
+	assert.Equal(t, expectedHeight, rect.Size().Height)
+	assert.Greater(t, rect.Size().Height, float32(50))
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

For multiple columns #2820 the row height could be larger than item widget min size. This PR adjusts the height of the item widget to fit the available space.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
