### PR TITLE
fix(glfw): normalize systray jpg icons on unix

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/fyne-io/image/ico"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/internal/animation"
 	intapp "fyne.io/fyne/v2/internal/app"
@@ -20,7 +22,6 @@ import (
 	"fyne.io/fyne/v2/internal/painter"
 	intRepo "fyne.io/fyne/v2/internal/repository"
 	"fyne.io/fyne/v2/storage/repository"
-	"github.com/fyne-io/image/ico"
 )
 
 var curWindow *window
@@ -52,9 +53,8 @@ func toOSIcon(icon []byte) ([]byte, error) {
 	return toOSIconForRuntime(icon, runtime.GOOS)
 }
 
-// toOSIconForRuntime make a helper so test can work.
+// toOSIconForRuntime make a helper so test can work
 func toOSIconForRuntime(icon []byte, goos string) ([]byte, error) {
-	// not sure how other os works, keep current behavior
 	if goos != "windows" && !usesUnixSystrayIcon(goos) {
 		return icon, nil
 	}
@@ -64,9 +64,9 @@ func toOSIconForRuntime(icon []byte, goos string) ([]byte, error) {
 		return nil, err
 	}
 
-	buf := &bytes.Buffer{}
 	// keep windows behavior: convert to ico
 	if goos == "windows" {
+		buf := &bytes.Buffer{}
 		if err = ico.Encode(buf, img); err != nil {
 			return nil, err
 		}
@@ -75,12 +75,18 @@ func toOSIconForRuntime(icon []byte, goos string) ([]byte, error) {
 	if format == "png" {
 		return icon, nil
 	}
-	// the Unix systray backend reads low 8-bit RGBA values, so normalize
-	// formats like JPEG/YCbCr to an 8-bit PNG before handing bytes over.
+
+	// Unix systray expects a PNG bitmap.
+	return convertToPNG(img)
+}
+
+func convertToPNG(img image.Image) ([]byte, error) {
 	bounds := img.Bounds()
 	nrgba := image.NewNRGBA(bounds)
 	draw.Draw(nrgba, bounds, img, bounds.Min, draw.Src)
-	if err = png.Encode(buf, nrgba); err != nil {
+
+	buf := &bytes.Buffer{}
+	if err := png.Encode(buf, nrgba); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -5,10 +5,11 @@ package glfw
 import (
 	"bytes"
 	"image"
+	"image/draw"
+	_ "image/jpeg"
+	"image/png"
 	"os"
 	"runtime"
-
-	"github.com/fyne-io/image/ico"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/internal/animation"
@@ -19,6 +20,7 @@ import (
 	"fyne.io/fyne/v2/internal/painter"
 	intRepo "fyne.io/fyne/v2/internal/repository"
 	"fyne.io/fyne/v2/storage/repository"
+	"github.com/fyne-io/image/ico"
 )
 
 var curWindow *window
@@ -47,21 +49,45 @@ func (d *gLDriver) init() {
 }
 
 func toOSIcon(icon []byte) ([]byte, error) {
-	if runtime.GOOS != "windows" {
+	return toOSIconForRuntime(icon, runtime.GOOS)
+}
+
+// toOSIconForRuntime make a helper so test can work.
+func toOSIconForRuntime(icon []byte, goos string) ([]byte, error) {
+	// not sure how other os works, keep current behavior
+	if goos != "windows" && !usesUnixSystrayIcon(goos) {
 		return icon, nil
 	}
 
-	img, _, err := image.Decode(bytes.NewReader(icon))
+	img, format, err := image.Decode(bytes.NewReader(icon))
 	if err != nil {
 		return nil, err
 	}
 
 	buf := &bytes.Buffer{}
-	err = ico.Encode(buf, img)
-	if err != nil {
+	// keep windows behavior: convert to ico
+	if goos == "windows" {
+		if err = ico.Encode(buf, img); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+	if format == "png" {
+		return icon, nil
+	}
+	// the Unix systray backend reads low 8-bit RGBA values, so normalize
+	// formats like JPEG/YCbCr to an 8-bit PNG before handing bytes over.
+	bounds := img.Bounds()
+	nrgba := image.NewNRGBA(bounds)
+	draw.Draw(nrgba, bounds, img, bounds.Min, draw.Src)
+	if err = png.Encode(buf, nrgba); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func usesUnixSystrayIcon(goos string) bool {
+	return goos == "linux" || goos == "freebsd" || goos == "openbsd" || goos == "netbsd"
 }
 
 func (d *gLDriver) DoFromGoroutine(f func(), wait bool) {

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -53,7 +53,8 @@ func toOSIcon(icon []byte) ([]byte, error) {
 	return toOSIconForRuntime(icon, runtime.GOOS)
 }
 
-// toOSIconForRuntime make a helper so test can work
+// toOSIconForRuntime takes the input image bytes and converts it to an image type
+// that is suitable for the specified GOOS runtime. Which makes platform-specific icon handling testable.
 func toOSIconForRuntime(icon []byte, goos string) ([]byte, error) {
 	if goos != "windows" && !usesUnixSystrayIcon(goos) {
 		return icon, nil

--- a/internal/driver/glfw/driver_xdg_test.go
+++ b/internal/driver/glfw/driver_xdg_test.go
@@ -1,0 +1,113 @@
+//go:build !no_glfw && !mobile && !windows && !darwin
+
+package glfw
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToOSIconEncodesJPGAsPNG(t *testing.T) {
+	img := testTrayIconImage()
+
+	jpg := bytes.NewBuffer(nil)
+	require.NoError(t, jpeg.Encode(jpg, img, &jpeg.Options{Quality: 95}))
+
+	converted, err := toOSIcon(jpg.Bytes())
+	require.NoError(t, err)
+
+	_, format, err := image.DecodeConfig(bytes.NewReader(converted))
+	require.NoError(t, err)
+	assert.Equal(t, "png", format)
+
+	_, err = png.Decode(bytes.NewReader(converted))
+	require.NoError(t, err)
+}
+
+func TestToOSIconJPGPixelsMatchSystrayPixelConversion(t *testing.T) {
+	source := color.NRGBA{R: 230, G: 43, B: 30, A: 255}
+	img := image.NewNRGBA(image.Rect(0, 0, 64, 64))
+	for y := 0; y < img.Bounds().Dy(); y++ {
+		for x := 0; x < img.Bounds().Dx(); x++ {
+			img.SetNRGBA(x, y, source)
+		}
+	}
+
+	jpg := bytes.NewBuffer(nil)
+	require.NoError(t, jpeg.Encode(jpg, img, &jpeg.Options{Quality: 95}))
+
+	converted, err := toOSIcon(jpg.Bytes())
+	require.NoError(t, err)
+
+	decoded, _, err := image.Decode(bytes.NewReader(converted))
+	require.NoError(t, err)
+
+	r, g, b, a := decoded.At(0, 0).RGBA()
+	assert.InDelta(t, source.A, byte(a), 0)
+	assert.InDelta(t, source.R, byte(r), 3)
+	assert.InDelta(t, source.G, byte(g), 3)
+	assert.InDelta(t, source.B, byte(b), 3)
+}
+
+func TestToOSIconLeavesPNGUnchanged(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	img.SetNRGBA(0, 0, color.NRGBA{R: 230, G: 43, B: 30, A: 255})
+
+	source := bytes.NewBuffer(nil)
+	require.NoError(t, png.Encode(source, img))
+
+	converted, err := toOSIcon(source.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, source.Bytes(), converted)
+}
+
+func TestToOSIconDarwinLeavesOriginalBytesUnchanged(t *testing.T) {
+	source := []byte("darwin accepts icon bytes unchanged")
+
+	converted, err := toOSIconForRuntime(source, "darwin")
+	require.NoError(t, err)
+	assert.Equal(t, source, converted)
+}
+
+func TestToOSIconWindowsEncodesICO(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	img.SetNRGBA(0, 0, color.NRGBA{R: 230, G: 43, B: 30, A: 255})
+
+	source := bytes.NewBuffer(nil)
+	require.NoError(t, png.Encode(source, img))
+
+	converted, err := toOSIconForRuntime(source.Bytes(), "windows")
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0, 0, 1, 0}, converted[:4])
+}
+
+func TestToOSIconRejectsInvalidImage(t *testing.T) {
+	_, err := toOSIconForRuntime([]byte("not an image"), "linux")
+	require.Error(t, err)
+}
+
+func TestUsesUnixSystrayIcon(t *testing.T) {
+	assert.True(t, usesUnixSystrayIcon("linux"))
+	assert.True(t, usesUnixSystrayIcon("freebsd"))
+	assert.True(t, usesUnixSystrayIcon("openbsd"))
+	assert.True(t, usesUnixSystrayIcon("netbsd"))
+	assert.False(t, usesUnixSystrayIcon("darwin"))
+	assert.False(t, usesUnixSystrayIcon("windows"))
+}
+
+func testTrayIconImage() image.Image {
+	img := image.NewNRGBA(image.Rect(0, 0, 2, 2))
+	img.SetNRGBA(0, 0, color.NRGBA{R: 230, G: 43, B: 30, A: 255})
+	img.SetNRGBA(1, 0, color.NRGBA{R: 33, G: 160, B: 79, A: 255})
+	img.SetNRGBA(0, 1, color.NRGBA{R: 33, G: 89, B: 210, A: 255})
+	img.SetNRGBA(1, 1, color.NRGBA{R: 246, G: 190, B: 34, A: 255})
+
+	return img
+}


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
fix incorrect color rendering for jpg tray icons on unix tray backends.

the problem is that systray backend reads low 8-bit rgba channel values from decoded images. JPG images decode through `YCbCr`, so passing jpg bytes through directly could produce incorrect tray icon colors. 

other behavior remains unchanged.

Fixes: https://github.com/fyne-io/fyne/issues/4783

after fix
<img width="390" height="385" alt="image" src="https://github.com/user-attachments/assets/51169dc4-cb37-459f-9b5e-4ba9d6f33c9c" />


### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

