### PR TITLE
Markdown: render code blocks on a distinct panel

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -112,7 +112,7 @@ func renderNode(source []byte, n ast.Node, quotingDepth int, listDepth int) ([]R
 		if data[len(data)-1] == '\n' {
 			data = data[:len(data)-1]
 		}
-		return []RichTextSegment{&TextSegment{Style: RichTextStyleCodeBlock, Text: string(data)}}, nil
+		return []RichTextSegment{&CodeBlockSegment{Text: string(data)}}, nil
 	case *ast.Emphasis:
 		return renderEmphasis(source, n, quotingDepth, n.(*ast.Emphasis).Level, listDepth)
 	case *ast2.Strikethrough:

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -1,12 +1,13 @@
 package widget
 
 import (
+	"strings"
 	"testing"
 
+	"fyne.io/fyne/v2/storage"
+	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
 	"github.com/stretchr/testify/assert"
-
-	"fyne.io/fyne/v2/storage"
 )
 
 func TestRichTextMarkdown_Blockquote(t *testing.T) {
@@ -51,6 +52,16 @@ func TestRichTextMarkdown_Code(t *testing.T) {
 	} else {
 		t.Error("Segment should be CodeBlock")
 	}
+}
+
+func TestRichTextMarkdown_CodeBlockScrolls(t *testing.T) {
+	long := strings.Repeat("abcdefghij", 50) // one ~500-char line
+	cb := newRichCodeBlock(long)
+	test.TempWidgetRenderer(t, cb)
+	min := cb.MinSize()
+
+	assert.Less(t, min.Width, float32(200)) // scrolls rather than demanding full width
+	assert.Greater(t, min.Height, float32(10))
 }
 
 func TestRichTextMarkdown_Code_Incomplete(t *testing.T) {

--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -46,11 +46,10 @@ func TestRichTextMarkdown_Code(t *testing.T) {
 
 	r.ParseMarkdown("``` go\ncode\nblock\n```")
 	assert.Len(t, r.Segments, 1)
-	if text, ok := r.Segments[0].(*TextSegment); ok {
-		assert.Equal(t, "code\nblock", text.Text)
-		assert.Equal(t, RichTextStyleCodeBlock, text.Style)
+	if code, ok := r.Segments[0].(*CodeBlockSegment); ok {
+		assert.Equal(t, "code\nblock", code.Text)
 	} else {
-		t.Error("Segment should be Text")
+		t.Error("Segment should be CodeBlock")
 	}
 }
 

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/scale"
+	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -467,12 +468,14 @@ func (c *richCodeBlock) CreateRenderer() fyne.WidgetRenderer {
 	c.bg.CornerRadius = theme.Size(theme.SizeNameInputRadius)
 	c.label = NewLabelWithStyle(c.text, fyne.TextAlignLeading, fyne.TextStyle{Monospace: true})
 	c.label.Wrapping = fyne.TextWrapOff
-	cont := &fyne.Container{Layout: &richCodeBlockLayout{}, Objects: []fyne.CanvasObject{c.bg, c.label}}
+
+	scroll := widget.NewHScroll(c.label)
+	scroll.SetMinSize(fyne.NewSize(0, c.label.MinSize().Height)) // keep height, scroll width
+
+	cont := &fyne.Container{Layout: &richCodeBlockLayout{}, Objects: []fyne.CanvasObject{c.bg, scroll}}
 	return NewSimpleRenderer(cont)
 }
 
-// richCodeBlockLayout stretches the background to fill the block while the
-// label (with its own inner padding) insets the code text from the edges.
 type richCodeBlockLayout struct{}
 
 func (l *richCodeBlockLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -467,11 +467,7 @@ func (c *richCodeBlock) CreateRenderer() fyne.WidgetRenderer {
 	c.bg.StrokeWidth = 1
 	c.bg.CornerRadius = theme.Size(theme.SizeNameInputRadius)
 	c.label = NewLabelWithStyle(c.text, fyne.TextAlignLeading, fyne.TextStyle{Monospace: true})
-	c.label.Wrapping = fyne.TextWrapOff
-
 	scroll := widget.NewHScroll(c.label)
-	scroll.SetMinSize(fyne.NewSize(0, c.label.MinSize().Height)) // keep height, scroll width
-
 	cont := &fyne.Container{Layout: &richCodeBlockLayout{}, Objects: []fyne.CanvasObject{c.bg, scroll}}
 	return NewSimpleRenderer(cont)
 }

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -396,6 +396,96 @@ func (s *SeparatorSegment) SelectedText() string {
 func (s *SeparatorSegment) Unselect() {
 }
 
+// CodeBlockSegment represents a fenced or indented code block. It renders its
+// content as monospace text on a panel, so the block stands apart from the
+// surrounding prose.
+//
+// Since: 2.8
+type CodeBlockSegment struct {
+	Text string
+}
+
+// Inline returns false as a code block is a full-width block element.
+func (c *CodeBlockSegment) Inline() bool {
+	return false
+}
+
+// Textual returns the raw content of this code block.
+func (c *CodeBlockSegment) Textual() string {
+	return c.Text
+}
+
+// Visual returns a new panel widget rendering this code block.
+func (c *CodeBlockSegment) Visual() fyne.CanvasObject {
+	return newRichCodeBlock(c.Text)
+}
+
+// Update applies the current content of this segment to an existing visual.
+func (c *CodeBlockSegment) Update(o fyne.CanvasObject) {
+	o.(*richCodeBlock).setText(c.Text)
+}
+
+// Select does nothing for a code block.
+func (c *CodeBlockSegment) Select(_, _ fyne.Position) {
+}
+
+// SelectedText returns the code block content.
+func (c *CodeBlockSegment) SelectedText() string {
+	return c.Text
+}
+
+// Unselect does nothing for a code block.
+func (c *CodeBlockSegment) Unselect() {
+}
+
+// richCodeBlock is the internal widget that draws a code block: monospace text
+// on a rounded, bordered panel.
+type richCodeBlock struct {
+	BaseWidget
+	text  string
+	bg    *canvas.Rectangle
+	label *Label
+}
+
+func newRichCodeBlock(text string) *richCodeBlock {
+	c := &richCodeBlock{text: text}
+	c.ExtendBaseWidget(c)
+	return c
+}
+
+func (c *richCodeBlock) setText(text string) {
+	c.text = text
+	if c.label != nil {
+		c.label.SetText(text)
+	}
+}
+
+func (c *richCodeBlock) CreateRenderer() fyne.WidgetRenderer {
+	c.bg = canvas.NewRectangle(theme.Color(theme.ColorNameBackground))
+	c.bg.StrokeColor = theme.Color(theme.ColorNameInputBorder)
+	c.bg.StrokeWidth = 1
+	c.bg.CornerRadius = theme.Size(theme.SizeNameInputRadius)
+	c.label = NewLabelWithStyle(c.text, fyne.TextAlignLeading, fyne.TextStyle{Monospace: true})
+	c.label.Wrapping = fyne.TextWrapOff
+	cont := &fyne.Container{Layout: &richCodeBlockLayout{}, Objects: []fyne.CanvasObject{c.bg, c.label}}
+	return NewSimpleRenderer(cont)
+}
+
+// richCodeBlockLayout stretches the background to fill the block while the
+// label (with its own inner padding) insets the code text from the edges.
+type richCodeBlockLayout struct{}
+
+func (l *richCodeBlockLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	return objects[1].MinSize()
+}
+
+func (l *richCodeBlockLayout) Layout(objects []fyne.CanvasObject, s fyne.Size) {
+	for _, o := range objects {
+		o.Move(fyne.NewPos(0, 0))
+		o.Resize(s)
+	}
+}
+
 // RichTextStyle describes the details of a text object inside a RichText widget.
 //
 // Since: 2.1


### PR DESCRIPTION
### Description:

Render fenced and indented code blocks via a new `CodeBlockSegment` that draws the monospace content on a rounded, bordered panel, so code stands apart from the surrounding prose instead of being plain inline-styled monospace text.

The new segment follows the existing block-segment pattern (`SeparatorSegment`/`ImageSegment`): an internal `richCodeBlock` widget builds the panel via `fyne.Container` + `NewSimpleRenderer`, so the `widget` package gains no dependency on `container`.

Part of #6330.

Note: this changes what the markdown parser emits for a code block from `TextSegment{Style: RichTextStyleCodeBlock}` to the new `CodeBlockSegment` (the `RichTextStyleCodeBlock` style var remains exported and unused). If you'd prefer a renderer-level background that keeps the `TextSegment` output instead, I'm happy to take that direction.

### Rendering

Tested change with https://github.com/laszukdawid/terminal-agent GUI. The image below renders code

```
## Code

Inline `code` then a fenced block:

```go
package main

import "fmt"

func main() {
	fmt.Println("Hello, Markdown!")
}
\```

```

<img width="558" height="254" alt="image" src="https://github.com/user-attachments/assets/3c1c78e5-e164-47e7-822b-7ac2b01ccea8" />

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed. (Code-block emission now uses `CodeBlockSegment` — see note above; happy to discuss.)