### PR TITLE
Markdown: blockquote headings, lists, hyperlinks

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -63,7 +63,7 @@ func renderNode(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]R
 	case *ast.List:
 		items, err := renderChildren(source, n, quotingDepth, listDepth+1)
 		return []RichTextSegment{
-			&ListSegment{startIndex: t.Start - 1, Items: items, Ordered: t.Marker != '*' && t.Marker != '-' && t.Marker != '+', indentationLevel: listDepth},
+			&ListSegment{startIndex: t.Start - 1, Items: items, Ordered: t.Marker != '*' && t.Marker != '-' && t.Marker != '+', indentationLevel: listDepth, quotingLevel: quotingDepth},
 		}, err
 	case *ast.ListItem:
 		children, err := renderChildren(source, n, quotingDepth, listDepth)

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -99,11 +99,11 @@ func renderNode(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]R
 	case *ast.Link:
 		link, _ := url.Parse(string(t.Destination))
 		text := forceIntoText(source, n)
-		return []RichTextSegment{&HyperlinkSegment{Alignment: fyne.TextAlignLeading, Text: decodeText(text), URL: link}}, nil
+		return []RichTextSegment{&HyperlinkSegment{Alignment: fyne.TextAlignLeading, Text: decodeText(text), URL: link, quotingLevel: quotingDepth}}, nil
 	case *ast.AutoLink:
 		link, _ := url.Parse(string(t.URL(source)))
 		text := string(t.Label(source))
-		return []RichTextSegment{&HyperlinkSegment{Alignment: fyne.TextAlignLeading, Text: decodeText(text), URL: link}}, nil
+		return []RichTextSegment{&HyperlinkSegment{Alignment: fyne.TextAlignLeading, Text: decodeText(text), URL: link, quotingLevel: quotingDepth}}, nil
 	case *ast.CodeSpan:
 		text := forceIntoText(source, n)
 		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeInline, Text: text}}, nil

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -213,6 +213,10 @@ func renderHeading(source []byte, n ast.Node, quotingDepth int, listDepth int) (
 	default:
 		style = RichTextStyleStrong
 	}
+	if quotingDepth > 0 {
+		style.QuotingDepth = quotingDepth
+		style.TextStyle.Italic = true
+	}
 
 	children := make([]RichTextSegment, 0, n.ChildCount())
 	for childCount, child := n.ChildCount(), n.FirstChild(); childCount > 0; childCount-- {

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -120,7 +120,7 @@ func renderNode(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]R
 		if data[len(data)-1] == '\n' {
 			data = data[:len(data)-1]
 		}
-		return []RichTextSegment{&CodeBlockSegment{Text: string(data)}}, nil
+		return []RichTextSegment{&CodeBlockSegment{Text: string(data), quotingLevel: quotingDepth}}, nil
 	case *ast.Emphasis:
 		return renderEmphasis(source, n, quotingDepth, n.(*ast.Emphasis).Level, listDepth)
 	case *ast2.Strikethrough:

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -20,6 +20,60 @@ func TestRichTextMarkdown_Blockquote(t *testing.T) {
 	} else {
 		t.Error("Segment should be Text")
 	}
+
+	r = NewRichTextFromMarkdown("> # Head1\n> > # Head2")
+
+	assert.Len(t, r.Segments, 4)
+	if text, ok := r.Segments[0].(*TextSegment); ok {
+		assert.Equal(t, "Head1", text.Text)
+		assert.Equal(t, RichTextStyleHeading.SizeName, text.Style.SizeName)
+		assert.Equal(t, true, text.Style.TextStyle.Bold)
+		assert.Equal(t, true, text.Style.TextStyle.Italic)
+		assert.Equal(t, 1, text.Style.QuotingDepth)
+	} else {
+		t.Error("Segment should be blockquoted Heading")
+	}
+	if text, ok := r.Segments[2].(*TextSegment); ok {
+		assert.Equal(t, "Head2", text.Text)
+		assert.Equal(t, RichTextStyleHeading.SizeName, text.Style.SizeName)
+		assert.Equal(t, true, text.Style.TextStyle.Bold)
+		assert.Equal(t, true, text.Style.TextStyle.Italic)
+		assert.Equal(t, 2, text.Style.QuotingDepth)
+	} else {
+		t.Error("Segment should be a blockquoted Heading")
+	}
+
+	r = NewRichTextFromMarkdown("> - quoted list item")
+
+	assert.Len(t, r.Segments, 1)
+	if list, ok := r.Segments[0].(*ListSegment); ok {
+		assert.Len(t, list.Items[0].(*ParagraphSegment).Texts, 1)
+		assert.Equal(t, "quoted list item", list.Items[0].(*ParagraphSegment).Texts[0].(*TextSegment).Text)
+		assert.Equal(t, 1, list.Items[0].(*ParagraphSegment).Texts[0].(*TextSegment).Style.QuotingDepth)
+		assert.Equal(t, 1, list.quotingLevel)
+	} else {
+		t.Error("Segment should be a List")
+	}
+
+	r = NewRichTextFromMarkdown("> [fyne.io](https://fyne.io/)")
+
+	assert.Len(t, r.Segments, 2)
+	if link, ok := r.Segments[0].(*HyperlinkSegment); ok {
+		assert.Equal(t, "fyne.io", link.Text)
+		assert.Equal(t, 1, link.quotingLevel)
+	} else {
+		t.Error("Segment should be a blockquoted hyperlink")
+	}
+
+	r = NewRichTextFromMarkdown("> ```go\n> package main\n> ```")
+
+	assert.Len(t, r.Segments, 1)
+	if block, ok := r.Segments[0].(*CodeBlockSegment); ok {
+		assert.Equal(t, "package main", block.Text)
+		assert.Equal(t, 1, block.quotingLevel)
+	} else {
+		t.Error("Segment should be a blockquoted code block")
+	}
 }
 
 func TestRichTextMarkdown_NestedBlockquote(t *testing.T) {

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -1224,6 +1224,11 @@ func rowPaddingAndAlign(bound rowBoundary, lineSpacing float32, currentAlign fyn
 			if link.quotingLevel > 0 {
 				leftPad = lineSpacing * 4 * float32(link.quotingLevel)
 			}
+		} else if block, ok := bound.segments[0].(*CodeBlockSegment); ok {
+			align = fyne.TextAlignLeading
+			if block.quotingLevel > 0 {
+				leftPad = lineSpacing * 4 * float32(block.quotingLevel)
+			}
 		}
 	}
 	return leftPad, align

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -458,6 +458,9 @@ func (t *RichText) updateRowBounds() {
 			} else if linkSeg, ok := seg.(*HyperlinkSegment); ok {
 				textStyle = linkSeg.TextStyle
 				textSize = theme.SizeForWidget(theme.SizeNameText, t)
+				if linkSeg.quotingLevel > 0 {
+					leftPad = innerPadding * 2 * float32(linkSeg.quotingLevel)
+				}
 			}
 			retBounds, height := lineBounds(t, seg, wrapWidth-leftPad, fyne.NewSize(maxWidth, fitSize.Height), func(text []rune) fyne.Size {
 				return fyne.MeasureText(string(text), textSize, textStyle)
@@ -1218,6 +1221,9 @@ func rowPaddingAndAlign(bound rowBoundary, lineSpacing float32, currentAlign fyn
 			}
 		} else if link, ok := bound.segments[0].(*HyperlinkSegment); ok {
 			align = link.Alignment
+			if link.quotingLevel > 0 {
+				leftPad = lineSpacing * 4 * float32(link.quotingLevel)
+			}
 		}
 	}
 	return leftPad, align

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -239,6 +239,7 @@ type ListSegment struct {
 	// number to any int, including 0.
 	startIndex       int
 	indentationLevel int
+	quotingLevel     int
 }
 
 // SetStartNumber sets the starting number for an ordered list.
@@ -274,7 +275,9 @@ func (l *ListSegment) Segments() []RichTextSegment {
 				j++
 			}
 			indentation := strings.Repeat(" ", l.indentationLevel*4)
-			bullet := &TextSegment{Text: indentation + txt + " ", Style: RichTextStyleStrong}
+			style := RichTextStyleStrong
+			style.QuotingDepth = l.quotingLevel
+			bullet := &TextSegment{Text: indentation + txt + " ", Style: style}
 			texts = append(texts, bullet)
 			if _, ok := in.(*ParagraphSegment); !ok {
 				in = &ParagraphSegment{Texts: []RichTextSegment{in}}

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -120,7 +120,8 @@ type HyperlinkSegment struct {
 	// Since 2.8
 	TextStyle fyne.TextStyle
 	// Since 2.8
-	SizeName fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
+	SizeName     fyne.ThemeSizeName // The theme name of the text size to use, if blank will be the standard text size
+	quotingLevel int
 }
 
 // Inline returns true as hyperlinks are inside other elements.

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -407,7 +407,8 @@ func (s *SeparatorSegment) Unselect() {
 //
 // Since: 2.8
 type CodeBlockSegment struct {
-	Text string
+	Text         string
+	quotingLevel int
 }
 
 // Inline returns false as a code block is a full-width block element.


### PR DESCRIPTION
### Description:

- Indent and slant blockquoted headings
- Indent blockquoted lists
- Indent blockquoted hyperlinks (not slanted)
- Indent blockquoted code blocks

Blockquoted images are not rendered in a special way because they are centered (when created from Markdown).

Fixes #6318.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

### Example screenshot

<img width="500" height="1000" alt="2026-06-02 09 28 28 500x1000 Window" src="https://github.com/user-attachments/assets/bf8e97b4-b625-45ab-9646-2806f6c40df2" />