### PR TITLE
fix animation progress when duration changes mid-run

### DIFF
--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -8,17 +8,14 @@ import (
 
 type anim struct {
 	a           *fyne.Animation
-	end         time.Time
 	repeatsLeft int
 	reverse     bool
 	start       time.Time
-	total       int64
 	stopped     bool
 }
 
 func newAnim(a *fyne.Animation) *anim {
-	animate := &anim{a: a, start: time.Now(), end: time.Now().Add(a.Duration)}
-	animate.total = animate.end.Sub(animate.start).Milliseconds()
+	animate := &anim{a: a, start: time.Now()}
 	animate.repeatsLeft = a.RepeatCount
 	return animate
 }

--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -29,12 +29,6 @@ func newAnim(a *fyne.Animation) *anim {
 	return animate
 }
 
-// progressFraction returns the linear 0..1 position at `now`, interpolating
-// from the pinned snapshot (pinTime, pinProgress) toward 1.0 at start+duration.
-// With an unchanged Duration this is just elapsed/duration. When Duration is
-// changed mid-animation, re-pinning before updating lastDuration keeps the
-// value passed to Tick continuous and lets the new total duration drive the
-// remaining segment to 1.0.
 func (a *anim) progressFraction(now time.Time, duration time.Duration) float32 {
 	remaining := a.start.Add(duration).Sub(a.pinTime)
 	if remaining <= 0 {

--- a/internal/animation/animation.go
+++ b/internal/animation/animation.go
@@ -7,17 +7,54 @@ import (
 )
 
 type anim struct {
-	a           *fyne.Animation
-	repeatsLeft int
-	reverse     bool
-	start       time.Time
-	stopped     bool
+	a            *fyne.Animation
+	repeatsLeft  int
+	reverse      bool
+	start        time.Time
+	lastDuration time.Duration
+	pinTime      time.Time
+	pinProgress  float32
+	stopped      bool
 }
 
 func newAnim(a *fyne.Animation) *anim {
-	animate := &anim{a: a, start: time.Now()}
+	now := time.Now()
+	animate := &anim{
+		a:            a,
+		start:        now,
+		lastDuration: a.Duration,
+		pinTime:      now,
+	}
 	animate.repeatsLeft = a.RepeatCount
 	return animate
+}
+
+// progressFraction returns the linear 0..1 position at `now`, interpolating
+// from the pinned snapshot (pinTime, pinProgress) toward 1.0 at start+duration.
+// With an unchanged Duration this is just elapsed/duration. When Duration is
+// changed mid-animation, re-pinning before updating lastDuration keeps the
+// value passed to Tick continuous and lets the new total duration drive the
+// remaining segment to 1.0.
+func (a *anim) progressFraction(now time.Time, duration time.Duration) float32 {
+	remaining := a.start.Add(duration).Sub(a.pinTime)
+	if remaining <= 0 {
+		return 1
+	}
+	val := a.pinProgress + (1-a.pinProgress)*float32(now.Sub(a.pinTime))/float32(remaining)
+	if val > 1 {
+		return 1
+	}
+	if val < 0 {
+		return 0
+	}
+	return val
+}
+
+func (a *anim) resetCycle(now time.Time) {
+	a.start = now
+	a.pinTime = now
+	a.pinProgress = 0
+	a.lastDuration = a.a.Duration
 }
 
 func (a *anim) setStopped() {

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -61,6 +61,51 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 	run.animationMutex.RUnlock()
 }
 
+func TestRunner_DurationChangedMidAnimation(t *testing.T) {
+	progress := make(chan float32, 4)
+	run := &Runner{}
+	a := &fyne.Animation{
+		Duration: time.Second,
+		Curve:    fyne.AnimationLinear,
+		Tick: func(d float32) {
+			progress <- d
+		},
+	}
+
+	run.Start(a)
+
+	// First tick — only a few ms in on a 1s animation, progress should be tiny.
+	time.Sleep(20 * time.Millisecond)
+	run.TickAnimations()
+	select {
+	case d := <-progress:
+		assert.Less(t, d, float32(0.1), "progress should reflect long original duration")
+	case <-time.After(time.Second):
+		t.Fatal("animation was not ticked")
+	}
+
+	a.Duration = 100 * time.Millisecond
+
+	time.Sleep(40 * time.Millisecond)
+	run.TickAnimations()
+	select {
+	case d := <-progress:
+		assert.Greater(t, d, float32(0.3), "progress should be normalized to the new shorter duration")
+	case <-time.After(time.Second):
+		t.Fatal("animation was not ticked after duration change")
+	}
+
+	// Sleep past the new duration; tick should now report completion (1.0).
+	time.Sleep(120 * time.Millisecond)
+	run.TickAnimations()
+	select {
+	case d := <-progress:
+		assert.Equal(t, float32(1.0), d, "animation should complete based on the new duration")
+	case <-time.After(time.Second):
+		t.Fatal("animation did not complete after duration change")
+	}
+}
+
 func TestGLDriver_StopAnimationImmediatelyAndInsideTick(t *testing.T) {
 	var wg sync.WaitGroup
 	run := &Runner{}

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -82,9 +82,7 @@ func TestRunner_DurationIncreasedMidAnimation(t *testing.T) {
 		t.Fatal("animation was not ticked")
 	}
 
-	// Extend the duration. The value passed to Tick must not snap backwards
-	// — dividing the same elapsed time by the new (larger) total would yield
-	// a smaller progress and visibly jump a progress bar in reverse.
+	// Extend the duration; progress should not snap backwards.
 	a.Duration = 4 * time.Second
 	run.TickAnimations()
 	var after float32
@@ -96,8 +94,6 @@ func TestRunner_DurationIncreasedMidAnimation(t *testing.T) {
 	assert.InDelta(t, before, after, 0.1,
 		"progress should be preserved when Duration grows: before=%v after=%v", before, after)
 
-	// And from here it should pace against the new longer total — far from
-	// completing within a tiny extra wait.
 	time.Sleep(100 * time.Millisecond)
 	run.TickAnimations()
 	select {
@@ -132,8 +128,7 @@ func TestRunner_DurationDecreasedMidAnimation(t *testing.T) {
 		t.Fatal("animation was not ticked")
 	}
 
-	// Shorten Duration but keep it longer than time already elapsed. Progress
-	// must be preserved at the moment of change and then advance faster.
+	// Shorten Duration but keep it longer than elapsed time.
 	a.Duration = 400 * time.Millisecond
 	run.TickAnimations()
 	var after float32
@@ -145,7 +140,6 @@ func TestRunner_DurationDecreasedMidAnimation(t *testing.T) {
 	assert.InDelta(t, before, after, 0.1,
 		"progress should be preserved when Duration shrinks: before=%v after=%v", before, after)
 
-	// Sleeping past the new total should drive it to 1.0.
 	time.Sleep(300 * time.Millisecond)
 	run.TickAnimations()
 	select {
@@ -176,8 +170,7 @@ func TestRunner_DurationShortenedBelowElapsed(t *testing.T) {
 		t.Fatal("animation was not ticked")
 	}
 
-	// Shorten Duration below the elapsed time — animation must finish on the
-	// next tick rather than overshoot or stall.
+	// Shorten Duration below the elapsed time.
 	a.Duration = 50 * time.Millisecond
 	run.TickAnimations()
 	select {

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -61,7 +61,102 @@ func TestGLDriver_StopAnimation(t *testing.T) {
 	run.animationMutex.RUnlock()
 }
 
-func TestRunner_DurationChangedMidAnimation(t *testing.T) {
+func TestRunner_DurationIncreasedMidAnimation(t *testing.T) {
+	progress := make(chan float32, 8)
+	run := &Runner{}
+	a := &fyne.Animation{
+		Duration: time.Second,
+		Curve:    fyne.AnimationLinear,
+		Tick: func(d float32) {
+			progress <- d
+		},
+	}
+	run.Start(a)
+
+	time.Sleep(200 * time.Millisecond)
+	run.TickAnimations()
+	var before float32
+	select {
+	case before = <-progress:
+	case <-time.After(time.Second):
+		t.Fatal("animation was not ticked")
+	}
+
+	// Extend the duration. The value passed to Tick must not snap backwards
+	// — dividing the same elapsed time by the new (larger) total would yield
+	// a smaller progress and visibly jump a progress bar in reverse.
+	a.Duration = 4 * time.Second
+	run.TickAnimations()
+	var after float32
+	select {
+	case after = <-progress:
+	case <-time.After(time.Second):
+		t.Fatal("animation was not ticked after duration change")
+	}
+	assert.InDelta(t, before, after, 0.1,
+		"progress should be preserved when Duration grows: before=%v after=%v", before, after)
+
+	// And from here it should pace against the new longer total — far from
+	// completing within a tiny extra wait.
+	time.Sleep(100 * time.Millisecond)
+	run.TickAnimations()
+	select {
+	case d := <-progress:
+		assert.Greater(t, d, after,
+			"progress should continue forward after pin: after=%v d=%v", after, d)
+		assert.Less(t, d, float32(0.6),
+			"progress should pace against the new longer duration: d=%v", d)
+	case <-time.After(time.Second):
+		t.Fatal("animation did not continue ticking")
+	}
+}
+
+func TestRunner_DurationDecreasedMidAnimation(t *testing.T) {
+	progress := make(chan float32, 8)
+	run := &Runner{}
+	a := &fyne.Animation{
+		Duration: time.Second,
+		Curve:    fyne.AnimationLinear,
+		Tick: func(d float32) {
+			progress <- d
+		},
+	}
+	run.Start(a)
+
+	time.Sleep(200 * time.Millisecond)
+	run.TickAnimations()
+	var before float32
+	select {
+	case before = <-progress:
+	case <-time.After(time.Second):
+		t.Fatal("animation was not ticked")
+	}
+
+	// Shorten Duration but keep it longer than time already elapsed. Progress
+	// must be preserved at the moment of change and then advance faster.
+	a.Duration = 400 * time.Millisecond
+	run.TickAnimations()
+	var after float32
+	select {
+	case after = <-progress:
+	case <-time.After(time.Second):
+		t.Fatal("animation was not ticked after duration change")
+	}
+	assert.InDelta(t, before, after, 0.1,
+		"progress should be preserved when Duration shrinks: before=%v after=%v", before, after)
+
+	// Sleeping past the new total should drive it to 1.0.
+	time.Sleep(300 * time.Millisecond)
+	run.TickAnimations()
+	select {
+	case d := <-progress:
+		assert.Equal(t, float32(1.0), d, "animation should complete on the new shorter duration")
+	case <-time.After(time.Second):
+		t.Fatal("animation did not complete after duration change")
+	}
+}
+
+func TestRunner_DurationShortenedBelowElapsed(t *testing.T) {
 	progress := make(chan float32, 4)
 	run := &Runner{}
 	a := &fyne.Animation{
@@ -71,49 +166,26 @@ func TestRunner_DurationChangedMidAnimation(t *testing.T) {
 			progress <- d
 		},
 	}
-
 	run.Start(a)
 
-	// Tick once against the original 1s duration.
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	run.TickAnimations()
-	var before float32
 	select {
-	case before = <-progress:
+	case <-progress:
 	case <-time.After(time.Second):
 		t.Fatal("animation was not ticked")
 	}
 
-	// Shorten the duration. With the fix, the next tick must rescale to the
-	// new 100ms total — the same elapsed time should now represent a much
-	// larger fraction of progress. Without the fix it would still be divided
-	// by the original 1s and stay close to `before`.
-	a.Duration = 100 * time.Millisecond
-	run.TickAnimations()
-	var after float32
-	select {
-	case after = <-progress:
-	case <-time.After(time.Second):
-		t.Fatal("animation was not ticked after duration change")
-	}
-	// Either we jumped well above the original progress, or elapsed time was
-	// already past the new duration so the animation completed on this tick.
-	// Both prove the new duration was honored.
-	assert.True(t, after == 1.0 || after > before*3,
-		"progress should rescale to the new duration: before=%v after=%v", before, after)
-
-	if after == 1.0 {
-		return // already completed on the rescale (slow scheduler)
-	}
-
-	// Sleeping past the new duration should drive it to completion.
-	time.Sleep(120 * time.Millisecond)
+	// Shorten Duration below the elapsed time — animation must finish on the
+	// next tick rather than overshoot or stall.
+	a.Duration = 50 * time.Millisecond
 	run.TickAnimations()
 	select {
 	case d := <-progress:
-		assert.Equal(t, float32(1.0), d, "animation should complete based on the new duration")
+		assert.Equal(t, float32(1.0), d,
+			"animation should complete when new duration is shorter than elapsed time")
 	case <-time.After(time.Second):
-		t.Fatal("animation did not complete after duration change")
+		t.Fatal("animation did not complete")
 	}
 }
 

--- a/internal/animation/animation_test.go
+++ b/internal/animation/animation_test.go
@@ -74,28 +74,39 @@ func TestRunner_DurationChangedMidAnimation(t *testing.T) {
 
 	run.Start(a)
 
-	// First tick — only a few ms in on a 1s animation, progress should be tiny.
+	// Tick once against the original 1s duration.
 	time.Sleep(20 * time.Millisecond)
 	run.TickAnimations()
+	var before float32
 	select {
-	case d := <-progress:
-		assert.Less(t, d, float32(0.1), "progress should reflect long original duration")
+	case before = <-progress:
 	case <-time.After(time.Second):
 		t.Fatal("animation was not ticked")
 	}
 
+	// Shorten the duration. With the fix, the next tick must rescale to the
+	// new 100ms total — the same elapsed time should now represent a much
+	// larger fraction of progress. Without the fix it would still be divided
+	// by the original 1s and stay close to `before`.
 	a.Duration = 100 * time.Millisecond
-
-	time.Sleep(40 * time.Millisecond)
 	run.TickAnimations()
+	var after float32
 	select {
-	case d := <-progress:
-		assert.Greater(t, d, float32(0.3), "progress should be normalized to the new shorter duration")
+	case after = <-progress:
 	case <-time.After(time.Second):
 		t.Fatal("animation was not ticked after duration change")
 	}
+	// Either we jumped well above the original progress, or elapsed time was
+	// already past the new duration so the animation completed on this tick.
+	// Both prove the new duration was honored.
+	assert.True(t, after == 1.0 || after > before*3,
+		"progress should rescale to the new duration: before=%v after=%v", before, after)
 
-	// Sleep past the new duration; tick should now report completion (1.0).
+	if after == 1.0 {
+		return // already completed on the rescale (slow scheduler)
+	}
+
+	// Sleeping past the new duration should drive it to completion.
 	time.Sleep(120 * time.Millisecond)
 	run.TickAnimations()
 	select {

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -131,7 +131,17 @@ func (r *Runner) runOneFrame() (done bool) {
 // tickAnimation will process a frame of animation and return true if this should continue animating
 func (r *Runner) tickAnimation(a *anim) bool {
 	duration := a.a.Duration
-	if time.Since(a.start) >= duration {
+	now := time.Now()
+
+	// If Duration changed since the last tick, pin progress to its current
+	// value so the value passed to Tick stays continuous across the change.
+	if duration != a.lastDuration {
+		a.pinProgress = a.progressFraction(now, a.lastDuration)
+		a.pinTime = now
+		a.lastDuration = duration
+	}
+
+	if !now.Before(a.start.Add(duration)) {
 		if a.reverse {
 			a.a.Tick(0.0)
 			if a.repeatsLeft == 0 {
@@ -153,14 +163,11 @@ func (r *Runner) tickAnimation(a *anim) bool {
 			}
 		}
 
-		a.start = time.Now()
+		a.resetCycle(time.Now())
 		return true
 	}
 
-	delta := time.Since(a.start).Milliseconds()
-	total := duration.Milliseconds()
-
-	val := float32(delta) / float32(total)
+	val := a.progressFraction(now, duration)
 	curve := a.a.Curve
 	if curve == nil {
 		curve = fyne.AnimationEaseInOut

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -133,8 +133,6 @@ func (r *Runner) tickAnimation(a *anim) bool {
 	duration := a.a.Duration
 	now := time.Now()
 
-	// If Duration changed since the last tick, pin progress to its current
-	// value so the value passed to Tick stays continuous across the change.
 	if duration != a.lastDuration {
 		a.pinProgress = a.progressFraction(now, a.lastDuration)
 		a.pinTime = now

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -130,7 +130,8 @@ func (r *Runner) runOneFrame() (done bool) {
 
 // tickAnimation will process a frame of animation and return true if this should continue animating
 func (r *Runner) tickAnimation(a *anim) bool {
-	if time.Now().After(a.end) {
+	duration := a.a.Duration
+	if time.Since(a.start) >= duration {
 		if a.reverse {
 			a.a.Tick(0.0)
 			if a.repeatsLeft == 0 {
@@ -153,13 +154,13 @@ func (r *Runner) tickAnimation(a *anim) bool {
 		}
 
 		a.start = time.Now()
-		a.end = a.start.Add(a.a.Duration)
 		return true
 	}
 
 	delta := time.Since(a.start).Milliseconds()
+	total := duration.Milliseconds()
 
-	val := float32(delta) / float32(a.total)
+	val := float32(delta) / float32(total)
 	curve := a.a.Curve
 	if curve == nil {
 		curve = fyne.AnimationEaseInOut


### PR DESCRIPTION
### Description:

Fixes #5970

The `anim` struct cached `total` at construction, so updating
`Animation.Duration` while it was running didn't affect the progress
value passed to `Tick`. Reading `Duration` on each tick fixes that, and
the end-time check is updated the same way so the two stay consistent.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.