### PR TITLE
Fix content position in dialog layout

### DIFF
--- a/dialog/base.go
+++ b/dialog/base.go
@@ -236,15 +236,15 @@ func (l *dialogLayout) Layout(obj []fyne.CanvasObject, size fyne.Size) {
 	obj[1].Move(fyne.NewPos(0, 0))
 	obj[1].Resize(size)
 
+	// buttons
+	obj[3].Resize(btnMin)
+	obj[3].Move(fyne.NewPos(size.Width/2-(btnMin.Width/2), size.Height-padHeight-btnMin.Height))
+
 	// content
 	contentStart := obj[4].Position().Y + labelMin.Height + padHeight
 	contentEnd := obj[3].Position().Y - theme.Padding()
 	obj[2].Move(fyne.NewPos(padWidth/2, labelMin.Height+padHeight))
 	obj[2].Resize(fyne.NewSize(size.Width-padWidth, contentEnd-contentStart))
-
-	// buttons
-	obj[3].Resize(btnMin)
-	obj[3].Move(fyne.NewPos(size.Width/2-(btnMin.Width/2), size.Height-padHeight-btnMin.Height))
 }
 
 func (l *dialogLayout) MinSize(obj []fyne.CanvasObject) fyne.Size {

--- a/dialog/custom_test.go
+++ b/dialog/custom_test.go
@@ -174,12 +174,10 @@ func TestCustom_ContentLayout(t *testing.T) {
 	d := NewCustom("Title", "OK", label, w)
 	d.Show()
 
-	p := d.win
-	r := p.CreateRenderer()
-	r.Layout(p.Size())
+	c := d.win.Content.(*fyne.Container)
+	c.Layout.Layout(c.Objects, c.MinSize())
 	initialSize := d.content.Size()
 
-	c := d.win.Content.(*fyne.Container)
-	c.Layout.Layout(c.Objects, c.Size())
+	c.Layout.Layout(c.Objects, c.MinSize())
 	assert.Equal(t, d.content.Size(), initialSize)
 }

--- a/dialog/custom_test.go
+++ b/dialog/custom_test.go
@@ -163,3 +163,23 @@ func TestCustom_SetIcon(t *testing.T) {
 
 	test.AssertRendersToImage(t, "dialog-custom-seticon-nil.png", w.Canvas())
 }
+
+func TestCustom_ContentLayout(t *testing.T) {
+	test.NewTempApp(t)
+	w := test.NewTempWindow(t, canvas.NewRectangle(color.Transparent))
+	w.Resize(fyne.NewSize(200, 300))
+
+	label := widget.NewLabel("iiiiiiiiiimmmmmmmmmm")
+	label.Wrapping = fyne.TextWrapWord
+	d := NewCustom("Title", "OK", label, w)
+	d.Show()
+
+	p := d.win
+	r := p.CreateRenderer()
+	r.Layout(p.Size())
+	initialSize := d.content.Size()
+
+	c := d.win.Content.(*fyne.Container)
+	c.Layout.Layout(c.Objects, c.Size())
+	assert.Equal(t, d.content.Size(), initialSize)
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Just move `content`'s layout after `button`'s layout because `content` needs `button`'s position to calculate its end position.

Fixes #6181

This issue is easily observed when using a wrapped label in a custom dialog, so I've added a test for that.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
