### PR TITLE
show a static ellipsis on Activity when animations are disabled

### DIFF
--- a/widget/activity.go
+++ b/widget/activity.go
@@ -99,6 +99,10 @@ func (a *activityRenderer) Destroy() {
 func (a *activityRenderer) Layout(size fyne.Size) {
 	a.maxRad = fyne.Min(size.Width, size.Height) / 2
 	a.bound = size
+
+	if a.parent.started && !fyne.CurrentApp().Settings().ShowAnimations() {
+		a.drawStaticEllipsis()
+	}
 }
 
 func (a *activityRenderer) MinSize() fyne.Size {
@@ -162,12 +166,51 @@ func (a *activityRenderer) scaleDot(dot *canvas.Circle, off float32) {
 
 func (a *activityRenderer) start() {
 	a.wasStarted = true
+	if !fyne.CurrentApp().Settings().ShowAnimations() {
+		a.drawStaticEllipsis()
+		return
+	}
 	a.anim.Start()
 }
 
 func (a *activityRenderer) stop() {
 	a.wasStarted = false
 	a.anim.Stop()
+	if !fyne.CurrentApp().Settings().ShowAnimations() {
+		a.hideDots()
+	}
+}
+
+// drawStaticEllipsis places the three dots in a horizontal row, like an
+// ellipsis. Used when animations are disabled so the widget still indicates
+// something is happening without any motion.
+func (a *activityRenderer) drawStaticEllipsis() {
+	d := fyne.Min(a.bound.Width/4, a.bound.Height)
+	if d <= 0 {
+		a.hideDots()
+		return
+	}
+	radius := d / 2
+	totalW := 4 * d
+	startX := (a.bound.Width - totalW) / 2
+	cy := a.bound.Height / 2
+	fill := color.NRGBA{R: a.maxCol.R, G: a.maxCol.G, B: a.maxCol.B, A: a.maxCol.A}
+	for i, obj := range a.dots {
+		dot := obj.(*canvas.Circle)
+		cx := startX + radius + float32(i)*1.5*d
+		dot.Move(fyne.NewPos(cx-radius, cy-radius))
+		dot.Resize(fyne.NewSquareSize(d))
+		dot.FillColor = fill
+		dot.Refresh()
+	}
+}
+
+func (a *activityRenderer) hideDots() {
+	for _, obj := range a.dots {
+		dot := obj.(*canvas.Circle)
+		dot.Resize(fyne.NewSquareSize(0))
+		dot.Refresh()
+	}
 }
 
 func (a *activityRenderer) updateColor() {

--- a/widget/activity_internal_test.go
+++ b/widget/activity_internal_test.go
@@ -3,6 +3,10 @@ package widget
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/test"
 )
 
@@ -29,4 +33,52 @@ func TestActivity_Animation(t *testing.T) {
 	// check reset to loop
 	render.anim.Tick(1.0)
 	test.AssertImageMatches(t, "activity/animate_0.0.png", w.Canvas().Capture())
+}
+
+func TestActivity_StaticEllipsisLayout(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.NewTheme())
+
+	a := NewActivity()
+	w := test.NewWindow(a)
+	defer w.Close()
+	w.SetPadded(false)
+
+	size := fyne.NewSize(40, 12)
+	w.Resize(size)
+
+	render := test.TempWidgetRenderer(t, a).(*activityRenderer)
+	render.bound = size
+	render.drawStaticEllipsis()
+
+	dots := make([]*canvas.Circle, len(render.dots))
+	for i, obj := range render.dots {
+		dots[i] = obj.(*canvas.Circle)
+	}
+
+	// All three dots are the same non-zero size.
+	d0 := dots[0].Size()
+	assert.Greater(t, d0.Width, float32(0), "dot should have non-zero width")
+	for _, d := range dots[1:] {
+		assert.Equal(t, d0, d.Size(), "all dots should be the same size")
+	}
+
+	// All three sit on the same y-position — horizontal row.
+	y := dots[0].Position().Y
+	for _, d := range dots[1:] {
+		assert.Equal(t, y, d.Position().Y, "dots must share a baseline")
+	}
+
+	// X-positions advance left to right with equal spacing.
+	gap1 := dots[1].Position().X - dots[0].Position().X
+	gap2 := dots[2].Position().X - dots[1].Position().X
+	assert.Greater(t, gap1, float32(0), "second dot must be right of the first")
+	assert.InDelta(t, gap1, gap2, 0.001, "dots should be evenly spaced")
+
+	// The row should be horizontally centered in the bound.
+	rowLeft := dots[0].Position().X
+	rowRight := dots[2].Position().X + dots[2].Size().Width
+	leftMargin := rowLeft
+	rightMargin := size.Width - rowRight
+	assert.InDelta(t, leftMargin, rightMargin, 0.001, "row should be centered horizontally")
 }


### PR DESCRIPTION
### Description:

Fixes #5252

When `Settings().ShowAnimations()` is false (either via the `no_animations` build tag or the user preference), Activity used to keep running its animation loop. It now lays the three dots out as a horizontal ellipsis instead — matching the indicator-without-motion approach the maintainers agreed on in the issue thread.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.