### PR TITLE
Markdown: Support nested block quotes

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -46,29 +46,29 @@ type markdownRenderer []RichTextSegment
 func (m *markdownRenderer) AddOptions(...renderer.Option) {}
 
 func (m *markdownRenderer) Render(_ io.Writer, source []byte, n ast.Node) error {
-	segs, err := renderNode(source, n, false, 0)
+	segs, err := renderNode(source, n, 0, 0)
 	*m = segs
 	return err
 }
 
-func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]RichTextSegment, error) {
+func renderNode(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]RichTextSegment, error) {
 	switch t := n.(type) {
 	case *ast.Document:
-		return renderChildren(source, n, blockquote, listDepth)
+		return renderChildren(source, n, quotingDepth, listDepth)
 	case *ast.Paragraph:
-		children, err := renderChildren(source, n, blockquote, listDepth)
-		if !blockquote && listDepth == 0 {
+		children, err := renderChildren(source, n, quotingDepth, listDepth)
+		if quotingDepth == 0 && listDepth == 0 {
 			linebreak := &TextSegment{Style: RichTextStyleParagraph}
 			children = append(children, linebreak)
 		}
 		return children, err
 	case *ast.List:
-		items, err := renderChildren(source, n, blockquote, listDepth+1)
+		items, err := renderChildren(source, n, quotingDepth, listDepth+1)
 		return []RichTextSegment{
 			&ListSegment{startIndex: t.Start - 1, Items: items, Ordered: t.Marker != '*' && t.Marker != '-' && t.Marker != '+', indentationLevel: listDepth},
 		}, err
 	case *ast.ListItem:
-		children, err := renderChildren(source, n, blockquote, listDepth)
+		children, err := renderChildren(source, n, quotingDepth, listDepth)
 		var texts []RichTextSegment
 		var sublist RichTextSegment
 		for _, child := range children {
@@ -85,9 +85,9 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		}
 		return result, err
 	case *ast.TextBlock:
-		return renderChildren(source, n, blockquote, listDepth)
+		return renderChildren(source, n, quotingDepth, listDepth)
 	case *ast.Heading:
-		return renderHeading(source, n, blockquote, listDepth)
+		return renderHeading(source, n, quotingDepth, listDepth)
 	case *ast.ThematicBreak:
 		return []RichTextSegment{&SeparatorSegment{}}, nil
 	case *ast.Link:
@@ -116,9 +116,9 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		}
 		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeBlock, Text: string(data)}}, nil
 	case *ast.Emphasis:
-		return renderEmphasis(source, n, blockquote, n.(*ast.Emphasis).Level, listDepth)
+		return renderEmphasis(source, n, quotingDepth, n.(*ast.Emphasis).Level, listDepth)
 	case *ast2.Strikethrough:
-		return renderEmphasis(source, n, blockquote, 3, listDepth)
+		return renderEmphasis(source, n, quotingDepth, 3, listDepth)
 	case *ast.Text:
 		text := string(t.Value(source))
 		if text == "" {
@@ -128,22 +128,25 @@ func renderNode(source []byte, n ast.Node, blockquote bool, listDepth int) ([]Ri
 		if n.(*ast.Text).SoftLineBreak() {
 			text = text + " "
 		}
-		if blockquote {
-			return []RichTextSegment{&TextSegment{Style: RichTextStyleBlockquote, Text: text}}, nil
+		if quotingDepth > 0 {
+			style := RichTextStyleBlockquote
+			style.QuotingDepth = quotingDepth
+			return []RichTextSegment{&TextSegment{Style: style, Text: text}}, nil
 		}
 		return []RichTextSegment{&TextSegment{Style: RichTextStyleInline, Text: decodeText(text)}}, nil
 	case *ast.Blockquote:
-		return renderChildren(source, n, true, listDepth)
+		quotingDepth++
+		return renderChildren(source, n, quotingDepth, listDepth)
 	case *ast.Image:
 		return parseMarkdownImage(t), nil
 	}
 	return nil, nil
 }
 
-func renderChildren(source []byte, n ast.Node, blockquote bool, listDepth int) ([]RichTextSegment, error) {
+func renderChildren(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]RichTextSegment, error) {
 	children := make([]RichTextSegment, 0, n.ChildCount())
 	for childCount, child := n.ChildCount(), n.FirstChild(); childCount > 0; childCount-- {
-		segs, err := renderNode(source, child, blockquote, listDepth)
+		segs, err := renderNode(source, child, quotingDepth, listDepth)
 		if err != nil {
 			return children, err
 		}
@@ -153,7 +156,7 @@ func renderChildren(source []byte, n ast.Node, blockquote bool, listDepth int) (
 	return children, nil
 }
 
-func renderEmphasis(source []byte, n ast.Node, blockquote bool, strength, listDepth int) ([]RichTextSegment, error) {
+func renderEmphasis(source []byte, n ast.Node, quotingDepth int, strength, listDepth int) ([]RichTextSegment, error) {
 	style := RichTextStyleInline
 	switch strength {
 	case 1:
@@ -178,7 +181,7 @@ func renderEmphasis(source []byte, n ast.Node, blockquote bool, strength, listDe
 		}
 	}
 
-	children, err := renderChildren(source, n, blockquote, listDepth)
+	children, err := renderChildren(source, n, quotingDepth, listDepth)
 	for _, child := range children {
 		switch t := child.(type) {
 		case *TextSegment:
@@ -194,7 +197,7 @@ func renderEmphasis(source []byte, n ast.Node, blockquote bool, strength, listDe
 	return children, err
 }
 
-func renderHeading(source []byte, n ast.Node, blockquote bool, listDepth int) ([]RichTextSegment, error) {
+func renderHeading(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]RichTextSegment, error) {
 	var style RichTextStyle
 	switch n.(*ast.Heading).Level {
 	case 1:
@@ -212,7 +215,7 @@ func renderHeading(source []byte, n ast.Node, blockquote bool, listDepth int) ([
 			text := string(t.Value(source))
 			children = append(children, &TextSegment{Style: style, Text: decodeText(text)})
 		default:
-			segs, err := renderNode(source, child, blockquote, listDepth)
+			segs, err := renderNode(source, child, quotingDepth, listDepth)
 			if err != nil {
 				return children, err
 			}

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -57,10 +57,8 @@ func renderNode(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]R
 		return renderChildren(source, n, quotingDepth, listDepth)
 	case *ast.Paragraph:
 		children, err := renderChildren(source, n, quotingDepth, listDepth)
-		if quotingDepth == 0 && listDepth == 0 {
-			linebreak := &TextSegment{Style: RichTextStyleParagraph}
-			children = append(children, linebreak)
-		}
+		linebreak := &TextSegment{Style: RichTextStyleParagraph}
+		children = append(children, linebreak)
 		return children, err
 	case *ast.List:
 		items, err := renderChildren(source, n, quotingDepth, listDepth+1)

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -12,7 +12,7 @@ import (
 func TestRichTextMarkdown_Blockquote(t *testing.T) {
 	r := NewRichTextFromMarkdown("p1\n\n> quote\n\np2")
 
-	assert.Len(t, r.Segments, 5)
+	assert.Len(t, r.Segments, 6)
 	if text, ok := r.Segments[2].(*TextSegment); ok {
 		assert.Equal(t, "quote", text.Text)
 		assert.Equal(t, 1, text.Style.QuotingDepth)
@@ -24,8 +24,8 @@ func TestRichTextMarkdown_Blockquote(t *testing.T) {
 func TestRichTextMarkdown_NestedBlockquote(t *testing.T) {
 	r := NewRichTextFromMarkdown("p1\n\n> quote\n> > nested quote\n\np2")
 
-	assert.Len(t, r.Segments, 6)
-	if text, ok := r.Segments[3].(*TextSegment); ok {
+	assert.Len(t, r.Segments, 8)
+	if text, ok := r.Segments[4].(*TextSegment); ok {
 		assert.Equal(t, "nested quote", text.Text)
 		assert.Equal(t, 2, text.Style.QuotingDepth)
 	} else {

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -15,7 +15,19 @@ func TestRichTextMarkdown_Blockquote(t *testing.T) {
 	assert.Len(t, r.Segments, 5)
 	if text, ok := r.Segments[2].(*TextSegment); ok {
 		assert.Equal(t, "quote", text.Text)
-		assert.Equal(t, RichTextStyleBlockquote, text.Style)
+		assert.Equal(t, 1, text.Style.QuotingDepth)
+	} else {
+		t.Error("Segment should be Text")
+	}
+}
+
+func TestRichTextMarkdown_NestedBlockquote(t *testing.T) {
+	r := NewRichTextFromMarkdown("p1\n\n> quote\n> > nested quote\n\np2")
+
+	assert.Len(t, r.Segments, 6)
+	if text, ok := r.Segments[3].(*TextSegment); ok {
+		assert.Equal(t, "nested quote", text.Text)
+		assert.Equal(t, 2, text.Style.QuotingDepth)
 	} else {
 		t.Error("Segment should be Text")
 	}

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -452,8 +452,8 @@ func (t *RichText) updateRowBounds() {
 			if textSeg, ok := seg.(*TextSegment); ok {
 				textStyle = textSeg.Style.TextStyle
 				textSize = textSeg.size()
-				if textSeg.Style == RichTextStyleBlockquote {
-					leftPad = innerPadding * 2
+				if textSeg.Style.QuotingDepth > 0 {
+					leftPad = innerPadding * 2 * float32(textSeg.Style.QuotingDepth)
 				}
 			} else if linkSeg, ok := seg.(*HyperlinkSegment); ok {
 				textStyle = linkSeg.TextStyle
@@ -1213,8 +1213,8 @@ func rowPaddingAndAlign(bound rowBoundary, lineSpacing float32, currentAlign fyn
 	if len(bound.segments) > 0 {
 		if text, ok := bound.segments[0].(*TextSegment); ok {
 			align = text.Style.Alignment
-			if text.Style == RichTextStyleBlockquote {
-				leftPad = lineSpacing * 4
+			if text.Style.QuotingDepth > 0 {
+				leftPad = lineSpacing * 4 * float32(text.Style.QuotingDepth)
 			}
 		} else if link, ok := bound.segments[0].(*HyperlinkSegment); ok {
 			align = link.Alignment

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -18,7 +18,7 @@ var (
 	// Since: 2.1
 	RichTextStyleBlockquote = RichTextStyle{
 		ColorName: theme.ColorNameForeground,
-		Inline:    false,
+		Inline:    true,
 		SizeName:  theme.SizeNameText,
 		TextStyle: fyne.TextStyle{Italic: true},
 	}

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -405,6 +405,8 @@ type RichTextStyle struct {
 	Inline    bool
 	SizeName  fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
 	TextStyle fyne.TextStyle
+	// Since: 2.8
+	QuotingDepth int
 
 	// an internal detail where we obscure password fields
 	concealed bool


### PR DESCRIPTION
### Description:

Support nested block quotes and allow blockquoted inline text.

#### Example:

```markdown
Alice wrote:
> Hi Bob!
> 
> Bob wrote:
> > Hi Alice!

New paragraph
```

#### develop branch:
<img width="189" height="250" alt="image" src="https://github.com/user-attachments/assets/1fde0165-4d03-4768-9967-f0727f715a6d" />

#### This pull request:
<img width="186" height="191" alt="image" src="https://github.com/user-attachments/assets/fb315bd4-b440-455a-905e-d45c54b7fe3d" />

Fixes #6311 and #6297.

- [x] This PR is probably in conflict with #6299. I'm going to update this PR after #6299 has been merged.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
