### PR TITLE
Fix text grid min size

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -499,6 +499,10 @@ func newTextGridContent(t *TextGrid) *textGridContent {
 	return grid
 }
 
+func (t *textGridContent) lineNumberWidth() int {
+	return len(strconv.Itoa(len(t.text.Rows)))
+}
+
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
 func (t *textGridContent) CreateRenderer() fyne.WidgetRenderer {
 	r := &textGridContentRenderer{text: t}
@@ -555,6 +559,11 @@ func (t *textGridContentRenderer) MinSize() fyne.Size {
 	for _, row := range t.text.text.Rows {
 		longestRow = fyne.Max(longestRow, float32(len(row.Cells)))
 	}
+
+	if t.text.text.ShowLineNumbers {
+		longestRow += float32(t.text.lineNumberWidth()) + 1
+	}
+
 	return fyne.NewSize(t.text.cellSize.Width*longestRow,
 		t.text.cellSize.Height*float32(len(t.text.text.Rows)))
 }
@@ -761,7 +770,7 @@ func (t *textGridRow) refreshCells() {
 	i := 0
 	if t.text.text.ShowLineNumbers {
 		lineStr := []rune(strconv.Itoa(t.row + 1))
-		pad := t.lineNumberWidth() - len(lineStr)
+		pad := t.text.lineNumberWidth() - len(lineStr)
 		for ; i < pad; i++ {
 			t.setCellRune(' ', x, TextGridStyleWhitespace, rowStyle) // padding space
 			x++
@@ -824,10 +833,6 @@ func (t *TextGrid) tabWidth() int {
 	return t.TabWidth
 }
 
-func (t *textGridRow) lineNumberWidth() int {
-	return len(strconv.Itoa(t.text.rows + 1))
-}
-
 func (t *textGridRow) updateGridSize(size fyne.Size) {
 	bufCols := int(size.Width / t.text.cellSize.Width)
 	for _, row := range t.text.text.Rows {
@@ -841,7 +846,7 @@ func (t *textGridRow) updateGridSize(size fyne.Size) {
 		bufCols++
 	}
 	if t.text.text.ShowLineNumbers {
-		bufCols += t.lineNumberWidth()
+		bufCols += t.text.lineNumberWidth()
 	}
 
 	t.cols = bufCols

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -876,11 +876,13 @@ func (t *textGridRowRenderer) Layout(size fyne.Size) {
 }
 
 func (t *textGridRowRenderer) MinSize() fyne.Size {
-	longestRow := float32(0)
-	for _, row := range t.obj.text.text.Rows {
-		longestRow = fyne.Max(longestRow, float32(len(row.Cells)))
+	if t.obj.row >= len(t.obj.text.text.Rows) {
+		return fyne.NewSize(0, 0)
 	}
-	return fyne.NewSize(t.obj.text.cellSize.Width*longestRow, t.obj.text.cellSize.Height)
+
+	return fyne.NewSize(
+		t.obj.text.cellSize.Width*float32(len(t.obj.text.text.Rows[t.obj.row].Cells)),
+		t.obj.text.cellSize.Height)
 }
 
 func (t *textGridRowRenderer) Refresh() {

--- a/widget/textgrid_test.go
+++ b/widget/textgrid_test.go
@@ -285,6 +285,31 @@ func TestTextGridRenderer_Resize(t *testing.T) {
 	assert.Equal(t, min, renderer.MinSize())
 }
 
+func TestTextGridRenderer_MinSize(t *testing.T) {
+	grid := NewTextGridFromString("ABC")
+	grid.ShowLineNumbers = false
+	renderer := test.TempWidgetRenderer(t, grid)
+
+	grid.Refresh()
+	assert.Equal(t, fyne.NewSize(24, 16), renderer.MinSize())
+
+	grid.ShowLineNumbers = true
+	grid.Refresh()
+	assert.Equal(t, fyne.NewSize(40, 16), renderer.MinSize())
+
+	grid.SetCell(8, 0, TextGridCell{Rune: 'A'})
+	grid.Refresh()
+	assert.Equal(t, fyne.NewSize(40, 144), renderer.MinSize())
+
+	grid.SetCell(10, 0, TextGridCell{Rune: 'B'})
+	grid.Refresh()
+	assert.Equal(t, fyne.NewSize(48, 176), renderer.MinSize())
+
+	grid.SetCell(5, 20, TextGridCell{Rune: 'C'})
+	grid.Refresh()
+	assert.Equal(t, fyne.NewSize(192, 176), renderer.MinSize())
+}
+
 func TestTextGridRenderer_ShowLineNumbers(t *testing.T) {
 	grid := NewTextGridFromString("1\n2\n3\n4\n5\n6\n7\n8\n9\n10")
 	grid.ShowLineNumbers = true


### PR DESCRIPTION
### Description:
The min size calculation for the text grid was not working when the ShowLineNumbers option was used. It's now working correctly. 

The MinSize function for the textGridRowRenderer is not looking for the longest line anymore. This was bad for the performance, when the text grid has a lot of lines.

Fixes #6218

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

