### PR TITLE
howManyRunesFit: Fix crash for negative availableWidth

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -878,6 +878,9 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 // rune slice.
 // howManyRunesFit returns how many runes fit into the available width.
 func howManyRunesFit(runes []rune, availableWidth float32, charWidth float32, measurer func([]rune) fyne.Size) int {
+	if availableWidth <= 0 {
+		return 0
+	}
 	length := len(runes)
 	fits := 0
 	tooLong := length + 1

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1305,6 +1305,12 @@ func TestText_howManyRunesFit(t *testing.T) {
 			assert.Equal(t, tt.want, howManyRunesFit([]rune(tt.text), maxWidth, charWidth, measurer))
 		})
 	}
+	t.Run("Zero width", func(t *testing.T) {
+		assert.Equal(t, 0, howManyRunesFit([]rune("foo"), 0, charWidth, measurer))
+	})
+	t.Run("Negative width", func(t *testing.T) {
+		assert.Equal(t, 0, howManyRunesFit([]rune("foo"), -1, charWidth, measurer))
+	})
 }
 
 func TestText_findSpaceIndex(t *testing.T) {


### PR DESCRIPTION
### Description:

When I tried to resize the app window like crazy (as small as possible, wide and low height, tiny, long and narrow and so on), I could cause a crash. The crash happens when `howManyRunesFit` receives a negative `availableWidth`.

This pull request fixes this by checking `availableWidth` and returning 0 if negative. An `availableWidth` of 0 is no problem but this case `howManyRunesFit` returns immediately, too.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.