### PR TITLE
Fix indentation of wrapped list items in RichText

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -57,7 +57,7 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		return renderChildren(source, n, blockquote, listDepth)
 	case *ast.Paragraph:
 		children, err := renderChildren(source, n, blockquote, listDepth)
-		if !blockquote {
+		if !blockquote && listDepth == 0 {
 			linebreak := &TextSegment{Style: RichTextStyleParagraph}
 			children = append(children, linebreak)
 		}

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -406,6 +406,7 @@ func (t *RichText) updateRowBounds() {
 	wrapWidth := maxWidth
 
 	var currentBound *rowBoundary
+	trueLineStart := true
 	var iterateSegments func(segList []RichTextSegment)
 	iterateSegments = func(segList []RichTextSegment) {
 		for _, seg := range segList {
@@ -415,6 +416,7 @@ func (t *RichText) updateRowBounds() {
 				if len(segs) > 0 && !segs[len(segs)-1].Inline() {
 					wrapWidth = maxWidth
 					currentBound = nil
+					trueLineStart = true
 				}
 				continue
 			}
@@ -435,6 +437,7 @@ func (t *RichText) updateRowBounds() {
 				} else {
 					wrapWidth = maxWidth
 					currentBound = nil
+					trueLineStart = true
 					fitSize.Height -= itemMin.Height + th.Size(theme.SizeNameLineSpacing)
 				}
 				continue
@@ -459,7 +462,9 @@ func (t *RichText) updateRowBounds() {
 				if len(retBounds) > 0 {
 					bounds[len(bounds)-1].end = retBounds[0].end // invalidate row ending as we have more content
 					bounds[len(bounds)-1].segments = append(bounds[len(bounds)-1].segments, seg)
-					alignWrappedText(&bounds[len(bounds)-1], retBounds[1:], seg, maxWidth-wrapWidth)
+					if trueLineStart {
+						alignWrappedText(&bounds[len(bounds)-1], retBounds[1:], seg, maxWidth-wrapWidth)
+					}
 					bounds = append(bounds, retBounds[1:]...)
 
 					fitSize.Height -= height
@@ -492,10 +497,12 @@ func (t *RichText) updateRowBounds() {
 					wrapWidth -= lastWidth
 				} else {
 					wrapWidth = maxWidth - lastWidth
+					trueLineStart = false
 				}
 			} else {
 				currentBound = nil
 				wrapWidth = maxWidth
+				trueLineStart = true
 			}
 		}
 	}

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -406,17 +406,17 @@ func (t *RichText) updateRowBounds() {
 	wrapWidth := maxWidth
 
 	var currentBound *rowBoundary
-	trueLineStart := true
-	var iterateSegments func(segList []RichTextSegment)
-	iterateSegments = func(segList []RichTextSegment) {
+	currentBoundDepth := 0
+	var iterateSegments func(segList []RichTextSegment, depth int)
+	iterateSegments = func(segList []RichTextSegment, depth int) {
 		for _, seg := range segList {
 			if parent, ok := seg.(RichTextBlock); ok {
 				segs := parent.Segments()
-				iterateSegments(segs)
+				iterateSegments(segs, depth+1)
 				if len(segs) > 0 && !segs[len(segs)-1].Inline() {
 					wrapWidth = maxWidth
 					currentBound = nil
-					trueLineStart = true
+					currentBoundDepth = depth
 				}
 				continue
 			}
@@ -427,6 +427,7 @@ func (t *RichText) updateRowBounds() {
 					bound := rowBoundary{segments: []RichTextSegment{seg}}
 					bounds = append(bounds, bound)
 					currentBound = &bound
+					currentBoundDepth = depth
 				} else {
 					bounds[len(bounds)-1].segments = append(bounds[len(bounds)-1].segments, seg)
 				}
@@ -437,7 +438,7 @@ func (t *RichText) updateRowBounds() {
 				} else {
 					wrapWidth = maxWidth
 					currentBound = nil
-					trueLineStart = true
+					currentBoundDepth = depth
 					fitSize.Height -= itemMin.Height + th.Size(theme.SizeNameLineSpacing)
 				}
 				continue
@@ -462,9 +463,11 @@ func (t *RichText) updateRowBounds() {
 				if len(retBounds) > 0 {
 					bounds[len(bounds)-1].end = retBounds[0].end // invalidate row ending as we have more content
 					bounds[len(bounds)-1].segments = append(bounds[len(bounds)-1].segments, seg)
-					if trueLineStart {
-						alignWrappedText(&bounds[len(bounds)-1], retBounds[1:], seg, maxWidth-wrapWidth)
+					xOff := float32(0)
+					if depth > currentBoundDepth {
+						xOff = maxWidth - wrapWidth
 					}
+					alignWrappedText(&bounds[len(bounds)-1], retBounds[1:], seg, xOff)
 					bounds = append(bounds, retBounds[1:]...)
 
 					fitSize.Height -= height
@@ -475,6 +478,7 @@ func (t *RichText) updateRowBounds() {
 				fitSize.Height -= height
 			}
 			currentBound = &bounds[len(bounds)-1]
+			currentBoundDepth = depth
 			if seg.Inline() {
 				last := bounds[len(bounds)-1]
 				begin := 0
@@ -497,17 +501,16 @@ func (t *RichText) updateRowBounds() {
 					wrapWidth -= lastWidth
 				} else {
 					wrapWidth = maxWidth - lastWidth
-					trueLineStart = false
 				}
 			} else {
 				currentBound = nil
+				currentBoundDepth = depth
 				wrapWidth = maxWidth
-				trueLineStart = true
 			}
 		}
 	}
 
-	iterateSegments(t.Segments)
+	iterateSegments(t.Segments, 0)
 	t.rowBounds = bounds
 }
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -459,20 +459,7 @@ func (t *RichText) updateRowBounds() {
 				if len(retBounds) > 0 {
 					bounds[len(bounds)-1].end = retBounds[0].end // invalidate row ending as we have more content
 					bounds[len(bounds)-1].segments = append(bounds[len(bounds)-1].segments, seg)
-					// continuation rows that result from wrapping (not \n) inherit the indent
-					// from the first row so that wrapped text aligns after the bullet/prefix.
-					continuationIndent := bounds[len(bounds)-1].indent + (maxWidth - wrapWidth)
-					if continuationIndent > 0 {
-						runes := []rune(seg.Textual())
-						for i := range retBounds[1:] {
-							b := &retBounds[1+i]
-							// skip newline-broken rows — text[b.begin-1] is '\n'
-							if b.begin > 0 && b.begin <= len(runes) && runes[b.begin-1] == '\n' {
-								continue
-							}
-							b.indent = continuationIndent
-						}
-					}
+					alignWrappedText(&bounds[len(bounds)-1], retBounds[1:], seg, maxWidth-wrapWidth)
 					bounds = append(bounds, retBounds[1:]...)
 
 					fitSize.Height -= height
@@ -1194,6 +1181,22 @@ func setAlign(obj fyne.CanvasObject, align fyne.TextAlign) {
 			link.Alignment = align
 			link.Refresh()
 		}
+	}
+}
+
+func alignWrappedText(priorBound *rowBoundary, wrappedBounds []rowBoundary, seg RichTextSegment, xOffset float32) {
+	indent := priorBound.indent + xOffset
+	if indent <= 0 {
+		return
+	}
+
+	runes := []rune(seg.Textual())
+	for i := range wrappedBounds {
+		b := &wrappedBounds[i]
+		if b.begin > 0 && b.begin <= len(runes) && runes[b.begin-1] == '\n' {
+			continue
+		}
+		b.indent = indent
 	}
 }
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -459,6 +459,20 @@ func (t *RichText) updateRowBounds() {
 				if len(retBounds) > 0 {
 					bounds[len(bounds)-1].end = retBounds[0].end // invalidate row ending as we have more content
 					bounds[len(bounds)-1].segments = append(bounds[len(bounds)-1].segments, seg)
+					// continuation rows that result from wrapping (not \n) inherit the indent
+					// from the first row so that wrapped text aligns after the bullet/prefix.
+					continuationIndent := bounds[len(bounds)-1].indent + (maxWidth - wrapWidth)
+					if continuationIndent > 0 {
+						runes := []rune(seg.Textual())
+						for i := range retBounds[1:] {
+							b := &retBounds[1+i]
+							// skip newline-broken rows — text[b.begin-1] is '\n'
+							if b.begin > 0 && b.begin <= len(runes) && runes[b.begin-1] == '\n' {
+								continue
+							}
+							b.indent = continuationIndent
+						}
+					}
 					bounds = append(bounds, retBounds[1:]...)
 
 					fitSize.Height -= height
@@ -564,7 +578,7 @@ func (r *textRenderer) Layout(size fyne.Size) {
 				continue
 			}
 
-			leftPad := float32(0)
+			leftPad := bound.indent
 			if text, ok := bound.segments[0].(*TextSegment); ok {
 				rowAlign = text.Style.Alignment
 				if text.Style == RichTextStyleBlockquote {
@@ -1018,7 +1032,7 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 
 			fitCount := howManyRunesFit(text[low:high], measureWidth, charWidth, measurer)
 			if fitCount == high-low { // all characters fit on this line
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0})
 				reuse++
 				low = high
 				high = l.end
@@ -1026,7 +1040,7 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 
 				yPos += lineHeight
 			} else if fitCount == 0 { // even a character won't fit
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false, 0})
 				reuse++
 				low++
 
@@ -1064,7 +1078,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			sub := text[low:high]
 			fitCount := howManyRunesFit(sub, measureWidth, charWidth, measurer)
 			if fitCount == high-low { // all characters fit on this line
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0})
 				reuse++
 				low = high
 				high = l.end
@@ -1078,7 +1092,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			}
 			if fitCount == 0 { // even a character won't fit
 				if measureWidth < max.Width {
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
+					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false, 0})
 					reuse++
 					measureWidth = max.Width
 					yPos += lineHeight
@@ -1090,7 +1104,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 					include = 0
 					ellipsis = true
 				}
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis, 0})
 				low++
 				high = low + 1
 				reuse++
@@ -1112,7 +1126,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			oldHigh := high
 			high = low + fitCount
 			if low == 0 && measureWidth < max.Width { // add a newline as there is more space on next
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false, 0})
 				reuse++
 				high = oldHigh
 				measureWidth = max.Width
@@ -1157,12 +1171,12 @@ func truncateLines(t *RichText, seg RichTextSegment, trunc fyne.TextTruncation, 
 			}
 			end, full := truncateLimit(string(txt), textObj, int(measureWidth), []rune{'…'})
 			high = low + end
-			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full})
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full, 0})
 			reuse++
 		} else if trunc == fyne.TextTruncateClip {
 			fitCount := howManyRunesFit(text[low:high], measureWidth, charWidth, measurer)
 			high = low + fitCount
-			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false})
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0})
 			reuse++
 		}
 	}
@@ -1193,11 +1207,11 @@ func splitLines(seg RichTextSegment) []rowBoundary {
 	for i := 0; i < length; i++ {
 		if text[i] == '\n' {
 			high = i
-			lines = append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, high, false})
+			lines = append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, high, false, 0})
 			low = i + 1
 		}
 	}
-	return append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, length, false})
+	return append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, length, false, 0})
 }
 
 func truncateLimit(s string, text *canvas.Text, limit int, ellipsis []rune) (int, bool) {
@@ -1250,4 +1264,5 @@ type rowBoundary struct {
 	firstSegmentReuse int
 	begin, end        int
 	ellipsis          bool
+	indent            float32
 }

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -407,6 +407,7 @@ func (t *RichText) updateRowBounds() {
 
 	var currentBound *rowBoundary
 	currentBoundDepth := 0
+	rowContinuationIndent := float32(-1)
 	var iterateSegments func(segList []RichTextSegment, depth int)
 	iterateSegments = func(segList []RichTextSegment, depth int) {
 		for _, seg := range segList {
@@ -417,6 +418,7 @@ func (t *RichText) updateRowBounds() {
 					wrapWidth = maxWidth
 					currentBound = nil
 					currentBoundDepth = depth
+					rowContinuationIndent = -1
 				}
 				continue
 			}
@@ -439,6 +441,7 @@ func (t *RichText) updateRowBounds() {
 					wrapWidth = maxWidth
 					currentBound = nil
 					currentBoundDepth = depth
+					rowContinuationIndent = -1
 					fitSize.Height -= itemMin.Height + th.Size(theme.SizeNameLineSpacing)
 				}
 				continue
@@ -459,15 +462,26 @@ func (t *RichText) updateRowBounds() {
 			retBounds, height := lineBounds(t, seg, wrapWidth-leftPad, fyne.NewSize(maxWidth, fitSize.Height), func(text []rune) fyne.Size {
 				return fyne.MeasureText(string(text), textSize, textStyle)
 			})
+			boundWasNil := currentBound == nil
 			if currentBound != nil {
 				if len(retBounds) > 0 {
 					bounds[len(bounds)-1].end = retBounds[0].end // invalidate row ending as we have more content
 					bounds[len(bounds)-1].segments = append(bounds[len(bounds)-1].segments, seg)
-					xOff := float32(0)
 					if depth > currentBoundDepth {
-						xOff = maxWidth - wrapWidth
+						if rowContinuationIndent == -1 {
+							rowContinuationIndent = maxWidth - wrapWidth
+						}
+						if rowContinuationIndent > 0 {
+							runes := []rune(seg.Textual())
+							for i := range retBounds[1:] {
+								b := &retBounds[1+i]
+								if b.begin > 0 && b.begin <= len(runes) && runes[b.begin-1] == '\n' {
+									continue
+								}
+								b.indent = rowContinuationIndent
+							}
+						}
 					}
-					alignWrappedText(&bounds[len(bounds)-1], retBounds[1:], seg, xOff)
 					bounds = append(bounds, retBounds[1:]...)
 
 					fitSize.Height -= height
@@ -478,7 +492,10 @@ func (t *RichText) updateRowBounds() {
 				fitSize.Height -= height
 			}
 			currentBound = &bounds[len(bounds)-1]
-			currentBoundDepth = depth
+			if boundWasNil {
+				currentBoundDepth = depth
+				rowContinuationIndent = -1
+			}
 			if seg.Inline() {
 				last := bounds[len(bounds)-1]
 				begin := 0
@@ -505,6 +522,7 @@ func (t *RichText) updateRowBounds() {
 			} else {
 				currentBound = nil
 				currentBoundDepth = depth
+				rowContinuationIndent = -1
 				wrapWidth = maxWidth
 			}
 		}
@@ -548,6 +566,9 @@ func (r *textRenderer) Layout(size fyne.Size) {
 	rowAlign := fyne.TextAlignLeading
 	i := 0
 	for row, bound := range bounds {
+		leftPad, align := rowPaddingAndAlign(bound, lineSpacing, rowAlign)
+		rowAlign = align
+
 		for segI := range bound.segments {
 			if i == len(objs) {
 				break // Refresh may not have created all objects for all rows yet...
@@ -558,14 +579,14 @@ func (r *textRenderer) Layout(size fyne.Size) {
 			_, isText := obj.(*canvas.Text)
 			if !isText && !inline {
 				if len(rowItems) != 0 {
-					width, _ := r.layoutRow(rowItems, rowAlign, left, yPos, lineWidth)
+					width, _ := r.layoutRow(rowItems, rowAlign, left+leftPad, yPos, lineWidth-leftPad)
 					left += width
 					rowItems = nil
 				}
 				height := obj.MinSize().Height
 
-				obj.Move(fyne.NewPos(left, yPos))
-				obj.Resize(fyne.NewSize(lineWidth, height))
+				obj.Move(fyne.NewPos(left+leftPad, yPos))
+				obj.Resize(fyne.NewSize(lineWidth-leftPad, height))
 				yPos += height
 				left = xInset
 				continue
@@ -575,15 +596,6 @@ func (r *textRenderer) Layout(size fyne.Size) {
 				continue
 			}
 
-			leftPad := bound.indent
-			if text, ok := bound.segments[0].(*TextSegment); ok {
-				rowAlign = text.Style.Alignment
-				if text.Style == RichTextStyleBlockquote {
-					leftPad = lineSpacing * 4
-				}
-			} else if link, ok := bound.segments[0].(*HyperlinkSegment); ok {
-				rowAlign = link.Alignment
-			}
 			_, y := r.layoutRow(rowItems, rowAlign, left+leftPad, yPos, lineWidth-leftPad)
 			yPos += y
 			rowItems = nil
@@ -1194,20 +1206,20 @@ func setAlign(obj fyne.CanvasObject, align fyne.TextAlign) {
 	}
 }
 
-func alignWrappedText(priorBound *rowBoundary, wrappedBounds []rowBoundary, seg RichTextSegment, xOffset float32) {
-	indent := priorBound.indent + xOffset
-	if indent <= 0 {
-		return
-	}
-
-	runes := []rune(seg.Textual())
-	for i := range wrappedBounds {
-		b := &wrappedBounds[i]
-		if b.begin > 0 && b.begin <= len(runes) && runes[b.begin-1] == '\n' {
-			continue
+func rowPaddingAndAlign(bound rowBoundary, lineSpacing float32, currentAlign fyne.TextAlign) (float32, fyne.TextAlign) {
+	leftPad := bound.indent
+	align := currentAlign
+	if len(bound.segments) > 0 {
+		if text, ok := bound.segments[0].(*TextSegment); ok {
+			align = text.Style.Alignment
+			if text.Style == RichTextStyleBlockquote {
+				leftPad = lineSpacing * 4
+			}
+		} else if link, ok := bound.segments[0].(*HyperlinkSegment); ok {
+			align = link.Alignment
 		}
-		b.indent = indent
 	}
+	return leftPad, align
 }
 
 // splitLines accepts a text segment and returns a slice of boundary metadata denoting the

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -1206,6 +1206,7 @@ func setAlign(obj fyne.CanvasObject, align fyne.TextAlign) {
 	}
 }
 
+// rowPaddingAndAlign returns the left padding and text alignment for a row.
 func rowPaddingAndAlign(bound rowBoundary, lineSpacing float32, currentAlign fyne.TextAlign) (float32, fyne.TextAlign) {
 	leftPad := bound.indent
 	align := currentAlign

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -275,6 +275,9 @@ func (l *ListSegment) Segments() []RichTextSegment {
 			indentation := strings.Repeat(" ", l.indentationLevel*4)
 			bullet := &TextSegment{Text: indentation + txt + " ", Style: RichTextStyleStrong}
 			texts = append(texts, bullet)
+			if _, ok := in.(*ParagraphSegment); !ok {
+				in = &ParagraphSegment{Texts: []RichTextSegment{in}}
+			}
 		}
 		texts = append(texts, in)
 		out[i] = &ParagraphSegment{Texts: texts}

--- a/widget/richtext_objects_test.go
+++ b/widget/richtext_objects_test.go
@@ -132,3 +132,23 @@ func TestRichText_OrderedListDifferentIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestRichText_List_WrappedIndent(t *testing.T) {
+	text := NewRichText(&ListSegment{Items: []RichTextSegment{
+		&TextSegment{Text: "A very long line that will wrap around and test the indentation of the second line"},
+	}})
+	text.Wrapping = fyne.TextWrapWord
+	text.Resize(fyne.NewSize(100, 200))
+
+	objs := test.TempWidgetRenderer(t, text).Objects()
+	assert.GreaterOrEqual(t, len(objs), 3, "expected text to wrap into multiple segments")
+
+	bullet := objs[0].(*canvas.Text)
+	assert.Equal(t, "•", strings.TrimSpace(bullet.Text))
+
+	line1 := objs[1].(*canvas.Text)
+	line2 := objs[2].(*canvas.Text)
+
+	assert.Equal(t, line1.Position().X, line2.Position().X, "wrapped line should align with start of first line")
+	assert.Greater(t, line1.Position().X, bullet.Position().X, "text should be indented from bullet")
+}


### PR DESCRIPTION
### Description:
Description:
Wrapped list items now indent continuation lines to align with the start of the item text, not the left margin.

An indent field is added to `rowBoundary` and stamped on wrap-continuation rows in `updateRowBounds` using the consumed bullet/prefix width. Newline-broken rows are excluded.

Fixes #6298

Example: 
<img width="356" height="276" alt="Screenshot from 2026-05-12 02-12-27" src="https://github.com/user-attachments/assets/c9fcfd34-b12a-4bb0-a63e-4c42807cfea3" />


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
