### PR TITLE
Fix failing to fall back to English in some cases

### DIFF
--- a/lang/lang.go
+++ b/lang/lang.go
@@ -71,7 +71,11 @@ func LocalizeKey(key, fallback string, data ...any) string {
 	})
 	if err != nil {
 		fyne.LogError("Translation failure", err)
-		return fallbackWithData(key, fallback, d0)
+
+		// ret can still have a fallback string even if err is set
+		if ret == "" {
+			return fallbackWithData(key, fallback, d0)
+		}
 	}
 	return ret
 }
@@ -105,7 +109,11 @@ func LocalizePluralKey(key, fallback string, count int, data ...any) string {
 	})
 	if err != nil {
 		fyne.LogError("Translation failure", err)
-		return fallbackWithData(key, fallback, d0)
+
+		// ret can still have a fallback string even if err is set
+		if ret == "" {
+			return fallbackWithData(key, fallback, d0)
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

go-i18n can still return a translated string, even when `err != nil`:
```
// LocalizeWithTag returns a localized message and the language tag.
// It may return a best effort localized message even if an error happens.
func (l *Localizer) LocalizeWithTag(lc *LocalizeConfig) (string, language.Tag, error) {
```

The previous code assumed that an error always meant total failure. This resulted in improper fallbacks to the raw key, instead of using the English translation by default. (See #6331 for an MRP of this.) This PR fixes it so that it verifies that getting a translation of any kind has failed before using the key.

Fixes #6331

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
