### PR TITLE
Add form validation

### DIFF
--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -468,6 +468,10 @@ func makeFormTab(_ fyne.Window) fyne.CanvasObject {
 	form.Append("Password", password)
 	form.Append("Disabled", disabled)
 	form.Append("Message", largeText)
+
+	form.Items[2].Required = true
+	form.Items[3].Required = true
+	form.Refresh()
 	return form
 }
 

--- a/validation.go
+++ b/validation.go
@@ -11,6 +11,16 @@ type Validatable interface {
 	SetOnValidationChanged(func(error))
 }
 
+// Requireable is implemented by any widgets that want to support the
+// [Required] field of a [FormItem]
+//
+// Since: 2.8
+type Requireable interface {
+	HasValue() bool
+
+	SetRequiredChanged(func(bool))
+}
+
 // StringValidator is a function signature for validating string inputs.
 //
 // Since: 1.4

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -67,6 +67,7 @@ type Entry struct {
 	validationStatus    *validationStatus
 	onValidationChanged func(error)
 	validationError     error
+	onRequiredChanged   func(bool)
 
 	// If true, the Validator runs automatically on render without user interaction.
 	// It will reflect any validation errors found or those explicitly set via SetValidationError().
@@ -1391,7 +1392,14 @@ func (e *Entry) updateMousePointer(p fyne.Position, rightClick bool) {
 // It assumes that a lock exists on the widget.
 func (e *Entry) updateText(text string, fromBinding bool) bool {
 	changed := e.Text != text
+	wasEmpty := e.Text == ""
 	e.Text = text
+	if e.onRequiredChanged != nil {
+		empty := text == ""
+		if wasEmpty != empty {
+			e.onRequiredChanged(!empty)
+		}
+	}
 	e.syncSegments()
 	e.text.updateRowBounds()
 

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -83,12 +83,12 @@ type Entry struct {
 
 	cursorAnim *entryCursorAnimation
 
-	dirty       bool
-	focused     bool
-	text        RichText
-	placeholder RichText
-	content     *entryContent
-	scroll      *widget.Scroll
+	dirty               bool
+	focused, hasFocused bool
+	text                RichText
+	placeholder         RichText
+	content             *entryContent
+	scroll              *widget.Scroll
 
 	// useful for Form validation (as the error text should only be shown when
 	// the entry is unfocused)
@@ -303,6 +303,7 @@ func (e *Entry) ExtendBaseWidget(wid fyne.Widget) {
 // FocusGained is called when the Entry has been given focus.
 func (e *Entry) FocusGained() {
 	e.setFieldsAndRefresh(func() {
+		e.hasFocused = true
 		e.dirty = true
 		e.focused = true
 	})
@@ -317,6 +318,10 @@ func (e *Entry) FocusLost() {
 		e.focused = false
 		e.selectKeyDown = false
 	})
+	if e.Validator != nil {
+		e.validate()
+		e.Refresh()
+	}
 	if e.onFocusChanged != nil {
 		e.onFocusChanged(false)
 	}

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -6,8 +6,10 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-var _ fyne.Requireable = (*Entry)(nil)
-var _ fyne.Validatable = (*Entry)(nil)
+var (
+	_ fyne.Requireable = (*Entry)(nil)
+	_ fyne.Validatable = (*Entry)(nil)
+)
 
 // HasValue is used for required validation and returns true if the text is not entry.
 //

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -51,6 +51,12 @@ func (e *Entry) validate() {
 // The function might be overwritten by a parent that cares about child validation (e.g. widget.Form).
 func (e *Entry) SetOnValidationChanged(callback func(error)) {
 	e.onValidationChanged = callback
+
+	if e.Validator != nil && callback != nil && e.Text != "" {
+		if err := e.Validator(e.Text); err != nil {
+			callback(err)
+		}
+	}
 }
 
 // SetValidationError manually updates the validation status until the next input change.
@@ -76,17 +82,18 @@ func (e *Entry) setValidationError(err error) bool {
 		}
 		return true
 	}
-	if e.focused || !e.hasFocused {
-		return false
-	}
-	if err == nil && e.validationError == nil {
+
+	gone := err == nil
+	if !gone && (e.focused || (!e.hasFocused && e.Text == "")) {
 		return false
 	}
 
 	changed := e.validationError != err
 	e.validationError = err
-	if e.onValidationChanged != nil && changed {
-		e.onValidationChanged(err)
+	if e.onValidationChanged != nil {
+		if changed || gone {
+			e.onValidationChanged(err)
+		}
 	}
 
 	return true

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -6,7 +6,23 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
+var _ fyne.Requireable = (*Entry)(nil)
 var _ fyne.Validatable = (*Entry)(nil)
+
+// HasValue is used for required validation and returns true if the text is not entry.
+//
+// Since: 2.8
+func (e *Entry) HasValue() bool {
+	return e.Text != ""
+}
+
+// SetRequiredChanged is intended for parent widgets or containers to hook into the required state.
+// The function might be overwritten by a parent that cares about child state (e.g. widget.Form).
+//
+// Since: 2.8
+func (e *Entry) SetRequiredChanged(callback func(bool)) {
+	e.onRequiredChanged = callback
+}
 
 // Validate validates the current text in the widget.
 func (e *Entry) Validate() error {

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -69,6 +69,13 @@ func (e *Entry) SetValidationError(err error) {
 // setValidationError sets the validation error and returns a bool to indicate if it changes.
 // It assumes that the widget has a validator.
 func (e *Entry) setValidationError(err error) bool {
+	if e.AlwaysShowValidationError {
+		e.validationError = err
+		if e.onValidationChanged != nil {
+			e.onValidationChanged(err)
+		}
+		return true
+	}
 	if e.focused || !e.hasFocused {
 		return false
 	}

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -27,23 +27,22 @@ func (e *Entry) SetRequiredChanged(callback func(bool)) {
 }
 
 // Validate validates the current text in the widget.
-func (e *Entry) Validate() error {
-	if e.Validator == nil {
-		return nil
+func (e *Entry) Validate() (err error) {
+	if e.Validator != nil {
+		err = e.Validator(e.Text)
 	}
 
-	err := e.Validator(e.Text)
 	e.SetValidationError(err)
 	return err
 }
 
 // validate works like Validate but only updates the internal state and does not refresh.
 func (e *Entry) validate() {
-	if e.Validator == nil {
-		return
-	}
+	var err error
 
-	err := e.Validator(e.Text)
+	if e.Validator != nil {
+		err = e.Validator(e.Text)
+	}
 	e.setValidationError(err)
 }
 
@@ -61,10 +60,6 @@ func (e *Entry) SetOnValidationChanged(callback func(error)) {
 
 // SetValidationError manually updates the validation status until the next input change.
 func (e *Entry) SetValidationError(err error) {
-	if e.Validator == nil && !e.AlwaysShowValidationError {
-		return
-	}
-
 	if !e.setValidationError(err) {
 		return
 	}
@@ -88,12 +83,9 @@ func (e *Entry) setValidationError(err error) bool {
 		return false
 	}
 
-	changed := e.validationError != err
 	e.validationError = err
 	if e.onValidationChanged != nil {
-		if changed || gone {
-			e.onValidationChanged(err)
-		}
+		e.onValidationChanged(err)
 	}
 
 	return true

--- a/widget/entry_validation.go
+++ b/widget/entry_validation.go
@@ -1,8 +1,6 @@
 package widget
 
 import (
-	"errors"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/theme"
@@ -53,16 +51,15 @@ func (e *Entry) SetValidationError(err error) {
 // setValidationError sets the validation error and returns a bool to indicate if it changes.
 // It assumes that the widget has a validator.
 func (e *Entry) setValidationError(err error) bool {
-	if err == nil && e.validationError == nil {
+	if e.focused || !e.hasFocused {
 		return false
 	}
-	if errors.Is(err, e.validationError) {
+	if err == nil && e.validationError == nil {
 		return false
 	}
 
 	changed := e.validationError != err
 	e.validationError = err
-
 	if e.onValidationChanged != nil && changed {
 		e.onValidationChanged(err)
 	}

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -88,12 +88,14 @@ func TestEntry_SetValidationError(t *testing.T) {
 
 	entry.Validator = validator
 
+	entry.FocusGained()
 	entry.SetText("2020-30-30")
 	entry.SetValidationError(errors.New("set invalid"))
 	test.AssertImageMatches(t, "entry/validation_set_invalid.png", c.Capture())
 
 	entry.SetText("set valid")
 	entry.SetValidationError(nil)
+	entry.FocusLost()
 	test.AssertImageMatches(t, "entry/validation_set_valid.png", c.Capture())
 }
 
@@ -107,16 +109,22 @@ func TestEntry_SetOnValidationChanged(t *testing.T) {
 		modified = true
 	})
 
+	entry.FocusGained()
 	test.Type(entry, "2020")
+	entry.FocusLost()
 	assert.True(t, modified)
 
 	modified = false
+	entry.FocusGained()
 	test.Type(entry, "-01-01")
+	entry.FocusLost()
 	assert.True(t, modified)
 
 	modified = false
 	entry.SetOnValidationChanged(nil)
+	entry.FocusGained()
 	test.Type(entry, "invalid")
+	entry.FocusLost()
 	assert.False(t, modified)
 }
 

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -32,12 +32,15 @@ func TestEntry_ValidatedEntry(t *testing.T) {
 	entry.Validator = r
 	test.AssertRendersToMarkup(t, "entry/validate_initial.xml", c)
 
+	entry.FocusGained()
 	test.Type(entry, "2020-02")
 	assert.Error(t, r(entry.Text))
 	entry.FocusLost()
 	test.AssertRendersToMarkup(t, "entry/validate_invalid.xml", c)
 
+	entry.FocusGained()
 	test.Type(entry, "-12")
+	entry.FocusLost()
 	assert.NoError(t, r(entry.Text))
 	test.AssertRendersToMarkup(t, "entry/validate_valid.xml", c)
 }
@@ -90,12 +93,14 @@ func TestEntry_SetValidationError(t *testing.T) {
 
 	entry.FocusGained()
 	entry.SetText("2020-30-30")
+	entry.FocusLost()
 	entry.SetValidationError(errors.New("set invalid"))
 	test.AssertImageMatches(t, "entry/validation_set_invalid.png", c.Capture())
 
+	entry.FocusGained()
 	entry.SetText("set valid")
-	entry.SetValidationError(nil)
 	entry.FocusLost()
+	entry.SetValidationError(nil)
 	test.AssertImageMatches(t, "entry/validation_set_valid.png", c.Capture())
 }
 

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -172,10 +172,10 @@ func TestEntry_AlwaysShowValidationError_WithoutValidator_Error(t *testing.T) {
 
 	entry := widget.NewEntry()
 	entry.AlwaysShowValidationError = true
+	w := test.NewTempWindow(t, entry)
 
 	entry.SetValidationError(errors.New("error"))
 
-	w := test.NewTempWindow(t, entry)
 	test.AssertRendersToMarkup(t, "entry/always_on_without_validator_error.xml", w.Canvas())
 }
 
@@ -186,7 +186,6 @@ func TestEntry_AlwaysShowValidationError_WithoutValidator_Success(t *testing.T) 
 	entry.AlwaysShowValidationError = true
 
 	entry.SetValidationError(errors.New("error"))
-	entry.SetValidationError(nil)
 
 	w := test.NewTempWindow(t, entry)
 	test.AssertRendersToMarkup(t, "entry/always_on_without_validator_success.xml", w.Canvas())

--- a/widget/entry_validation_test.go
+++ b/widget/entry_validation_test.go
@@ -32,13 +32,11 @@ func TestEntry_ValidatedEntry(t *testing.T) {
 	entry.Validator = r
 	test.AssertRendersToMarkup(t, "entry/validate_initial.xml", c)
 
-	entry.FocusGained()
 	test.Type(entry, "2020-02")
 	assert.Error(t, r(entry.Text))
 	entry.FocusLost()
 	test.AssertRendersToMarkup(t, "entry/validate_invalid.xml", c)
 
-	entry.FocusGained()
 	test.Type(entry, "-12")
 	entry.FocusLost()
 	assert.NoError(t, r(entry.Text))

--- a/widget/form.go
+++ b/widget/form.go
@@ -107,7 +107,7 @@ func (f *Form) Refresh() {
 	f.ensureRenderItems()
 	f.updateButtons()
 	f.updateLabels()
-	f.checkValidation(f.validationError)
+	f.checkValidation(nil)
 
 	if f.isVertical() {
 		f.itemGrid.Layout = layout.NewVBoxLayout()
@@ -286,6 +286,7 @@ func (f *Form) checkValidation(err error) {
 			f.submitButton.Disable()
 			return
 		} else {
+			f.validationError = nil
 			f.validateText.Hide()
 		}
 	}

--- a/widget/form.go
+++ b/widget/form.go
@@ -11,10 +11,6 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-// errFormItemInitialState defines the error if the initial validation for a FormItem result
-// in an error
-var errFormItemInitialState = errors.New("widget.FormItem initial state error")
-
 // FormItem provides the details for a row in a form
 type FormItem struct {
 	Text   string
@@ -299,9 +295,7 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 		if i >= len(f.Items) {
 			return // called after form has been truncated
 		}
-		if err == errFormItemInitialState {
-			return
-		}
+
 		f.Items[i].validationError = err
 		f.Items[i].invalid = err != nil
 		f.setValidationError(err)
@@ -310,15 +304,6 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 	}
 	if w, ok := widget.(fyne.Validatable); ok {
 		f.Items[i].invalid = w.Validate() != nil
-		if e, ok := w.(*Entry); ok {
-			e.onFocusChanged = func(bool) {
-				updateValidation(e.validationError)
-			}
-			if e.Validator != nil && f.Items[i].invalid {
-				// set initial state error to guarantee next error (if triggers) is always different
-				e.SetValidationError(errFormItemInitialState)
-			}
-		}
 		w.SetOnValidationChanged(updateValidation)
 	}
 }
@@ -410,7 +395,6 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 	f.submitButton = &Button{Icon: th.Icon(theme.IconNameConfirm), OnTapped: f.OnSubmit, Importance: HighImportance}
 	buttons := &fyne.Container{Layout: layout.NewGridLayoutWithRows(1), Objects: []fyne.CanvasObject{f.cancelButton, f.submitButton}}
 	f.buttonBox = &fyne.Container{Layout: layout.NewBorderLayout(nil, nil, nil, buttons), Objects: []fyne.CanvasObject{buttons}}
-	f.validationError = errFormItemInitialState // set initial state error to guarantee next error (if triggers) is always different
 
 	f.itemGrid = &fyne.Container{Layout: layout.NewFormLayout()}
 	if f.isVertical() {

--- a/widget/form.go
+++ b/widget/form.go
@@ -57,8 +57,14 @@ type Form struct {
 	// Since: 2.5
 	Orientation Orientation
 
+	// Validator allows a form to handle some overall validation before it will enable Submit.
+	//
+	// Since: 2.8
+	Validator func() error `json:"-"`
+
 	itemGrid     *fyne.Container
 	buttonBox    *fyne.Container
+	validateText *canvas.Text
 	cancelButton *Button
 	submitButton *Button
 
@@ -271,6 +277,19 @@ func (f *Form) checkValidation(err error) {
 		}
 	}
 
+	if f.Validator != nil {
+		err := f.Validator()
+		if err != nil {
+			f.validationError = err
+			f.validateText.Text = err.Error()
+			f.validateText.Show()
+			f.submitButton.Disable()
+			return
+		} else {
+			f.validateText.Hide()
+		}
+	}
+
 	if !f.disabled {
 		f.submitButton.Enable()
 	}
@@ -453,6 +472,11 @@ func (f *Form) updateLabels() {
 		r.Refresh()
 		f.updateHelperText(item)
 	}
+
+	if f.validateText != nil {
+		f.validateText.Color = theme.ColorForWidget(theme.ColorNameError, f)
+		f.validateText.Refresh()
+	}
 }
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer
@@ -470,7 +494,11 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 	} else {
 		f.itemGrid.Layout = layout.NewFormLayout()
 	}
-	content := &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: []fyne.CanvasObject{f.itemGrid, f.buttonBox}}
+	f.validateText = canvas.NewText("", theme.ColorForWidget(theme.ColorNameError, f))
+	f.validateText.TextSize = th.Size(theme.SizeNameCaptionText)
+	f.validateText.Hide()
+
+	content := &fyne.Container{Layout: layout.NewVBoxLayout(), Objects: []fyne.CanvasObject{f.itemGrid, f.validateText, f.buttonBox}}
 	renderer := NewSimpleRenderer(content)
 	f.ensureRenderItems()
 	f.updateButtons()

--- a/widget/form.go
+++ b/widget/form.go
@@ -359,24 +359,18 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 }
 
 func (f *Form) setValidationError(err error) {
-	if err == nil && f.validationError == nil {
-		return
-	}
-
-	if !errors.Is(err, f.validationError) {
-		if err == nil {
-			for _, item := range f.Items {
-				if item.invalid {
-					err = item.validationError
-					break
-				}
+	if err == nil {
+		for _, item := range f.Items {
+			if item.invalid {
+				err = item.validationError
+				break
 			}
 		}
-		f.validationError = err
+	}
+	f.validationError = err
 
-		if f.onValidationChanged != nil {
-			f.onValidationChanged(err)
-		}
+	if f.onValidationChanged != nil {
+		f.onValidationChanged(err)
 	}
 }
 

--- a/widget/form.go
+++ b/widget/form.go
@@ -327,7 +327,6 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 			f.Items[i].validationError = nil
 			f.Items[i].meetsRequired = false
 		} else {
-
 			if hasValue {
 				f.Items[i].validationError = nil
 				f.Items[i].meetsRequired = false

--- a/widget/form.go
+++ b/widget/form.go
@@ -19,10 +19,13 @@ type FormItem struct {
 	// Since: 2.0
 	HintText string
 
-	validationError error
-	invalid         bool
-	helperOutput    *canvas.Text
-	wasFocused      bool
+	// Since: 2.8
+	Required bool
+
+	validationError        error
+	invalid, meetsRequired bool
+	helperOutput           *canvas.Text
+	wasFocused             bool
 }
 
 // NewFormItem creates a new form item with the specified label text and input widget
@@ -77,7 +80,7 @@ func (f *Form) AppendItem(item *FormItem) {
 
 	f.Items = append(f.Items, item)
 	if f.itemGrid != nil {
-		f.itemGrid.Add(f.createLabel(item.Text))
+		f.itemGrid.Add(f.createLabel(item))
 		f.itemGrid.Add(f.createInput(item))
 		f.setUpValidation(item.Widget, len(f.Items)-1)
 	}
@@ -98,6 +101,7 @@ func (f *Form) Refresh() {
 	f.ensureRenderItems()
 	f.updateButtons()
 	f.updateLabels()
+	f.checkValidation(f.validationError)
 
 	if f.isVertical() {
 		f.itemGrid.Layout = layout.NewVBoxLayout()
@@ -189,14 +193,24 @@ func (f *Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
 	return validator != nil
 }
 
-func (f *Form) createLabel(text string) fyne.CanvasObject {
-	label := &Label{
-		Text:      text,
-		Alignment: fyne.TextAlignTrailing,
-		TextStyle: fyne.TextStyle{Bold: true},
-	}
+func (f *Form) createLabel(item *FormItem) fyne.CanvasObject {
+	label := NewRichTextWithText(item.Text)
+	seg1 := label.Segments[0].(*TextSegment)
+	seg1.Style.Alignment = fyne.TextAlignTrailing
+	seg1.Style.TextStyle.Bold = true
 	if f.isVertical() {
-		label.Alignment = fyne.TextAlignLeading
+		seg1.Style.Alignment = fyne.TextAlignLeading
+	}
+
+	if item.Required {
+		marker := &TextSegment{Text: "* "}
+		if dis, ok := item.Widget.(fyne.Disableable); ok && dis.Disabled() {
+			marker.Style.ColorName = theme.ColorNameDisabled
+		} else {
+			marker.Style.ColorName = theme.ColorNameError
+		}
+		marker.Style.Inline = true
+		label.Segments = append([]RichTextSegment{marker}, label.Segments...)
 	}
 
 	return label
@@ -243,6 +257,12 @@ func (f *Form) checkValidation(err error) {
 			f.submitButton.Disable()
 			return
 		}
+		if item.Required {
+			if has, ok := item.Widget.(fyne.Requireable); ok && !has.HasValue() {
+				f.submitButton.Disable()
+				return
+			}
+		}
 	}
 
 	if !f.disabled {
@@ -265,7 +285,7 @@ func (f *Form) ensureRenderItems() {
 			continue
 		}
 
-		objects[off] = f.createLabel(item.Text)
+		objects[off] = f.createLabel(item)
 		off++
 		f.setUpValidation(item.Widget, i)
 		objects[off] = f.createInput(item)
@@ -302,8 +322,33 @@ func (f *Form) setUpValidation(widget fyne.CanvasObject, i int) {
 		f.checkValidation(err)
 		f.updateHelperText(f.Items[i])
 	}
+	updateRequired := func(hasValue bool) {
+		if !f.Items[i].Required {
+			f.Items[i].validationError = nil
+			f.Items[i].meetsRequired = false
+		} else {
+
+			if hasValue {
+				f.Items[i].validationError = nil
+				f.Items[i].meetsRequired = false
+			} else {
+				if f.Items[i].validationError == nil {
+					f.Items[i].validationError = errors.New("item is required")
+				}
+				f.Items[i].meetsRequired = true
+			}
+		}
+
+		f.checkValidation(f.Items[i].validationError)
+		f.updateHelperText(f.Items[i])
+	}
 	if w, ok := widget.(fyne.Validatable); ok {
 		f.Items[i].invalid = w.Validate() != nil
+		if r, ok := w.(fyne.Requireable); ok {
+			r.SetRequiredChanged(updateRequired)
+		} else if f.Items[i].Required {
+			fyne.LogError("Cannot mark a widget that is not `Requirable` as required", nil)
+		}
 		w.SetOnValidationChanged(updateValidation)
 	}
 }
@@ -365,24 +410,48 @@ func (f *Form) updateHelperText(item *FormItem) {
 
 func (f *Form) updateLabels() {
 	for i, item := range f.Items {
-		l := f.itemGrid.Objects[i*2].(*Label)
-		if dis, ok := item.Widget.(fyne.Disableable); ok {
-			if dis.Disabled() {
-				l.Importance = LowImportance
-			} else {
-				l.Importance = MediumImportance
+		r := f.itemGrid.Objects[i*2].(*RichText)
+
+		if len(r.Segments) == 1 {
+			if item.Required {
+				marker := &TextSegment{Text: "* "}
+				marker.Style.ColorName = theme.ColorNameError
+				marker.Style.Inline = true
+				r.Segments = append([]RichTextSegment{marker}, r.Segments...)
 			}
 		} else {
-			l.Importance = MediumImportance
+			if !item.Required {
+				r.Segments = r.Segments[1:]
+			}
+		}
+
+		if item.Required {
+			m := r.Segments[0].(*TextSegment)
+			if dis, ok := item.Widget.(fyne.Disableable); ok && dis.Disabled() {
+				m.Style.ColorName = theme.ColorNameDisabled
+			} else {
+				m.Style.ColorName = theme.ColorNameError
+			}
+		}
+
+		l := r.Segments[len(r.Segments)-1].(*TextSegment)
+		if dis, ok := item.Widget.(fyne.Disableable); ok {
+			if dis.Disabled() {
+				l.Style.ColorName = theme.ColorNameDisabled
+			} else {
+				l.Style.ColorName = theme.ColorNameForeground
+			}
+		} else {
+			l.Style.ColorName = theme.ColorNameForeground
 		}
 
 		l.Text = item.Text
 		if f.isVertical() {
-			l.Alignment = fyne.TextAlignLeading
+			l.Style.Alignment = fyne.TextAlignLeading
 		} else {
-			l.Alignment = fyne.TextAlignTrailing
+			l.Style.Alignment = fyne.TextAlignTrailing
 		}
-		l.Refresh()
+		r.Refresh()
 		f.updateHelperText(item)
 	}
 }

--- a/widget/form.go
+++ b/widget/form.go
@@ -144,6 +144,12 @@ func (f *Form) Disabled() bool {
 // The function might be overwritten by a parent that cares about child validation (e.g. widget.Form)
 func (f *Form) SetOnValidationChanged(callback func(error)) {
 	f.onValidationChanged = callback
+
+	if callback != nil {
+		if f.validationError != nil {
+			callback(f.validationError)
+		}
+	}
 }
 
 // Validate validates the entire form and returns the first error that is encountered.

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -258,6 +258,33 @@ func TestForm_Validation(t *testing.T) {
 	test.AssertImageMatches(t, "form/validation_valid.png", w.Canvas().Capture())
 }
 
+func TestForm_Validator(t *testing.T) {
+	test.NewTempApp(t)
+
+	valid := false
+	form := &Form{
+		Items:    []*FormItem{{Text: "First", Widget: &Entry{Text: "value"}}},
+		OnSubmit: func() {},
+		Validator: func() error {
+			if !valid {
+				return errors.New("form is not valid yet")
+			}
+			return nil
+		},
+	}
+	test.NewTempWindow(t, form)
+
+	assert.True(t, form.submitButton.Disabled())
+
+	valid = true
+	form.Refresh()
+	assert.False(t, form.submitButton.Disabled())
+
+	valid = false
+	form.Refresh()
+	assert.True(t, form.submitButton.Disabled())
+}
+
 func TestForm_Validation_Reset(t *testing.T) {
 	test.NewTempApp(t)
 	test.ApplyTheme(t, test.Theme())

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -191,6 +191,39 @@ func TestForm_Hints(t *testing.T) {
 	test.AssertImageMatches(t, "form/hint_valid.png", w.Canvas().Capture())
 }
 
+func TestForm_Required(t *testing.T) {
+	test.NewTempApp(t)
+	test.ApplyTheme(t, test.Theme())
+
+	entry1 := &Entry{Text: "anything"}
+	entry2 := &Entry{}
+	items := []*FormItem{
+		{Text: "First", Widget: entry1},
+		{Text: "Second", Widget: entry2, Required: true},
+	}
+
+	form := &Form{Items: items, OnSubmit: func() {}, OnCancel: func() {}}
+	w := test.NewWindow(form)
+	defer w.Close()
+
+	label1 := form.itemGrid.Objects[0].(*RichText)
+	label2 := form.itemGrid.Objects[2].(*RichText)
+	assert.Equal(t, "First", label1.String())
+	assert.Equal(t, "* Second", label2.String())
+	assert.True(t, form.submitButton.Disabled())
+
+	test.Type(entry2, "thing")
+	assert.False(t, form.submitButton.Disabled())
+
+	entry2.SetText("")
+	assert.True(t, form.submitButton.Disabled())
+
+	form.Items[1].Required = false
+	form.Refresh()
+	assert.Equal(t, "Second", label2.String())
+	assert.False(t, form.submitButton.Disabled())
+}
+
 func TestForm_Validation(t *testing.T) {
 	test.NewTempApp(t)
 	test.ApplyTheme(t, test.Theme())

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -53,7 +53,7 @@ func TestForm_Append_Items(t *testing.T) {
 
 	form.Refresh()
 	c := renderer.Objects()[0].(*fyne.Container).Objects[0].(*fyne.Container)
-	assert.Equal(t, "test2", c.Objects[2].(*Label).Text)
+	assert.Equal(t, "test2", c.Objects[2].(*RichText).String())
 }
 
 func TestForm_CustomButtonsText(t *testing.T) {
@@ -118,11 +118,11 @@ func TestForm_ChangeText(t *testing.T) {
 
 	renderer := test.TempWidgetRenderer(t, form)
 	c := renderer.Objects()[0].(*fyne.Container).Objects[0].(*fyne.Container)
-	assert.Equal(t, "Test", c.Objects[0].(*Label).Text)
+	assert.Equal(t, "Test", c.Objects[0].(*RichText).String())
 
 	item.Text = "Changed"
 	form.Refresh()
-	assert.Equal(t, "Changed", c.Objects[0].(*Label).Text)
+	assert.Equal(t, "Changed", c.Objects[0].(*RichText).String())
 }
 
 func TestForm_ChangeTheme(t *testing.T) {

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -176,6 +176,8 @@ func TestForm_Hints(t *testing.T) {
 	}
 
 	form := &Form{Items: items, OnSubmit: func() {}, OnCancel: func() {}}
+	entry2.FocusGained()
+	entry2.FocusLost()
 	w := test.NewWindow(form)
 	defer w.Close()
 
@@ -243,8 +245,9 @@ func TestForm_Validation(t *testing.T) {
 
 	test.AssertImageMatches(t, "form/validation_initial.png", w.Canvas().Capture())
 
-	test.Type(entry2, "not-")
 	entry1.SetText("incorrect")
+	test.Type(entry2, "not-")
+	form.Refresh() // this was expecting a full refresh during type
 	w = test.NewTempWindow(t, form)
 
 	test.AssertImageMatches(t, "form/validation_invalid.png", w.Canvas().Capture())
@@ -300,9 +303,8 @@ func TestForm_EntryValidation_FirstTypeValid(t *testing.T) {
 	test.AssertImageMatches(t, "form/validation_entry_first_type_initial.png", w.Canvas().Capture())
 
 	test.Type(entry1, "H")
+	entry1.FocusLost()
 	test.Type(entry2, "L")
-	entry1.focused = false
-	entry1.Refresh()
 	w = test.NewTempWindow(t, form)
 
 	test.AssertImageMatches(t, "form/validation_entry_first_type_valid.png", w.Canvas().Capture())
@@ -355,6 +357,9 @@ func TestForm_Disable_Validation(t *testing.T) {
 	test.ApplyTheme(t, test.Theme())
 
 	entry := &Entry{Validator: validation.NewRegexp(`^\d{2}-\w{4}$`, "Input is not valid"), Text: "wrong"}
+	// user has interacted
+	entry.FocusGained()
+	entry.FocusLost()
 
 	form := &Form{Items: []*FormItem{{Text: "test", Widget: entry}}, OnSubmit: func() {}, OnCancel: func() {}}
 	w := test.NewWindow(form)
@@ -463,6 +468,7 @@ func TestForm_SetOnValidationChanged(t *testing.T) {
 	form.CreateRenderer()
 
 	entry1.SetText("incorrect")
+	entry1.FocusLost()
 	assert.Error(t, form.Validate())
 	assert.True(t, validationError)
 

--- a/widget/testdata/entry/validate_valid.xml
+++ b/widget/testdata/entry/validate_valid.xml
@@ -2,12 +2,11 @@
 	<content>
 		<widget pos="10,10" size="120x35" type="*widget.Entry">
 			<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="116x31"/>
-			<rectangle pos="1,1" radius="4" size="117x32" strokeColor="primary" strokeWidth="2"/>
+			<rectangle pos="1,1" radius="4" size="117x32" strokeColor="inputBorder" strokeWidth="2"/>
 			<widget pos="0,2" size="88x31" type="*widget.entryContent">
 				<widget size="88x31" type="*widget.RichText">
 					<text pos="8,6" size="73x19">2020-02-12</text>
 				</widget>
-				<rectangle fillColor="primary" pos="80,6" size="2x19"/>
 			</widget>
 			<widget pos="92,8" size="20x20" type="*widget.validationStatus">
 				<image rsc="confirmIcon" size="iconInlineSize" themed="foreground"/>

--- a/widget/testdata/form/extended_entry.xml
+++ b/widget/testdata/form/extended_entry.xml
@@ -3,10 +3,8 @@
 		<widget pos="4,4" size="187x35" type="*widget.Form">
 			<container size="187x35">
 				<container size="187x35">
-					<widget size="123x35" type="*widget.Label">
-						<widget size="123x35" type="*widget.RichText">
-							<text alignment="trailing" bold pos="8,8" size="107x19">Extended entry</text>
-						</widget>
+					<widget size="123x35" type="*widget.RichText">
+						<text alignment="trailing" bold pos="8,8" size="107x19">Extended entry</text>
 					</widget>
 					<widget pos="127,0" size="60x35" type="*widget.SelectEntry">
 						<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="56x31"/>

--- a/widget/testdata/form/layout.xml
+++ b/widget/testdata/form/layout.xml
@@ -3,10 +3,8 @@
 		<widget pos="4,4" size="187x114" type="*widget.Form">
 			<container size="187x114">
 				<container size="187x74">
-					<widget size="51x35" type="*widget.Label">
-						<widget size="51x35" type="*widget.RichText">
-							<text alignment="trailing" bold pos="8,8" size="35x19">test1</text>
-						</widget>
+					<widget size="51x35" type="*widget.RichText">
+						<text alignment="trailing" bold pos="8,8" size="35x19">test1</text>
 					</widget>
 					<widget pos="55,0" size="132x35" type="*widget.Entry">
 						<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="128x31"/>
@@ -22,10 +20,8 @@
 							</widget>
 						</widget>
 					</widget>
-					<widget pos="0,39" size="51x35" type="*widget.Label">
-						<widget size="51x35" type="*widget.RichText">
-							<text alignment="trailing" bold pos="8,8" size="35x19">test2</text>
-						</widget>
+					<widget pos="0,39" size="51x35" type="*widget.RichText">
+						<text alignment="trailing" bold pos="8,8" size="35x19">test2</text>
 					</widget>
 					<widget pos="55,39" size="132x35" type="*widget.Entry">
 						<rectangle fillColor="inputBackground" pos="2,2" radius="4" size="128x31"/>


### PR DESCRIPTION
Adding Form.Validator to check the whole of a form and control if Submit is enabled.
(this is built on top of `FormItem.Required` to avoid conflicts)

```go
// Package main loads a very basic Hello World graphical application.
package main

import (
	"errors"

	"fyne.io/fyne/v2/app"
	"fyne.io/fyne/v2/widget"
)

func main() {
	a := app.New()
	w := a.NewWindow("Hello")

	en1 := widget.NewEntry()
	en2 := widget.NewEntry()
	en2.Validator = func(in string) error {
		if in != "hi" {
			return errors.New("must be hi")
		}
		return nil
	}

	f := widget.NewForm(
		widget.NewFormItem("1", en1),
		widget.NewFormItem("2", en2))
	f.Validator = func() error {
		if en1.Text != en2.Text {
			return errors.New("en1 != en2")
		}
		return nil
	}
	f.OnSubmit = func() {}
	w.SetContent(f)

	w.ShowAndRun()
}
```

Fixes #2562 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.
- [x] Public APIs match existing style and have Since: line.
