### PR TITLE
Don't reread svg file on resize just rasterize

### DIFF
--- a/canvas/image.go
+++ b/canvas/image.go
@@ -206,8 +206,16 @@ func (i *Image) Resize(s fyne.Size) {
 	}
 
 	i.baseObject.Resize(s)
-	if i.isSVG || i.Image == nil {
-		i.Refresh() // we need to rasterise at the new size
+	if i.isSVG {
+		// we need to rasterize at the new size
+		tex, err := i.renderSVG(s.Width, s.Height)
+		if err != nil {
+			fyne.LogError("Failed to render SVG", err)
+			return
+		}
+		i.Image = tex
+	} else if i.Image == nil {
+		i.Refresh()
 	} else {
 		Refresh(i) // just re-size using GPU scaling
 	}


### PR DESCRIPTION
### Description:

Previously, resizing an svg image executed `image.Refresh`, which reads the svg contents, reparses the xml, and recomputes various data about the image. This is all not needed for a resize operation on an SVG.

This PR skips all that and just calls `image.renderSVG`, which is all thats needed to rasterize at the new size.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

