### PR TITLE
Fix issue with window placement and fullscreen for macOS 26

### DIFF
--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -243,7 +243,8 @@ func (i *Installer) installToIOSSimulator(target string) error {
 	cmd := execabs.Command(
 		"xcrun", "simctl", "install",
 		"booted", // Install to the booted simulator.
-		target)
+		target,
+	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("Install to a simulator error: %s%s", out, err)
 	}

--- a/cmd/fyne/internal/commands/translate.go
+++ b/cmd/fyne/internal/commands/translate.go
@@ -54,7 +54,8 @@ func Translate() *cli.Command {
 			}
 
 			usage := func() {
-				fmt.Fprintf(os.Stderr, "usage: %s %s [command options] %s\n",
+				fmt.Fprintf(
+					os.Stderr, "usage: %s %s [command options] %s\n",
 					ctx.App.Name,
 					ctx.Command.Name,
 					ctx.Command.ArgsUsage,

--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -212,7 +212,8 @@ func envInit() (err error) {
 		if before116 {
 			os = "darwin"
 		}
-		env = append(env,
+		env = append(
+			env,
 			"GOOS="+os,
 			"GOARCH="+arch,
 			"CC="+clang,

--- a/cmd/fyne_demo/main.go
+++ b/cmd/fyne_demo/main.go
@@ -65,7 +65,8 @@ func main() {
 	}
 
 	tutorial := container.NewBorder(
-		container.NewVBox(title, widget.NewSeparator(), intro), nil, nil, nil, content)
+		container.NewVBox(title, widget.NewSeparator(), intro), nil, nil, nil, content,
+	)
 	if fyne.CurrentDevice().IsMobile() {
 		w.SetContent(makeNav(setTutorial, false))
 	} else {
@@ -76,7 +77,8 @@ func main() {
 	w.Resize(fyne.NewSize(640, 460))
 
 	notice := widget.NewRichTextFromMarkdown(
-		"This demo has been moved to a new repository.\n\n[Fyne demo on GitHub](https://github.com/fyne-io/demo)")
+		"This demo has been moved to a new repository.\n\n[Fyne demo on GitHub](https://github.com/fyne-io/demo)",
+	)
 	notice.Segments[2].(*widget.HyperlinkSegment).Alignment = fyne.TextAlignCenter
 	dialog.ShowCustom("Fyne Demo Moved", "OK", notice, w)
 
@@ -107,7 +109,8 @@ func makeMenu(a fyne.App, w fyne.Window) *fyne.MainMenu {
 	otherItem := fyne.NewMenuItem("Other", nil)
 	mailItem := fyne.NewMenuItem("Mail", func() { fmt.Println("Menu New->Other->Mail") })
 	mailItem.Icon = theme.MailComposeIcon()
-	otherItem.ChildMenu = fyne.NewMenu("",
+	otherItem.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("Project", func() { fmt.Println("Menu New->Other->Project") }),
 		mailItem,
 	)
@@ -115,7 +118,8 @@ func makeMenu(a fyne.App, w fyne.Window) *fyne.MainMenu {
 	fileItem.Icon = theme.FileIcon()
 	dirItem := fyne.NewMenuItem("Directory", func() { fmt.Println("Menu New->Directory") })
 	dirItem.Icon = theme.FolderIcon()
-	newItem.ChildMenu = fyne.NewMenu("",
+	newItem.ChildMenu = fyne.NewMenu(
+		"",
 		fileItem,
 		dirItem,
 		otherItem,
@@ -252,7 +256,8 @@ func makeNav(setTutorial func(tutorial tutorials.Tutorial), loadPrevious bool) f
 		tree.Select(currentPref)
 	}
 
-	themes := container.NewGridWithColumns(2,
+	themes := container.NewGridWithColumns(
+		2,
 		widget.NewButton("Dark", func() {
 			a.Settings().SetTheme(&forcedVariant{Theme: theme.DefaultTheme(), variant: theme.VariantDark})
 		}),

--- a/cmd/fyne_demo/tutorials/advanced.go
+++ b/cmd/fyne_demo/tutorials/advanced.go
@@ -89,7 +89,8 @@ func advancedScreen(win fyne.Window) fyne.CanvasObject {
 	}
 
 	return container.NewHBox(
-		container.NewVBox(screen,
+		container.NewVBox(
+			screen,
 			widget.NewButton("Custom Theme", func() {
 				fyne.CurrentApp().Settings().SetTheme(newCustomTheme())
 			}),
@@ -98,7 +99,8 @@ func advancedScreen(win fyne.Window) fyne.CanvasObject {
 			}),
 			secondary,
 		),
-		container.NewBorder(label, labelBuildStatus, nil, nil,
+		container.NewBorder(
+			label, labelBuildStatus, nil, nil,
 			container.NewGridWithColumns(2, genericCard, deskCard),
 		),
 	)

--- a/cmd/fyne_demo/tutorials/animation.go
+++ b/cmd/fyne_demo/tutorials/animation.go
@@ -101,7 +101,8 @@ func makeAnimationCurveItem(label string, curve fyne.AnimationCurve, yOff float3
 		fyne.NewPos(0, yOff), fyne.NewPos(380, yOff), time.Second, func(p fyne.Position) {
 			box.Move(p)
 			box.Refresh()
-		})
+		},
+	)
 	anim.Curve = curve
 	anim.AutoReverse = true
 	anim.RepeatCount = 1

--- a/cmd/fyne_demo/tutorials/canvas.go
+++ b/cmd/fyne_demo/tutorials/canvas.go
@@ -36,7 +36,8 @@ func canvasScreen(_ fyne.Window) fyne.CanvasObject {
 		}
 	}()
 
-	return container.NewGridWrap(fyne.NewSize(90, 90),
+	return container.NewGridWrap(
+		fyne.NewSize(90, 90),
 		canvas.NewImageFromResource(data.FyneLogo),
 		&canvas.Rectangle{
 			FillColor:   color.NRGBA{0x80, 0, 0, 0xff},

--- a/cmd/fyne_demo/tutorials/collection.go
+++ b/cmd/fyne_demo/tutorials/collection.go
@@ -17,7 +17,8 @@ func collectionScreen(_ fyne.Window) fyne.CanvasObject {
 		widget.NewLabelWithStyle("func CreateItem() fyne.CanvasObject", fyne.TextAlignLeading, fyne.TextStyle{Monospace: true}),
 		widget.NewLabelWithStyle("func UpdateItem(ListItemID, fyne.CanvasObject)", fyne.TextAlignLeading, fyne.TextStyle{Monospace: true}),
 		widget.NewLabelWithStyle("func OnSelected(ListItemID)", fyne.TextAlignLeading, fyne.TextStyle{Monospace: true}),
-		widget.NewLabelWithStyle("func OnUnselected(ListItemID)", fyne.TextAlignLeading, fyne.TextStyle{Monospace: true}))
+		widget.NewLabelWithStyle("func OnUnselected(ListItemID)", fyne.TextAlignLeading, fyne.TextStyle{Monospace: true}),
+	)
 	return container.NewCenter(content)
 }
 
@@ -113,7 +114,8 @@ func makeTableTab(_ fyne.Window) fyne.CanvasObject {
 			default:
 				label.SetText(fmt.Sprintf("Cell %d, %d", id.Row+1, id.Col+1))
 			}
-		})
+		},
+	)
 	t.SetColumnWidth(0, 102)
 	t.SetRowHeight(2, 50)
 	return t

--- a/cmd/fyne_demo/tutorials/container.go
+++ b/cmd/fyne_demo/tutorials/container.go
@@ -21,7 +21,8 @@ func containerScreen(_ fyne.Window) fyne.CanvasObject {
 		widget.NewLabelWithStyle("Bottom", fyne.TextAlignCenter, fyne.TextStyle{}),
 		widget.NewLabel("Left"),
 		widget.NewLabel("Right"),
-		widget.NewLabel("Border Container"))
+		widget.NewLabel("Border Container"),
+	)
 	return container.NewCenter(content)
 }
 
@@ -115,7 +116,8 @@ func makeInnerWindowTab(_ fyne.Window) fyne.CanvasObject {
 		label,
 		widget.NewButton("Tap Me", func() {
 			label.SetText("Tapped")
-		})))
+		}),
+	))
 	win1.Icon = data.FyneLogo
 	win1.OnMaximized = func() {
 		log.Println("Should maximize here")

--- a/cmd/fyne_demo/tutorials/welcome.go
+++ b/cmd/fyne_demo/tutorials/welcome.go
@@ -47,7 +47,8 @@ func welcomeScreen(_ fyne.Window) fyne.CanvasObject {
 		widget.NewLabelWithStyle("\n\nWelcome to the Fyne toolkit demo app", fyne.TextAlignCenter, fyne.TextStyle{Bold: true}),
 		logo,
 		container.NewCenter(authors),
-		widget.NewLabelWithStyle("\nWith great thanks to our many kind sponsors\n", fyne.TextAlignCenter, fyne.TextStyle{Italic: true}))
+		widget.NewLabelWithStyle("\nWith great thanks to our many kind sponsors\n", fyne.TextAlignCenter, fyne.TextStyle{Italic: true}),
+	)
 	scroll := container.NewScroll(content)
 
 	bgColor := withAlpha(theme.Color(theme.ColorNameBackground), 0xe0)

--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -79,7 +79,8 @@ func makeActivityTab(win fyne.Window) fyne.CanvasObject {
 	return container.NewCenter(container.NewGridWithColumns(1,
 		container.NewCenter(container.NewVBox(
 			container.NewHBox(widget.NewLabel("Working..."), a1),
-			container.NewStack(button, a2))),
+			container.NewStack(button, a2),
+		)),
 		container.NewCenter(widget.NewButton("Show dialog", func() {
 			prop := canvas.NewRectangle(color.Transparent)
 			prop.SetMinSize(fyne.NewSize(50, 50))
@@ -103,11 +104,13 @@ func makeButtonTab(_ fyne.Window) fyne.CanvasObject {
 	disabled.Disable()
 
 	shareItem := fyne.NewMenuItem("Share via", nil)
-	shareItem.ChildMenu = fyne.NewMenu("",
+	shareItem.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("Twitter", func() { fmt.Println("context menu Share->Twitter") }),
 		fyne.NewMenuItem("Reddit", func() { fmt.Println("context menu Share->Reddit") }),
 	)
-	menuLabel := newContextMenuButton("tap me for pop-up menu with submenus", fyne.NewMenu("",
+	menuLabel := newContextMenuButton("tap me for pop-up menu with submenus", fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("Copy", func() { fmt.Println("context menu copy") }),
 		shareItem,
 	))
@@ -181,7 +184,8 @@ func makeEntryTab(_ fyne.Window) fyne.CanvasObject {
 		entry,
 		entryDisabled,
 		entryValidated,
-		entryMultiLine)
+		entryMultiLine,
+	)
 }
 
 func makeTextGrid() *widget.TextGrid {
@@ -328,7 +332,8 @@ This styled row should also wrap as expected, but only *when required*.
 		widget.NewForm(
 			widget.NewFormItem("Text Alignment", radioAlign),
 			widget.NewFormItem("Wrapping", radioWrap),
-			widget.NewFormItem("Truncation", radioTrunc)),
+			widget.NewFormItem("Truncation", radioTrunc),
+		),
 		label,
 		hyperlink,
 	)
@@ -424,7 +429,8 @@ func makeProgressTab(_ fyne.Window) fyne.CanvasObject {
 	return container.NewVBox(
 		widget.NewLabel("Percent"), progress,
 		widget.NewLabel("Formatted"), fprogress,
-		widget.NewLabel("Infinite"), infProgress)
+		widget.NewLabel("Infinite"), infProgress,
+	)
 }
 
 func makeFormTab(_ fyne.Window) fyne.CanvasObject {
@@ -466,7 +472,8 @@ func makeFormTab(_ fyne.Window) fyne.CanvasObject {
 }
 
 func makeToolbarTab(_ fyne.Window) fyne.CanvasObject {
-	t := widget.NewToolbar(widget.NewToolbarAction(theme.MailComposeIcon(), func() { fmt.Println("New") }),
+	t := widget.NewToolbar(
+		widget.NewToolbarAction(theme.MailComposeIcon(), func() { fmt.Println("New") }),
 		widget.NewToolbarSeparator(),
 		widget.NewToolbarSpacer(),
 		widget.NewToolbarAction(theme.ContentCutIcon(), func() { fmt.Println("Cut") }),
@@ -482,7 +489,8 @@ func widgetScreen(_ fyne.Window) fyne.CanvasObject {
 	content := container.NewVBox(
 		widget.NewLabel("Labels"),
 		widget.NewButtonWithIcon("Icons", theme.HomeIcon(), func() {}),
-		widget.NewSlider(0, 1))
+		widget.NewSlider(0, 1),
+	)
 	return container.NewCenter(content)
 }
 

--- a/cmd/fyne_demo/tutorials/window.go
+++ b/cmd/fyne_demo/tutorials/window.go
@@ -70,7 +70,8 @@ func windowScreen(_ fyne.Window) fyne.CanvasObject {
 				visibilityWindow.Show()
 			}
 			visibilityState = !visibilityState
-		}))
+		}),
+	)
 
 	drv := fyne.CurrentApp().Driver()
 	if drv, ok := drv.(desktop.Driver); ok {

--- a/cmd/fyne_settings/main.go
+++ b/cmd/fyne_settings/main.go
@@ -15,7 +15,8 @@ func main() {
 
 	appearance := s.LoadAppearanceScreen(w)
 	tabs := container.NewAppTabs(
-		&container.TabItem{Text: "Appearance", Icon: s.AppearanceIcon(), Content: appearance})
+		&container.TabItem{Text: "Appearance", Icon: s.AppearanceIcon(), Content: appearance},
+	)
 	tabs.SetTabLocation(container.TabLocationLeading)
 	w.SetContent(tabs)
 

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -86,7 +86,8 @@ func (s *Settings) LoadAppearanceScreen(w fyne.Window) fyne.CanvasObject {
 	appearance := widget.NewForm(
 		widget.NewFormItem("Animations", animations),
 		widget.NewFormItem("Main Color", swatch),
-		widget.NewFormItem("Theme", themes))
+		widget.NewFormItem("Theme", themes),
+	)
 
 	box.Add(widget.NewCard("Appearance", "", appearance))
 	bottom := container.NewHBox(layout.NewSpacer(),
@@ -283,7 +284,8 @@ func createPreviewWidget() fyne.CanvasObject {
 	form.OnCancel = func() {}
 	form.OnSubmit = func() {}
 	content := container.NewVBox(
-		widget.NewLabelWithStyle("Theme Preview", fyne.TextAlignCenter, fyne.TextStyle{Bold: true}), form)
+		widget.NewLabelWithStyle("Theme Preview", fyne.TextAlignCenter, fyne.TextStyle{Bold: true}), form,
+	)
 
 	over := container.NewStack(intWidget.NewShadow(intWidget.ShadowAround, intWidget.DialogLevel),
 		container.NewPadded(content))

--- a/container/tabs_test.go
+++ b/container/tabs_test.go
@@ -31,7 +31,8 @@ func TestTab_ThemeChange(t *testing.T) {
 
 	tabs := NewAppTabs(
 		NewTabItem("a", widget.NewLabel("a")),
-		NewTabItem("b", widget.NewLabel("b")))
+		NewTabItem("b", widget.NewLabel("b")),
+	)
 	w := test.NewTempWindow(t, tabs)
 	w.Resize(fyne.NewSize(180, 120))
 

--- a/data/binding/lists_test.go
+++ b/data/binding/lists_test.go
@@ -75,7 +75,7 @@ func TestBindFloatList(t *testing.T) {
 	assert.Equal(t, 5.0, v)
 
 	assert.NotNil(t, f.(*boundList[float64]).val)
-	assert.Equal(t, 3, len(*(f.(*boundList[float64]).val)))
+	assert.Equal(t, 3, len(*f.(*boundList[float64]).val))
 
 	_, err = f.GetValue(-1)
 	assert.NotNil(t, err)
@@ -104,7 +104,7 @@ func TestExternalFloatList_Reload(t *testing.T) {
 	assert.True(t, calledChild)
 
 	assert.NotNil(t, f.(*boundList[float64]).val)
-	assert.Equal(t, 3, len(*(f.(*boundList[float64]).val)))
+	assert.Equal(t, 3, len(*f.(*boundList[float64]).val))
 
 	_, err = f.GetValue(-1)
 	assert.NotNil(t, err)

--- a/data/binding/preference.go
+++ b/data/binding/preference.go
@@ -27,7 +27,8 @@ func BindPreferenceBool(key string, p fyne.Preferences) Bool {
 //
 // Since: 2.6
 func BindPreferenceBoolList(key string, p fyne.Preferences) BoolList {
-	return bindPreferenceListComparable(key, p,
+	return bindPreferenceListComparable(
+		key, p,
 		func(p fyne.Preferences) (func(string) []bool, func(string, []bool)) {
 			return p.BoolList, p.SetBoolList
 		},
@@ -50,7 +51,8 @@ func BindPreferenceFloat(key string, p fyne.Preferences) Float {
 //
 // Since: 2.6
 func BindPreferenceFloatList(key string, p fyne.Preferences) FloatList {
-	return bindPreferenceListComparable(key, p,
+	return bindPreferenceListComparable(
+		key, p,
 		func(p fyne.Preferences) (func(string) []float64, func(string, []float64)) {
 			return p.FloatList, p.SetFloatList
 		},
@@ -73,7 +75,8 @@ func BindPreferenceInt(key string, p fyne.Preferences) Int {
 //
 // Since: 2.6
 func BindPreferenceIntList(key string, p fyne.Preferences) IntList {
-	return bindPreferenceListComparable(key, p,
+	return bindPreferenceListComparable(
+		key, p,
 		func(p fyne.Preferences) (func(string) []int, func(string, []int)) {
 			return p.IntList, p.SetIntList
 		},
@@ -96,7 +99,8 @@ func BindPreferenceString(key string, p fyne.Preferences) String {
 //
 // Since: 2.6
 func BindPreferenceStringList(key string, p fyne.Preferences) StringList {
-	return bindPreferenceListComparable(key, p,
+	return bindPreferenceListComparable(
+		key, p,
 		func(p fyne.Preferences) (func(string) []string, func(string, []string)) {
 			return p.StringList, p.SetStringList
 		},

--- a/data/binding/trees_test.go
+++ b/data/binding/trees_test.go
@@ -85,7 +85,7 @@ func TestBindStringTree(t *testing.T) {
 	assert.Equal(t, "five", v)
 
 	assert.NotNil(t, f.(*boundTree[string]).val)
-	assert.Equal(t, 3, len(*(f.(*boundTree[string]).val)))
+	assert.Equal(t, 3, len(*f.(*boundTree[string]).val))
 
 	_, err = f.GetValue("nan")
 	assert.NotNil(t, err)
@@ -115,7 +115,7 @@ func TestExternalFloatTree_Reload(t *testing.T) {
 	assert.True(t, calledChild)
 
 	assert.NotNil(t, f.(*boundTree[float64]).val)
-	assert.Equal(t, 3, len(*(f.(*boundTree[float64]).val)))
+	assert.Equal(t, 3, len(*f.(*boundTree[float64]).val))
 
 	_, err = f.GetValue("-1")
 	assert.NotNil(t, err)

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -135,7 +135,8 @@ func (d *dialog) create(buttons fyne.CanvasObject) {
 		image = &layout.Spacer{}
 	}
 
-	content := container.New(&dialogLayout{d: d},
+	content := container.New(
+		&dialogLayout{d: d},
 		image,
 		newThemedBackground(),
 		d.content,

--- a/dialog/color_picker.go
+++ b/dialog/color_picker.go
@@ -187,7 +187,8 @@ func (p *colorAdvancedPicker) CreateRenderer() fyne.WidgetRenderer {
 			container.NewPadded(wheel),
 			hslBox,
 			rgbBox),
-		container.NewGridWithColumns(3,
+		container.NewGridWithColumns(
+			3,
 			container.NewPadded(preview),
 
 			hex,

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -239,17 +239,20 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 		optionsButton,
 	)
 
-	header := container.NewBorder(nil, nil, nil, optionsbuttons,
+	header := container.NewBorder(
+		nil, nil, nil, optionsbuttons,
 		f.title,
 	)
 
-	footer := container.NewBorder(nil, nil, nil, buttons,
+	footer := container.NewBorder(
+		nil, nil, nil, buttons,
 		container.NewHScroll(f.fileName),
 	)
 
 	body := container.NewHSplit(
 		f.favoritesList,
-		container.NewBorder(f.breadcrumbScroll, nil, nil, nil,
+		container.NewBorder(
+			f.breadcrumbScroll, nil, nil, nil,
 			f.filesScroll,
 		),
 	)

--- a/driver/software/render_test.go
+++ b/driver/software/render_test.go
@@ -44,7 +44,8 @@ func TestRenderCanvas(t *testing.T) {
 		container.NewTabItem("Tab 1", container.NewVBox(
 			widget.NewLabel("Label"),
 			widget.NewButton("Button", func() {}),
-		)))
+		)),
+	)
 
 	c := NewCanvas()
 	c.SetContent(obj)

--- a/internal/animation/runner_test.go
+++ b/internal/animation/runner_test.go
@@ -15,7 +15,8 @@ func BenchmarkRunnerAllocs(b *testing.B) {
 		r.pendingAnimations = append(r.pendingAnimations, newAnim(
 			fyne.NewAnimation(1000*time.Second, func(f float32) {
 				fl = f
-			})))
+			}),
+		))
 	}
 	for n := 0; n < b.N; n++ {
 		r.runOneFrame()

--- a/internal/driver/glfw/window_darwin.m
+++ b/internal/driver/glfw/window_darwin.m
@@ -10,6 +10,19 @@ void setFullScreen(bool full, void *win) {
         return;
     }
 
+    if (full) {
+        // macOS 26 ignores the window's current screen for toggleFullScreen, so re-seat
+        // the frame on that screen explicitly to force fullscreen on the right display.
+        NSScreen *targetScreen = [window screen];
+        if (targetScreen != nil) {
+            NSRect frame = [window frame];
+            NSRect screen = [targetScreen frame];
+            frame.origin.x = screen.origin.x + (screen.size.width - frame.size.width) / 2;
+            frame.origin.y = screen.origin.y + (screen.size.height - frame.size.height) / 2;
+            [window setFrame:frame display:YES];
+        }
+    }
+
     [window toggleFullScreen:NULL];
 }
 
@@ -23,9 +36,12 @@ void setFullScreenSecondary(bool full, void *win) {
     }
 
     if (full) {
+        // pick a screen that is not the one the window is already on, so launching
+        // on a secondary display still sends "secondary fullscreen" to the other display.
+        NSScreen *currentScreen = [window screen];
         NSScreen *targetScreen = nil;
         for (NSScreen *screen in [NSScreen screens]) {
-            if (screen != [NSScreen mainScreen]) {
+            if (screen != currentScreen) {
                 targetScreen = screen;
                 break;
             }
@@ -33,7 +49,8 @@ void setFullScreenSecondary(bool full, void *win) {
         if (targetScreen != nil) {
             NSRect frame = [window frame];
             NSRect screen = [targetScreen frame];
-            frame.origin = NSMakePoint(frame.origin.x + screen.origin.x, frame.origin.y + screen.origin.y);
+            frame.origin.x = screen.origin.x + (screen.size.width - frame.size.width) / 2;
+            frame.origin.y = screen.origin.y + (screen.size.height - frame.size.height) / 2;
             [window setFrame:frame display:YES];
         }
     }

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -352,6 +352,18 @@ func (w *window) getSecondaryMonitor() *monitor {
 	return primary
 }
 
+// findSiblingMonitor returns the monitor of an already-visible window in this app, or nil.
+func (w *window) findSiblingMonitor() *glfw.Monitor {
+	for _, other := range w.driver.windowList() {
+		ow, ok := other.(*window)
+		if !ok || ow == w || !ow.visible || ow.viewport == nil {
+			continue
+		}
+		return ow.getMonitorForWindow()
+	}
+	return nil
+}
+
 func (w *window) detectScale() float32 {
 	if build.IsWayland { // Wayland controls scale through content scaling
 		return 1
@@ -812,6 +824,17 @@ func (w *window) create() {
 	w.viewport = win
 	if w.view() == nil { // something went wrong above, it will have been logged
 		return
+	}
+
+	// macOS 26 places new windows on a different screen than existing app windows;
+	// default new windows onto the same monitor as a visible sibling when no position was set.
+	if runtime.GOOS == "darwin" && !build.IsWayland && w.xpos == 0 && w.ypos == 0 {
+		if monitor := w.findSiblingMonitor(); monitor != nil {
+			monX, monY := monitor.GetPos()
+			monMode := monitor.GetVideoMode()
+			w.xpos = monX + (monMode.Width-pixWidth)/2
+			w.ypos = monY + (monMode.Height-pixHeight)/2
+		}
 	}
 
 	if (w.xpos != 0 || w.ypos != 0) && !build.IsWayland {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -766,7 +766,8 @@ func (w *window) RescaleContext() {
 		w.width, w.height = w.viewport.GetSize()
 		scaledFull := fyne.NewSize(
 			scale.ToFyneCoordinate(w.canvas, w.width),
-			scale.ToFyneCoordinate(w.canvas, w.height))
+			scale.ToFyneCoordinate(w.canvas, w.height),
+		)
 		w.canvas.Resize(scaledFull)
 		return
 	}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -424,7 +424,8 @@ func TestWindow_HandleDragging(t *testing.T) {
 
 		// drag start and drag event with pressed mouse button
 		w.moveMouse(8, 8)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(4, 4),
@@ -439,7 +440,8 @@ func TestWindow_HandleDragging(t *testing.T) {
 
 		// drag event going outside the widget's area
 		w.moveMouse(16, 8)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(12, 4),
@@ -454,7 +456,8 @@ func TestWindow_HandleDragging(t *testing.T) {
 
 		// drag event entering a _different_ widget's area still for the widget dragged initially
 		w.moveMouse(22, 6)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(18, 2),
@@ -485,7 +488,8 @@ func TestWindow_HandleDragging(t *testing.T) {
 		// drag event for other widget
 		w.moveMouse(26, 9)
 		assert.Nil(t, d1.popDragEvent())
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(8, 5),
@@ -512,7 +516,8 @@ func TestWindow_DragObjectThatMoves(t *testing.T) {
 		w.moveMouse(12, 12)
 		w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
 		w.moveMouse(10, 10)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(6, 6),
@@ -529,7 +534,8 @@ func TestWindow_DragObjectThatMoves(t *testing.T) {
 
 		// drag again -> position is relative to new element position
 		w.moveMouse(12, 12)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(9, 9),
@@ -561,14 +567,16 @@ func TestWindow_DragIntoNewObjectKeepingFocus(t *testing.T) {
 		w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
 
 		// we should only have 2 mouse events on d1
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&desktop.MouseEvent{
 				PointEvent: fyne.PointEvent{Position: fyne.NewPos(7, 7), AbsolutePosition: fyne.NewPos(11, 11)},
 				Button:     desktop.MouseButtonPrimary,
 			},
 			d1.popMouseEvent(),
 		)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&desktop.MouseEvent{
 				PointEvent: fyne.PointEvent{Position: fyne.NewPos(17, 7), AbsolutePosition: fyne.NewPos(21, 11)},
 				Button:     desktop.MouseButtonPrimary,
@@ -615,7 +623,8 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 
 	runOnMain(func() {
 		w.moveMouse(10, 10)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&desktop.MouseEvent{PointEvent: fyne.PointEvent{
 				Position:         fyne.NewPos(6, 6),
 				AbsolutePosition: fyne.NewPos(10, 10),
@@ -624,7 +633,8 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 		)
 		w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
 		w.moveMouse(12, 12)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(8, 8),
@@ -637,7 +647,8 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 
 		// drag event going outside the widget's area
 		w.moveMouse(20, 12)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(16, 8),
@@ -652,7 +663,8 @@ func TestWindow_HoverableOnDragging(t *testing.T) {
 
 		// drag event going inside the widget's area again
 		w.moveMouse(12, 12)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			&fyne.DragEvent{
 				PointEvent: fyne.PointEvent{
 					Position:         fyne.NewPos(8, 8),

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -513,7 +513,8 @@ func (w *window) RescaleContext() {
 	w.width, w.height = w.viewport.GetSize()
 	scaledFull := fyne.NewSize(
 		scale.ToFyneCoordinate(w.canvas, w.width),
-		scale.ToFyneCoordinate(w.canvas, w.height))
+		scale.ToFyneCoordinate(w.canvas, w.height),
+	)
 	w.canvas.Resize(scaledFull)
 
 	// Ensure textures re-rasterize at the new scale

--- a/internal/driver/mobile/gl/gl.go
+++ b/internal/driver/mobile/gl/gl.go
@@ -160,12 +160,13 @@ func (ctx *context) CreateBuffer() Buffer {
 func (ctx *context) CreateProgram() Program {
 	return Program{
 		Init: true,
-		Value: uint32(ctx.enqueue(call{
-			args: fnargs{
-				fn: glfnCreateProgram,
+		Value: uint32(ctx.enqueue(
+			call{
+				args: fnargs{
+					fn: glfnCreateProgram,
+				},
+				blocking: true,
 			},
-			blocking: true,
-		},
 		)),
 	}
 }

--- a/internal/driver/mobile/menu_test.go
+++ b/internal/driver/mobile/menu_test.go
@@ -19,7 +19,8 @@ func TestMobileCanvas_DismissBar(t *testing.T) {
 	c := newCanvas(fyne.CurrentDevice()).(*canvas)
 	c.SetContent(fynecanvas.NewRectangle(theme.Color(theme.ColorNameBackground)))
 	menu := fyne.NewMainMenu(
-		fyne.NewMenu("Test"))
+		fyne.NewMenu("Test"),
+	)
 	c.showMenu(menu)
 	c.Resize(fyne.NewSize(100, 100))
 
@@ -35,7 +36,8 @@ func TestMobileCanvas_DismissMenu(t *testing.T) {
 	c.padded = false
 	c.SetContent(fynecanvas.NewRectangle(theme.Color(theme.ColorNameBackground)))
 	menu := fyne.NewMainMenu(
-		fyne.NewMenu("Test", fyne.NewMenuItem("TapMe", func() {})))
+		fyne.NewMenu("Test", fyne.NewMenuItem("TapMe", func() {})),
+	)
 	c.showMenu(menu)
 	c.Resize(fyne.NewSize(100, 100))
 
@@ -54,7 +56,8 @@ func TestMobileCanvas_Menu(t *testing.T) {
 	labels := []string{"File", "Edit"}
 	menu := fyne.NewMainMenu(
 		fyne.NewMenu(labels[0]),
-		fyne.NewMenu(labels[1]))
+		fyne.NewMenu(labels[1]),
+	)
 
 	c.showMenu(menu)
 	menuObjects := c.menu.(*fyne.Container).Objects[1].(*fyne.Container)
@@ -81,7 +84,8 @@ func TestMobileCanvas_MenuChild(t *testing.T) {
 	parent := fyne.NewMenuItem("Parent", func() {})
 	parent.ChildMenu = child
 	menu := fyne.NewMainMenu(
-		fyne.NewMenu("Top", parent))
+		fyne.NewMenu("Top", parent),
+	)
 
 	c.showMenu(menu)
 	topObj := c.menu.(*fyne.Container).Objects[1].(*fyne.Container).Objects[1].(*menuLabel)

--- a/internal/driver/mobile/mobileinit/ctx_android.go
+++ b/internal/driver/mobile/mobileinit/ctx_android.go
@@ -86,7 +86,7 @@ var currentCtx C.jobject
 func SetCurrentContext(vm unsafe.Pointer, ctx uintptr) {
 	currentVM = (*C.JavaVM)(vm)
 	currentCtxPrev := currentCtx
-	currentCtx = (C.jobject)(ctx)
+	currentCtx = C.jobject(ctx)
 	RunOnJVM(func(vm, jniEnv, ctx uintptr) error {
 		env := (*C.JNIEnv)(unsafe.Pointer(jniEnv))
 		C.deletePrevCtx(env, C.jobject(currentCtxPrev))

--- a/internal/driver/util_test.go
+++ b/internal/driver/util_test.go
@@ -293,10 +293,12 @@ func TestReverseWalkVisibleObjectTree_Clip(t *testing.T) {
 	rect := canvas.NewRectangle(color.White)
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	child := canvas.NewRectangle(color.Black)
-	base := container.NewGridWithColumns(1,
+	base := container.NewGridWithColumns(
+		1,
 		rect,
 		internal_widget.NewScroll(child),
-		container.NewGridWithColumns(2,
+		container.NewGridWithColumns(
+			2,
 			canvas.NewCircle(color.White),
 			canvas.NewCircle(color.White),
 			canvas.NewCircle(color.White),
@@ -364,10 +366,12 @@ func TestWalkVisibleObjectTree_Clip(t *testing.T) {
 	rect := canvas.NewRectangle(color.White)
 	rect.SetMinSize(fyne.NewSize(100, 100))
 	child := canvas.NewRectangle(color.Black)
-	base := container.NewGridWithColumns(1,
+	base := container.NewGridWithColumns(
+		1,
 		rect,
 		internal_widget.NewScroll(child),
-		container.NewGridWithColumns(2,
+		container.NewGridWithColumns(
+			2,
 			canvas.NewCircle(color.White),
 			canvas.NewCircle(color.White),
 			canvas.NewCircle(color.White),

--- a/internal/painter/draw.go
+++ b/internal/painter/draw.go
@@ -493,14 +493,16 @@ func drawRegularPolygon(cx, cy, radius, cornerRadius, rot float64, sides int, p 
 
 	// start at s0, arc corner 0, then line+arc around, close last edge
 	p.Start(rasterx.ToFixedP(sPts[0].x, sPts[0].y))
-	gf(p,
+	gf(
+		p,
 		rasterx.ToFixedP(cPts[0].x, cPts[0].y),
 		rasterx.ToFixedP(vS[0].x, vS[0].y),
 		rasterx.ToFixedP(vE[0].x, vE[0].y),
 	)
 	for i := 1; i < sides; i++ {
 		p.Line(rasterx.ToFixedP(sPts[i].x, sPts[i].y))
-		gf(p,
+		gf(
+			p,
 			rasterx.ToFixedP(cPts[i].x, cPts[i].y),
 			rasterx.ToFixedP(vS[i].x, vS[i].y),
 			rasterx.ToFixedP(vE[i].x, vE[i].y),
@@ -588,7 +590,8 @@ func drawArbitraryPolygon(xs, ys, radii []float64, p rasterx.Adder) {
 		nxtIdx := (i + 1) % num
 
 		// draw the arc at the current vertex
-		rasterx.RoundGap(p,
+		rasterx.RoundGap(
+			p,
 			rasterx.ToFixedP(centers[i].x, centers[i].y),
 			rasterx.ToFixedP(startPoints[i].x-centers[i].x, startPoints[i].y-centers[i].y),
 			rasterx.ToFixedP(endPoints[i].x-centers[i].x, endPoints[i].y-centers[i].y),

--- a/layout/boxlayout_test.go
+++ b/layout/boxlayout_test.go
@@ -76,7 +76,7 @@ func TestHBoxLayout_HiddenItem(t *testing.T) {
 	// We are not in a window. Resize the container to a default size.
 	container.Resize(container.MinSize())
 
-	assert.Equal(t, container.MinSize(), fyne.NewSize(100+(theme.Padding()), 50))
+	assert.Equal(t, container.MinSize(), fyne.NewSize(100+theme.Padding(), 50))
 
 	assert.Equal(t, obj1.Size(), cellSize)
 	cell3Pos := fyne.NewPos(50+theme.Padding(), 0)
@@ -218,7 +218,7 @@ func TestVBoxLayout_HiddenItem(t *testing.T) {
 	// We are not in a window. Resize the container to a default size.
 	container.Resize(container.MinSize())
 
-	assert.Equal(t, container.MinSize(), fyne.NewSize(50, 100+(theme.Padding())))
+	assert.Equal(t, container.MinSize(), fyne.NewSize(50, 100+theme.Padding()))
 
 	assert.Equal(t, obj1.Size(), cellSize)
 	cell3Pos := fyne.NewPos(0, 50+theme.Padding())

--- a/widget/calendar.go
+++ b/widget/calendar.go
@@ -220,8 +220,8 @@ func (g *calendarLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
 // Get the leading edge position of a grid cell.
 // The row and col specify where the cell is in the calendar.
 func (g *calendarLayout) getLeading(row, col int) fyne.Position {
-	x := (g.cellSize.Width) * float32(col)
-	y := (g.cellSize.Height) * float32(row)
+	x := g.cellSize.Width * float32(col)
+	y := g.cellSize.Height * float32(row)
 
 	return fyne.NewPos(float32(math.Round(float64(x))), float32(math.Round(float64(y))))
 }

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -155,7 +155,8 @@ func TestForm_Disabled(t *testing.T) {
 	disabled.Disable()
 	f := NewForm(
 		NewFormItem("Form Item 1", NewEntry()),
-		NewFormItem("Form Item 2", disabled))
+		NewFormItem("Form Item 2", disabled),
+	)
 
 	w := test.NewWindow(f)
 	defer w.Close()

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -95,7 +95,8 @@ func NewGridWrapWithData(data binding.DataList, createItem func() fyne.CanvasObj
 				return
 			}
 			updateItem(item, o)
-		})
+		},
+	)
 
 	data.AddListener(binding.NewDataListener(gwList.Refresh))
 	return gwList

--- a/widget/list.go
+++ b/widget/list.go
@@ -100,7 +100,8 @@ func NewListWithData(data binding.DataList, createItem func() fyne.CanvasObject,
 				return
 			}
 			updateItem(item, o)
-		})
+		},
+	)
 
 	data.AddListener(binding.NewDataListener(l.Refresh))
 	return l

--- a/widget/list_internal_test.go
+++ b/widget/list_internal_test.go
@@ -40,7 +40,8 @@ func TestNewListWithData(t *testing.T) {
 		data.Append(fmt.Sprintf("Test Item %d", i))
 	}
 
-	list := NewListWithData(data,
+	list := NewListWithData(
+		data,
 		func() fyne.CanvasObject {
 			return NewLabel("Template Object")
 		},
@@ -80,7 +81,8 @@ func TestList_MinSize(t *testing.T) {
 					r.Resize(tt.cellSize)
 					return r
 				},
-				func(ListItemID, fyne.CanvasObject) {}).MinSize())
+				func(ListItemID, fyne.CanvasObject) {},
+			).MinSize())
 		})
 	}
 }
@@ -105,7 +107,8 @@ func TestList_Resize(t *testing.T) {
 			return NewButton("", func() {})
 		},
 		func(ListItemID, fyne.CanvasObject) {
-		})
+		},
+	)
 	list.Resize(list.Size())
 }
 
@@ -118,7 +121,8 @@ func TestList_SetItemHeight(t *testing.T) {
 			return r
 		},
 		func(ListItemID, fyne.CanvasObject) {
-		})
+		},
+	)
 
 	lay := test.TempWidgetRenderer(t, list).(*listRenderer).layout
 	assert.Equal(t, fyne.NewSize(32, 32), list.MinSize())
@@ -144,7 +148,8 @@ func TestList_SetItemHeight_InUpdate(t *testing.T) {
 		},
 		func(id ListItemID, o fyne.CanvasObject) {
 			list.SetItemHeight(id, 32)
-		})
+		},
+	)
 
 	done := make(chan struct{})
 	go func() {

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -89,7 +89,8 @@ func setupList(t *testing.T) (*widget.List, fyne.Window, []*resizeRefreshCountin
 		},
 		func(id widget.ListItemID, o fyne.CanvasObject) {
 			o.(*resizeRefreshCountingLabel).SetText(fmt.Sprintf("Test Item %d", id))
-		})
+		},
+	)
 	w := test.NewTempWindow(t, list)
 	w.SetPadded(false)
 	w.Resize(fyne.NewSize(200, 200))

--- a/widget/menu_desktop_test.go
+++ b/widget/menu_desktop_test.go
@@ -207,7 +207,8 @@ func TestMenu_Scrolling(t *testing.T) {
 	w.SetPadded(false)
 	c := w.Canvas()
 
-	menu := fyne.NewMenu("",
+	menu := fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("A", nil),
 		fyne.NewMenuItem("B", nil),
 		fyne.NewMenuItem("C", nil),
@@ -249,11 +250,13 @@ func TestMenu_TraverseMenu(t *testing.T) {
 	c := w.Canvas()
 
 	itemWithChild := fyne.NewMenuItem("Bar", nil)
-	itemWithChild.ChildMenu = fyne.NewMenu("",
+	itemWithChild.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("SubA", nil),
 		fyne.NewMenuItem("SubB", nil),
 	)
-	m := widget.NewMenu(fyne.NewMenu("",
+	m := widget.NewMenu(fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("Foo", nil),
 		fyne.NewMenuItemSeparator(),
 		itemWithChild,
@@ -326,12 +329,14 @@ func TestMenu_TriggerTraversedMenu(t *testing.T) {
 		triggered = ""
 		dismissed = false
 		itemWithChild := fyne.NewMenuItem("Bar", func() { triggered = "2nd" })
-		itemWithChild.ChildMenu = fyne.NewMenu("",
+		itemWithChild.ChildMenu = fyne.NewMenu(
+			"",
 			fyne.NewMenuItem("SubA", func() { triggered = "1st sub" }),
 			fyne.NewMenuItem("SubB", nil),
 			fyne.NewMenuItem("SubC", func() { triggered = "3rd sub" }),
 		)
-		m := widget.NewMenu(fyne.NewMenu("",
+		m := widget.NewMenu(fyne.NewMenu(
+			"",
 			fyne.NewMenuItem("Foo", func() { triggered = "1st" }),
 			fyne.NewMenuItemSeparator(),
 			itemWithChild,

--- a/widget/menu_internal_desktop_test.go
+++ b/widget/menu_internal_desktop_test.go
@@ -15,23 +15,27 @@ import (
 
 func TestMenu_ItemHovered(t *testing.T) {
 	sub1 := fyne.NewMenuItem("sub1", nil)
-	sub1.ChildMenu = fyne.NewMenu("",
+	sub1.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("sub1 A", nil),
 		fyne.NewMenuItem("sub1 B", nil),
 	)
 	sub2sub := fyne.NewMenuItem("sub2sub", nil)
-	sub2sub.ChildMenu = fyne.NewMenu("",
+	sub2sub.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("sub2sub A", nil),
 		fyne.NewMenuItem("sub2sub B", nil),
 	)
 	sub2 := fyne.NewMenuItem("sub2", nil)
-	sub2.ChildMenu = fyne.NewMenu("",
+	sub2.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("sub2 A", nil),
 		fyne.NewMenuItem("sub2 B", nil),
 		sub2sub,
 	)
 	m := NewMenu(
-		fyne.NewMenu("",
+		fyne.NewMenu(
+			"",
 			fyne.NewMenuItem("Foo", nil),
 			fyne.NewMenuItemSeparator(),
 			fyne.NewMenuItem("Bar", nil),

--- a/widget/menu_internal_mobile_test.go
+++ b/widget/menu_internal_mobile_test.go
@@ -13,23 +13,27 @@ import (
 
 func TestMenu_ItemWithChildTapped(t *testing.T) {
 	sub1 := fyne.NewMenuItem("sub1", nil)
-	sub1.ChildMenu = fyne.NewMenu("",
+	sub1.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("sub1 A", nil),
 		fyne.NewMenuItem("sub1 B", nil),
 	)
 	sub2sub := fyne.NewMenuItem("sub2sub", nil)
-	sub2sub.ChildMenu = fyne.NewMenu("",
+	sub2sub.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("sub2sub A", nil),
 		fyne.NewMenuItem("sub2sub B", nil),
 	)
 	sub2 := fyne.NewMenuItem("sub2", nil)
-	sub2.ChildMenu = fyne.NewMenu("",
+	sub2.ChildMenu = fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("sub2 A", nil),
 		fyne.NewMenuItem("sub2 B", nil),
 		sub2sub,
 	)
 	m := NewMenu(
-		fyne.NewMenu("",
+		fyne.NewMenu(
+			"",
 			fyne.NewMenuItem("Foo", nil),
 			fyne.NewMenuItemSeparator(),
 			fyne.NewMenuItem("Bar", nil),

--- a/widget/menu_mobile_test.go
+++ b/widget/menu_mobile_test.go
@@ -141,7 +141,8 @@ func TestMenu_Dragging(t *testing.T) {
 	w.SetPadded(false)
 	c := w.Canvas()
 
-	menu := fyne.NewMenu("",
+	menu := fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("A", nil),
 		fyne.NewMenuItem("B", nil),
 		fyne.NewMenuItem("C", nil),

--- a/widget/menu_test.go
+++ b/widget/menu_test.go
@@ -26,7 +26,8 @@ func TestMenu_RefreshOptions(t *testing.T) {
 	itemBar.Icon = theme.AccountIcon()
 	itemBaz := fyne.NewMenuItem("Baz", nil)
 
-	m := widget.NewMenu(fyne.NewMenu("",
+	m := widget.NewMenu(fyne.NewMenu(
+		"",
 		itemFoo,
 		fyne.NewMenuItemSeparator(),
 		itemBar,
@@ -73,7 +74,8 @@ func TestMenu_TappedPaddingOrSeparator(t *testing.T) {
 	c := w.Canvas()
 
 	var item1Hit, item2Hit, overlayContainerHit bool
-	m := widget.NewMenu(fyne.NewMenu("",
+	m := widget.NewMenu(fyne.NewMenu(
+		"",
 		fyne.NewMenuItem("Foo", func() { item1Hit = true }),
 		fyne.NewMenuItemSeparator(),
 		fyne.NewMenuItem("Bar", func() { item2Hit = true }),

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -69,7 +69,8 @@ func TestShowPopUpAtRelativePosition(t *testing.T) {
 	parent1 := NewLabel("Parent1")
 	parent2 := NewLabel("Parent2")
 	w := test.NewTempWindow(
-		t, &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: []fyne.CanvasObject{parent1, parent2}})
+		t, &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: []fyne.CanvasObject{parent1, parent2}},
+	)
 	w.Resize(fyne.NewSize(100, 200))
 
 	ShowPopUpAtRelativePosition(label, w.Canvas(), pos, parent2)

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -423,7 +423,8 @@ func TestText_DeleteFromTo_Segments(t *testing.T) {
 func TestText_Multiline(t *testing.T) {
 	text := NewRichText(
 		&TextSegment{Text: "line1\nli", Style: RichTextStyleStrong},
-		&TextSegment{Text: "ne2\nline3", Style: RichTextStyleInline})
+		&TextSegment{Text: "ne2\nline3", Style: RichTextStyleInline},
+	)
 
 	w := test.NewTempWindow(t, text)
 	w.Resize(fyne.NewSize(64, 90))

--- a/widget/select_entry_internal_test.go
+++ b/widget/select_entry_internal_test.go
@@ -96,7 +96,8 @@ func TestSelectEntry_DropDownMove(t *testing.T) {
 	// first movement
 	e.Move(fyne.NewPos(10, 10))
 	assert.Equal(t, fyne.NewPos(10, 10), e.Entry.Position())
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		fyne.NewPos(10, 10+entrySize.Height-theme.InputBorderSize()).Subtract(inset),
 		e.popUp.Position(),
 	)
@@ -104,7 +105,8 @@ func TestSelectEntry_DropDownMove(t *testing.T) {
 	// second movement
 	e.Move(fyne.NewPos(30, 27))
 	assert.Equal(t, fyne.NewPos(30, 27), e.Entry.Position())
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		fyne.NewPos(30, 27+entrySize.Height-theme.InputBorderSize()).Subtract(inset),
 		e.popUp.Position(),
 	)

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -488,13 +488,15 @@ func (s *sliderRenderer) Layout(size fyne.Size) {
 		activeSize = fyne.NewSize(trackWidth, trackSize.Height-activeOffset+endPad)
 
 		thumbPos = fyne.NewPos(
-			trackPos.X-(diameter-trackSize.Width)/2, activeOffset-(diameter/2))
+			trackPos.X-(diameter-trackSize.Width)/2, activeOffset-(diameter/2),
+		)
 	case Horizontal:
 		activePos = trackPos
 		activeSize = fyne.NewSize(activeOffset-endPad, trackWidth)
 
 		thumbPos = fyne.NewPos(
-			activeOffset-(diameter/2), trackPos.Y-(diameter-trackSize.Height)/2)
+			activeOffset-(diameter/2), trackPos.Y-(diameter-trackSize.Height)/2,
+		)
 	}
 
 	s.active.Move(activePos)

--- a/widget/table_desktop_test.go
+++ b/widget/table_desktop_test.go
@@ -22,7 +22,8 @@ func TestTable_Hovered(t *testing.T) {
 		},
 		func(id TableCellID, c fyne.CanvasObject) {
 			c.(*Label).SetText(fmt.Sprintf("Cell %d, %d", id.Row, id.Col))
-		})
+		},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()

--- a/widget/table_internal_test.go
+++ b/widget/table_internal_test.go
@@ -33,7 +33,8 @@ func TestTable_Cache(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 	c.SetContent(table)
 	c.SetPadded(false)
 	c.Resize(fyne.NewSize(120, 148))
@@ -63,7 +64,8 @@ func TestTable_ChangeTheme(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 	table.CreateRenderer()
 
 	table.Resize(fyne.NewSize(50, 30))
@@ -95,7 +97,8 @@ func TestTable_Filled(t *testing.T) {
 			r.Resize(fyne.NewSize(30, 20))
 			return r
 		},
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -115,7 +118,8 @@ func TestTable_Focus(t *testing.T) {
 			r.Resize(fyne.NewSize(30, 20))
 			return r
 		},
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	window := test.NewWindow(table)
 	defer window.Close()
@@ -156,7 +160,8 @@ func TestTable_Headers(t *testing.T) {
 			return NewLabel("text")
 		},
 		func(_ TableCellID, _ fyne.CanvasObject) {
-		})
+		},
+	)
 	table.Resize(fyne.NewSize(120, 120))
 
 	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
@@ -177,7 +182,8 @@ func TestTable_JustHeaders(t *testing.T) {
 			return NewLabel("text")
 		},
 		func(_ TableCellID, _ fyne.CanvasObject) {
-		})
+		},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -194,7 +200,8 @@ func TestTable_Sticky(t *testing.T) {
 		},
 		func(i TableCellID, o fyne.CanvasObject) {
 			o.(*Label).SetText(fmt.Sprintf("text %d,%d", i.Row, i.Col))
-		})
+		},
+	)
 	table.Resize(fyne.NewSize(120, 120))
 
 	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells)).(*tableCellsRenderer)
@@ -290,7 +297,8 @@ func TestTable_MinSize(t *testing.T) {
 					r.Resize(tt.cellSize)
 					return r
 				},
-				func(TableCellID, fyne.CanvasObject) {})
+				func(TableCellID, fyne.CanvasObject) {},
+			)
 			table.ShowHeaderRow = tt.headRow
 			table.ShowHeaderColumn = tt.headCol
 			table.CreateHeader = func() fyne.CanvasObject {
@@ -313,7 +321,8 @@ func TestTable_Resize(t *testing.T) {
 		func() fyne.CanvasObject {
 			return NewLabel("abc")
 		},
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	w := test.NewTempWindow(t, table)
 	w.Resize(fyne.NewSize(100, 100))
@@ -331,7 +340,8 @@ func TestTable_Unselect(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 	unselectedRow, unselectedColumn := -1, -1
 	table.OnUnselected = func(id TableCellID) {
 		unselectedRow = id.Row
@@ -368,7 +378,8 @@ func TestTable_Refresh(t *testing.T) {
 		},
 		func(_ TableCellID, obj fyne.CanvasObject) {
 			obj.(*Label).SetText(displayText)
-		})
+		},
+	)
 	table.Resize(fyne.NewSize(120, 120))
 
 	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
@@ -404,7 +415,8 @@ func TestTable_Highlight(t *testing.T) {
 	table := NewTable(
 		func() (int, int) { return maxRows, maxCols },
 		func() fyne.CanvasObject { return templ },
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -440,7 +452,8 @@ func TestTable_ScrollTo(t *testing.T) {
 	table := NewTable(
 		func() (int, int) { return maxRows, maxCols },
 		func() fyne.CanvasObject { return templ },
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -533,7 +546,8 @@ func TestTable_ScrollToBottom(t *testing.T) {
 	table := NewTable(
 		func() (int, int) { return maxRows, maxCols },
 		func() fyne.CanvasObject { return templ },
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -561,7 +575,8 @@ func TestTable_ScrollToLeading(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -591,7 +606,8 @@ func TestTable_ScrollToOffset(t *testing.T) {
 	table := NewTable(
 		func() (int, int) { return maxRows, maxCols },
 		func() fyne.CanvasObject { return templ },
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -618,7 +634,8 @@ func TestTable_ScrollToTop(t *testing.T) {
 	table := NewTable(
 		func() (int, int) { return maxRows, maxCols },
 		func() fyne.CanvasObject { return templ },
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -644,7 +661,8 @@ func TestTable_ScrollToTrailing(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -672,7 +690,8 @@ func TestTable_Selection(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 	assert.Nil(t, table.selectedCell)
 
 	w := test.NewWindow(table)
@@ -715,7 +734,8 @@ func TestTable_Selection_OnHeader(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 	assert.Nil(t, table.selectedCell)
 
 	w := test.NewWindow(table)
@@ -744,7 +764,8 @@ func TestTable_Select(t *testing.T) {
 		func(id TableCellID, c fyne.CanvasObject) {
 			text := fmt.Sprintf("Cell %d, %d", id.Row, id.Col)
 			c.(*Label).SetText(text)
-		})
+		},
+	)
 
 	w := test.NewWindow(table)
 	defer w.Close()
@@ -798,7 +819,8 @@ func TestTable_SetColumnWidth(t *testing.T) {
 				obj.(*Label).Text = "placeholder"
 			}
 			obj.Refresh()
-		})
+		},
+	)
 	table.SetColumnWidth(0, 32)
 	table.Resize(fyne.NewSize(120, 120))
 	table.Select(TableCellID{1, 0})
@@ -829,7 +851,8 @@ func TestTable_SetColumnWidth_Dragged(t *testing.T) {
 			return NewLabel("")
 		},
 		func(id TableCellID, obj fyne.CanvasObject) {
-		})
+		},
+	)
 	table.ShowHeaderColumn = false
 	table.StickyColumnCount = 0
 	table.Refresh()
@@ -878,7 +901,8 @@ func TestTable_SetRowHeight(t *testing.T) {
 				obj.(*Label).Text = "place\nholder"
 			}
 			obj.Refresh()
-		})
+		},
+	)
 	table.SetRowHeight(0, 48)
 	table.Resize(fyne.NewSize(120, 120))
 	table.Select(TableCellID{0, 1})
@@ -909,7 +933,8 @@ func TestTable_SetRowHeight_Dragged(t *testing.T) {
 			return NewLabel("")
 		},
 		func(id TableCellID, obj fyne.CanvasObject) {
-		})
+		},
+	)
 	table.ShowHeaderRow = false
 	table.StickyRowCount = 0
 	table.Refresh()
@@ -948,7 +973,8 @@ func TestTable_ShowVisible(t *testing.T) {
 		func() fyne.CanvasObject {
 			return NewLabel("placeholder")
 		},
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 	table.Resize(fyne.NewSize(120, 120))
 
 	cellRenderer := test.TempWidgetRenderer(t, table.content.Content.(*tableCells))
@@ -966,7 +992,8 @@ func TestTable_SeparatorThicknessZero_NotPanics(t *testing.T) {
 		func() fyne.CanvasObject {
 			return NewLabel("placeholder")
 		},
-		func(TableCellID, fyne.CanvasObject) {})
+		func(TableCellID, fyne.CanvasObject) {},
+	)
 
 	assert.NotPanics(t, func() {
 		table.Resize(fyne.NewSize(400, 644))

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -892,7 +892,8 @@ func (t *textGridRowRenderer) MinSize() fyne.Size {
 
 	return fyne.NewSize(
 		t.obj.text.cellSize.Width*float32(len(t.obj.text.text.Rows[t.obj.row].Cells)),
-		t.obj.text.cellSize.Height)
+		t.obj.text.cellSize.Height,
+	)
 }
 
 func (t *textGridRowRenderer) Refresh() {

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -97,7 +97,8 @@ func NewTreeWithData(data binding.DataTree, createItem func(bool) fyne.CanvasObj
 				return
 			}
 			updateItem(item, branch, o)
-		})
+		},
+	)
 
 	data.AddListener(binding.NewDataListener(t.Refresh))
 	return t

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -449,7 +449,7 @@ func TestTree_MinSize(t *testing.T) {
 			opened: []string{"A"},
 			want: fyne.NewSize(
 				templateMinSize.Width+indentation()+2*theme.Padding()+theme.IconInlineSize(),
-				(fyne.Max(templateMinSize.Height, theme.IconInlineSize()))*2+separatorThickness,
+				fyne.Max(templateMinSize.Height, theme.IconInlineSize())*2+separatorThickness,
 			),
 		},
 		"multiple_items": {
@@ -466,7 +466,7 @@ func TestTree_MinSize(t *testing.T) {
 			},
 			want: fyne.NewSize(
 				templateMinSize.Width+2*theme.Padding()+theme.IconInlineSize(),
-				(fyne.Max(templateMinSize.Height, theme.IconInlineSize()))*2+separatorThickness,
+				fyne.Max(templateMinSize.Height, theme.IconInlineSize())*2+separatorThickness,
 			),
 		},
 		"multiple_items_opened": {
@@ -484,7 +484,7 @@ func TestTree_MinSize(t *testing.T) {
 			opened: []string{"A", "B", "C"},
 			want: fyne.NewSize(
 				templateMinSize.Width+2*indentation()+theme.IconInlineSize()+2*theme.Padding(),
-				(fyne.Max(templateMinSize.Height, theme.IconInlineSize()))*6+(5*separatorThickness),
+				fyne.Max(templateMinSize.Height, theme.IconInlineSize())*6+(5*separatorThickness),
 			),
 		},
 	} {
@@ -583,7 +583,7 @@ func TestTree_ScrollTo(t *testing.T) {
 	)
 
 	// Resize tall enough to display two nodes and the separator between them
-	treeHeight := 2*(min.Height) + sep
+	treeHeight := 2*min.Height + sep
 	w.Resize(fyne.Size{
 		Width:  100,
 		Height: treeHeight + 2*theme.Padding(),
@@ -625,7 +625,7 @@ func TestTree_ScrollToBottom(t *testing.T) {
 	)
 
 	// Resize tall enough to display two nodes and the separator between them
-	treeHeight := 2*(min.Height) + sep
+	treeHeight := 2*min.Height + sep
 	w.Resize(fyne.Size{
 		Width:  400,
 		Height: treeHeight + 2*theme.Padding(),

--- a/widget/tree_test.go
+++ b/widget/tree_test.go
@@ -32,7 +32,8 @@ func TestNewTreeWithData(t *testing.T) {
 		data.Append("1", fmt.Sprintf("%d", 1000+i), fmt.Sprintf("Child Item %d", i))
 	}
 
-	tree := widget.NewTreeWithData(data,
+	tree := widget.NewTreeWithData(
+		data,
 		func(bool) fyne.CanvasObject {
 			return widget.NewLabel("Template Object")
 		},


### PR DESCRIPTION
All windows go to biggest screen rather than main or current. We want current for windows then fullscreenSeconary is the secondary UNLESS that is current, in which case next.

Fixes issues where an app opens windows on a different display and fullscreen and fullscreensecondary use the same screen

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included. <- launch fyne_demo and open a new window. On multi-monitor macOS 26 you might see them appear on different displays
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

