### PR TITLE
Don't allow dragging outside of the multiple-window boundary

### DIFF
--- a/container/multiplewindows.go
+++ b/container/multiplewindows.go
@@ -95,6 +95,12 @@ func (m *MultipleWindows) refreshChildren() {
 
 func (m *MultipleWindows) setupChild(w *InnerWindow) {
 	w.OnDragged = func(ev *fyne.DragEvent) {
+		abs := fyne.CurrentApp().Driver().AbsolutePositionForObject(m)
+		rel := ev.AbsolutePosition.Subtract(abs)
+		if rel.X < 0 || rel.Y < 0 || rel.X > m.Size().Width || rel.Y > m.Size().Height {
+			return
+		}
+
 		w.Move(w.Position().Add(ev.Dragged))
 	}
 	w.OnResized = func(ev *fyne.DragEvent) {

--- a/container/multiplewindows_test.go
+++ b/container/multiplewindows_test.go
@@ -20,6 +20,7 @@ func TestMultipleWindows_Add(t *testing.T) {
 func TestMultipleWindows_Drag(t *testing.T) {
 	w := NewInnerWindow("1", widget.NewLabel("Inside"))
 	m := NewMultipleWindows(w)
+	m.Resize(fyne.NewSize(30, 30))
 	_ = test.TempWidgetRenderer(t, m) // initialise display
 	assert.Equal(t, 1, len(m.Windows))
 
@@ -27,6 +28,13 @@ func TestMultipleWindows_Drag(t *testing.T) {
 	w.OnDragged(&fyne.DragEvent{Dragged: fyne.Delta{DX: 10, DY: 5}})
 	assert.Equal(t, float32(10), w.Position().X)
 	assert.Equal(t, float32(5), w.Position().Y)
+
+	drag := &fyne.DragEvent{Dragged: fyne.Delta{DX: -10, DY: -5}}
+	drag.Position = fyne.NewPos(5, 5)
+	drag.AbsolutePosition = fyne.NewPos(5, 5)
+	w.OnDragged(drag)
+	assert.Equal(t, float32(0), w.Position().X)
+	assert.Equal(t, float32(0), w.Position().Y)
 }
 
 func TestMultipleWindows_RaiseToTop(t *testing.T) {


### PR DESCRIPTION
Fixes #6210

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

