### PR TITLE
Skip EnsureMinSize calls on mobile

### DIFF
--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -343,11 +343,7 @@ func (d *driver) handlePaint(e paint.Event, w *window) {
 	if canvasNeedRefresh {
 		newSize := fyne.NewSize(float32(d.currentSize.WidthPx)/c.scale, float32(d.currentSize.HeightPx)/c.scale)
 
-		if c.EnsureMinSize() {
-			c.sizeContent(newSize) // force resize of content
-		} else { // if screen changed
-			w.Resize(newSize)
-		}
+		w.Resize(newSize)
 
 		d.paintWindow(w, newSize)
 		d.app.Publish()


### PR DESCRIPTION
### Description:

When the RichText widget of [this test app](https://gist.github.com/MaxGyver83/1022b44649df8ac4b69dce6a352f0e28) is being dragged, `*driver.handlePaint` draws become very slow on Android, see #6233. While dragging, `canvasNeedRefresh` is `true` and `c.EnsureMinSize()` is called. These `EnsureMinSize` calls take 4.36 ms on average (for the test app). Instead of trying to optimize `EnsureMinSize` (as in #6234), this PR is more radical: It skips EnsureMinSize calls completely (on mobile).

This might be wrong for some reason. But so far, I couldn't find any problems with it. Resizing the window in mobile simulation on Linux still works. Even split windows on Android work with this PR.

This should improve scrolling performance.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.