### PR TITLE
Mobile: Don't let horizontally draggable block vertical dragging

### DIFF
--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -37,6 +37,7 @@ type canvas struct {
 	dragOffset fyne.Position
 	dragStart  fyne.Position
 	dragging   fyne.Draggable
+	dragging2  fyne.Draggable
 
 	onTypedKey  func(event *fyne.KeyEvent)
 	onTypedRune func(rune)
@@ -227,6 +228,7 @@ func (c *canvas) tapDown(pos fyne.Position, tapID int) {
 	c.lastTapDown[tapID] = time.Now()
 	c.lastTapDownPos[tapID] = pos
 	c.dragging = nil
+	c.dragging2 = nil
 
 	co, objPos, layer := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
 		switch object.(type) {
@@ -276,6 +278,24 @@ func (c *canvas) tapMove(pos fyne.Position, tapID int,
 
 		return false
 	})
+	var scrollOtherDirection fyne.CanvasObject
+	if scr, ok := co.(*container.Scroll); ok {
+		var otherDirection container.ScrollDirection
+		if scr.Direction == container.ScrollHorizontalOnly {
+			otherDirection = container.ScrollVerticalOnly
+		} else if scr.Direction == container.ScrollVerticalOnly {
+			otherDirection = container.ScrollHorizontalOnly
+		}
+		if otherDirection != container.ScrollBoth {
+			scrollOtherDirection, _, _ = c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
+				if scr, ok := object.(*container.Scroll); ok {
+					return scr.Direction == otherDirection
+				}
+
+				return false
+			})
+		}
+	}
 
 	if c.touched[tapID] != nil {
 		if touch, ok := co.(mobile.Touchable); !ok || c.touched[tapID] != touch {
@@ -293,6 +313,9 @@ func (c *canvas) tapMove(pos fyne.Position, tapID int,
 			c.dragging = drag
 			c.dragOffset = previousPos.Subtract(objPos)
 			c.dragStart = co.Position()
+			if scrollOtherDirection != nil {
+				c.dragging2 = scrollOtherDirection.(fyne.Draggable)
+			}
 		} else {
 			return
 		}
@@ -304,6 +327,9 @@ func (c *canvas) tapMove(pos fyne.Position, tapID int,
 	ev.Dragged = offset
 
 	dragCallback(c.dragging, ev)
+	if c.dragging2 != nil {
+		dragCallback(c.dragging2, ev)
+	}
 }
 
 func (c *canvas) tapUp(pos fyne.Position, tapID int,
@@ -319,8 +345,12 @@ func (c *canvas) tapUp(pos fyne.Position, tapID int,
 		ev.Position = pos.Subtract(c.dragOffset).Add(draggedObjDelta)
 		ev.AbsolutePosition = pos
 		dragCallback(c.dragging, ev)
+		if c.dragging2 != nil {
+			dragCallback(c.dragging2, ev)
+		}
 
 		c.dragging = nil
+		c.dragging2 = nil
 		return
 	}
 

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -37,7 +37,7 @@ type canvas struct {
 	dragOffset     fyne.Position
 	dragStart      fyne.Position
 	dragging       fyne.Draggable
-	dragging2      fyne.Draggable
+	draggingOuter  fyne.Draggable
 	otherDirection container.ScrollDirection
 
 	onTypedKey  func(event *fyne.KeyEvent)
@@ -229,7 +229,7 @@ func (c *canvas) tapDown(pos fyne.Position, tapID int) {
 	c.lastTapDown[tapID] = time.Now()
 	c.lastTapDownPos[tapID] = pos
 	c.dragging = nil
-	c.dragging2 = nil
+	c.draggingOuter = nil
 
 	co, objPos, layer := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
 		switch object.(type) {
@@ -314,7 +314,7 @@ func (c *canvas) tapMove(pos fyne.Position, tapID int,
 			c.dragOffset = previousPos.Subtract(objPos)
 			c.dragStart = co.Position()
 			if scrollOtherDirection != nil {
-				c.dragging2 = scrollOtherDirection.(fyne.Draggable)
+				c.draggingOuter = scrollOtherDirection.(fyne.Draggable)
 			}
 		} else {
 			return
@@ -327,13 +327,13 @@ func (c *canvas) tapMove(pos fyne.Position, tapID int,
 	ev.Dragged = offset
 
 	dragCallback(c.dragging, ev)
-	if c.dragging2 != nil {
+	if c.draggingOuter != nil {
 		if c.otherDirection == container.ScrollVerticalOnly {
 			ev.Dragged.DX = 0
 		} else {
 			ev.Dragged.DY = 0
 		}
-		dragCallback(c.dragging2, ev)
+		dragCallback(c.draggingOuter, ev)
 	}
 }
 
@@ -350,17 +350,17 @@ func (c *canvas) tapUp(pos fyne.Position, tapID int,
 		ev.Position = pos.Subtract(c.dragOffset).Add(draggedObjDelta)
 		ev.AbsolutePosition = pos
 		dragCallback(c.dragging, ev)
-		if c.dragging2 != nil {
+		if c.draggingOuter != nil {
 			if c.otherDirection == container.ScrollVerticalOnly {
 				ev.Dragged.DX = 0
 			} else {
 				ev.Dragged.DY = 0
 			}
-			dragCallback(c.dragging2, ev)
+			dragCallback(c.draggingOuter, ev)
 		}
 
 		c.dragging = nil
-		c.dragging2 = nil
+		c.draggingOuter = nil
 		c.otherDirection = container.ScrollBoth
 		return
 	}

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -34,10 +34,11 @@ type canvas struct {
 	touched        map[int]mobile.Touchable
 	windowHead     fyne.CanvasObject
 
-	dragOffset fyne.Position
-	dragStart  fyne.Position
-	dragging   fyne.Draggable
-	dragging2  fyne.Draggable
+	dragOffset     fyne.Position
+	dragStart      fyne.Position
+	dragging       fyne.Draggable
+	dragging2      fyne.Draggable
+	otherDirection container.ScrollDirection
 
 	onTypedKey  func(event *fyne.KeyEvent)
 	onTypedRune func(rune)
@@ -280,16 +281,15 @@ func (c *canvas) tapMove(pos fyne.Position, tapID int,
 	})
 	var scrollOtherDirection fyne.CanvasObject
 	if scr, ok := co.(*container.Scroll); ok {
-		var otherDirection container.ScrollDirection
 		if scr.Direction == container.ScrollHorizontalOnly {
-			otherDirection = container.ScrollVerticalOnly
+			c.otherDirection = container.ScrollVerticalOnly
 		} else if scr.Direction == container.ScrollVerticalOnly {
-			otherDirection = container.ScrollHorizontalOnly
+			c.otherDirection = container.ScrollHorizontalOnly
 		}
-		if otherDirection != container.ScrollBoth {
+		if c.otherDirection != container.ScrollBoth {
 			scrollOtherDirection, _, _ = c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
 				if scr, ok := object.(*container.Scroll); ok {
-					return scr.Direction == otherDirection
+					return scr.Direction == c.otherDirection || scr.Direction == container.ScrollBoth
 				}
 
 				return false
@@ -328,6 +328,11 @@ func (c *canvas) tapMove(pos fyne.Position, tapID int,
 
 	dragCallback(c.dragging, ev)
 	if c.dragging2 != nil {
+		if c.otherDirection == container.ScrollVerticalOnly {
+			ev.Dragged.DX = 0
+		} else {
+			ev.Dragged.DY = 0
+		}
 		dragCallback(c.dragging2, ev)
 	}
 }
@@ -346,11 +351,17 @@ func (c *canvas) tapUp(pos fyne.Position, tapID int,
 		ev.AbsolutePosition = pos
 		dragCallback(c.dragging, ev)
 		if c.dragging2 != nil {
+			if c.otherDirection == container.ScrollVerticalOnly {
+				ev.Dragged.DX = 0
+			} else {
+				ev.Dragged.DY = 0
+			}
 			dragCallback(c.dragging2, ev)
 		}
 
 		c.dragging = nil
 		c.dragging2 = nil
+		c.otherDirection = container.ScrollBoth
 		return
 	}
 

--- a/internal/driver/mobile/canvas_dragged_test.go
+++ b/internal/driver/mobile/canvas_dragged_test.go
@@ -37,3 +37,35 @@ func Test_canvas_Dragged(t *testing.T) {
 	assert.True(t, dragged)
 	assert.Equal(t, fyne.NewPos(0, 5), scroll.Offset)
 }
+
+func Test_canvas_Dragged_nested(t *testing.T) {
+	dragged := false
+	var draggedObj fyne.Draggable
+	childScroll := container.NewHScroll(widget.NewLabel("Child *Scroll"))
+	parentScroll := container.NewScroll(container.NewVBox(childScroll, widget.NewLabel("Hi\nHi\nHi")))
+	c := newCanvas(fyne.CurrentDevice()).(*canvas)
+	c.SetContent(parentScroll)
+	c.Resize(fyne.NewSize(40, 24))
+	assert.Equal(t, fyne.NewPos(0, 0), parentScroll.Offset)
+	assert.Equal(t, fyne.NewPos(0, 0), childScroll.Offset)
+
+	c.tapDown(fyne.NewPos(10, 10), 0)
+	c.tapMove(fyne.NewPos(15, 15), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+		wid.Dragged(ev)
+		dragged = true
+		draggedObj = wid
+	})
+	assert.True(t, dragged)
+	assert.Equal(t, parentScroll, draggedObj)
+	assert.Equal(t, fyne.NewPos(0, 0), parentScroll.Offset)
+	assert.Equal(t, fyne.NewPos(0, 0), childScroll.Offset)
+
+	dragged = false
+	c.tapMove(fyne.NewPos(9, 7), 0, func(wid fyne.Draggable, ev *fyne.DragEvent) {
+		wid.Dragged(ev)
+		dragged = true
+	})
+	assert.True(t, dragged)
+	assert.Equal(t, fyne.NewPos(0, 8), parentScroll.Offset)
+	assert.Equal(t, fyne.NewPos(6, 0), childScroll.Offset)
+}


### PR DESCRIPTION
### Description:

When you are dragging a `container.Scroll` that is scrollable/draggable in only one direction, check if there is another `container.Scroll` (at a lower layer) that is draggable in the other direction and then call the `dragCallback` on both of them.

Fixes #6158.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.