### PR TITLE
RichText: Let MinSize return cached value

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -94,12 +94,15 @@ func (t *RichText) CreateRenderer() fyne.WidgetRenderer {
 // MinSize calculates the minimum size of a rich text widget.
 // This is based on the contained text with a standard amount of padding added.
 func (t *RichText) MinSize() fyne.Size {
-	// we don't return the minCache here, as any internal segments could have caused it to change...
+	// We return the minCache here which might be outdated if internal segments were changed.
+	// Users must call Refresh() to force an update after any changes to t.
 	t.ExtendBaseWidget(t)
 
-	min := t.BaseWidget.MinSize()
-	t.minCache = min
-	return min
+	if t.minCache.IsZero() {
+		min := t.BaseWidget.MinSize()
+		t.minCache = min
+	}
+	return t.minCache
 }
 
 // Refresh triggers a redraw of the rich text.


### PR DESCRIPTION
### Description:

Calls to `*RichText.MinSize` can be expensive and they happen often. `RichText` already caches the min size in `minCache` but doesn't return it in `MinSize()`. I would like to change this.

#### How often is MinSize called (numbers for this patch applied)

|                                               | MinSize calls (cached) | MinSize calls (uncached) |
|--|--:|--:|
|Linux/X11, Window resize (in one step)            | 36 |  8 |
|Linux/X11, Scroll by 20 pixels (in one step)      | 90 |  9 |
|Linux/X11 mobile, Drag by 20 pixels (in one step) |124 | 56 |
|Android, Drag by 20 pixels (in one step)          |207 | 56 |

(without this patch, it's most likely the sum of both columns)

In an app with a scrollable RichText generated from a 30 kB Markdown file, on Android, one `Dragged` call takes about 6 ms. With this PR applied, it's about 17-170 µs.

I think this makes scrolling a little bit faster on Android but I can't tell for sure.

The price for this change is that users have to call `Refresh` after modifying a RichText widget. But I think this happens rarely. Probably, most RichText widgets are created before calling `window.ShowAndRun()` and then not modified anymore.

I'm aware that this is controversial and `minCache` isn't returned for a reason. This is just for discussion. (I'm going to use this change in my apps anyway.)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.