### PR TITLE
Support HyperlinkSegments in lineBounds and splitLines

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -415,7 +415,9 @@ func (t *RichText) updateRowBounds() {
 				}
 				continue
 			}
-			if _, ok := seg.(*TextSegment); !ok {
+			_, isText := seg.(*TextSegment)
+			_, isHyperlink := seg.(*HyperlinkSegment)
+			if !isText && !isHyperlink {
 				if currentBound == nil {
 					bound := rowBoundary{segments: []RichTextSegment{seg}}
 					bounds = append(bounds, bound)
@@ -434,15 +436,20 @@ func (t *RichText) updateRowBounds() {
 				}
 				continue
 			}
-			textSeg := seg.(*TextSegment)
-			textStyle := textSeg.Style.TextStyle
-			textSize := textSeg.size()
-
+			var textStyle fyne.TextStyle
+			var textSize float32
 			leftPad := float32(0)
-			if textSeg.Style == RichTextStyleBlockquote {
-				leftPad = innerPadding * 2
+			if textSeg, ok := seg.(*TextSegment); ok {
+				textStyle = textSeg.Style.TextStyle
+				textSize = textSeg.size()
+				if textSeg.Style == RichTextStyleBlockquote {
+					leftPad = innerPadding * 2
+				}
+			} else if linkSeg, ok := seg.(*HyperlinkSegment); ok {
+				textStyle = linkSeg.TextStyle
+				textSize = theme.SizeForWidget(theme.SizeNameText, t)
 			}
-			retBounds, height := lineBounds(textSeg, t.Wrapping, t.Truncation, wrapWidth-leftPad, fyne.NewSize(maxWidth, fitSize.Height), func(text []rune) fyne.Size {
+			retBounds, height := lineBounds(seg, t.Wrapping, t.Truncation, wrapWidth-leftPad, fyne.NewSize(maxWidth, fitSize.Height), func(text []rune) fyne.Size {
 				return fyne.MeasureText(string(text), textSize, textStyle)
 			})
 			if currentBound != nil {
@@ -465,7 +472,7 @@ func (t *RichText) updateRowBounds() {
 				if len(last.segments) == 1 {
 					begin = last.begin
 				}
-				runes := []rune(textSeg.Text)
+				runes := []rune(seg.Textual())
 				// check ranges - as we resize it can be wrong?
 				if begin > len(runes) {
 					begin = len(runes)
@@ -475,7 +482,7 @@ func (t *RichText) updateRowBounds() {
 					end = len(runes)
 				}
 				text := string(runes[begin:end])
-				measured := fyne.MeasureText(text, textSeg.size(), textSeg.Style.TextStyle)
+				measured := fyne.MeasureText(text, textSize, textStyle)
 				lastWidth := measured.Width
 				if len(retBounds) == 1 {
 					wrapWidth -= lastWidth
@@ -946,7 +953,7 @@ func float32ToFixed266(f float32) fixed.Int26_6 {
 // measure text size.
 // It will return a slice containing the boundary metadata of each line with the given wrapping applied and the
 // total height required to render the boundaries at the given width/height constraints
-func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation, firstWidth float32, max fyne.Size, measurer func([]rune) fyne.Size) ([]rowBoundary, float32) {
+func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation, firstWidth float32, max fyne.Size, measurer func([]rune) fyne.Size) ([]rowBoundary, float32) {
 	lines := splitLines(seg)
 
 	if wrap == fyne.TextWrap(fyne.TextTruncateClip) {
@@ -961,7 +968,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 	}
 
 	measureWidth := float32(math.Min(float64(firstWidth), float64(max.Width)))
-	text := []rune(seg.Text)
+	text := []rune(seg.Textual())
 	widthChecker := func(low int, high int) float32 {
 		return measurer(text[low:high]).Width / measureWidth
 	}
@@ -1079,7 +1086,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 			}
 		default:
 			if trunc == fyne.TextTruncateEllipsis {
-				txt := []rune(seg.Text)[low:high]
+				txt := []rune(seg.Textual())[low:high]
 				end, full := truncateLimit(string(txt), seg.Visual().(*canvas.Text), int(measureWidth), []rune{'…'})
 				high = low + end
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
@@ -1110,10 +1117,10 @@ func setAlign(obj fyne.CanvasObject, align fyne.TextAlign) {
 
 // splitLines accepts a text segment and returns a slice of boundary metadata denoting the
 // start and end indices of each line delimited by the newline character.
-func splitLines(seg *TextSegment) []rowBoundary {
+func splitLines(seg RichTextSegment) []rowBoundary {
 	var low, high int
 	var lines []rowBoundary
-	text := []rune(seg.Text)
+	text := []rune(seg.Textual())
 	length := len(text)
 	for i := 0; i < length; i++ {
 		if text[i] == '\n' {

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -1096,7 +1096,14 @@ func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncati
 		default:
 			if trunc == fyne.TextTruncateEllipsis {
 				txt := []rune(seg.Textual())[low:high]
-				end, full := truncateLimit(string(txt), seg.Visual().(*canvas.Text), int(measureWidth), []rune{'…'})
+				var textObj *canvas.Text
+				switch seg.(type) {
+				case *TextSegment:
+					textObj = seg.Visual().(*canvas.Text)
+				case *HyperlinkSegment:
+					textObj = canvas.NewText(string(txt), color.Black)
+				}
+				end, full := truncateLimit(string(txt), textObj, int(measureWidth), []rune{'…'})
 				high = low + end
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 				reuse++

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -977,11 +977,23 @@ func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncati
 	}
 
 	measureWidth := float32(math.Min(float64(firstWidth), float64(max.Width)))
+
+	switch wrap {
+	case fyne.TextWrapBreak:
+		return wrapBreakLines(seg, trunc, measureWidth, max, measurer, lines)
+	case fyne.TextWrapWord:
+		return wrapWordLines(seg, trunc, measureWidth, max, measurer, lines)
+	default:
+		return truncateLines(seg, trunc, measureWidth, max, measurer, lines)
+	}
+}
+
+func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
+
 	text := []rune(seg.Textual())
 	widthChecker := func(low int, high int) float32 {
 		return measurer(text[low:high]).Width / measureWidth
 	}
-
 	reuse := 0
 	yPos := float32(0)
 	var bounds []rowBoundary
@@ -994,124 +1006,160 @@ func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncati
 			bounds = append(bounds, l)
 			continue
 		}
+		for low < high {
+			measured := measurer(text[low:high])
+			if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
+				return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
+			}
 
-		switch wrap {
-		case fyne.TextWrapBreak:
-			for low < high {
-				measured := measurer(text[low:high])
-				if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
-					return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
-				}
+			if measured.Width <= measureWidth {
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+				reuse++
+				low = high
+				high = l.end
+				measureWidth = max.Width
 
-				if measured.Width <= measureWidth {
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+				yPos += measured.Height
+			} else {
+				ratio := measured.Width / measureWidth
+				newHigh := ratioSearch(widthChecker, low, high, ratio)
+				if newHigh <= low {
+					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
 					reuse++
-					low = high
-					high = l.end
-					measureWidth = max.Width
+					low++
 
 					yPos += measured.Height
 				} else {
-					ratio := measured.Width / measureWidth
-					newHigh := ratioSearch(widthChecker, low, high, ratio)
-					if newHigh <= low {
-						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
-						reuse++
-						low++
-
-						yPos += measured.Height
-					} else {
-						high = newHigh
-					}
+					high = newHigh
 				}
 			}
-		case fyne.TextWrapWord:
-			for low < high {
-				sub := text[low:high]
-				measured := measurer(sub)
-				if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
-					return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
+		}
+	}
+	return bounds, yPos
+}
+
+func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
+	text := []rune(seg.Textual())
+	widthChecker := func(low int, high int) float32 {
+		return measurer(text[low:high]).Width / measureWidth
+	}
+	reuse := 0
+	yPos := float32(0)
+	var bounds []rowBoundary
+	for _, l := range lines {
+		low := l.begin
+		high := l.end
+		if low == high {
+			l.firstSegmentReuse = reuse
+			reuse++
+			bounds = append(bounds, l)
+			continue
+		}
+		for low < high {
+			sub := text[low:high]
+			measured := measurer(sub)
+			if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
+				return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
+			}
+
+			subWidth := measured.Width
+			if subWidth <= measureWidth {
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+				reuse++
+				low = high
+				high = l.end
+				if low < high && unicode.IsSpace(text[low]) {
+					low++
 				}
+				measureWidth = max.Width
 
-				subWidth := measured.Width
-				if subWidth <= measureWidth {
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
-					reuse++
-					low = high
-					high = l.end
-					if low < high && unicode.IsSpace(text[low]) {
-						low++
-					}
-					measureWidth = max.Width
+				yPos += measured.Height
+			} else {
+				oldHigh := high
+				last := low + len(sub) - 1
+				ratio := measured.Width / measureWidth
+				fallback := ratioSearch(widthChecker, low, last, ratio) - low
 
-					yPos += measured.Height
-				} else {
-					oldHigh := high
-					last := low + len(sub) - 1
-					ratio := measured.Width / measureWidth
-					fallback := ratioSearch(widthChecker, low, last, ratio) - low
-
-					if fallback < 1 { // even a character won't fit
-						if measureWidth < max.Width {
-							bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
-							reuse++
-							measureWidth = max.Width
-							yPos += measured.Height
-							continue
-						}
-						include := 1
-						ellipsis := false
-						if trunc == fyne.TextTruncateEllipsis {
-							include = 0
-							ellipsis = true
-						}
-						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis})
-						low++
-						high = low + 1
-						reuse++
-
-						yPos += measured.Height
-						if high > l.end {
-							return bounds, yPos
-						}
-					} else {
-						spaceIndex := findSpaceIndex(sub, fallback)
-						if spaceIndex == 0 {
-							spaceIndex = 1
-						}
-
-						high = low + spaceIndex
-					}
-					if high == fallback && subWidth <= max.Width { // add a newline as there is more space on next
+				if fallback < 1 { // even a character won't fit
+					if measureWidth < max.Width {
 						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
 						reuse++
-						high = oldHigh
 						measureWidth = max.Width
-
 						yPos += measured.Height
 						continue
 					}
+					include := 1
+					ellipsis := false
+					if trunc == fyne.TextTruncateEllipsis {
+						include = 0
+						ellipsis = true
+					}
+					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis})
+					low++
+					high = low + 1
+					reuse++
+
+					yPos += measured.Height
+					if high > l.end {
+						return bounds, yPos
+					}
+				} else {
+					spaceIndex := findSpaceIndex(sub, fallback)
+					if spaceIndex == 0 {
+						spaceIndex = 1
+					}
+
+					high = low + spaceIndex
+				}
+				if high == fallback && subWidth <= max.Width { // add a newline as there is more space on next
+					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
+					reuse++
+					high = oldHigh
+					measureWidth = max.Width
+
+					yPos += measured.Height
+					continue
 				}
 			}
-		default:
-			if trunc == fyne.TextTruncateEllipsis {
-				txt := []rune(seg.Textual())[low:high]
-				var textObj *canvas.Text
-				switch seg.(type) {
-				case *TextSegment:
-					textObj = seg.Visual().(*canvas.Text)
-				case *HyperlinkSegment:
-					textObj = canvas.NewText(string(txt), color.Black)
-				}
-				end, full := truncateLimit(string(txt), textObj, int(measureWidth), []rune{'…'})
-				high = low + end
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
-				reuse++
-			} else if trunc == fyne.TextTruncateClip {
-				high = ratioSearch(widthChecker, low, high, -1.0)
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
-				reuse++
+		}
+	}
+	return bounds, yPos
+}
+
+func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
+	text := []rune(seg.Textual())
+	widthChecker := func(low int, high int) float32 {
+		return measurer(text[low:high]).Width / measureWidth
+	}
+	yPos := float32(0)
+	var bounds []rowBoundary
+	reuse := 0
+	for _, l := range lines {
+		low := l.begin
+		high := l.end
+		if low == high {
+			l.firstSegmentReuse = reuse
+			reuse++
+			bounds = append(bounds, l)
+			continue
+		}
+		if trunc == fyne.TextTruncateEllipsis {
+			txt := []rune(seg.Textual())[low:high]
+			var textObj *canvas.Text
+			switch seg.(type) {
+			case *TextSegment:
+				textObj = seg.Visual().(*canvas.Text)
+			case *HyperlinkSegment:
+				textObj = canvas.NewText(string(txt), color.Black)
 			}
+			end, full := truncateLimit(string(txt), textObj, int(measureWidth), []rune{'…'})
+			high = low + end
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
+			reuse++
+		} else if trunc == fyne.TextTruncateClip {
+			high = ratioSearch(widthChecker, low, high, -1.0)
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+			reuse++
 		}
 	}
 	return bounds, yPos

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -989,7 +989,6 @@ func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncati
 }
 
 func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
-
 	text := []rune(seg.Textual())
 	widthChecker := func(low int, high int) float32 {
 		return measurer(text[low:high]).Width / measureWidth

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -696,7 +696,9 @@ func (r *textRenderer) Refresh() {
 	var objs []fyne.CanvasObject
 	for _, bound := range bounds {
 		for i, seg := range bound.segments {
-			if _, ok := seg.(*TextSegment); !ok {
+			_, isText := seg.(*TextSegment)
+			_, isHyperlink := seg.(*HyperlinkSegment)
+			if !isText && !isHyperlink {
 				obj := r.obj.cachedSegmentVisual(seg, 0)
 				seg.Update(obj)
 				objs = append(objs, obj)
@@ -709,28 +711,34 @@ func (r *textRenderer) Refresh() {
 			}
 			obj := r.obj.cachedSegmentVisual(seg, reuse)
 			seg.Update(obj)
-			txt := obj.(*canvas.Text)
-			textSeg := seg.(*TextSegment)
-			runes := []rune(textSeg.Text)
+			var txt string
+			runes := []rune(seg.Textual())
 
 			if i == 0 {
 				if len(bound.segments) == 1 {
-					txt.Text = string(runes[bound.begin:bound.end])
+					txt = string(runes[bound.begin:bound.end])
 				} else {
-					txt.Text = string(runes[bound.begin:])
+					txt = string(runes[bound.begin:])
 				}
 			} else if i == len(bound.segments)-1 && len(bound.segments) > 1 {
-				txt.Text = string(runes[:bound.end])
+				txt = string(runes[:bound.end])
+			} else {
+				txt = string(runes)
 			}
 			if bound.ellipsis && i == len(bound.segments)-1 {
-				txt.Text = txt.Text + "…"
+				txt = txt + "…"
 			}
 
 			if concealed(seg) {
-				txt.Text = strings.Repeat(passwordChar, len(runes))
+				txt = strings.Repeat(passwordChar, len(runes))
 			}
 
-			objs = append(objs, txt)
+			if isText {
+				obj.(*canvas.Text).Text = txt
+			} else if isHyperlink {
+				obj.(*fyne.Container).Objects[0].(*Hyperlink).Text = txt
+			}
+			objs = append(objs, obj)
 		}
 	}
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -737,6 +737,7 @@ func (r *textRenderer) Refresh() {
 				obj.(*canvas.Text).Text = txt
 			} else if isHyperlink {
 				obj.(*fyne.Container).Objects[0].(*Hyperlink).Text = txt
+				obj.(*fyne.Container).Objects[0].(*Hyperlink).Refresh()
 			}
 			objs = append(objs, obj)
 		}

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -143,7 +143,6 @@ func (h *HyperlinkSegment) Visual() fyne.CanvasObject {
 // Update applies the current state of this hyperlink segment to an existing visual.
 func (h *HyperlinkSegment) Update(o fyne.CanvasObject) {
 	link := o.(*fyne.Container).Objects[0].(*Hyperlink)
-	link.Text = h.Text
 	link.URL = h.URL
 	link.Alignment = h.Alignment
 	link.SizeName = h.SizeName

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1081,6 +1081,81 @@ func TestText_lineBounds(t *testing.T) {
 	}
 }
 
+func TestText_lineBounds_hyperlinks(t *testing.T) {
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), 14, fyne.TextStyle{})
+	}
+	tests := []struct {
+		name     string
+		text     string
+		wrap     fyne.TextWrap
+		trunc    fyne.TextTruncation
+		want     [][2]int
+		ellipses int
+	}{
+		{
+			name: "Hyperlink_Truncate",
+			text: "this is a long link",
+			wrap: fyne.TextWrap(fyne.TextTruncateClip),
+			want: [][2]int{
+				{0, 9},
+			},
+		},
+		{
+			name:  "Hyperlink_TruncateClip",
+			text:  "this is a long link",
+			trunc: fyne.TextTruncateClip,
+			want: [][2]int{
+				{0, 9},
+			},
+		},
+		{
+			name:  "Hyperlink_TruncateEllipsis",
+			text:  "this is a long link",
+			trunc: fyne.TextTruncateEllipsis,
+			want: [][2]int{
+				{0, 8},
+			},
+			ellipses: 1,
+		},
+		{
+			name: "Hyperlink_WrapBreak",
+			text: "this is a long link",
+			wrap: fyne.TextWrapBreak,
+			want: [][2]int{
+				{0, 9},
+				{9, 17},
+			},
+		},
+		{
+			name: "Hyperlink_WrapWord",
+			text: "this is a long link",
+			wrap: fyne.TextWrapWord,
+			want: [][2]int{
+				{0, 9},
+				{10, 14},
+				{15, 19},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ellipses := 0
+			u, _ := url.Parse("https://fyne.io/")
+			got, _ := lineBounds(&HyperlinkSegment{Text: tt.text, URL: u}, tt.wrap, tt.trunc, 50, fyne.NewSize(50, 64), measurer)
+			for i, wantRow := range tt.want {
+				assert.Equal(t, wantRow[0], got[i].begin)
+				assert.Equal(t, wantRow[1], got[i].end)
+
+				if got[i].ellipsis {
+					ellipses++
+				}
+			}
+			assert.Equal(t, tt.ellipses, ellipses)
+		})
+	}
+}
+
 func TestText_lineBounds_variable_char_width(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
### Description:

Currently, hyperlinks that don't fit in a row aren't pushed to the next row.

This PR fixes this by treating hyperlinks same as text. This is achieved by letting `lineBounds` and `splitLines` accept a `RichTextSegment` instead of a `*TextSegment`.

It also splits at word boundaries inside links.

<img width="90" height="87" alt="image" src="https://github.com/user-attachments/assets/943fe223-6967-4cc3-bd02-e7f520c063a6" />

Fixes #4303 (in combination with #6200), #3393 and #4336.

### To Do

- [x] Determine size of `HyperlinkSegment` (`widget/richtext.go:439`). ~~Any ideas how to do this?~~

#### Two more issues:

- [x] Long links are moved to the **overnext** line (should be next)
- [x] Such a long link is rendered in a strange way: Maybe twice at the same position?

Before (develop branch):
<img width="496" height="25" alt="image" src="https://github.com/user-attachments/assets/c566c0f8-1fb5-4bcc-a32a-35fab50a84ff" />

This PR (old):
<img width="495" height="64" alt="image" src="https://github.com/user-attachments/assets/2876b1dd-1d2c-49cc-ad6a-2bdda4fda8fc" />

This PR (fixed):
<img width="492" height="71" alt="image" src="https://github.com/user-attachments/assets/d8624300-da25-4271-b1a1-e03f16650c7f" />

#### New issue:

- [x] Sometimes when a link gets wrapped, the first part isn't truncated:
  <img width="194" height="47" alt="image" src="https://github.com/user-attachments/assets/fa62f89d-c27a-4a23-9478-b7aedb7924f7" />

- [x] After multiple wraps, it gets even worse:
  <img width="94" height="115" alt="image" src="https://github.com/user-attachments/assets/93f28648-7354-4f19-b8b9-05b92d8d684f" />

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass (all except `data/binding` for `-tags=mobile`).