### PR TITLE
Update tests to match new padding (commit 30a2d298c)

### DIFF
--- a/container/testdata/apptabs/desktop/layout_leading_icon_and_text.xml
+++ b/container/testdata/apptabs/desktop/layout_leading_icon_and_text.xml
@@ -4,7 +4,7 @@
 			<container size="45x150">
 				<container size="45x150">
 					<widget size="45x53" type="*container.tabButton">
-						<text alignment="center" bold color="primary" pos="4,30" size="37x19">Text1</text>
+						<text alignment="center" bold color="primary" pos="4,34" size="37x19">Text1</text>
 						<image pos="7,4" rsc="cancelIcon" size="30x30" themed="primary"/>
 					</widget>
 				</container>

--- a/container/testdata/apptabs/desktop/layout_trailing_icon_and_text.xml
+++ b/container/testdata/apptabs/desktop/layout_trailing_icon_and_text.xml
@@ -4,7 +4,7 @@
 			<container pos="104,0" size="45x150">
 				<container size="45x150">
 					<widget size="45x53" type="*container.tabButton">
-						<text alignment="center" bold color="primary" pos="4,30" size="37x19">Text1</text>
+						<text alignment="center" bold color="primary" pos="4,34" size="37x19">Text1</text>
 						<image pos="7,4" rsc="cancelIcon" size="30x30" themed="primary"/>
 					</widget>
 				</container>

--- a/container/testdata/apptabs/mobile/layout_bottom_icon_and_text.xml
+++ b/container/testdata/apptabs/mobile/layout_bottom_icon_and_text.xml
@@ -4,7 +4,7 @@
 			<container pos="0,101" size="150x48">
 				<container size="150x48">
 					<widget size="150x48" type="*container.tabButton">
-						<text alignment="center" bold color="primary" pos="4,30" size="142x14" textSize="11">Text1</text>
+						<text alignment="center" bold color="primary" pos="4,34" size="142x14" textSize="11">Text1</text>
 						<image pos="60,4" rsc="cancelIcon" size="30x30" themed="primary"/>
 					</widget>
 				</container>

--- a/container/testdata/apptabs/mobile/layout_top_icon_and_text.xml
+++ b/container/testdata/apptabs/mobile/layout_top_icon_and_text.xml
@@ -4,7 +4,7 @@
 			<container size="150x48">
 				<container size="150x48">
 					<widget size="150x48" type="*container.tabButton">
-						<text alignment="center" bold color="primary" pos="4,30" size="142x14" textSize="11">Text1</text>
+						<text alignment="center" bold color="primary" pos="4,34" size="142x14" textSize="11">Text1</text>
 						<image pos="60,4" rsc="cancelIcon" size="30x30" themed="primary"/>
 					</widget>
 				</container>

--- a/container/testdata/doctabs/desktop/layout_leading_icon_and_text.xml
+++ b/container/testdata/doctabs/desktop/layout_leading_icon_and_text.xml
@@ -5,7 +5,7 @@
 				<widget size="69x110" type="*widget.Scroll">
 					<container size="69x110">
 						<widget size="69x53" type="*container.tabButton">
-							<text bold color="primary" pos="4,30" size="61x19">Text1</text>
+							<text bold color="primary" pos="4,34" size="61x19">Text1</text>
 							<image pos="19,4" rsc="cancelIcon" size="30x30" themed="primary"/>
 						</widget>
 					</container>

--- a/container/testdata/doctabs/desktop/layout_trailing_icon_and_text.xml
+++ b/container/testdata/doctabs/desktop/layout_trailing_icon_and_text.xml
@@ -5,7 +5,7 @@
 				<widget size="69x110" type="*widget.Scroll">
 					<container size="69x110">
 						<widget size="69x53" type="*container.tabButton">
-							<text bold color="primary" pos="4,30" size="61x19">Text1</text>
+							<text bold color="primary" pos="4,34" size="61x19">Text1</text>
 							<image pos="19,4" rsc="cancelIcon" size="30x30" themed="primary"/>
 						</widget>
 					</container>


### PR DESCRIPTION
### Description:

Some `container` tests fail since commit 30a2d298c. This pull request updates the failing tests to match the updated padding from 30a2d298c.

Fixes container tests.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.