### PR TITLE
walkString callback: Don't reuse y position

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -189,11 +189,8 @@ func DrawString(dst draw.Image, s string, color color.Color, f shaping.Fontmap, 
 	}
 
 	advance := float32(0)
-	y := math.MinInt
 	walkString(f, s, float32ToFixed266(fontSize), style, &advance, scale, func(run shaping.Output, x float32) {
-		if y == math.MinInt {
-			y = int(math.Ceil(float64(fixed266ToFloat32(run.LineBounds.Ascent) * r.PixScale)))
-		}
+		y := int(math.Ceil(float64(fixed266ToFloat32(run.LineBounds.Ascent) * r.PixScale)))
 		if len(run.Glyphs) == 1 {
 			if run.Glyphs[0].GlyphID == 0 {
 				r.DrawStringAt(string([]rune{0xfffd}), dst, int(x), y, f.ResolveFace(0xfffd))


### PR DESCRIPTION
### Description:

In a mixed string like "🚧 Bugfixes", the emoji and the ASCII text have different ascents and thus different y positions (p.e. 12 and 15). Calculating a y of 12 for "🚧" and reusing it for "Bugfixes" results in displaced text. That's why it must be recalculated (for every run).

Fixes #6259.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.