### PR TITLE
lineBounds: Skip height calculation for wrap width of 0

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -945,7 +945,7 @@ func lineBounds(seg *TextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation,
 		wrap = fyne.TextWrapOff
 	}
 
-	if max.Width < 0 || wrap == fyne.TextWrapOff && trunc == fyne.TextTruncateOff {
+	if max.Width <= 0 || wrap == fyne.TextWrapOff && trunc == fyne.TextTruncateOff {
 		return lines, 0 // don't bother returning a calculated height, our MinSize is going to cover it
 	}
 


### PR DESCRIPTION
### Description:

Currently, `lineBounds` returns early for `max.Width < 0`. This results in 66 bounds/text height calculations for my app that uses a fixed width window and shows Markdown in full width container. I'm wondering what these calculations are good for for a (temporary) container with `max.Width = 0`. With this PR, `lineBounds` returns early for `max.Width <= 0` which reduces the bounds/text height calculation count to 27.

I think the performance gain is negligible. This is just saving some calculations whose results aren't used anyway.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.