### PR TITLE
Set shaping language for localized glyphs

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -260,6 +260,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 	s = strings.ReplaceAll(s, "\r", "")
 
 	runes := []rune(s)
+	langID := language.Language(lang.SystemLocale().LanguageString())
 	in := shaping.Input{
 		Text:      []rune{' '},
 		RunStart:  0,
@@ -267,6 +268,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 		Direction: di.DirectionLTR,
 		Face:      faces.ResolveFace(' '),
 		Size:      textSize,
+		Language:  langID,
 	}
 	shaper := &shaping.HarfbuzzShaper{}
 	segmenter := &shaping.Segmenter{}


### PR DESCRIPTION
### Description:

This change passes the current system locale language into the text shaping input.

Some CJK fonts contain different glyph shapes for the same Unicode character. For example, `Noto Sans CJK SC` is intended for Simplified Chinese, while `Noto Sans CJK JP` is intended for Japanese. The Unicode text can be the same, but the rendered glyph can look different depending on the language passed to the shaping engine.

In local testing with `zh-CN`, some Simplified Chinese characters were rendered with JP-style glyphs. After passing the system locale language into the shaping input, those characters rendered with the expected Simplified Chinese glyphs.

During testing, one golden/markup difference was observed in:

`fyne.io/fyne/v2/widget: TestMenu_Layout/menu_with_shortcuts`

The difference appears to be limited to shortcut arrow glyph layout/widths. My small local testing showed that, with locale-aware font selection, shortcut arrows rendered as normal text may resolve to a different font under `zh-CN` than under the default test locale. Arrows rendered with `TextStyle{Symbol: true}` continue to resolve to the symbol font.

One possible related cause is that shortcut arrows such as `↓`, `←`, `→`, and `↑` are single runes but multiple bytes in UTF-8. If code checks `len(s) == 1`, these arrows are not treated as single-character symbols. A possible follow-up fix would be to use rune-counting for that check.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

### Testing:

Ran:

```sh
gofmt -w internal/painter/font.go
go vet ./internal/painter
go vet ./...
go test ./internal/painter
```

These passed locally.

Also ran:

```sh
go test ./...
```

This did not fully pass in the local environment. Observed failures included:

- `fyne.io/fyne/v2/widget`: `TestMenu_Layout/menu_with_shortcuts` golden/markup difference involving shortcut arrow glyph widths.
- `fyne.io/fyne/v2/internal/driver/glfw`: golden image mismatch.
- `fyne.io/fyne/v2/internal/driver/mobile`: `Test_canvas_Dragged`.
- `fyne.io/fyne/v2/internal/repository`: HTTP repository tests.

The `widget` failure may be related to this change because the shortcut arrow glyphs can resolve to a different font. The other failures were not investigated as part of this change.