### PR TITLE
Faster text wrapping (again)

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -870,11 +870,11 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	return xPos - initialX, height
 }
 
-// howManyRunesDoFit accepts a rune slice, an available width, an average
+// howManyRunesFit accepts a rune slice, an available width, an average
 // character width, and a function that calculates the (pixel) size of a given
 // rune slice.
-// howManyRunesDoFit returns how many runes fit into the available width.
-func howManyRunesDoFit(runes []rune, availableWidth float32, charWidth float32, measurer func([]rune) fyne.Size) int {
+// howManyRunesFit returns how many runes fit into the available width.
+func howManyRunesFit(runes []rune, availableWidth float32, charWidth float32, measurer func([]rune) fyne.Size) int {
 	length := len(runes)
 	fits := 0
 	tooLong := length + 1
@@ -918,7 +918,7 @@ func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width f
 	seg := prior.segments[0].(*TextSegment)
 	ellipsisSize := fyne.MeasureText("…", seg.size(), seg.Style.TextStyle)
 
-	fitCount := howManyRunesDoFit([]rune(seg.Text)[prior.begin:prior.end], width-ellipsisSize.Width, charWidth, measurer)
+	fitCount := howManyRunesFit([]rune(seg.Text)[prior.begin:prior.end], width-ellipsisSize.Width, charWidth, measurer)
 	prior.end = prior.begin + fitCount
 
 	prior.ellipsis = true
@@ -997,7 +997,7 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 				return ellipsisPriorBound(bounds, trunc, measureWidth, charWidth, measurer), yPos
 			}
 
-			fitCount := howManyRunesDoFit(text[low:high], measureWidth, charWidth, measurer)
+			fitCount := howManyRunesFit(text[low:high], measureWidth, charWidth, measurer)
 			if fitCount == high-low { // all characters fit on this line
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
@@ -1043,7 +1043,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			}
 
 			sub := text[low:high]
-			fitCount := howManyRunesDoFit(sub, measureWidth, charWidth, measurer)
+			fitCount := howManyRunesFit(sub, measureWidth, charWidth, measurer)
 			if fitCount == high-low { // all characters fit on this line
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
@@ -1133,7 +1133,7 @@ func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 			reuse++
 		} else if trunc == fyne.TextTruncateClip {
-			fitCount := howManyRunesDoFit(text[low:high], measureWidth, charWidth, measurer)
+			fitCount := howManyRunesFit(text[low:high], measureWidth, charWidth, measurer)
 			high = low + fitCount
 			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 			reuse++

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -870,43 +870,34 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	return xPos - initialX, height
 }
 
-// ratioSearch accepts a function that, given a start and end rune index and a
-// precalculated ratio, returns the ratio of the text width to the maximum
-// allowed width. The low and maxHigh parameters are the start and end rune
-// indices to search between. ratioSearch returns the index of the rune located
-// as close as possible to the maximum line width.
-func ratioSearch(widthToMaxWidthRatio func(int, int) float32, low int, maxHigh int, ratio float32) int {
-	if low >= maxHigh {
-		return low
+// howManyRunesDoFit accepts a rune slice, an available width, an average
+// character width, and a function that calculates the (pixel) size of a given
+// rune slice.
+// howManyRunesDoFit returns how many runes fit into the available width.
+func howManyRunesDoFit(runes []rune, availableWidth float32, charWidth float32, measurer func([]rune) fyne.Size) int {
+	length := len(runes)
+	fits := 0
+	tooLong := length + 1
+	estimation := int(availableWidth / charWidth)
+	if estimation > length {
+		estimation = length
 	}
-	if ratio == -1.0 {
-		ratio = widthToMaxWidthRatio(low, maxHigh)
-		if ratio <= 1.0 {
-			return maxHigh
-		}
-	}
-	tooHigh := maxHigh + 1
-	high := low
-	nextHigh := low + int(float32(maxHigh-low)/ratio)
-	if nextHigh <= high {
-		nextHigh = high + 1
-	}
-	for nextHigh < tooHigh {
-		ratio = widthToMaxWidthRatio(low, nextHigh)
-		if ratio <= 1.0 {
-			high = nextHigh
+	for tooLong-fits > 1 {
+		subWidth := measurer(runes[:estimation]).Width
+		if subWidth <= availableWidth {
+			fits = estimation
 		} else {
-			tooHigh = nextHigh
+			tooLong = estimation
 		}
-		nextHigh = low + int(float32(nextHigh-low)/ratio)
-		if nextHigh >= tooHigh {
-			nextHigh = tooHigh - 1
+		estimation = int(float32(estimation) * availableWidth / subWidth)
+		if estimation >= tooLong {
+			estimation = tooLong - 1
 		}
-		if nextHigh <= high {
-			nextHigh = high + 1
+		if estimation <= fits {
+			estimation = fits + 1
 		}
 	}
-	return high
+	return fits
 }
 
 // concealed returns true if the segment represents a password, meaning the text should be obscured.
@@ -918,7 +909,7 @@ func concealed(seg RichTextSegment) bool {
 	return false
 }
 
-func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width float32, measurer func([]rune) fyne.Size) []rowBoundary {
+func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width float32, charWidth float32, measurer func([]rune) fyne.Size) []rowBoundary {
 	if trunc != fyne.TextTruncateEllipsis || len(bounds) == 0 {
 		return bounds
 	}
@@ -927,12 +918,8 @@ func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width f
 	seg := prior.segments[0].(*TextSegment)
 	ellipsisSize := fyne.MeasureText("…", seg.size(), seg.Style.TextStyle)
 
-	widthChecker := func(low int, high int) float32 {
-		return measurer([]rune(seg.Text)[low:high]).Width / (width - ellipsisSize.Width)
-	}
-
-	limit := ratioSearch(widthChecker, prior.begin, prior.end, -1.0)
-	prior.end = limit
+	fitCount := howManyRunesDoFit([]rune(seg.Text)[prior.begin:prior.end], width-ellipsisSize.Width, charWidth, measurer)
+	prior.end = prior.begin + fitCount
 
 	prior.ellipsis = true
 	bounds[len(bounds)-1] = prior
@@ -990,10 +977,8 @@ func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncati
 
 func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
 	text := []rune(seg.Textual())
-	widthChecker := func(low int, high int) float32 {
-		return measurer(text[low:high]).Width / measureWidth
-	}
-	charSize := measurer([]rune("M"))
+	charSize := measurer([]rune("z"))
+	charWidth := charSize.Width
 	lineHeight := charSize.Height
 	reuse := 0
 	yPos := float32(0)
@@ -1009,11 +994,11 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 		}
 		for low < high {
 			if yPos+lineHeight > max.Height && trunc != fyne.TextTruncateOff {
-				return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
+				return ellipsisPriorBound(bounds, trunc, measureWidth, charWidth, measurer), yPos
 			}
 
-			measured := measurer(text[low:high])
-			if measured.Width <= measureWidth {
+			fitCount := howManyRunesDoFit(text[low:high], measureWidth, charWidth, measurer)
+			if fitCount == high-low { // all characters fit on this line
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
 				low = high
@@ -1021,18 +1006,14 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 				measureWidth = max.Width
 
 				yPos += lineHeight
-			} else {
-				ratio := measured.Width / measureWidth
-				newHigh := ratioSearch(widthChecker, low, high, ratio)
-				if newHigh <= low {
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
-					reuse++
-					low++
+			} else if fitCount == 0 { // even a character won't fit
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
+				reuse++
+				low++
 
-					yPos += lineHeight
-				} else {
-					high = newHigh
-				}
+				yPos += lineHeight
+			} else {
+				high = low + fitCount
 			}
 		}
 	}
@@ -1041,10 +1022,8 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 
 func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
 	text := []rune(seg.Textual())
-	widthChecker := func(low int, high int) float32 {
-		return measurer(text[low:high]).Width / measureWidth
-	}
-	charSize := measurer([]rune("M"))
+	charSize := measurer([]rune("z"))
+	charWidth := charSize.Width
 	lineHeight := charSize.Height
 	reuse := 0
 	yPos := float32(0)
@@ -1060,13 +1039,12 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 		}
 		for low < high {
 			if yPos+lineHeight > max.Height && trunc != fyne.TextTruncateOff {
-				return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
+				return ellipsisPriorBound(bounds, trunc, measureWidth, charWidth, measurer), yPos
 			}
 
 			sub := text[low:high]
-			measured := measurer(sub)
-			subWidth := measured.Width
-			if subWidth <= measureWidth {
+			fitCount := howManyRunesDoFit(sub, measureWidth, charWidth, measurer)
+			if fitCount == high-low { // all characters fit on this line
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
 				low = high
@@ -1077,52 +1055,48 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 				measureWidth = max.Width
 
 				yPos += lineHeight
-			} else {
-				oldHigh := high
-				last := low + len(sub) - 1
-				ratio := measured.Width / measureWidth
-				fallback := ratioSearch(widthChecker, low, last, ratio) - low
+				continue
+			}
 
-				if fallback < 1 { // even a character won't fit
-					if measureWidth < max.Width {
-						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
-						reuse++
-						measureWidth = max.Width
-						yPos += lineHeight
-						continue
-					}
-					include := 1
-					ellipsis := false
-					if trunc == fyne.TextTruncateEllipsis {
-						include = 0
-						ellipsis = true
-					}
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis})
-					low++
-					high = low + 1
-					reuse++
-
-					yPos += lineHeight
-					if high > l.end {
-						return bounds, yPos
-					}
-				} else {
-					spaceIndex := findSpaceIndex(sub, fallback)
-					if spaceIndex == 0 {
-						spaceIndex = 1
-					}
-
-					high = low + spaceIndex
-				}
-				if high == fallback && subWidth <= max.Width { // add a newline as there is more space on next
+			oldHigh := high
+			if fitCount < 1 { // even a character won't fit
+				if measureWidth < max.Width {
 					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
 					reuse++
-					high = oldHigh
 					measureWidth = max.Width
-
 					yPos += lineHeight
 					continue
 				}
+				include := 1
+				ellipsis := false
+				if trunc == fyne.TextTruncateEllipsis {
+					include = 0
+					ellipsis = true
+				}
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis})
+				low++
+				high = low + 1
+				reuse++
+
+				yPos += lineHeight
+				if high > l.end {
+					return bounds, yPos
+				}
+			} else {
+				spaceIndex := findSpaceIndex(sub, fitCount)
+				if spaceIndex == 0 {
+					spaceIndex = 1
+				}
+
+				high = low + spaceIndex
+			}
+			if high == fitCount && measureWidth < max.Width { // add a newline as there is more space on next
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
+				reuse++
+				high = oldHigh
+				measureWidth = max.Width
+
+				yPos += lineHeight
 			}
 		}
 	}
@@ -1131,11 +1105,10 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 
 func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
 	text := []rune(seg.Textual())
-	widthChecker := func(low int, high int) float32 {
-		return measurer(text[low:high]).Width / measureWidth
-	}
 	yPos := float32(0)
 	var bounds []rowBoundary
+	charSize := measurer([]rune("z"))
+	charWidth := charSize.Width
 	reuse := 0
 	for _, l := range lines {
 		low := l.begin
@@ -1160,7 +1133,8 @@ func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
 			reuse++
 		} else if trunc == fyne.TextTruncateClip {
-			high = ratioSearch(widthChecker, low, high, -1.0)
+			fitCount := howManyRunesDoFit(text[low:high], measureWidth, charWidth, measurer)
+			high = low + fitCount
 			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 			reuse++
 		}

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -993,6 +993,8 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 	widthChecker := func(low int, high int) float32 {
 		return measurer(text[low:high]).Width / measureWidth
 	}
+	charSize := measurer([]rune("M"))
+	lineHeight := charSize.Height
 	reuse := 0
 	yPos := float32(0)
 	var bounds []rowBoundary
@@ -1006,11 +1008,11 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 			continue
 		}
 		for low < high {
-			measured := measurer(text[low:high])
-			if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
+			if yPos+lineHeight > max.Height && trunc != fyne.TextTruncateOff {
 				return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
 			}
 
+			measured := measurer(text[low:high])
 			if measured.Width <= measureWidth {
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
 				reuse++
@@ -1018,7 +1020,7 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 				high = l.end
 				measureWidth = max.Width
 
-				yPos += measured.Height
+				yPos += lineHeight
 			} else {
 				ratio := measured.Width / measureWidth
 				newHigh := ratioSearch(widthChecker, low, high, ratio)
@@ -1027,7 +1029,7 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 					reuse++
 					low++
 
-					yPos += measured.Height
+					yPos += lineHeight
 				} else {
 					high = newHigh
 				}
@@ -1042,6 +1044,8 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 	widthChecker := func(low int, high int) float32 {
 		return measurer(text[low:high]).Width / measureWidth
 	}
+	charSize := measurer([]rune("M"))
+	lineHeight := charSize.Height
 	reuse := 0
 	yPos := float32(0)
 	var bounds []rowBoundary
@@ -1055,12 +1059,12 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			continue
 		}
 		for low < high {
-			sub := text[low:high]
-			measured := measurer(sub)
-			if yPos+measured.Height > max.Height && trunc != fyne.TextTruncateOff {
+			if yPos+lineHeight > max.Height && trunc != fyne.TextTruncateOff {
 				return ellipsisPriorBound(bounds, trunc, measureWidth, measurer), yPos
 			}
 
+			sub := text[low:high]
+			measured := measurer(sub)
 			subWidth := measured.Width
 			if subWidth <= measureWidth {
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
@@ -1072,7 +1076,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 				}
 				measureWidth = max.Width
 
-				yPos += measured.Height
+				yPos += lineHeight
 			} else {
 				oldHigh := high
 				last := low + len(sub) - 1
@@ -1084,7 +1088,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 						bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
 						reuse++
 						measureWidth = max.Width
-						yPos += measured.Height
+						yPos += lineHeight
 						continue
 					}
 					include := 1
@@ -1098,7 +1102,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 					high = low + 1
 					reuse++
 
-					yPos += measured.Height
+					yPos += lineHeight
 					if high > l.end {
 						return bounds, yPos
 					}
@@ -1116,7 +1120,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 					high = oldHigh
 					measureWidth = max.Width
 
-					yPos += measured.Height
+					yPos += lineHeight
 					continue
 				}
 			}

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -1,6 +1,7 @@
 package widget
 
 import (
+	"strings"
 	"testing"
 
 	"fyne.io/fyne/v2"
@@ -61,7 +62,7 @@ func BenchmarkText_lineBounds_WrapWord(b *testing.B) {
 }
 
 func BenchmarkText_howManyRunesDoFit(b *testing.B) {
-	text := loremIpsum
+	text := strings.Split(loremIpsum, "\n")[0]
 	maxWidth := float32(200)
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -61,7 +61,7 @@ func BenchmarkText_lineBounds_WrapWord(b *testing.B) {
 	benchmarkTextLineBounds(fyne.TextWrapWord, b)
 }
 
-func BenchmarkText_howManyRunesDoFit_latin(b *testing.B) {
+func BenchmarkText_howManyRunesFit_latin(b *testing.B) {
 	text := strings.Split(loremIpsum, "\n")[0]
 	maxWidth := float32(200)
 	textSize := float32(10)
@@ -71,11 +71,11 @@ func BenchmarkText_howManyRunesDoFit_latin(b *testing.B) {
 	}
 	charWidth := measurer([]rune("z")).Width
 	for n := 0; n < b.N; n++ {
-		howManyRunesDoFit([]rune(text), maxWidth, charWidth, measurer)
+		howManyRunesFit([]rune(text), maxWidth, charWidth, measurer)
 	}
 }
 
-func BenchmarkText_howManyRunesDoFit_chinese(b *testing.B) {
+func BenchmarkText_howManyRunesFit_chinese(b *testing.B) {
 	text := "昔者文公出走而正天下，畢云：「正，讀如征。」王念孫云「畢讀非也，《爾雅》曰：『正，長也。』晉文為諸侯盟主，故曰『正天下』，與下『霸諸侯』對文。又《廣雅》『正，君也』。《尚賢》篇曰：『堯、舜、禹、湯、文、武之所以王天下正諸侯者』。凡墨子書言正天下正諸侯者，非訓為長，即訓為君，皆非征伐之謂。」案：王說是也。"
 	maxWidth := float32(200)
 	textSize := float32(10)
@@ -85,6 +85,6 @@ func BenchmarkText_howManyRunesDoFit_chinese(b *testing.B) {
 	}
 	charWidth := measurer([]rune("z")).Width
 	for n := 0; n < b.N; n++ {
-		howManyRunesDoFit([]rune(text), maxWidth, charWidth, measurer)
+		howManyRunesFit([]rune(text), maxWidth, charWidth, measurer)
 	}
 }

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -60,18 +60,16 @@ func BenchmarkText_lineBounds_WrapWord(b *testing.B) {
 	benchmarkTextLineBounds(fyne.TextWrapWord, b)
 }
 
-func BenchmarkText_ratioSearch(b *testing.B) {
+func BenchmarkText_howManyRunesDoFit(b *testing.B) {
 	text := loremIpsum
 	maxWidth := float32(200)
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}
-	measurer := func(text []rune) float32 {
-		return fyne.MeasureText(string(text), textSize, textStyle).Width
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), textSize, textStyle)
 	}
-	checker := func(low int, high int) float32 {
-		return measurer([]rune(text[low:high])) / maxWidth
-	}
+	charWidth := measurer([]rune("z")).Width
 	for n := 0; n < b.N; n++ {
-		ratioSearch(checker, 0, len(text), -1.0)
+		howManyRunesDoFit([]rune(text), maxWidth, charWidth, measurer)
 	}
 }

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -61,8 +61,22 @@ func BenchmarkText_lineBounds_WrapWord(b *testing.B) {
 	benchmarkTextLineBounds(fyne.TextWrapWord, b)
 }
 
-func BenchmarkText_howManyRunesDoFit(b *testing.B) {
+func BenchmarkText_howManyRunesDoFit_latin(b *testing.B) {
 	text := strings.Split(loremIpsum, "\n")[0]
+	maxWidth := float32(200)
+	textSize := float32(10)
+	textStyle := fyne.TextStyle{}
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), textSize, textStyle)
+	}
+	charWidth := measurer([]rune("z")).Width
+	for n := 0; n < b.N; n++ {
+		howManyRunesDoFit([]rune(text), maxWidth, charWidth, measurer)
+	}
+}
+
+func BenchmarkText_howManyRunesDoFit_chinese(b *testing.B) {
+	text := "昔者文公出走而正天下，畢云：「正，讀如征。」王念孫云「畢讀非也，《爾雅》曰：『正，長也。』晉文為諸侯盟主，故曰『正天下』，與下『霸諸侯』對文。又《廣雅》『正，君也』。《尚賢》篇曰：『堯、舜、禹、湯、文、武之所以王天下正諸侯者』。凡墨子書言正天下正諸侯者，非訓為長，即訓為君，皆非征伐之謂。」案：王說是也。"
 	maxWidth := float32(200)
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1244,7 +1244,7 @@ func TestText_lineBounds_small_firstWidth(t *testing.T) {
 	assert.Equal(t, 6, got[1].end)
 }
 
-func TestText_howManyRunesDoFit(t *testing.T) {
+func TestText_howManyRunesFit(t *testing.T) {
 	maxWidth := float32(46)
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}
@@ -1290,7 +1290,7 @@ func TestText_howManyRunesDoFit(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, howManyRunesDoFit([]rune(tt.text), maxWidth, charWidth, measurer))
+			assert.Equal(t, tt.want, howManyRunesFit([]rune(tt.text), maxWidth, charWidth, measurer))
 		})
 	}
 }

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1244,13 +1244,14 @@ func TestText_lineBounds_small_firstWidth(t *testing.T) {
 	assert.Equal(t, 6, got[1].end)
 }
 
-func TestText_ratioSearch(t *testing.T) {
+func TestText_howManyRunesDoFit(t *testing.T) {
 	maxWidth := float32(46)
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}
-	measurer := func(text []rune) float32 {
-		return fyne.MeasureText(string(text), textSize, textStyle).Width
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), textSize, textStyle)
 	}
+	charWidth := measurer([]rune("z")).Width
 	for name, tt := range map[string]struct {
 		text string
 		want int
@@ -1288,11 +1289,8 @@ func TestText_ratioSearch(t *testing.T) {
 			want: 0,
 		},
 	} {
-		checker := func(low int, high int) float32 {
-			return measurer([]rune(tt.text[low:high])) / maxWidth
-		}
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, ratioSearch(checker, 0, len(tt.text), -1.0))
+			assert.Equal(t, tt.want, howManyRunesDoFit([]rune(tt.text), maxWidth, charWidth, measurer))
 		})
 	}
 }


### PR DESCRIPTION
### Description:

This PR improves the text wrapping performance (again).

The most expensive `measurer` (`MeasureText`) call in `lineBounds` is the first one (per iteration). It measures the width of the whole remaining text (p.e. of a paragraph). That is before `ratioSearch` is called.

This PR replaces `ratioSearch` by a new (but similar) function `howManyRunesDoFit`. The main difference is that `howManyRunesDoFit` doesn't need the initial text measurement. Instead, it estimates how many characters fit in a line based on the available line width and an average char width. ("z" turned out to be very close to the mean character width of a longer text.) Apart from that I think that the new function is easier to understand because of its self-explaining name.

The first commit of this PR alone is a little improvement. It calculates the line height based on a single letter ("M", later changed to "z"; same line height). This allows to skip `measurer` calls (for possibly long text) only for the line height.

~~This PR is in conflict with #6201. If you merge any of these, I'll update the other one.~~ This PR has been rebased to `develop`.

### Performance gains

##### Example code from #5297 (8000 chars):

||Before|After|
|--|--|--|
|time to set content|1.08s|810ms|
|time to resize|870ms|80ms|

##### Similar test app but using RichText instead of Entry and lorem ipsum text:

||Before|After|
|--|--|--|
|time to set content|173ms|150ms|
|time to resize|88ms|47ms|
|uncached MeasureText calls|416|339|

##### Benchmark

```console
$ go test -test.run xxx -test.bench BenchmarkText_ratioSearch -test.benchtime 1x ./widget
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_ratioSearch-4   	       1	   3,734,497 ns/op
PASS
ok  	fyne.io/fyne/v2/widget	0.061s
```
```console
$ go test -test.run xxx -test.bench BenchmarkText_howManyRunesDoFit -test.benchtime 1x ./widget
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_howManyRunesDoFit-4   	       1	    365,909 ns/op
PASS
ok  	fyne.io/fyne/v2/widget	0.058s
```

(I have added separators to make the numbers easier to distinguish.)

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.