### PR TITLE
Re-run TextGrid Layout after cellSize update in Refresh

### DIFF
--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -587,6 +587,13 @@ func (t *textGridContentRenderer) Refresh() {
 	t.updateCellSize()
 	t.updateGridSize(t.text.text.Size())
 
+	// Re-run Layout so row positions reflect the (possibly updated) cellSize.
+	// Without this, callers that update cellSize via Refresh (e.g. theme/font
+	// size changes) end up with rows positioned using the OLD cellSize while
+	// cells inside those rows are sized using the NEW cellSize, producing
+	// 1-pixel hairlines between rows at certain font/cell sizes.
+	t.Layout(t.text.Size())
+
 	for _, o := range t.text.visible {
 		o.Refresh()
 	}


### PR DESCRIPTION
Fixes gaps between cells due to cell-size vs cell-layout mismatch. After the cell size change, the layout was still using the old cell height.

<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes gaps appearing in the term grid after resizing.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
