### PR TITLE
Fix right-click not working when popup menu is already open

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -545,7 +545,20 @@ func (w *window) processMouseClicked(button desktop.MouseButton, action action, 
 			w.mousePressed = co
 		case release:
 			if co == mousePressed && button == desktop.MouseButtonSecondary && altTap {
+				prevOverlay := w.canvas.Overlays().Top()
 				secondary.TappedSecondary(ev)
+
+				// if the secondary tap dismissed an overlay, forward the event to the widget underneath
+				if prevOverlay != nil && w.canvas.Overlays().Top() != prevOverlay {
+					co2, pos2, _ := w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) bool {
+						_, ok := object.(fyne.SecondaryTappable)
+						return ok
+					})
+					if sec2, ok := co2.(fyne.SecondaryTappable); ok {
+						ev2 := &fyne.PointEvent{Position: pos2, AbsolutePosition: mousePos}
+						sec2.TappedSecondary(ev2)
+					}
+				}
 			}
 		}
 	}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1215,6 +1215,31 @@ func TestWindow_TappedSecondary(t *testing.T) {
 	})
 }
 
+func TestWindow_TappedSecondary_RedispatchAfterOverlayDismiss(t *testing.T) {
+	w := createWindow("Test")
+	o := &tappableObject{Rectangle: canvas.NewRectangle(color.White)}
+	o.SetMinSize(fyne.NewSize(100, 100))
+	w.SetContent(o)
+	ensureCanvasSize(t, w, fyne.NewSize(108, 108))
+
+	menu := fyne.NewMenu("", fyne.NewMenuItem("A", nil))
+	pop := widget.NewPopUpMenu(menu, w.canvas)
+
+	runOnMain(func() {
+		pop.ShowAtPosition(fyne.NewPos(0, 0))
+		assert.NotNil(t, w.canvas.Overlays().Top(), "overlay should be present")
+
+		// right-click outside the popup menu but inside the tappable object
+		w.mousePos = fyne.NewPos(80, 80)
+		w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Press, 0)
+		w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Release, 0)
+
+		assert.Nil(t, w.canvas.Overlays().Top(), "overlay should be dismissed")
+		assert.Nil(t, o.popTapEvent(), "no primary tap")
+		assert.NotNil(t, o.popSecondaryTapEvent(), "secondary tap should reach widget underneath")
+	})
+}
+
 func TestWindow_TappedSecondary_OnPrimaryOnlyTarget(t *testing.T) {
 	w := createWindow("Test")
 	tapped := false

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -374,7 +374,20 @@ func (c *canvas) tapUp(pos fyne.Position, tapID int,
 		}
 	} else {
 		if wid, ok := co.(fyne.SecondaryTappable); ok {
+			prevOverlay := c.Overlays().Top()
 			tapAltCallback(wid, ev)
+
+			// if the secondary tap dismissed an overlay, forward the event to the widget underneath
+			if prevOverlay != nil && c.Overlays().Top() != prevOverlay {
+				co2, objPos2, _ := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
+					_, ok := object.(fyne.SecondaryTappable)
+					return ok
+				})
+				if sec2, ok := co2.(fyne.SecondaryTappable); ok {
+					ev2 := &fyne.PointEvent{Position: objPos2, AbsolutePosition: pos}
+					tapAltCallback(sec2, ev2)
+				}
+			}
 		}
 	}
 }

--- a/internal/widget/overlay_container.go
+++ b/internal/widget/overlay_container.go
@@ -6,9 +6,10 @@ import (
 )
 
 var (
-	_ fyne.Widget       = (*OverlayContainer)(nil)
-	_ fyne.Tappable     = (*OverlayContainer)(nil)
-	_ desktop.Hoverable = (*OverlayContainer)(nil)
+	_ fyne.Widget            = (*OverlayContainer)(nil)
+	_ fyne.Tappable          = (*OverlayContainer)(nil)
+	_ fyne.SecondaryTappable = (*OverlayContainer)(nil)
+	_ desktop.Hoverable      = (*OverlayContainer)(nil)
 )
 
 // OverlayContainer is a transparent widget containing one fyne.CanvasObject and meant to be used as overlay.
@@ -79,6 +80,14 @@ func (o *OverlayContainer) Show() {
 // Tapped catches tap events not handled by the container’s content.
 // It performs the overlay container’s dismiss action.
 func (o *OverlayContainer) Tapped(*fyne.PointEvent) {
+	if o.onDismiss != nil {
+		o.onDismiss()
+	}
+}
+
+// TappedSecondary catches secondary tap events not handled by the container’s content.
+// It performs the overlay container’s dismiss action.
+func (o *OverlayContainer) TappedSecondary(*fyne.PointEvent) {
 	if o.onDismiss != nil {
 		o.onDismiss()
 	}

--- a/internal/widget/overlay_container_test.go
+++ b/internal/widget/overlay_container_test.go
@@ -1,0 +1,45 @@
+package widget
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+)
+
+type dummyCanvas struct {
+	fyne.Canvas
+}
+
+func TestOverlayContainer_Tapped_Dismiss(t *testing.T) {
+	dismissed := false
+	o := NewOverlayContainer(nil, &dummyCanvas{}, func() { dismissed = true })
+
+	o.Tapped(&fyne.PointEvent{})
+	assert.True(t, dismissed)
+}
+
+func TestOverlayContainer_TappedSecondary_Dismiss(t *testing.T) {
+	dismissed := false
+	o := NewOverlayContainer(nil, &dummyCanvas{}, func() { dismissed = true })
+
+	o.TappedSecondary(&fyne.PointEvent{})
+	assert.True(t, dismissed)
+}
+
+func TestOverlayContainer_Tapped_NilDismiss(t *testing.T) {
+	o := NewOverlayContainer(nil, &dummyCanvas{}, nil)
+
+	assert.NotPanics(t, func() {
+		o.Tapped(&fyne.PointEvent{})
+	})
+}
+
+func TestOverlayContainer_TappedSecondary_NilDismiss(t *testing.T) {
+	o := NewOverlayContainer(nil, &dummyCanvas{}, nil)
+
+	assert.NotPanics(t, func() {
+		o.TappedSecondary(&fyne.PointEvent{})
+	})
+}


### PR DESCRIPTION
### Description:

Right-clicking outside an open popup menu does nothing — the event is silently dropped and the menu stays visible.

`OverlayContainer` implements `fyne.Tappable` but not `fyne.SecondaryTappable`. When an overlay is active, `FindObjectAtPositionMatching` only walks the overlay tree. It finds `OverlayContainer` (satisfies the match via `Tappable`), but `processMouseClicked` then checks for `SecondaryTappable` which fails — neither `Tapped` nor `TappedSecondary` is called.

This is fixed in two steps:

1. **Add `TappedSecondary` to `OverlayContainer`** so the overlay dismisses on right-click, same as it already does on left-click.

2. **Re-dispatch the secondary tap to the widget underneath** after the overlay is dismissed. Without this the user would need a second right-click to open a new context menu. After `TappedSecondary` fires on the overlay, if the overlay was removed the driver re-finds the object at the cursor position and forwards `TappedSecondary` to it.

Both GLFW and mobile drivers are updated. The embedded driver passes `nil` for overlays in `FindObjectAtPositionMatching` so it is not affected.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
