### PR TITLE
NRGBA -> RGBA for text rasterize

### DIFF
--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -171,7 +171,7 @@ func (p *painter) newGlTextTexture(obj fyne.CanvasObject) Texture {
 	bounds := text.MinSize()
 	width := int(math.Ceil(float64(p.textureScale(bounds.Width) + paint.VectorPad(text)))) // potentially italic overspill
 	height := int(math.Ceil(float64(p.textureScale(bounds.Height))))
-	img := image.NewNRGBA(image.Rect(0, 0, width, height))
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
 
 	face := paint.CachedFontFace(text.TextStyle, text.FontSource, text)
 	paint.DrawString(img, text.Text, color, face.Fonts, text.TextSize, p.pixScale, text.TextStyle)


### PR DESCRIPTION
Take advantage of the RGBA fast path in golang.org/x/image for text rasterization.

Helps with the stuttering in #6233

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
