### PR TITLE
Remove refreshBars call from ScrollToTop

### DIFF
--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -523,7 +523,6 @@ func (s *Scroll) ScrollToBottom() {
 // ScrollToTop will scroll content to container top
 func (s *Scroll) ScrollToTop() {
 	s.ScrollToOffset(fyne.Position{})
-	s.refreshBars()
 }
 
 // MinSize returns the smallest size this widget can shrink to


### PR DESCRIPTION
### Description:

`ScrollToTop` calls `ScrollToOffset` which calls `refreshBars` anyway (if necessary).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.