### PR TITLE
Fix sporadically failing tests (p.e. TestGlCanvas_SetContent)

### DIFF
--- a/internal/driver/glfw/canvas_test.go
+++ b/internal/driver/glfw/canvas_test.go
@@ -20,6 +20,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGlCanvas_ChildMinSizeChangeAffectsAncestorsUpToRoot(t *testing.T) {
@@ -332,7 +333,7 @@ func TestGlCanvas_InsufficientSizeDoesntTriggerResizeIfSizeIsAlreadyMaxedOut(t *
 	c := w.Canvas()
 	canvasSize := fyne.NewSize(200, 100)
 	w.Resize(canvasSize)
-	ensureCanvasSize(t, w, canvasSize)
+	require.Equal(t, canvasSize, w.Canvas().Size())
 	popUpContent := canvas.NewRectangle(color.Black)
 	popUpContent.SetMinSize(fyne.NewSize(1000, 10))
 	popUp := widget.NewPopUp(popUpContent, c)
@@ -443,7 +444,7 @@ func TestGlCanvas_ResizeWithOtherOverlay(t *testing.T) {
 	})
 
 	w.Resize(size)
-	ensureCanvasSize(t, w, size)
+	require.Equal(t, size, w.Canvas().Size())
 	runOnMain(func() {
 		assert.Equal(t, size, content.Size(), "canvas content is resized")
 		assert.Equal(t, size, over.Size(), "canvas overlay is resized")
@@ -475,7 +476,7 @@ func TestGlCanvas_ResizeWithOverlays(t *testing.T) {
 	assert.NotEqual(t, size, o3.Size())
 
 	w.Resize(size)
-	ensureCanvasSize(t, w, size)
+	require.Equal(t, size, w.Canvas().Size())
 	assert.Equal(t, size, content.Size(), "canvas content is resized")
 	assert.Equal(t, size, o1.Size(), "canvas overlay 1 is resized")
 	assert.Equal(t, size, o2.Size(), "canvas overlay 2 is resized")
@@ -503,7 +504,7 @@ func TestGlCanvas_ResizeWithPopUpOverlay(t *testing.T) {
 	assert.NotEqual(t, size, overContentSize)
 
 	w.Resize(size)
-	ensureCanvasSize(t, w, size)
+	require.Equal(t, size, w.Canvas().Size())
 	assert.Equal(t, size, content.Size(), "canvas content is resized")
 	assert.Equal(t, size, over.Size(), "canvas overlay is resized")
 	assert.Equal(t, overContentSize, over.Content.Size(), "canvas overlay content is _not_ resized")
@@ -526,7 +527,7 @@ func TestGlCanvas_ResizeWithModalPopUpOverlay(t *testing.T) {
 
 	winSize := fyne.NewSize(1000, 600)
 	w.Resize(winSize)
-	ensureCanvasSize(t, w, winSize)
+	require.Equal(t, winSize, w.Canvas().Size())
 
 	// get popup content padding dynamically
 	popupContentPadding := popup.MinSize().Subtract(popup.Content.MinSize())
@@ -581,7 +582,7 @@ func TestGlCanvas_SetContent(t *testing.T) {
 			canvasSize := float32(200)
 			w.SetContent(content)
 			w.Resize(fyne.NewSize(canvasSize, canvasSize))
-			ensureCanvasSize(t, w, fyne.NewSize(canvasSize, canvasSize))
+			require.Equal(t, fyne.NewSize(canvasSize, canvasSize), w.Canvas().Size())
 
 			newContent := canvas.NewCircle(color.White)
 			assert.Equal(t, fyne.NewPos(0, 0), newContent.Position())

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -89,7 +89,7 @@ func TestGLDriver_CreateSplashWindow(t *testing.T) {
 }
 
 func TestWindow_MinSize_Fixed(t *testing.T) {
-	w := createWindow("Test")
+	w := createWindowWithResizeCallback("Test")
 	r := canvas.NewRectangle(color.White)
 	minSize := fyne.NewSize(100, 100)
 	minSizePlusPadding := minSize.AddWidthHeight(theme.Padding()*2, theme.Padding()*2)
@@ -1909,6 +1909,18 @@ func TestWindow_RescaleContext(t *testing.T) {
 }
 
 func createWindow(title string) *safeWindow {
+	var w *window
+	runOnMain(func() { // tests launch in a different context
+		w = d.CreateWindow(title).(*window)
+		w.create()
+		// disable the GLFW window size callback because it causes a delayed canvas
+		// resize that breaks some tests sometimes
+		w.view().SetSizeCallback(func(_ *glfw.Window, width, height int) {})
+	})
+	return &safeWindow{window: w}
+}
+
+func createWindowWithResizeCallback(title string) *safeWindow {
 	var w *window
 	runOnMain(func() { // tests launch in a different context
 		w = d.CreateWindow(title).(*window)


### PR DESCRIPTION
Unset the test window's size callback in `createWindow` because it causes
an unnecessary and in this case even unwanted resize to the old size
when the test is already trying to set a new size.

Replace `ensureCanvasSize` calls after `w.Resize` by `require.Equal` calls
because now it's guaranteed that the resize works.

Add a `createWindowWithResizeCallback` function that creates a window
while keeping the resize callback. This function is used in
`TestWindow_MinSize_Fixed` because it seems to depend on that callback.

### Description:

This test fails sometimes, p.e. here in a pull request's platform tests: [mobile: Keep selection on tap and hold · fyne-io/fyne@e7a762a](https://github.com/fyne-io/fyne/actions/runs/23191530598/job/67388613547?pr=6208#step:6:72)

#### What happened:

The test first resizes the test window to 69x36 pixels, then to 200x200. Every window resize results in three canvas resizes:

1. First action in `window.Resize`
2. In `window.processResized` (called by `window.Resize`)
3. Again in `window.processResized`, this time called by `window.resized` which is set as GLFW resize callback.

The problem is that the third canvas resize happens with a delay. Sometimes, this callback resets the canvas size to 69x36 **after** the test has called `w.Resize(fyne.NewSize(200, 200))`!

This PR fixes this issue by unsetting the callback for ~~this test~~ all tests in `internal/driver/glfw/` except `TestWindow_MinSize_Fixed`. (This callback is only necessary when the window is resized with the mouse. When `w.Resize` is used to resize the window, the callback function `window.processResized` is called anyway.)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
