### PR TITLE
ratioSearch: Set ratio to -1.0 as signal to measure width

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -852,7 +852,7 @@ func ratioSearch(widthToMaxWidthRatio func(int, int) float32, low int, maxHigh i
 	if low >= maxHigh {
 		return low
 	}
-	if ratio == 0.0 {
+	if ratio == -1.0 {
 		ratio = widthToMaxWidthRatio(low, maxHigh)
 		if ratio <= 1.0 {
 			return maxHigh
@@ -904,7 +904,7 @@ func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width f
 		return measurer([]rune(seg.Text)[low:high]).Width / (width - ellipsisSize.Width)
 	}
 
-	limit := ratioSearch(widthChecker, prior.begin, prior.end, 0.0)
+	limit := ratioSearch(widthChecker, prior.begin, prior.end, -1.0)
 	prior.end = limit
 
 	prior.ellipsis = true
@@ -1074,7 +1074,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 				reuse++
 			} else if trunc == fyne.TextTruncateClip {
-				high = ratioSearch(widthChecker, low, high, 0.0)
+				high = ratioSearch(widthChecker, low, high, -1.0)
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
 			}

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -72,6 +72,6 @@ func BenchmarkText_ratioSearch(b *testing.B) {
 		return measurer([]rune(text[low:high])) / maxWidth
 	}
 	for n := 0; n < b.N; n++ {
-		ratioSearch(checker, 0, len(text), 0.0)
+		ratioSearch(checker, 0, len(text), -1.0)
 	}
 }

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1217,7 +1217,7 @@ func TestText_ratioSearch(t *testing.T) {
 			return measurer([]rune(tt.text[low:high])) / maxWidth
 		}
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, ratioSearch(checker, 0, len(tt.text), 0.0))
+			assert.Equal(t, tt.want, ratioSearch(checker, 0, len(tt.text), -1.0))
 		})
 	}
 }


### PR DESCRIPTION
`-1.0` is safer to distinguish from a calculated ratio than `0.0`.

### Description:

This is a follow-up to #6187 that addresses [this comment from Claude](https://github.com/fyne-io/fyne/pull/6187#issuecomment-4061702366).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.