### PR TITLE
Start infinite progress bar animation in CreateRenderer rather than require an initial Refresh

### DIFF
--- a/widget/progressbarinfinite.go
+++ b/widget/progressbarinfinite.go
@@ -188,6 +188,7 @@ func (p *ProgressBarInfinite) CreateRenderer() fyne.WidgetRenderer {
 	render.SetObjects([]fyne.CanvasObject{&render.background, &render.bar})
 
 	p.running = true
+	render.start()
 	return render
 }
 


### PR DESCRIPTION

### Description:

Fixes #6221 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
