### PR TITLE
Fix word wrapping

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -932,17 +932,13 @@ func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width f
 	return bounds
 }
 
-// findSpaceIndex accepts a slice of runes and a fallback index
-// findSpaceIndex returns the index of the last space in the text, or fallback if there are no spaces
-func findSpaceIndex(text []rune, fallback int) int {
-	curIndex := fallback
+// findSpaceIndex accepts a slice of runes and a start position index
+// findSpaceIndex returns the index of the last space in the text, or -1 if there are no spaces
+func findSpaceIndex(text []rune, curIndex int) int {
 	for ; curIndex >= 0; curIndex-- {
 		if unicode.IsSpace(text[curIndex]) {
 			break
 		}
-	}
-	if curIndex < 0 {
-		return fallback
 	}
 	return curIndex
 }
@@ -1065,9 +1061,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 				yPos += lineHeight
 				continue
 			}
-
-			oldHigh := high
-			if fitCount < 1 { // even a character won't fit
+			if fitCount == 0 { // even a character won't fit
 				if measureWidth < max.Width {
 					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
 					reuse++
@@ -1090,15 +1084,19 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 				if high > l.end {
 					return bounds, yPos
 				}
-			} else {
-				spaceIndex := findSpaceIndex(sub, fitCount)
+				continue
+			}
+			spaceIndex := findSpaceIndex(sub, fitCount)
+			if spaceIndex >= 0 {
 				if spaceIndex == 0 {
 					spaceIndex = 1
 				}
-
 				high = low + spaceIndex
+				continue
 			}
-			if high == fitCount && measureWidth < max.Width { // add a newline as there is more space on next
+			oldHigh := high
+			high = low + fitCount
+			if low == 0 && measureWidth < max.Width { // add a newline as there is more space on next
 				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
 				reuse++
 				high = oldHigh

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1320,7 +1320,7 @@ func TestText_findSpaceIndex(t *testing.T) {
 	}{
 		"no_space_fallback": {
 			text: "iiiiiiiiiimmmmmmmmmm",
-			want: 19,
+			want: -1,
 		},
 		"single_space": {
 			text: "foobar foobar",


### PR DESCRIPTION
### Description:
When trying to fit a string into the remaining space on a line, if the fitting substring ended before a space, it was mistakenly pushed to the next line.

Example:

<img width="588" height="168" alt="wrong_wrapping" src="https://github.com/user-attachments/assets/a57ca79e-c294-483e-84ac-6d8023f578d0" />

The problem was that `findSpaceIndex` returned `fallback` in two cases:

1. There is a space at `text[fallback]` → all good, wrap after text.
2. There is no space neither in text nor after it → in this case the text might be pushed to the next line.

In the screenshot the substring "An assertion establishes truth (i.e. boolean" would have fit into the first line (after the bullet point) but `findSpaceIndex` returned `fallback` because there was a space after the text and not because the text would have to be wrapped within a word.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.