### PR TITLE
Markdown: Support GFM task lists (checkboxes)

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -83,6 +83,14 @@ func renderNode(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]R
 		}
 		return result, err
 	case *ast.TextBlock:
+		if c, ok := t.FirstChild().(*ast2.TaskCheckBox); ok {
+			child := c.NextSibling()
+			text := ""
+			if child != nil {
+				text = string(child.(*ast.Text).Value(source))
+			}
+			return []RichTextSegment{&CheckBoxSegment{Text: decodeText(text), Checked: c.IsChecked}}, nil
+		}
 		return renderChildren(source, n, quotingDepth, listDepth)
 	case *ast.Heading:
 		return renderHeading(source, n, quotingDepth, listDepth)
@@ -260,7 +268,7 @@ func forceIntoText(source []byte, n ast.Node) string {
 
 func parseMarkdown(content string) []RichTextSegment {
 	r := markdownRenderer{}
-	md := goldmark.New(goldmark.WithRenderer(&r), goldmark.WithExtensions(extension.Strikethrough))
+	md := goldmark.New(goldmark.WithRenderer(&r), goldmark.WithExtensions(extension.Strikethrough, extension.TaskList))
 	err := md.Convert([]byte(content), nil)
 	if err != nil {
 		fyne.LogError("Failed to parse markdown", err)

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -396,6 +396,53 @@ func (s *SeparatorSegment) SelectedText() string {
 func (s *SeparatorSegment) Unselect() {
 }
 
+// CheckBoxSegment represents checkbox (with text) in a rich text widget.
+//
+// Since: 2.8
+type CheckBoxSegment struct {
+	Checked bool
+	Text    string
+}
+
+// Inline returns true as a CheckBoxSegment is usually part of a list item.
+func (c *CheckBoxSegment) Inline() bool {
+	return true
+}
+
+// Textual returns the content of this segment rendered to plain text.
+func (c *CheckBoxSegment) Textual() string {
+	if c.Checked {
+		return "[x] "
+	}
+	return "[ ] "
+}
+
+// Visual returns a new instance of a check widget for this segment.
+func (c *CheckBoxSegment) Visual() fyne.CanvasObject {
+	check := NewCheck(c.Text, nil)
+	if c.Checked {
+		check.SetChecked(true)
+	}
+	return &fyne.Container{Layout: &unpadTextWidgetLayout{parent: check}, Objects: []fyne.CanvasObject{check}}
+}
+
+// Update doesn't need to change a checkbox
+func (c *CheckBoxSegment) Update(fyne.CanvasObject) {
+}
+
+// Select does nothing for a checkbox.
+func (c *CheckBoxSegment) Select(_, _ fyne.Position) {
+}
+
+// SelectedText returns the empty string for a checkbox.
+func (c *CheckBoxSegment) SelectedText() string {
+	return ""
+}
+
+// Unselect does nothing for a checkbox.
+func (c *CheckBoxSegment) Unselect() {
+}
+
 // RichTextStyle describes the details of a text object inside a RichText widget.
 //
 // Since: 2.1


### PR DESCRIPTION
### Description:

- markdown: Activate goldmark's TaskList extension.
- richtext: Add new `CheckBoxSegment`.

Fixes #6330 partly.

### Example:

```md
- [x] foo
  - [ ] bar
  - [x] baz
- [ ]
- [ ] bim
```

is rendered as

<img width="156" height="175" alt="2026-05-31 17 12 43 156x175 Window" src="https://github.com/user-attachments/assets/491f39bf-9bc5-4451-b81d-d1ce876c7192" />

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
