### PR TITLE
Delete superfluous ExtendBaseWidget calls

### DIFF
--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -640,25 +640,19 @@ func computeOffset(start, delta, outerWidth, innerWidth float32) float32 {
 // NewScroll creates a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize to be smaller than that of the passed object.
 func NewScroll(content fyne.CanvasObject) *Scroll {
-	s := newScrollContainerWithDirection(ScrollBoth, content)
-	s.ExtendBaseWidget(s)
-	return s
+	return newScrollContainerWithDirection(ScrollBoth, content)
 }
 
 // NewHScroll create a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize.Width to be smaller than that of the passed object.
 func NewHScroll(content fyne.CanvasObject) *Scroll {
-	s := newScrollContainerWithDirection(ScrollHorizontalOnly, content)
-	s.ExtendBaseWidget(s)
-	return s
+	return newScrollContainerWithDirection(ScrollHorizontalOnly, content)
 }
 
 // NewVScroll create a scrollable parent wrapping the specified content.
 // Note that this may cause the MinSize.Height to be smaller than that of the passed object.
 func NewVScroll(content fyne.CanvasObject) *Scroll {
-	s := newScrollContainerWithDirection(ScrollVerticalOnly, content)
-	s.ExtendBaseWidget(s)
-	return s
+	return newScrollContainerWithDirection(ScrollVerticalOnly, content)
 }
 
 func newScrollContainerWithDirection(direction ScrollDirection, content fyne.CanvasObject) *Scroll {


### PR DESCRIPTION
### Description:

This deletes cheap but superfluous `ExtendBaseWidget` calls, just for the code simplification.

(It's superfluous because `ExtendBaseWidget` is called in `newScrollContainerWithDirection` anyway.)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.