### PR TITLE
fix(widget): guard against nil canvas in pop-up paths (#5965)

### DIFF
--- a/container/tabs.go
+++ b/container/tabs.go
@@ -125,6 +125,11 @@ func tabsAdjustedLocation(l TabLocation, b baseTabs) TabLocation {
 func buildPopUpMenu(t baseTabs, button *widget.Button, items []*fyne.MenuItem) *widget.PopUpMenu {
 	d := fyne.CurrentApp().Driver()
 	c := d.CanvasForObject(button)
+	if c == nil {
+		// Overflow button detached from its canvas; nothing to host the
+		// pop-up on (see fyne-io/fyne#5965).
+		return nil
+	}
 	popUpMenu := widget.NewPopUpMenu(fyne.NewMenu("", items...), c)
 	buttonPos := d.AbsolutePositionForObject(button)
 	buttonSize := button.Size()

--- a/widget/date_entry.go
+++ b/widget/date_entry.go
@@ -149,6 +149,11 @@ func (e *DateEntry) setupDropDown() *Button {
 	}
 	dropDownButton := NewButton("", func() {
 		c := fyne.CurrentApp().Driver().CanvasForObject(e.super())
+		if c == nil {
+			// DateEntry detached from its canvas; cannot host calendar
+			// dropdown (see fyne-io/fyne#5965).
+			return
+		}
 
 		e.popUp = NewPopUp(e.dropDown, c)
 		e.popUp.ShowAtPosition(e.popUpPos())

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -583,9 +583,15 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	}
 
 	driver := app.Driver()
+	c := driver.CanvasForObject(super)
+	if c == nil {
+		// Entry was detached from its canvas between the tap event and
+		// this call (see fyne-io/fyne#5965). Skip the context menu.
+		return
+	}
 	entryPos := driver.AbsolutePositionForObject(super)
 	popUpPos := entryPos.Add(pe.Position)
-	e.popUp = NewPopUpMenu(fyne.NewMenu("", menuItems...), driver.CanvasForObject(super))
+	e.popUp = NewPopUpMenu(fyne.NewMenu("", menuItems...), c)
 	e.popUp.ShowAtPosition(popUpPos)
 }
 

--- a/widget/entry_password.go
+++ b/widget/entry_password.go
@@ -50,7 +50,9 @@ func (r *passwordRevealer) Tapped(*fyne.PointEvent) {
 	r.entry.setFieldsAndRefresh(func() {
 		r.entry.Password = !r.entry.Password
 	})
-	fyne.CurrentApp().Driver().CanvasForObject(r).Focus(r.entry.super().(fyne.Focusable))
+	if c := fyne.CurrentApp().Driver().CanvasForObject(r); c != nil {
+		c.Focus(r.entry.super().(fyne.Focusable))
+	}
 }
 
 var _ fyne.WidgetRenderer = (*passwordRevealerRenderer)(nil)

--- a/widget/popup_menu.go
+++ b/widget/popup_menu.go
@@ -21,6 +21,9 @@ type PopUpMenu struct {
 //
 // Since: 2.0
 func NewPopUpMenu(menu *fyne.Menu, c fyne.Canvas) *PopUpMenu {
+	if c == nil {
+		return nil
+	}
 	m := &Menu{}
 	m.setMenu(menu)
 	p := &PopUpMenu{Menu: m, canvas: c}
@@ -40,6 +43,9 @@ func NewPopUpMenu(menu *fyne.Menu, c fyne.Canvas) *PopUpMenu {
 // It will automatically be positioned at the provided location and shown as an overlay on the specified canvas.
 func ShowPopUpMenuAtPosition(menu *fyne.Menu, c fyne.Canvas, pos fyne.Position) {
 	m := NewPopUpMenu(menu, c)
+	if m == nil {
+		return
+	}
 	m.ShowAtPosition(pos)
 }
 

--- a/widget/popup_test.go
+++ b/widget/popup_test.go
@@ -534,6 +534,59 @@ func TestModalPopUp_ResizeOnShow(t *testing.T) {
 	pop.Hide()
 }
 
+// Repro for fyne-io/fyne#5965.
+//
+// Root cause: internal/widget.overlayRenderer.MinSize dereferences
+// OverlayContainer.canvas unconditionally. When the canvas reference is nil
+// (e.g. the owning widget was detached from its window between the tap event
+// and the popup creation) the call panics with a nil pointer dereference.
+//
+// Higher-level trigger seen in the wild: widget.Select.Tapped ->
+// showPopUp -> NewPopUpMenu(menu, c) where Driver.CanvasForObject(s.super())
+// returns nil because the Select was already removed from its parent tree.
+// That path is driver-specific (real GLFW driver consults the canvas cache;
+// the test driver fakes CanvasForObject), so the underlying contract is
+// exercised here directly.
+func TestNewPopUpMenu_NilCanvas_NoPanic(t *testing.T) {
+	test.NewTempApp(t)
+
+	menu := fyne.NewMenu(
+		"",
+		fyne.NewMenuItem("a", func() {}),
+		fyne.NewMenuItem("b", func() {}),
+		fyne.NewMenuItem("c", func() {}),
+	)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewPopUpMenu with nil canvas panicked: %v", r)
+		}
+	}()
+
+	pop := NewPopUpMenu(menu, nil)
+	if pop == nil {
+		return
+	}
+	pop.ShowAtPosition(fyne.NewPos(0, 0))
+}
+
+func TestShowPopUpMenuAtPosition_NilCanvas_NoPanic(t *testing.T) {
+	test.NewTempApp(t)
+
+	menu := fyne.NewMenu(
+		"",
+		fyne.NewMenuItem("only", func() {}),
+	)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ShowPopUpMenuAtPosition with nil canvas panicked: %v", r)
+		}
+	}()
+
+	ShowPopUpMenuAtPosition(menu, nil, fyne.NewPos(0, 0))
+}
+
 func TestModelPopUp_ResizeBeforeShow_CanvasSizeZero(t *testing.T) {
 	test.NewTempApp(t)
 

--- a/widget/select.go
+++ b/widget/select.go
@@ -280,6 +280,13 @@ func (s *Select) showPopUp() {
 	}
 
 	c := fyne.CurrentApp().Driver().CanvasForObject(s.super())
+	if c == nil {
+		// The Select was detached from its canvas (e.g. its parent
+		// container was rebuilt) between the tap event being delivered
+		// and this call. There is no canvas to host the pop-up, so do
+		// nothing rather than crash inside the overlay machinery.
+		return
+	}
 	pop := NewPopUpMenu(fyne.NewMenu("", items...), c)
 	pop.alignment = s.Alignment
 	pop.ShowAtPosition(s.popUpPos())

--- a/widget/select_entry.go
+++ b/widget/select_entry.go
@@ -97,6 +97,11 @@ func (e *SelectEntry) popUpPos() fyne.Position {
 func (e *SelectEntry) setupDropDown() *Button {
 	dropDownButton := NewButton("", func() {
 		c := fyne.CurrentApp().Driver().CanvasForObject(e.super())
+		if c == nil {
+			// SelectEntry detached from its canvas; nothing to host the
+			// dropdown on (see fyne-io/fyne#5965).
+			return
+		}
 
 		e.popUp = NewPopUpMenu(e.dropDown, c)
 		e.popUp.ShowAtPosition(e.popUpPos())

--- a/widget/select_test.go
+++ b/widget/select_test.go
@@ -3,11 +3,13 @@ package widget_test
 import (
 	"fmt"
 	"image"
+	"runtime/debug"
 	"testing"
 	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/layout"
@@ -610,6 +612,74 @@ func TestSelect_Layout(t *testing.T) {
 			assertRendersToPlatformMarkup(t, "select/%s/layout_"+name+".xml", window.Canvas())
 		})
 	}
+}
+
+// nilCanvasDriver wraps a fyne.Driver and returns nil from CanvasForObject
+// for one specific target, simulating the state observed on the real GLFW
+// driver after a widget is detached from its window between event delivery
+// and popup creation (fyne-io/fyne#5965). The stock test driver always
+// returns the last window's canvas regardless of the queried object, so the
+// detach scenario cannot otherwise be reproduced under the unit test driver.
+type nilCanvasDriver struct {
+	fyne.Driver
+	target fyne.CanvasObject
+}
+
+func (d *nilCanvasDriver) CanvasForObject(o fyne.CanvasObject) fyne.Canvas {
+	if o == d.target {
+		return nil
+	}
+	return d.Driver.CanvasForObject(o)
+}
+
+func (d *nilCanvasDriver) AbsolutePositionForObject(o fyne.CanvasObject) fyne.Position {
+	if o == d.target {
+		return fyne.NewPos(0, 0)
+	}
+	return d.Driver.AbsolutePositionForObject(o)
+}
+
+type wrappedApp struct {
+	fyne.App
+	drv fyne.Driver
+}
+
+func (a *wrappedApp) Driver() fyne.Driver { return a.drv }
+
+// Repro for fyne-io/fyne#5965: Select.Tapped must not panic when the widget
+// was already detached from its canvas (a frequent outcome of SetContent /
+// container rebuilds while a tap is in flight on the real driver).
+//
+// Failure mode on main: Select.Tapped -> showPopUp -> NewPopUpMenu(menu, nil)
+// -> OverlayContainer.Resize -> overlayRenderer.MinSize() -> nil deref on
+// OverlayContainer.canvas.
+func TestSelect_Tapped_AfterCanvasDetach_DoesNotPanic(t *testing.T) {
+	baseApp := test.NewTempApp(t)
+
+	sel := widget.NewSelect([]string{"a", "b", "c"}, nil)
+	w := test.NewWindow(container.NewVBox(sel))
+	defer w.Close()
+	w.Resize(fyne.NewSize(200, 200))
+
+	require.NotNil(t, fyne.CurrentApp().Driver().CanvasForObject(sel),
+		"precondition: Select is attached to a canvas before detach")
+
+	shim := &wrappedApp{App: baseApp, drv: &nilCanvasDriver{
+		Driver: baseApp.Driver(),
+		target: fyne.CanvasObject(sel),
+	}}
+	fyne.SetCurrentApp(shim)
+	t.Cleanup(func() { fyne.SetCurrentApp(baseApp) })
+
+	require.Nil(t, fyne.CurrentApp().Driver().CanvasForObject(fyne.CanvasObject(sel)),
+		"precondition: Select sees nil canvas after detach")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Select.Tapped panicked after canvas detach: %v\n%s", r, debug.Stack())
+		}
+	}()
+	sel.Tapped(&fyne.PointEvent{Position: fyne.NewPos(0, 0)})
 }
 
 func assertRendersToPlatformMarkup(t *testing.T, file string, c fyne.Canvas) {


### PR DESCRIPTION
### Description:

> ### Context
> 
> Surfaced in [a2text](https://github.com/partyzanex/a2text), a Linux voice-dictation daemon. Its Fyne settings window rebuilds part of its content on provider / backend toggle, so between `widget.Select.Tapped` and `showPopUp` the previous widget tree is detached from the canvas and `Driver().CanvasForObject(w)` returns `nil` ? exactly the path @dweymouth suggested in #5965.
>  
> The daemon currently survives via a `recover()` + event-loop restart wrapped around `app.Run`. With this PR upstream, that workaround becomes unnecessary.

`Driver.CanvasForObject(w)` returns nil on GLFW when `w` was detached between event delivery and pop-up creation, panicking in `overlayRenderer.MinSize`.

Added nil-canvas guards in `Select.showPopUp`, `Entry` context menu,  `SelectEntry` / `DateEntry` dropdowns, container/tabs` overflow menu,   `entry_password` Focus, plus no-op in `NewPopUpMenu` /  `ShowPopUpMenuAtPosition`.

Tests in `widget/popup_test.go` and `widget/select_test.go` reproduce the panic on `develop` and pass with the fix.

Fixes #5965 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

