### PR TITLE
Markdown: Add trailing space for soft line breaks

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -125,7 +125,9 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 			// These empty text elements indicate single line breaks after non-text elements in goldmark.
 			return []RichTextSegment{&TextSegment{Style: RichTextStyleInline, Text: " "}}, nil
 		}
-		text = suffixSpaceIfAppropriate(text, n)
+		if n.(*ast.Text).SoftLineBreak() {
+			text = text + " "
+		}
 		if blockquote {
 			return []RichTextSegment{&TextSegment{Style: RichTextStyleBlockquote, Text: text}}, nil
 		}
@@ -136,14 +138,6 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		return parseMarkdownImage(t), nil
 	}
 	return nil, nil
-}
-
-func suffixSpaceIfAppropriate(text string, n ast.Node) string {
-	next := n.NextSibling()
-	if next != nil && next.Type() == ast.TypeInline && !strings.HasSuffix(text, " ") {
-		return text + " "
-	}
-	return text
 }
 
 func renderChildren(source []byte, n ast.Node, blockquote bool, listDepth int) ([]RichTextSegment, error) {

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -305,6 +305,23 @@ func TestRichTextMarkdown_Lines(t *testing.T) {
 	}
 }
 
+func TestRichTextMarkdown_TrailingExclamationMark(t *testing.T) {
+	r := NewRichTextFromMarkdown("Hello! Hi!")
+
+	assert.Len(t, r.Segments, 3)
+	if text, ok := r.Segments[0].(*TextSegment); ok {
+		assert.Equal(t, "Hello! Hi", text.Text)
+		assert.True(t, text.Inline())
+	} else {
+		t.Error("Segment should be Text")
+	}
+	if text, ok := r.Segments[1].(*TextSegment); ok {
+		assert.Equal(t, "!", text.Text)
+	} else {
+		t.Error("Segment should be Text")
+	}
+}
+
 func TestRichTextMarkdown_List(t *testing.T) {
 	r := NewRichTextFromMarkdown("* line1 in _three_ segments\n* line2")
 


### PR DESCRIPTION
### Description:

Looking at the Markdown tests, the function `suffixSpaceIfAppropriate` was only needed to handle soft line breaks. This PR removes this function and checks directly for soft line breaks.

Fixes #5530.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.