### PR TITLE
WIP/discussion: Pre-render clipped texts

### DIFF
--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -57,11 +57,13 @@ type driver struct {
 	animation   animation.Runner
 	currentSize size.Event
 
-	theme           fyne.ThemeVariant
-	onConfigChanged func(*Configuration)
-	painting        bool
-	running         bool
-	queuedFuncs     *async.UnboundedChan[func()]
+	theme                  fyne.ThemeVariant
+	onConfigChanged        func(*Configuration)
+	painting               bool
+	running                bool
+	queuedFuncs            *async.UnboundedChan[func()]
+	queuedFuncsLowPriority *async.UnboundedChan[func()]
+	prerenderChecked       bool
 }
 
 // Declare conformity with Driver
@@ -182,6 +184,7 @@ func (d *driver) Run() {
 		async.SetMainGoroutine()
 		d.app = a
 		d.queuedFuncs = async.NewUnboundedChan[func()]()
+		d.queuedFuncsLowPriority = async.NewUnboundedChan[func()]()
 
 		fyne.CurrentApp().Settings().AddListener(func(s fyne.Settings) {
 			painter.ClearFontCache()
@@ -276,6 +279,8 @@ func (d *driver) Run() {
 						d.typeUpCanvas(c, e.Rune, e.Code, e.Modifiers)
 					}
 				}
+			case fn := <-d.queuedFuncsLowPriority.Out():
+				fn()
 			}
 		}
 	})
@@ -402,6 +407,65 @@ func (d *driver) paintWindow(window fyne.Window, size fyne.Size) {
 	}
 
 	c.WalkTrees(draw, afterDraw)
+
+	if !d.prerenderChecked {
+		d.findTextsForPrerender(size, c)
+	}
+}
+
+func (d *driver) findTextsForPrerender(size fyne.Size, c *canvas) {
+	if size.Width <= 0 || size.Height <= 0 {
+		return
+	}
+	clips := &internal.ClipStack{}
+	frame := size
+	p := c.Painter()
+	check := func(node *common.RenderCacheNode, pos fyne.Position) {
+		obj := node.Obj()
+		if !obj.Visible() {
+			return
+		}
+		if intdriver.IsClip(obj) {
+			clips.Push(pos, obj.Size())
+		}
+		if text, ok := obj.(*fynecanvas.Text); ok {
+			if text.Text == "" {
+				return
+			}
+			decorated := text.TextStyle.Underline || text.TextStyle.Strikethrough
+			if text.Text == " " && !decorated {
+				return
+			}
+
+			size := text.MinSize()
+			containerSize := text.Size()
+			switch text.Alignment {
+			case fyne.TextAlignTrailing:
+				pos = fyne.NewPos(pos.X+containerSize.Width-size.Width, pos.Y)
+			case fyne.TextAlignCenter:
+				pos = fyne.NewPos(pos.X+(containerSize.Width-size.Width)/2, pos.Y)
+			}
+
+			if containerSize.Height > size.Height {
+				pos = fyne.NewPos(pos.X, pos.Y+(containerSize.Height-size.Height)/2)
+			}
+
+			var clipPos fyne.Position
+			var clipSize fyne.Size
+			clip := clips.Top()
+			if clip != nil {
+				clipPos, clipSize = clip.Rect()
+			} else {
+				clipSize = frame
+			}
+			if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
+				pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
+				p.CreateTextTexture(text, d.queuedFuncsLowPriority.In())
+			}
+		}
+	}
+	c.WalkTrees(check, nil)
+	d.prerenderChecked = true
 }
 
 func (d *driver) sendPaintEvent() {

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -598,15 +598,8 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 	} else {
 		clipSize = frame
 	}
-	if pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X || pos.Y+size.Height < clipPos.Y {
-		return
-	}
-	if pos.Y > clipPos.Y+clipSize.Height {
-		// if text is slightly below the clip area, pre-render it in the background
-		// to make scrolling smoother
-		if pos.Y <= clipPos.Y+clipSize.Height*1.3 {
-			p.createTextTexture(text, p.newGlTextTexture)
-		}
+	if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
+		pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
 		return
 	}
 

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -598,8 +598,15 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 	} else {
 		clipSize = frame
 	}
-	if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
-		pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
+	if pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X || pos.Y+size.Height < clipPos.Y {
+		return
+	}
+	if pos.Y > clipPos.Y+clipSize.Height {
+		// if text is slightly below the clip area, pre-render it in the background
+		// to make scrolling smoother
+		if pos.Y <= clipPos.Y+clipSize.Height*1.3 {
+			p.createTextTexture(text, p.newGlTextTexture)
+		}
 		return
 	}
 

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -32,6 +32,8 @@ type Painter interface {
 	StartClipping(fyne.Position, fyne.Size)
 	// StopClipping stops clipping paint actions.
 	StopClipping()
+	// CreateTextTexture creates a texture from a canvas.Text object
+	CreateTextTexture(t *canvas.Text, queue chan<- func())
 }
 
 // NewPainter creates a new GL based renderer for the provided canvas.

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -45,10 +45,10 @@ func (p *painter) CreateTextTexture(t *canvas.Text, queue chan<- func()) {
 
 	if _, ok := cache.GetTextTexture(ent); !ok {
 		queue <- func() {
-			texture, ok := cache.GetTextTexture(ent)
+			_, ok := cache.GetTextTexture(ent)
 			if !ok {
 				tex := p.newGlTextTexture(t)
-				texture = cache.TextureType(tex)
+				texture := cache.TextureType(tex)
 				cache.SetTextTexture(ent, texture, p.canvas, func() {
 					p.ctx.DeleteTexture(tex)
 					p.logError()

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -32,6 +32,31 @@ func (p *painter) freeTexture(obj fyne.CanvasObject) {
 	cache.DeleteTexture(obj)
 }
 
+func (p *painter) createTextTexture(t *canvas.Text, creator func(canvasObject fyne.CanvasObject) Texture) {
+	custom := ""
+	if t.FontSource != nil {
+		custom = t.FontSource.Name()
+	}
+	ent := cache.FontCacheEntry{Color: t.Color, Canvas: p.canvas}
+	ent.Text = t.Text
+	ent.Size = t.TextSize
+	ent.Style = t.TextStyle
+	ent.Source = custom
+
+	texture, ok := cache.GetTextTexture(ent)
+
+	if !ok {
+		fyne.Do(func() {
+			tex := creator(t)
+			texture = cache.TextureType(tex)
+			cache.SetTextTexture(ent, texture, p.canvas, func() {
+				p.ctx.DeleteTexture(tex)
+				p.logError()
+			})
+		})
+	}
+}
+
 func (p *painter) getTexture(object fyne.CanvasObject, creator func(canvasObject fyne.CanvasObject) Texture) (Texture, error) {
 	if t, ok := object.(*canvas.Text); ok {
 		custom := ""

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -32,7 +32,7 @@ func (p *painter) freeTexture(obj fyne.CanvasObject) {
 	cache.DeleteTexture(obj)
 }
 
-func (p *painter) createTextTexture(t *canvas.Text, creator func(canvasObject fyne.CanvasObject) Texture) {
+func (p *painter) CreateTextTexture(t *canvas.Text, queue chan<- func()) {
 	custom := ""
 	if t.FontSource != nil {
 		custom = t.FontSource.Name()
@@ -43,17 +43,18 @@ func (p *painter) createTextTexture(t *canvas.Text, creator func(canvasObject fy
 	ent.Style = t.TextStyle
 	ent.Source = custom
 
-	texture, ok := cache.GetTextTexture(ent)
-
-	if !ok {
-		fyne.Do(func() {
-			tex := creator(t)
-			texture = cache.TextureType(tex)
-			cache.SetTextTexture(ent, texture, p.canvas, func() {
-				p.ctx.DeleteTexture(tex)
-				p.logError()
-			})
-		})
+	if _, ok := cache.GetTextTexture(ent); !ok {
+		queue <- func() {
+			texture, ok := cache.GetTextTexture(ent)
+			if !ok {
+				tex := p.newGlTextTexture(t)
+				texture = cache.TextureType(tex)
+				cache.SetTextTexture(ent, texture, p.canvas, func() {
+					p.ctx.DeleteTexture(tex)
+					p.logError()
+				})
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### Description:

Dragging (scrolling) isn't smooth in Fyne apps with a lot of text on Android.

I have visualized how long `*driver.handlePaint` calls take while dragging up a large RichText widget (generated from about 35 kB of Markdown). Test app: <https://gist.github.com/MaxGyver83/1022b44649df8ac4b69dce6a352f0e28>

<img width="1121" height="629" alt="2026-03-26 20 13 09 1121x629 Region" src="https://github.com/user-attachments/assets/50989a17-6f0d-4499-afef-76982b8aa935" />

The green areas show when my finger touches the screen (for dragging).

When new lines become visible, `painter.DrawString` is called for every new line and takes about 6 ms per line. A paint call shouldn't take more than 16 ms. Thus, with 3 new lines this goal can't be reached and dragging begins to stutter. (Dragging back in the other direction works better because then all texts are already cached.)

It would be cool if we could speed up `DrawString` itself. But I don't know how.

My next best idea is to pre-render (=draw strings into textures) during idle times. This PR tries to do this. When text is below the clip area (but not to far away), `p.createTextTexture` is called which check if the text is already cached, and if not, it creates such a texture using `fyne.Do`. AFAIU, this happens between `*driver.handlePaint` calls when there is some free time left, reading from `d.queudFuncs.Out()`:

```go
		for {
			select {
			case <-draw.C:
				d.sendPaintEvent()
			case fn := <-d.queuedFuncs.Out():
				fn()
```

Unfortunately, this fix doesn't work as expected. Dragging feels different now but still not good.

Here is a visualization:

<img width="902" height="617" alt="2026-03-26 20 38 26 902x617 Region" src="https://github.com/user-attachments/assets/79da541c-ee74-467a-b4fe-25e72e26b361" />

Do you have any ideas how this could be improved (or what to try instead)?

(This PR is work-in-progress and mainly for discussion.)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
