### PR TITLE
Fix size growth when setting custom scaling factor 

### DIFF
--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -100,7 +100,12 @@ func (c *glCanvas) Resize(size fyne.Size) {
 	// This might not be the ideal solution, but it effectively avoid the first frame to be blurry due to the
 	// rounding of the size to the loower integer when scale == 1. It does not affect the other cases as far as we tested.
 	// This can easily be seen with fyne/cmd/hello and a scale == 1 as the text will happear blurry without the following line.
-	nearestSize := fyne.NewSize(float32(math.Ceil(float64(size.Width))), float32(math.Ceil(float64(size.Height))))
+	var nearestSize fyne.Size
+	if c.scale == 1 {
+		nearestSize = fyne.NewSize(float32(math.Ceil(float64(size.Width))), float32(math.Ceil(float64(size.Height))))
+	} else {
+		nearestSize = size
+	}
 
 	c.size = nearestSize
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1894,6 +1894,20 @@ func TestWindow_Shortcut(t *testing.T) {
 	assert.Equal(t, "obj", called)
 }
 
+func TestWindow_RescaleContext(t *testing.T) {
+	w := createWindow("Test")
+	// Use a size that produces a float after scaling
+	w.Resize(fyne.NewSize(51, 51))
+	runOnMain(func() {
+		w.canvas.scale = 1.3
+		w.RescaleContext()
+		initialWidth := w.width
+
+		w.RescaleContext()
+		assert.Equal(t, initialWidth, w.width)
+	})
+}
+
 func createWindow(title string) *safeWindow {
 	var w *window
 	runOnMain(func() { // tests launch in a different context


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->
Just don't caculate nearestSize when scale != 1
If #3450 is only effective when scale == 1 then it is fine to me.

Fixes #5625, occurring when a custom scaling factor is set.

Add a test for size stability after multiple RescaleContext calls

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.