### PR TITLE
More realistic mobile screen size

### DIFF
--- a/internal/driver/mobile/app/darwin_desktop.m
+++ b/internal/driver/mobile/app/darwin_desktop.m
@@ -207,7 +207,7 @@ runApp(void) {
 	[menu addItem:quitMenuItem];
 	[menuItem setSubmenu:menu];
 
-	NSRect rect = NSMakeRect(0, 0, 600, 800);
+	NSRect rect = NSMakeRect(0, 0, 500, 1000);
 
 	NSWindow* window = [[[NSWindow alloc] initWithContentRect:rect
 			styleMask:NSWindowStyleMaskTitled

--- a/internal/driver/mobile/app/x11.c
+++ b/internal/driver/mobile/app/x11.c
@@ -112,7 +112,7 @@ createWindow(void) {
 		exit(1);
 	}
 	eglBindAPI(EGL_OPENGL_ES_API);
-	win = new_window(x_dpy, e_dpy, 600, 800, &e_ctx, &e_surf);
+	win = new_window(x_dpy, e_dpy, 500, 1000, &e_ctx, &e_surf);
 
 	wm_delete_window = XInternAtom(x_dpy, "WM_DELETE_WINDOW", True);
 	if (wm_delete_window != None) {

--- a/internal/driver/mobile/canvas_test.go
+++ b/internal/driver/mobile/canvas_test.go
@@ -211,7 +211,10 @@ func Test_canvas_InteractiveArea(t *testing.T) {
 		c.(*canvas).setWindowHead(windowHead)
 		pos, size := c.InteractiveArea()
 		assert.Equal(t, fyne.NewPos(float32(dev.safeLeft)/scale, float32(dev.safeTop)/scale+expectedOffset), pos)
-		assert.Equal(t, canvasSize.SubtractWidthHeight(float32(dev.safeLeft+dev.safeRight)/scale, float32(dev.safeTop+dev.safeBottom)/scale+expectedOffset), size)
+		expectedWidth := canvasSize.Width - float32(dev.safeLeft+dev.safeRight)/scale
+		expectedHeight := canvasSize.Height - float32(dev.safeTop+dev.safeBottom)/scale - expectedOffset
+		assert.InDelta(t, expectedWidth, size.Width, 0.001)
+		assert.InDelta(t, expectedHeight, size.Height, 0.001)
 	})
 }
 

--- a/internal/driver/mobile/device_desktop.go
+++ b/internal/driver/mobile/device_desktop.go
@@ -7,7 +7,7 @@ import "fyne.io/fyne/v2"
 const tapYOffset = 0 // no finger compensation on desktop (simulation)
 
 func (*device) SystemScaleForWindow(_ fyne.Window) float32 {
-	return 2 // this is simply due to the high number of pixels on a mobile device - just an approximation
+	return 1.4 // this is simply due to the high number of pixels on a mobile device - just an approximation
 }
 
 func setDisableScreenBlank(_ bool) {


### PR DESCRIPTION
### Description:

I would like to suggest updating the default window size for the mobile simulation.

- An **aspect ratio of 1:2** is much closer to what real smartphones use: 1080x1920 (9:16) and 1080x2400 (9:20) are very common (for Android devices). 1:2 is in between these two ratios.
- A **size of 500x1000** pixels matches this aspect ratio and still fits on usual computer screens which are usually at least as high as 1080 pixels.
- With a **scale of 1.4** the number of words or characters per (text) line seems to be the same as on a 1080 pixels wide smartphone (tested on my OnePlus Nord 2 5G).

With these numbers, an app in the mobile simulation looks very much like on a real device.

This is just a proposal, open for discussion. Maybe the numbers need to be tweaked to give developers for iOS a same as good preview as for Android.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.