### PR TITLE
Fix race when reactivating window from system tray click

### DIFF
--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -188,9 +188,9 @@ func (d *gLDriver) SetSystemTrayWindow(w fyne.Window) {
 	w.SetCloseIntercept(w.Hide)
 	glw := w.(*window)
 	if glw.decorate {
-		systray.SetOnTapped(glw.Show)
+		systray.SetOnTapped(func() { fyne.Do(glw.Show) })
 	} else {
-		systray.SetOnTapped(glw.toggleVisible)
+		systray.SetOnTapped(func() { fyne.Do(glw.toggleVisible) })
 	}
 }
 


### PR DESCRIPTION
### Description:
Fixes occasional crashing on Linux when reactivating window with left-click on systray icon.

See [here](https://github.com/dweymouth/supersonic/issues/823#issuecomment-4566603726) for more details

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
