### PR TITLE
Guard against nil font resources in lookupFaces/loadMeasureFont

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -140,8 +140,15 @@ func CachedFontFace(style fyne.TextStyle, source fyne.Resource, o fyne.CanvasObj
 		th := theme.CurrentForWidget(o)
 		font1 := th.Font(style)
 
-		emoji := theme.DefaultEmojiFont() // TODO only one emoji - maybe others too
-		fallbacks := []fyne.Resource{emoji, theme.DefaultSymbolFont()}
+		// Skip any nil fallback fonts — they can be nil when built with
+		// -tags no_emoji, and the lookupFaces loop expects non-nil entries.
+		var fallbacks []fyne.Resource
+		if emoji := theme.DefaultEmojiFont(); emoji != nil { // TODO only one emoji - maybe others too
+			fallbacks = append(fallbacks, emoji)
+		}
+		if sym := theme.DefaultSymbolFont(); sym != nil {
+			fallbacks = append(fallbacks, sym)
+		}
 		switch {
 		case style.Monospace:
 			faces = lookupFaces(font1, theme.DefaultTextMonospaceFont(), fallbacks, fontscan.Monospace, style)


### PR DESCRIPTION
When the app is built with `-tags no_emoji` we're triggering nil object errors:


> goroutine 1 [running, locked to thread]:\ngithub.com/.../...-terminal/internal.LogPanic({0x100bfae20, 0x101675300})\n\tgithub.com/.../...-terminal/internal/logger.go:159 +0x68\nmain.main.func1()\n\tgithub.com/.../...-terminal/cmd/term/main_darwin.go:31 +0x34\npanic({0x100bfae20?, 0x101675300?})\n\truntime/panic.go:783 +0x120\nfyne.io/fyne/v2/internal/painter.loadMeasureFont({0x0?, 0x0?})\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/internal/painter/font.go:207 +0x20\nfyne.io/fyne/v2/internal/painter.lookupFaces({0x100d151e0, 0x10168a8a0}, {0x100d151e0, 0x101688b20}, {0x1400057f148, 0x2, 0x30?}, {0x1009bab5d, 0xa}, {0x1, ...})\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/internal/painter/font.go:103 +0x230\nfyne.io/fyne/v2/internal/painter.CachedFontFace({0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, {0x0?, 0x0?}, {0x0, ...})\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/internal/painter/font.go:152 +0x424\nfyne.io/fyne/v2/internal/painter.measureText({0x140000da3f3, 0x0}, 0x41400000, {0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, ...)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/internal/painter/font.go:244 +0x78\nfyne.io/fyne/v2/internal/painter.RenderedTextSize({0x140000da3f3, 0x0}, 0x41400000, {0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, ...)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/internal/painter/font.go:230 +0xa0\nfyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).RenderedTextSize(0x1400017b2d8?, {0x140000da3f3?, 0x1400017b2d8?}, 0x0?, {0x1, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/internal/driver/glfw/driver.go:111 +0x74\nfyne.io/fyne/v2.MeasureText({0x140000da3f3, 0x0}, 0x41400000, {0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/text.go:73 +0x94\nfyne.io/fyne/v2/widget.(*RichText).updateRowBounds.func1({0x140000bc360?, 0x1009bcf85?, 0x1400017b628?}, 0x0)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/widget/richtext.go:515 +0xc2c\nfyne.io/fyne/v2/widget.(*RichText).updateRowBounds(0x14000108210)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/widget/richtext.go:531 +0x150\nfyne.io/fyne/v2/widget.(*RichText).Refresh(0x14000108210)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/widget/richtext.go:111 +0x28\nfyne.io/fyne/v2/widget.(*buttonRenderer).updateIconAndText(0x140001ce050)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/widget/button.go:437 +0x27c\nfyne.io/fyne/v2/widget.(*Button).CreateRenderer(0x1400016a500)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/widget/button.go:142 +0x3dc\nfyne.io/fyne/v2/internal/cache.Renderer({0x100d21a38, 0x1400016a500})\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/internal/cache/widget.go:20 +0x3c\nfyne.io/fyne/v2/widget.(*BaseWidget).Refresh(0x1400017b848?)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/widget/widget.go:127 +0x4c\nfyne.io/fyne/v2/widget.(*DisableableWidget).Disable(0x140000cc801?)\n\tfyne.io/fyne/v2@v2.7.5-0.20260527133038-c4b071dabed6/widget/widget.go:191 +0x3c\nmain.updateFixButtonState()\n\tgithub.com/.../...-terminal/cmd/term/main.go:750 +0xb8\nmain.newMainWindow({0x100d25478, 0x140003d4540}, 0x140004bc270)\n\tgithub.com/.../...-terminal/cmd/term/main.go:1798 +0x12dc\nmain.cmdMain(0x140001ff100?, {0x1016f9500, 0x0, 0x1009b3890?})\n\tgithub.com/.../...-terminal/cmd/term/commands.go:97 +0x160\ngithub.com/spf13/cobra.(*Command).execute(0x1400028e908, {0x140000bc050, 0x0, 0x0})\n\tgithub.com/spf13/cobra@v1.10.1/command.go:1019 +0x7bc\ngithub.com/spf13/cobra.(*Command).ExecuteC(0x1400028e908)\n\tgithub.com/spf13/cobra@v1.10.1/command.go:1148 +0x350\ngithub.com/spf13/cobra.(*Command).Execute(...)\n\tgithub.com/spf13/cobra@v1.10.1/command.go:1071\nmain.run()\n\tgithub.com/.../...-terminal/cmd/term/main.go:1336 +0x6c\nmain.main()\n\tgithub.com/.../...-terminal/cmd/term/main_darwin.go:74 +0x244\n","goroutines":7,"heap_alloc":4391592,"heap_sys":7700480,"timestamp":"2026-05-28 22:11:30.725503 +0700 +07 m=+0.166081459","location":"github.com/.../...-terminal/internal/logger.go:172","message":"Application panic recovered"}

Not all tests pass, but it doesn't appear related to my changes.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
