### PR TITLE
Fix displaced hyperlinks

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -816,7 +816,11 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 		} else if c, ok := text.(*fyne.Container); ok {
 			wid := c.Objects[0]
 			if link, ok := wid.(*Hyperlink); ok {
-				textSize := theme.SizeForWidget(link.SizeName, r.obj)
+				sizeName := link.SizeName
+				if sizeName == "" {
+					sizeName = theme.SizeNameText
+				}
+				textSize := theme.SizeForWidget(sizeName, r.obj)
 				s, base := driver.RenderedTextSize(link.Text, textSize, link.TextStyle, nil)
 				if base > tallestBaseline {
 					if tallestBaseline > 0 {


### PR DESCRIPTION
### Description:

In `textRenderer.layoutRow`, if a hyperlink's `SizeName` wasn't set, its apparent text size and baseline were 0. This alone didn't matter, except when p.e. a monospace text object with a lower baseline was in the row. This triggered a realignment which displaced hyperlinks because of their wrong baseline of 0.

Fixes the issue mentioned in this comment: <https://github.com/fyne-io/fyne/issues/6259#issuecomment-4206931742> (but not issue #6259 itself).

<img width="603" height="62" alt="image" src="https://github.com/user-attachments/assets/40258705-a440-4911-81a1-0cda212c4c39" />

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.