### PR TITLE
Improve BenchmarkText_lineBounds_xxx

### DIFF
--- a/internal/cache/text.go
+++ b/internal/cache/text.go
@@ -57,6 +57,13 @@ func SetFontMetrics(text string, fontSize float32, style fyne.TextStyle, source 
 	fontSizeCache.Store(ent, metric)
 }
 
+// ResetFontMetrics clears the fontSizeCache (for testing/benchmarks)
+//
+// Since: 2.8
+func ResetFontMetrics() {
+	fontSizeCache = async.Map[fontSizeEntry, *fontMetric]{}
+}
+
 // destroyExpiredFontMetrics destroys expired fontSizeCache entries
 func destroyExpiredFontMetrics(now time.Time) {
 	fontSizeCache.Range(func(k fontSizeEntry, v *fontMetric) bool {

--- a/internal/cache/text.go
+++ b/internal/cache/text.go
@@ -57,10 +57,8 @@ func SetFontMetrics(text string, fontSize float32, style fyne.TextStyle, source 
 	fontSizeCache.Store(ent, metric)
 }
 
-// ResetFontMetrics clears the fontSizeCache (for testing/benchmarks)
-//
-// Since: 2.8
-func ResetFontMetrics() {
+// ClearFontMetrics clears the fontSizeCache (for testing/benchmarks)
+func ClearFontMetrics() {
 	fontSizeCache = async.Map[fontSizeEntry, *fontMetric]{}
 }
 

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/cache"
 )
 
 const loremIpsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque quis consectetur nisi. Suspendisse id interdum felis. Sed egestas eget tellus eu pharetra. Praesent pulvinar sed massa id placerat. Etiam sem libero, semper vitae consequat ut, volutpat id mi. Mauris volutpat pellentesque convallis. Curabitur rutrum venenatis orci nec ornare. Maecenas quis pellentesque neque. Aliquam consectetur dapibus nulla, id maximus odio ultrices ac. Sed luctus at felis sed faucibus. Cras leo augue, congue in velit ut, mattis rhoncus lectus.
@@ -44,6 +45,7 @@ func benchmarkTextLineBounds(wrap fyne.TextWrap, b *testing.B) {
 	richText.Wrapping = wrap
 	richText.Truncation = fyne.TextTruncateOff
 	for n := 0; n < b.N; n++ {
+		cache.ResetFontMetrics()
 		lineBounds(richText, richText.Segments[0], 10, fyne.NewSize(10, 14), measurer)
 	}
 }

--- a/widget/richtext_benchmark_test.go
+++ b/widget/richtext_benchmark_test.go
@@ -45,7 +45,7 @@ func benchmarkTextLineBounds(wrap fyne.TextWrap, b *testing.B) {
 	richText.Wrapping = wrap
 	richText.Truncation = fyne.TextTruncateOff
 	for n := 0; n < b.N; n++ {
-		cache.ResetFontMetrics()
+		cache.ClearFontMetrics()
 		lineBounds(richText, richText.Segments[0], 10, fyne.NewSize(10, 14), measurer)
 	}
 }


### PR DESCRIPTION
### Description:
Reset the font metrics cache before every `lineBounds` benchmark run. Otherwise, the first run is slow and all further are fast because they can use the cached measurements of the first run.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
