### PR TITLE
Faster text measuring for ASCII

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -213,9 +213,22 @@ func loadMeasureFont(data fyne.Resource) *font.Face {
 	return loaded
 }
 
+func isSimple(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 0x80 || c == '\t' {
+			return false
+		}
+	}
+	return true
+}
+
 // MeasureString returns how far dot would advance by drawing s with f.
 // Tabs are translated into a dot location change.
 func MeasureString(f shaping.Fontmap, s string, textSize float32, style fyne.TextStyle) (size fyne.Size, advance float32) {
+	if isSimple(s) {
+		return walkStringFast(f, s, textSize)
+	}
 	return walkString(f, s, float32ToFixed266(textSize), style, &advance, 1, func(shaping.Output, float32) {})
 }
 
@@ -253,6 +266,34 @@ func tabStop(spacew, x float32, tabWidth int) float32 {
 	tabw := spacew * float32(tabWidth)
 	tabs, _ := math.Modf(float64((x + tabw) / tabw))
 	return tabw * float32(tabs)
+}
+
+func lineMetrics(face *font.Face, size float32) (ascent, thickness float32) {
+	ext, ok := face.FontHExtents()
+	if !ok {
+		return 0, 0
+	}
+	scale := size / float32(face.Upem())
+	thickness = (ext.Ascender - ext.Descender + ext.LineGap) * scale
+	return ext.Ascender * scale, thickness
+}
+
+func walkStringFast(faces shaping.Fontmap, s string, textSize float32) (size fyne.Size, base float32) {
+	face := faces.ResolveFace('a')
+	var adv float32
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\r' {
+			continue
+		}
+		gid, ok := face.Font.NominalGlyph(rune(c))
+		if ok {
+			adv += face.HorizontalAdvance(gid)
+		}
+	}
+	scaled := adv * textSize / float32(face.Upem())
+	ascent, thickness := lineMetrics(face, textSize)
+	return fyne.NewSize(scaled, thickness), ascent
 }
 
 func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style fyne.TextStyle, advance *float32, scale float32,


### PR DESCRIPTION
### Description:

For apps with a lot of text, measuring text sizes is still a bottleneck.

This PR provides a "fast path" for ASCII-only text that skips glyph shaping.

This change reduces the duration of a resize for the example app from #5297 from about 50 ms to about 12 ms (on Linux).

The price for this is that the measures from the fast path are not exactly the same as from the regular path. I have compared two screenshots of the same app using `develop` and  this branch. Some text lines look identical, some are off by about one pixel.

### Benchmark:

```sh
go test -test.run xxx -test.bench BenchmarkText_howManyRunesFit ./widget
```

#### develop

```
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_howManyRunesFit_latin-4     	    8184	    146185 ns/op
BenchmarkText_howManyRunesFit_chinese-4   	    4386	    271585 ns/op
```

#### this PR

```
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkText_howManyRunesFit_latin-4     	  198138	      5089 ns/op
BenchmarkText_howManyRunesFit_chinese-4   	    4372	    272654 ns/op
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.