### PR TITLE
richtext: underline all wrapped hyperlink segments on hover

### DIFF
--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -44,6 +44,8 @@ type Hyperlink struct {
 	textSize         fyne.Size // updated in syncSegments
 	focused, hovered bool
 	provider         RichText
+
+	siblings []*Hyperlink // other visual instances of the same HyperlinkSegment when wrapped in RichText
 }
 
 // NewHyperlink creates a new hyperlink widget with the set text content
@@ -111,6 +113,9 @@ func (hl *Hyperlink) MouseMoved(e *desktop.MouseEvent) {
 	hl.hovered = hl.isPosOverText(e.Position)
 	if hl.hovered != oldHovered {
 		hl.BaseWidget.Refresh()
+		for _, s := range hl.siblings {
+			s.setHovered(hl.hovered)
+		}
 	}
 }
 
@@ -120,7 +125,19 @@ func (hl *Hyperlink) MouseOut() {
 	hl.hovered = false
 	if changed {
 		hl.BaseWidget.Refresh()
+		for _, s := range hl.siblings {
+			s.setHovered(false)
+		}
 	}
+}
+
+// setHovered updates the hovered state without propagating to siblings, to avoid recursion.
+func (hl *Hyperlink) setHovered(hovered bool) {
+	if hl.hovered == hovered {
+		return
+	}
+	hl.hovered = hovered
+	hl.BaseWidget.Refresh()
 }
 
 func (hl *Hyperlink) focusWidth() float32 {

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -697,7 +697,7 @@ func (r *textRenderer) Refresh() {
 	for _, bound := range bounds {
 		for i, seg := range bound.segments {
 			_, isText := seg.(*TextSegment)
-			_, isHyperlink := seg.(*HyperlinkSegment)
+			hlSeg, isHyperlink := seg.(*HyperlinkSegment)
 			if !isText && !isHyperlink {
 				obj := r.obj.cachedSegmentVisual(seg, 0)
 				seg.Update(obj)
@@ -736,8 +736,20 @@ func (r *textRenderer) Refresh() {
 			if isText {
 				obj.(*canvas.Text).Text = txt
 			} else if isHyperlink {
-				obj.(*fyne.Container).Objects[0].(*Hyperlink).Text = txt
-				obj.(*fyne.Container).Objects[0].(*Hyperlink).Refresh()
+				hl := obj.(*fyne.Container).Objects[0].(*Hyperlink)
+				hl.Text = txt
+				// A wrapping hyperlink produces one Hyperlink widget per row, each
+				// cached at successive offsets for the same segment. reuse is both
+				// this visual's cache offset and the count of prior row visuals, so
+				// the earlier ones sit at offsets 0..reuse-1 and can be fetched
+				// directly from the cache to build the all-to-all sibling list.
+				hl.siblings = hl.siblings[:0]
+				for prev := 0; prev < reuse; prev++ {
+					prevHL := r.obj.cachedSegmentVisual(hlSeg, prev).(*fyne.Container).Objects[0].(*Hyperlink)
+					prevHL.siblings = append(prevHL.siblings, hl)
+					hl.siblings = append(hl.siblings, prevHL)
+				}
+				hl.Refresh()
 			}
 			objs = append(objs, obj)
 		}

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -738,7 +738,7 @@ func (r *textRenderer) Refresh() {
 			} else if isHyperlink {
 				hl := obj.(*fyne.Container).Objects[0].(*Hyperlink)
 				hl.Text = txt
-				r.associateSiblings(hl)
+				r.associateSiblings(hl, hlSeg, reuse)
 				hl.Refresh()
 			}
 			objs = append(objs, obj)
@@ -762,7 +762,7 @@ func (r *textRenderer) Refresh() {
 	r.obj.cleanVisualCache()
 }
 
-func (r *textRenderer) associateSiblings(hl *widget.Hyperlink) {
+func (r *textRenderer) associateSiblings(hl *Hyperlink, hlSeg *HyperlinkSegment, reuse int) {
 	hl.siblings = hl.siblings[:0]
 	for prev := 0; prev < reuse; prev++ {
 		prevHL := r.obj.cachedSegmentVisual(hlSeg, prev).(*fyne.Container).Objects[0].(*Hyperlink)

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -738,11 +738,8 @@ func (r *textRenderer) Refresh() {
 			} else if isHyperlink {
 				hl := obj.(*fyne.Container).Objects[0].(*Hyperlink)
 				hl.Text = txt
-				// A wrapping hyperlink produces one Hyperlink widget per row, each
-				// cached at successive offsets for the same segment. reuse is both
-				// this visual's cache offset and the count of prior row visuals, so
-				// the earlier ones sit at offsets 0..reuse-1 and can be fetched
-				// directly from the cache to build the all-to-all sibling list.
+				// create the all-to-all sibling list linking the *Hyperlinks
+				// rendering each wrapped row of the same HyperlinkSegment
 				hl.siblings = hl.siblings[:0]
 				for prev := 0; prev < reuse; prev++ {
 					prevHL := r.obj.cachedSegmentVisual(hlSeg, prev).(*fyne.Container).Objects[0].(*Hyperlink)

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -738,14 +738,7 @@ func (r *textRenderer) Refresh() {
 			} else if isHyperlink {
 				hl := obj.(*fyne.Container).Objects[0].(*Hyperlink)
 				hl.Text = txt
-				// create the all-to-all sibling list linking the *Hyperlinks
-				// rendering each wrapped row of the same HyperlinkSegment
-				hl.siblings = hl.siblings[:0]
-				for prev := 0; prev < reuse; prev++ {
-					prevHL := r.obj.cachedSegmentVisual(hlSeg, prev).(*fyne.Container).Objects[0].(*Hyperlink)
-					prevHL.siblings = append(prevHL.siblings, hl)
-					hl.siblings = append(hl.siblings, prevHL)
-				}
+				r.associateSiblings(hl)
 				hl.Refresh()
 			}
 			objs = append(objs, obj)
@@ -767,6 +760,15 @@ func (r *textRenderer) Refresh() {
 	canvas.Refresh(r.obj.super())
 
 	r.obj.cleanVisualCache()
+}
+
+func (r *textRenderer) associateSiblings(hl *widget.Hyperlink) {
+	hl.siblings = hl.siblings[:0]
+	for prev := 0; prev < reuse; prev++ {
+		prevHL := r.obj.cachedSegmentVisual(hlSeg, prev).(*fyne.Container).Objects[0].(*Hyperlink)
+		prevHL.siblings = append(prevHL.siblings, hl)
+		hl.siblings = append(hl.siblings, prevHL)
+	}
 }
 
 func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign, xPos, yPos, lineWidth float32) (float32, float32) {

--- a/widget/richtext_objects_test.go
+++ b/widget/richtext_objects_test.go
@@ -93,9 +93,9 @@ func TestRichText_HyperLink_WrappedHoverSynced(t *testing.T) {
 	}
 	assert.GreaterOrEqual(t, len(links), 2, "expected hyperlink to wrap into multiple segments")
 
-	// MouseIn on the first segment — position must be inside the text area.
-	// The test theme uses InnerPadding=20, so the text area starts at pos (10,10).
-	inside := &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(15, 15)}}
+	// MouseIn on the first segment — choose a position inside the hyperlink's bounds.
+	center := fyne.NewPos(links[0].Size().Width/2, links[0].Size().Height/2)
+	inside := &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: center}}
 	links[0].MouseIn(inside)
 	for i, hl := range links {
 		assert.True(t, hl.hovered, "expected link[%d] to be hovered after MouseIn on link[0]", i)

--- a/widget/richtext_objects_test.go
+++ b/widget/richtext_objects_test.go
@@ -1,6 +1,7 @@
 package widget
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/test"
 )
@@ -69,6 +71,41 @@ func TestRichText_OrderedList(t *testing.T) {
 	assert.Equal(t, "One", texts[1].(*canvas.Text).Text)
 	assert.Equal(t, "2.", strings.TrimSpace(texts[2].(*canvas.Text).Text))
 	assert.Equal(t, "Two", texts[3].(*canvas.Text).Text)
+}
+
+func TestRichText_HyperLink_WrappedHoverSynced(t *testing.T) {
+	u, _ := url.Parse("https://fyne.io")
+	seg := &HyperlinkSegment{Text: "this is a long hyperlink that wraps", URL: u}
+	rt := NewRichText(seg)
+	rt.Wrapping = fyne.TextWrapWord
+	// Render narrow enough to force wrapping into at least 2 rows.
+	rt.Resize(fyne.NewSize(100, 200))
+
+	objs := test.TempWidgetRenderer(t, rt).Objects()
+	// Collect all Hyperlink visuals for the segment (one per wrapped row).
+	var links []*Hyperlink
+	for _, obj := range objs {
+		if c, ok := obj.(*fyne.Container); ok {
+			if hl, ok := c.Objects[0].(*Hyperlink); ok {
+				links = append(links, hl)
+			}
+		}
+	}
+	assert.GreaterOrEqual(t, len(links), 2, "expected hyperlink to wrap into multiple segments")
+
+	// MouseIn on the first segment — position must be inside the text area.
+	// The test theme uses InnerPadding=20, so the text area starts at pos (10,10).
+	inside := &desktop.MouseEvent{PointEvent: fyne.PointEvent{Position: fyne.NewPos(15, 15)}}
+	links[0].MouseIn(inside)
+	for i, hl := range links {
+		assert.True(t, hl.hovered, "expected link[%d] to be hovered after MouseIn on link[0]", i)
+	}
+
+	// MouseOut on the first segment — all siblings should be unhovered too.
+	links[0].MouseOut()
+	for i, hl := range links {
+		assert.False(t, hl.hovered, "expected link[%d] to be unhovered after MouseOut on link[0]", i)
+	}
 }
 
 func TestRichText_OrderedListDifferentIndex(t *testing.T) {


### PR DESCRIPTION
### Description:

When a HyperlinkSegment wraps across multiple rows, each row gets its own Hyperlink widget instance. Hovering one now propagates the hovered state to all sibling instances so the underline appears across the full link, not just the segment under the cursor.

Siblings are linked inline during textRenderer.Refresh using the existing visualCache: reuse equals the current visual's cache offset and the count of prior row visuals, so earlier instances are fetched at offsets 0..reuse-1 and wired into an all-to-all sibling list with no extra allocations per refresh.

Fixes #6226

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
