### PR TITLE
Support multi-touch move reporting

### DIFF
--- a/driver/mobile/touch.go
+++ b/driver/mobile/touch.go
@@ -19,3 +19,12 @@ type Touchable interface {
 	TouchUp(*TouchEvent)
 	TouchCancel(*TouchEvent)
 }
+
+// Movable represents a mobile touch event dragging across the screen.
+// Where multiple fingers are moving then will be reported as different events.
+// The ID of the TouchEvent indicates which finger moved.
+//
+// Since: 2.8
+type Movable interface {
+	TouchMoved(*TouchEvent)
+}

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -443,6 +443,22 @@ func (d *driver) tapMoveCanvas(w *window, x, y float32, tapID touch.Sequence) {
 	tapY := scale.ToFyneCoordinate(w.canvas, int(y))
 	pos := fyne.NewPos(tapX, tapY+tapYOffset)
 
+	co, pos, _ := w.canvas.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
+		if _, ok := object.(mobile.Movable); ok {
+			return true
+		}
+		return false
+	})
+
+	if co != nil {
+		co.(mobile.Movable).TouchMoved(&mobile.TouchEvent{
+			PointEvent: fyne.PointEvent{
+				Position: pos,
+			},
+			ID: int(tapID),
+		})
+	}
+
 	if tapID == 0 {
 		w.canvas.tapMove(pos, int(tapID), func(wid fyne.Draggable, ev *fyne.DragEvent) {
 			wid.Dragged(ev)


### PR DESCRIPTION
This is required for gestures, a future API for such will be added later.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes #(issue)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

---

I made this short app to demo:

```go
// Package main loads a very basic Hello World graphical application.
package main

import (
	"image/color"

	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/canvas"
	"fyne.io/fyne/v2/container"
	"fyne.io/fyne/v2/driver/mobile"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.New()
	w := a.NewWindow("Hello")

	w.SetContent(&touches{pads: make(map[int]fyne.CanvasObject)})

	w.ShowAndRun()
}

type touches struct {
	widget.BaseWidget

	pads map[int]fyne.CanvasObject
	hold *fyne.Container
}

func (t *touches) CreateRenderer() fyne.WidgetRenderer {
	t.hold = container.NewWithoutLayout()
	return widget.NewSimpleRenderer(t.hold)
}

func (t *touches) TouchDown(ev *mobile.TouchEvent) {
	pad := canvas.NewCircle(color.NRGBA{R: 255, A: 255})
	pad.Resize(fyne.NewSquareSize(50))
	pad.Move(ev.Position.Subtract(fyne.NewSquareSize(25)))
	t.pads[ev.ID] = pad
	var all []fyne.CanvasObject
	for _, o := range t.pads {
		all = append(all, o)
	}
	t.hold.Objects = all
	t.hold.Refresh()
}

func (t *touches) TouchUp(ev *mobile.TouchEvent) {
	delete(t.pads, ev.ID)

	var all []fyne.CanvasObject
	for _, o := range t.pads {
		all = append(all, o)
	}
	t.hold.Objects = all
	t.hold.Refresh()
}

func (t *touches) TouchCancel(ev *mobile.TouchEvent) {
	delete(t.pads, ev.ID)

	var all []fyne.CanvasObject
	for _, o := range t.pads {
		all = append(all, o)
	}
	t.hold.Objects = all
	t.hold.Refresh()
}

func (t *touches) TouchMoved(ev *mobile.TouchEvent) {
	t.pads[ev.ID].Move(ev.Position.Subtract(fyne.NewSquareSize(25)))
}
```

https://github.com/user-attachments/assets/fe7e40f2-91ec-4f11-8bba-ef064cecc9a6

