### PR TITLE
Reuse shaper to use internal cache

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -38,6 +38,8 @@ var (
 	loaded       bool
 )
 
+var shaper = &shaping.HarfbuzzShaper{}
+
 func loadMap() {
 	loaded = true
 
@@ -269,7 +271,6 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 		Face:      faces.ResolveFace(' '),
 		Size:      textSize,
 	}
-	shaper := &shaping.HarfbuzzShaper{}
 	segmenter := &shaping.Segmenter{}
 	out := shaper.Shape(in)
 
@@ -291,7 +292,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 			if r == '\t' {
 				if pending {
 					in.RunEnd = i
-					x = shapeCallback(shaper, in, x, scale, cb)
+					x = shapeCallback(in, x, scale, cb)
 				}
 				x = tabStop(spacew, x, style.TabWidth)
 
@@ -303,7 +304,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 			}
 		}
 
-		x = shapeCallback(shaper, in, x, scale, cb)
+		x = shapeCallback(in, x, scale, cb)
 	}
 
 	*advance = x
@@ -311,7 +312,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 		fixed266ToFloat32(out.LineBounds.Ascent)
 }
 
-func shapeCallback(shaper shaping.Shaper, in shaping.Input, x, scale float32, cb func(shaping.Output, float32)) float32 {
+func shapeCallback(in shaping.Input, x, scale float32, cb func(shaping.Output, float32)) float32 {
 	out := shaper.Shape(in)
 	glyphs := out.Glyphs
 	start := 0


### PR DESCRIPTION
This avoids reinitializing the font for every string.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
