### PR TITLE
Set correct text style and size for hyperlink truncation

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -1145,11 +1145,15 @@ func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 		if trunc == fyne.TextTruncateEllipsis {
 			txt := []rune(seg.Textual())[low:high]
 			var textObj *canvas.Text
-			switch seg.(type) {
+			switch t := seg.(type) {
 			case *TextSegment:
 				textObj = seg.Visual().(*canvas.Text)
 			case *HyperlinkSegment:
 				textObj = canvas.NewText(string(txt), color.Black)
+				textObj.TextStyle = t.TextStyle
+				if t.SizeName != "" {
+					textObj.TextSize = theme.Current().Size(t.SizeName)
+				}
 			}
 			end, full := truncateLimit(string(txt), textObj, int(measureWidth), []rune{'…'})
 			high = low + end

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -984,7 +984,7 @@ func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncati
 	case fyne.TextWrapWord:
 		return wrapWordLines(seg, trunc, measureWidth, max, measurer, lines)
 	default:
-		return truncateLines(seg, trunc, measureWidth, max, measurer, lines)
+		return truncateLines(seg, trunc, measureWidth, measurer, lines)
 	}
 }
 
@@ -1125,7 +1125,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 	return bounds, yPos
 }
 
-func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, max fyne.Size, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
+func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
 	text := []rune(seg.Textual())
 	widthChecker := func(low int, high int) float32 {
 		return measurer(text[low:high]).Width / measureWidth

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -449,7 +449,7 @@ func (t *RichText) updateRowBounds() {
 				textStyle = linkSeg.TextStyle
 				textSize = theme.SizeForWidget(theme.SizeNameText, t)
 			}
-			retBounds, height := lineBounds(seg, t.Wrapping, t.Truncation, wrapWidth-leftPad, fyne.NewSize(maxWidth, fitSize.Height), func(text []rune) fyne.Size {
+			retBounds, height := lineBounds(t, seg, wrapWidth-leftPad, fyne.NewSize(maxWidth, fitSize.Height), func(text []rune) fyne.Size {
 				return fyne.MeasureText(string(text), textSize, textStyle)
 			})
 			if currentBound != nil {
@@ -962,7 +962,9 @@ func float32ToFixed266(f float32) fixed.Int26_6 {
 // measure text size.
 // It will return a slice containing the boundary metadata of each line with the given wrapping applied and the
 // total height required to render the boundaries at the given width/height constraints
-func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncation, firstWidth float32, max fyne.Size, measurer func([]rune) fyne.Size) ([]rowBoundary, float32) {
+func lineBounds(t *RichText, seg RichTextSegment, firstWidth float32, max fyne.Size, measurer func([]rune) fyne.Size) ([]rowBoundary, float32) {
+	wrap := t.Wrapping
+	trunc := t.Truncation
 	lines := splitLines(seg)
 
 	if wrap == fyne.TextWrap(fyne.TextTruncateClip) {
@@ -984,7 +986,7 @@ func lineBounds(seg RichTextSegment, wrap fyne.TextWrap, trunc fyne.TextTruncati
 	case fyne.TextWrapWord:
 		return wrapWordLines(seg, trunc, measureWidth, max, measurer, lines)
 	default:
-		return truncateLines(seg, trunc, measureWidth, measurer, lines)
+		return truncateLines(t, seg, trunc, measureWidth, measurer, lines)
 	}
 }
 
@@ -1125,7 +1127,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 	return bounds, yPos
 }
 
-func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
+func truncateLines(t *RichText, seg RichTextSegment, trunc fyne.TextTruncation, measureWidth float32, measurer func([]rune) fyne.Size, lines []rowBoundary) ([]rowBoundary, float32) {
 	text := []rune(seg.Textual())
 	widthChecker := func(low int, high int) float32 {
 		return measurer(text[low:high]).Width / measureWidth
@@ -1145,15 +1147,17 @@ func truncateLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 		if trunc == fyne.TextTruncateEllipsis {
 			txt := []rune(seg.Textual())[low:high]
 			var textObj *canvas.Text
-			switch t := seg.(type) {
+			switch s := seg.(type) {
 			case *TextSegment:
 				textObj = seg.Visual().(*canvas.Text)
 			case *HyperlinkSegment:
 				textObj = canvas.NewText(string(txt), color.Black)
-				textObj.TextStyle = t.TextStyle
-				if t.SizeName != "" {
-					textObj.TextSize = theme.Current().Size(t.SizeName)
+				textObj.TextStyle = s.TextStyle
+				sizeName := s.SizeName
+				if sizeName == "" {
+					sizeName = theme.SizeNameText
 				}
+				textObj.TextSize = theme.SizeForWidget(sizeName, t)
 			}
 			end, full := truncateLimit(string(txt), textObj, int(measureWidth), []rune{'…'})
 			high = low + end

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -39,8 +39,11 @@ func benchmarkTextLineBounds(wrap fyne.TextWrap, b *testing.B) {
 	measurer := func(text []rune) fyne.Size {
 		return fyne.MeasureText(string(text), textSize, textStyle)
 	}
+	richText := NewRichTextWithText(loremIpsum)
+	richText.Wrapping = wrap
+	richText.Truncation = fyne.TextTruncateOff
 	for n := 0; n < b.N; n++ {
-		lineBounds(&TextSegment{Text: loremIpsum}, wrap, fyne.TextTruncateOff, 10, fyne.NewSize(10, 14), measurer)
+		lineBounds(richText, richText.Segments[0], 10, fyne.NewSize(10, 14), measurer)
 	}
 }
 

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1067,7 +1067,10 @@ func TestText_lineBounds(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ellipses := 0
-			got, _ := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 76, fyne.NewSize(76, 64), measurer)
+			richText := NewRichTextWithText(tt.text)
+			richText.Wrapping = tt.wrap
+			richText.Truncation = tt.trunc
+			got, _ := lineBounds(richText, richText.Segments[0], 76, fyne.NewSize(76, 64), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)
@@ -1142,7 +1145,10 @@ func TestText_lineBounds_hyperlinks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ellipses := 0
 			u, _ := url.Parse("https://fyne.io/")
-			got, _ := lineBounds(&HyperlinkSegment{Text: tt.text, URL: u}, tt.wrap, tt.trunc, 50, fyne.NewSize(50, 64), measurer)
+			richText := NewRichText(&HyperlinkSegment{Text: tt.text, URL: u})
+			richText.Wrapping = tt.wrap
+			richText.Truncation = tt.trunc
+			got, _ := lineBounds(richText, richText.Segments[0], 50, fyne.NewSize(50, 64), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)
@@ -1224,7 +1230,10 @@ func TestText_lineBounds_variable_char_width(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := lineBounds(&TextSegment{Text: tt.text}, tt.wrap, tt.trunc, 46, fyne.NewSize(46, 184), measurer)
+			richText := NewRichTextWithText(tt.text)
+			richText.Wrapping = tt.wrap
+			richText.Truncation = tt.trunc
+			got, _ := lineBounds(richText, richText.Segments[0], 46, fyne.NewSize(46, 184), measurer)
 			for i, wantRow := range tt.want {
 				assert.Equal(t, wantRow[0], got[i].begin)
 				assert.Equal(t, wantRow[1], got[i].end)
@@ -1237,7 +1246,10 @@ func TestText_lineBounds_small_firstWidth(t *testing.T) {
 	measurer := func(text []rune) fyne.Size {
 		return fyne.MeasureText(string(text), 14, fyne.TextStyle{})
 	}
-	got, _ := lineBounds(&TextSegment{Text: "foobar"}, fyne.TextWrapWord, fyne.TextTruncateOff, 0.1, fyne.NewSize(64, 20), measurer)
+	richText := NewRichTextWithText("foobar")
+	richText.Wrapping = fyne.TextWrapWord
+	richText.Truncation = fyne.TextTruncateOff
+	got, _ := lineBounds(richText, richText.Segments[0], 0.1, fyne.NewSize(64, 20), measurer)
 	assert.Equal(t, 0, got[0].begin)
 	assert.Equal(t, 0, got[0].end)
 	assert.Equal(t, 0, got[1].begin)


### PR DESCRIPTION
### Description:

In pull request #6201, the text style and size of hyperlinks isn't set for calculation of where to truncate. This PR fixes this.

See this [review comment](https://github.com/fyne-io/fyne/pull/6201#discussion_r2972090924).

<img width="186" height="157" alt="2026-03-24 08 12 54 186x157 Window" src="https://github.com/user-attachments/assets/728a7e55-34c6-4e7b-9b8e-701ed112628c" />

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass (all except `TestGlCanvas_MinSizeShrinkTriggersLayout`).