### PR TITLE
Fix strange wrapping which results in one char per line

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -1019,6 +1019,13 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 					fallback := ratioSearch(widthChecker, low, last) - low
 
 					if fallback < 1 { // even a character won't fit
+						if measureWidth < max.Width {
+							bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
+							reuse++
+							measureWidth = max.Width
+							yPos += measured.Height
+							continue
+						}
 						include := 1
 						ellipsis := false
 						if trunc == fyne.TextTruncateEllipsis {

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1158,6 +1158,17 @@ func TestText_lineBounds_variable_char_width(t *testing.T) {
 	}
 }
 
+func TestText_lineBounds_small_firstWidth(t *testing.T) {
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), 14, fyne.TextStyle{})
+	}
+	got, _ := lineBounds(&TextSegment{Text: "foobar"}, fyne.TextWrapWord, fyne.TextTruncateOff, 0.1, fyne.NewSize(64, 20), measurer)
+	assert.Equal(t, 0, got[0].begin)
+	assert.Equal(t, 0, got[0].end)
+	assert.Equal(t, 0, got[1].begin)
+	assert.Equal(t, 6, got[1].end)
+}
+
 func TestText_ratioSearch(t *testing.T) {
 	maxWidth := float32(46)
 	textSize := float32(10)


### PR DESCRIPTION
### Description:

When `lineBounds` tries to fit a `TextSegment` (with `TextWrapWord`) into the last remaining pixels of a row and not even a character fits there, wrapping breaks: `lineBounds` force-wraps after every character as if the whole container was only a few pixels wide.

This PR checks if `measureWidth < max.Width` in this case (which means that this is about filling up a partially filled row) and returns an zero-char boundary and resets `measureWidth` to `max.Width`. (Some code duplication, could maybe be solved in a more elegant way.)

This fixes #3711/#4303 partially, i.e. only regarding `TextSegment`, not `HyperlinkSegments`, like these markdown strings:

```go
markdown := "This is a test of the RichText widget's interactions between markdown and `word` wrapping."

markdown := `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque x.
Mauris`
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass (all except `data/binding` for `-tags=mobile`).