### PR TITLE
Android: Allow listContentURI to list content of a subfolder

### DIFF
--- a/internal/driver/mobile/android.c
+++ b/internal/driver/mobile/android.c
@@ -426,7 +426,14 @@ char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 	if (contractClass == NULL) { // API 19
 		return "ERROR: Cannot list content for URI";
 	}
-	jmethodID getDoc = find_static_method(env, contractClass, "getTreeDocumentId", "(Landroid/net/Uri;)Ljava/lang/String;");
+
+	bool tree = isTreeURI(env, contractClass, uri);
+	bool document = isDocumentURI(env, ctx, contractClass, uri);
+	char *methodName = "getDocumentId";
+	if (tree && !document) {
+		methodName = "getTreeDocumentId";
+	}
+	jmethodID getDoc = find_static_method(env, contractClass, methodName, "(Landroid/net/Uri;)Ljava/lang/String;");
 	if (getDoc == NULL) { // API 21
 		return "ERROR: Cannot list content for URI";
 	}
@@ -440,9 +447,6 @@ char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 
 	jclass resolverClass = (*env)->GetObjectClass(env, resolver);
 	jmethodID query = find_method(env, resolverClass, "query", "(Landroid/net/Uri;[Ljava/lang/String;Landroid/os/Bundle;Landroid/os/CancellationSignal;)Landroid/database/Cursor;");
-	if (getDoc == NULL) { // API 26
-		return "ERROR: Cannot list content for URI";
-	}
 
 	jobject cursor = (jobject)(*env)->CallObjectMethod(env, resolver, query, childrenUri, project, NULL, NULL);
 	if ((*env)->ExceptionCheck(env)) {


### PR DESCRIPTION
### Description:

Assume this file structure, p.e. in `/sdcard/Download/`:

```
folder
├── a
└── subfolder
    └── b
```

When you list the content of `folder`, you get `a` and `subfolder` (as expected). But when you then try to list the content of `folder/subfolder`, you get `a` and `subfolder` again instead of `b`.

This pull request fixes this. _Update:_ There was already an issue for this: #4705.

### Test program:

```go
package main

import (
	"fmt"
	"net/url"

	"fyne.io/fyne/v2"
	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/container"
	"fyne.io/fyne/v2/dialog"
	"fyne.io/fyne/v2/storage"
	"fyne.io/fyne/v2/widget"
)

var w fyne.Window

func main() {
	a := app.New()
	w = a.NewWindow("List content of subdirectory")
	btn := widget.NewButton("Open folder", selectFolder)
	w.SetContent(container.NewVBox(btn))
	w.ShowAndRun()
}

func selectFolder() {
	dialog.ShowFolderOpen(func(u fyne.ListableURI, err error) {
		if err != nil || u == nil {
			return
		}
		openFolder(u)
	}, w)
}

func openFolder(u fyne.URI) {
	fmt.Println("Open folder", u.String())
	filelist, err := storage.List(u)
	if err != nil {
		fmt.Println(err)
		return
	}

	for _, file := range filelist {
		name, _ := url.PathUnescape(file.Name())
		fmt.Println("-", name)
		if isdir, err := storage.CanList(file); err == nil && isdir {
			filelist, err := storage.List(file)
			if err == nil {
				for _, file := range filelist {
					name, _ = url.PathUnescape(file.Name())
					fmt.Println("  -", name)
				}
			}
		}
	}
}
```

Output on develop:

```
04-03 15:09:22.286 23985 25311 I Fyne    : - primary:Download/folder/a
04-03 15:09:22.299 23985 25311 I Fyne    : - primary:Download/folder/subfolder
04-03 15:09:22.327 23985 25311 I Fyne    :   - primary:Download/folder/a
04-03 15:09:22.327 23985 25311 I Fyne    :   - primary:Download/folder/subfolder
```

With this PR:

```
04-03 15:11:02.795 24825 25891 I Fyne    : - primary:Download/folder/a
04-03 15:11:02.803 24825 25891 I Fyne    : - primary:Download/folder/subfolder
04-03 15:11:02.826 24825 25891 I Fyne    :   - primary:Download/folder/subfolder/b
```

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.