### PR TITLE
Chore: fix LANG environment variable in CI workflow

### DIFF
--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
 
       - name: Set environment variable LANG
-        run: export LANG=en_EN.UTF-8
+        run: echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
         if: ${{ runner.os == 'Linux' }}
 
       - name: Tests

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install --no-install-recommends clang lld libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev xvfb language-pack-en
 
       - name: Set environment variable LANG
-        run: export LANG=en_EN.UTF-8
+        run: echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
 
       - name: Install analysis tools
         run: |


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

There are two issues. 

- First, the language tag `en-EN` is incorrect—it should be `en-US`, `en-GB`, or simply `en`. 

- Second, the method used to set the environment variable in the GitHub Actions workflow was wrong; I've corrected it to use `echo "xxx=xxx" >> $GITHUB_ENV`.

This results in occasional check errors.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
