### PR TITLE
test/driver: Call f unchanged in DoFromGoroutine

### DIFF
--- a/test/driver.go
+++ b/test/driver.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/internal/async"
 	intdriver "fyne.io/fyne/v2/internal/driver"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/painter/software"
@@ -53,7 +52,7 @@ func NewDriverWithPainter(painter SoftwarePainter) fyne.Driver {
 // DoFromGoroutine on a test driver ignores the wait flag as our threading is simple
 func (d *driver) DoFromGoroutine(f func(), _ bool) {
 	// Tests all run on a single (but potentially different per-test) thread
-	async.EnsureNotMain(f)
+	f()
 }
 
 func (d *driver) AbsolutePositionForObject(co fyne.CanvasObject) fyne.Position {


### PR DESCRIPTION
Proposed by Andy:
https://github.com/fyne-io/fyne/pull/6154#issuecomment-3993420381

### Description:

Fixes multiple `data/binding` tests for `-tags mobile`.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.