### PR TITLE
Cache minsize of canvas text

### DIFF
--- a/canvas/text.go
+++ b/canvas/text.go
@@ -28,6 +28,8 @@ type Text struct {
 	//
 	// Since: 2.5
 	FontSource fyne.Resource
+
+	minCache fyne.Size
 }
 
 // Hide will set this text to not be visible
@@ -40,8 +42,10 @@ func (t *Text) Hide() {
 // MinSize returns the minimum size of this text object based on its font size and content.
 // This is normally determined by the render implementation.
 func (t *Text) MinSize() fyne.Size {
-	s, _ := fyne.CurrentApp().Driver().RenderedTextSize(t.Text, t.TextSize, t.TextStyle, t.FontSource)
-	return s
+	if t.minCache.IsZero() {
+		t.minCache, _ = fyne.CurrentApp().Driver().RenderedTextSize(t.Text, t.TextSize, t.TextStyle, t.FontSource)
+	}
+	return t.minCache
 }
 
 // Move the text to a new position, relative to its parent / canvas
@@ -72,6 +76,7 @@ func (t *Text) SetMinSize(fyne.Size) {
 
 // Refresh causes this text to be redrawn with its configured state.
 func (t *Text) Refresh() {
+	t.minCache = fyne.Size{}
 	Refresh(t)
 }
 

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -708,6 +708,7 @@ func (r *tabButtonRenderer) Refresh() {
 	} else {
 		r.label.Show()
 	}
+	r.label.Refresh()
 
 	r.icon.Resource = r.button.icon
 	if r.icon.Resource != nil {


### PR DESCRIPTION
### Description:

When the RichText widget of [this test app](https://gist.github.com/MaxGyver83/1022b44649df8ac4b69dce6a352f0e28) is being dragged, `*driver.handlePaint` draws become very slow on Android, see #6233. While dragging, `canvasNeedRefresh` is `true` and `c.EnsureMinSize()` is called. These `EnsureMinSize` calls take 4.36 ms on average (for the test app). This PR caches `MinSize` of `canvas.Text`. With this applied, `EnsureMinSize` calls take only 1.61 ms on average.

This change breaks some tests:

- 4059d36 fixes the tests using tabs.
- `TestRender` in `driver/software/render_test.go` still fails: The created canvas screenshot is one pixel too wide. ~~So far, I couldn't find a way to refresh the `canvas.Text` in or after `app.ApplyThemeTo(obj, c)`.~~ `canvas.Text`'s min size is updated after `ApplyThemeTo`. It's only different than on _develop_ until `ApplyThemeTo` is called. This `canvas.Text` should be created "on-the-fly" in `*TextSegment.Visual()`. I don't know how this can re-use the cached MinSize that was set for the default theme. Calling `cache.DestroyRenderer(o)` in `ApplyThemeTo` didn't help.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
