### PR TITLE
mobile: Keep selection on tap and hold

### DIFF
--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -227,30 +227,6 @@ func (c *canvas) tapDown(pos fyne.Position, tapID int) {
 	c.lastTapDown[tapID] = time.Now()
 	c.lastTapDownPos[tapID] = pos
 	c.dragging = nil
-
-	co, objPos, layer := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
-		switch object.(type) {
-		case mobile.Touchable, fyne.Focusable:
-			return true
-		}
-
-		return false
-	})
-
-	if wid, ok := co.(mobile.Touchable); ok {
-		touchEv := &mobile.TouchEvent{}
-		touchEv.ID = tapID
-		touchEv.Position = objPos
-		touchEv.AbsolutePosition = pos
-		wid.TouchDown(touchEv)
-		c.touched[tapID] = wid
-	}
-
-	if layer != 1 { // 0 - overlay, 1 - window head / menu, 2 - content
-		if wid, ok := co.(fyne.Focusable); !ok || wid != c.Focused() {
-			c.Unfocus()
-		}
-	}
 }
 
 func (c *canvas) tapMove(pos fyne.Position, tapID int,
@@ -347,12 +323,11 @@ func (c *canvas) tapUp(pos fyne.Position, tapID int,
 		return false
 	})
 
-	if wid, ok := co.(mobile.Touchable); ok {
+	if _, ok := co.(mobile.Touchable); ok {
 		touchEv := &mobile.TouchEvent{}
 		touchEv.ID = tapID
 		touchEv.Position = objPos
 		touchEv.AbsolutePosition = pos
-		wid.TouchUp(touchEv)
 		c.touched[tapID] = nil
 	}
 

--- a/internal/driver/mobile/canvas_test.go
+++ b/internal/driver/mobile/canvas_test.go
@@ -254,20 +254,20 @@ func Test_canvas_Tappable(t *testing.T) {
 	content.Resize(fyne.NewSize(24, 24))
 
 	c.tapDown(fyne.NewPos(15, 15), 0)
-	assert.True(t, content.down)
+	assert.False(t, content.down)
 
 	c.tapUp(fyne.NewPos(15, 15), 0, func(wid fyne.Tappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.SecondaryTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
-	assert.True(t, content.up)
+	assert.False(t, content.down)
 
 	c.tapDown(fyne.NewPos(15, 15), 0)
 	c.tapMove(fyne.NewPos(35, 15), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 		wid.Dragged(ev)
 	})
-	assert.True(t, content.cancel)
+	assert.False(t, content.cancel)
 }
 
 func Test_canvas_TouchID(t *testing.T) {
@@ -284,7 +284,7 @@ func Test_canvas_TouchID(t *testing.T) {
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
-	assert.True(t, content.ids[0])
+	assert.False(t, content.ids[0])
 
 	c.tapDown(fyne.NewPos(15, 15), 1)
 	c.tapUp(fyne.NewPos(15, 15), 1, func(wid fyne.Tappable, ev *fyne.PointEvent) {
@@ -292,7 +292,7 @@ func Test_canvas_TouchID(t *testing.T) {
 	}, func(wid fyne.DoubleTappable, ev *fyne.PointEvent) {
 	}, func(wid fyne.Draggable, ev *fyne.DragEvent) {
 	})
-	assert.True(t, content.ids[1])
+	assert.False(t, content.ids[1])
 }
 
 func Test_canvas_Tapped(t *testing.T) {


### PR DESCRIPTION
### Description:

With this PR, a click happens only after the finger is released because at the moment of touching the screen, you can't know if the user is going to perform a regular (short) or a secondary (long) tap.

I'm still unsure if this breaks anything. At least the demo app seems to behave normal when compiled with `-tags=mobile`.

Fixes #6207.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.