### PR TITLE
Cache font lookups for rune

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -368,13 +368,22 @@ type noopLogger struct{}
 func (n noopLogger) Printf(string, ...any) {}
 
 type dynamicFontMap struct {
-	faces  []*font.Face
-	family string
+	faces     []*font.Face
+	family    string
+	faceCache map[rune]*font.Face
 }
 
 func (d *dynamicFontMap) ResolveFace(r rune) *font.Face {
+	if d.faceCache == nil {
+		d.faceCache = make(map[rune]*font.Face)
+	}
+	if f, ok := d.faceCache[r]; ok {
+		d.faceCache[r] = f
+		return f
+	}
 	for _, f := range d.faces {
 		if _, ok := f.NominalGlyph(r); ok {
+			d.faceCache[r] = f
 			return f
 		}
 	}
@@ -382,9 +391,10 @@ func (d *dynamicFontMap) ResolveFace(r rune) *font.Face {
 	toAdd := lookupRuneFont(r, d.family, font.Aspect{})
 	if toAdd != nil {
 		d.addFace(toAdd)
+		d.faceCache[r] = toAdd
 		return toAdd
 	}
-
+	d.faceCache[r] = d.faces[0]
 	return d.faces[0]
 }
 


### PR DESCRIPTION
### Description:
This significantly speeds up layout for chinese characters, bringing them much closer to latin text layout:

```
redawl@workstation ~/projects/fyne $ benchstat /tmp/{old,new}.txt
goos: linux
goarch: amd64
pkg: fyne.io/fyne/v2/widget
cpu: AMD Ryzen 7 7800X3D 8-Core Processor
                                │  /tmp/old.txt   │            /tmp/new.txt             │
                                │     sec/op      │   sec/op     vs base                │
Text_howManyRunesFit_chinese-16   61387.31µ ± 44%   32.10µ ± 2%  -99.95% (p=0.000 n=10)
redawl@workstation ~/projects/fyne $
```

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
