### PR TITLE
Don't scale image for ImageFillCover

### DIFF
--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -37,6 +37,10 @@ func paintImage(img *canvas.Image, width, height int) (dst image.Image, err erro
 		dst = image.NewNRGBA(image.Rect(0, 0, width, height))
 	}
 
+	if img.FillMode == canvas.ImageFillCover {
+		return dst, nil
+	}
+
 	size := dst.Bounds().Size()
 	if width != size.X || height != size.Y {
 		dst = scaleImage(dst, width, height, img.ScaleMode)


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Don't scale images for `ImageFillCover`, otherwise the image is scaled into the windows size, then stretched to the original image aspect before clipping.

Fixes #6282

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

