### PR TITLE
Window transparency & opacity

### DIFF
--- a/cmd/fyne_demo/tutorials/window.go
+++ b/cmd/fyne_demo/tutorials/window.go
@@ -71,6 +71,23 @@ func windowScreen(_ fyne.Window) fyne.CanvasObject {
 			}
 			visibilityState = !visibilityState
 		}),
+		widget.NewButton("Transparent window", func() {
+			w := fyne.CurrentApp().NewWindow("Transparent")
+			w.SetContent(container.NewCenter(widget.NewLabel("Hello World!")))
+			w.SetTransparent(true)
+			w.Show()
+		}),
+		widget.NewButton("Fixed opacity window", func() {
+			w := fyne.CurrentApp().NewWindow("Fixed Opacity")
+			slider := widget.NewSlider(0, 1)
+			slider.Step = 0.1
+			slider.Value = 1.0
+			slider.OnChanged = func(value float64) {
+				w.SetOpacity(float32(value))
+			}
+			w.SetContent(slider)
+			w.Show()
+		}),
 	)
 
 	drv := fyne.CurrentApp().Driver()

--- a/internal/driver/embedded/window.go
+++ b/internal/driver/embedded/window.go
@@ -132,6 +132,24 @@ func (w *noosWindow) Clipboard() fyne.Clipboard {
 	return nil
 }
 
+func (w *noosWindow) Transparent() bool {
+	// TODO implement me
+	return false
+}
+
+func (w *noosWindow) SetTransparent(transparent bool) {
+	// TODO implement me
+}
+
+func (w *noosWindow) Opacity() float32 {
+	// TODO implement me
+	return 1.0
+}
+
+func (w *noosWindow) SetOpacity(opacity float32) {
+	// TODO implement me
+}
+
 func newWindow(d *noosDriver) fyne.Window {
 	return &noosWindow{c: newTouchCanvas(), d: d}
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -249,6 +249,14 @@ func (w *window) Canvas() fyne.Canvas {
 	return w.canvas
 }
 
+func (w *window) Transparent() bool {
+	return w.transparent
+}
+
+func (w *window) SetTransparent(transparent bool) {
+	w.transparent = transparent
+}
+
 func (w *window) processClosed() {
 	if w.onCloseIntercepted != nil {
 		w.onCloseIntercepted()
@@ -1017,14 +1025,6 @@ func (d *gLDriver) CreateSplashWindow() fyne.Window {
 
 func (d *gLDriver) AllWindows() []fyne.Window {
 	return d.windows
-}
-
-func (w *window) Transparent() bool {
-	return w.transparent
-}
-
-func (w *window) SetTransparent(transparent bool) {
-	w.transparent = transparent
 }
 
 func isKeyModifier(keyName fyne.KeyName) bool {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -1019,6 +1019,14 @@ func (d *gLDriver) AllWindows() []fyne.Window {
 	return d.windows
 }
 
+func (w *window) Transparent() bool {
+	return w.transparent
+}
+
+func (w *window) SetTransparent(transparent bool) {
+	w.transparent = transparent
+}
+
 func isKeyModifier(keyName fyne.KeyName) bool {
 	return keyName == desktop.KeyShiftLeft || keyName == desktop.KeyShiftRight ||
 		keyName == desktop.KeyControlLeft || keyName == desktop.KeyControlRight ||

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -142,7 +142,6 @@ func (w *window) Show() {
 		}
 
 		if !w.created {
-			w.created = true
 			w.create()
 		}
 
@@ -254,6 +253,9 @@ func (w *window) Transparent() bool {
 }
 
 func (w *window) SetTransparent(transparent bool) {
+	if w.created {
+		return // cannot change after creation
+	}
 	w.transparent = transparent
 }
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -69,12 +69,13 @@ func initCursors() {
 var _ fyne.Window = (*window)(nil)
 
 type window struct {
-	viewport  *glfw.Window
-	created   bool
-	decorate  bool
-	closing   bool
-	fixedSize bool
+	viewport    *glfw.Window
+	created     bool
+	decorate    bool
+	closing     bool
+	fixedSize   bool
 	transparent bool
+	opacity     float32
 
 	cursor       desktop.Cursor
 	customCursor *glfw.Cursor
@@ -252,6 +253,17 @@ func (w *window) SetIcon(icon fyne.Resource) {
 
 func (w *window) SetMaster() {
 	w.master = true
+}
+
+func (w *window) Opacity() float32 {
+	return w.opacity
+}
+
+func (w *window) SetOpacity(opacity float32) {
+	w.opacity = opacity
+	w.runOnMainWhenCreated(func() {
+		w.view().SetOpacity(opacity)
+	})
 }
 
 func (w *window) fitContent() {
@@ -821,6 +833,7 @@ func (w *window) create() {
 	if pixHeight == 0 {
 		pixHeight = 10
 	}
+	w.opacity = 1.0
 
 	win, err := glfw.CreateWindow(pixWidth, pixHeight, w.title, nil, nil)
 	if err != nil {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -74,6 +74,7 @@ type window struct {
 	decorate  bool
 	closing   bool
 	fixedSize bool
+	transparent bool
 
 	cursor       desktop.Cursor
 	customCursor *glfw.Cursor
@@ -802,6 +803,11 @@ func (w *window) create() {
 		glfw.WindowHint(glfw.Floating, glfw.True)
 	} else {
 		glfw.WindowHint(glfw.Floating, glfw.False)
+	}
+	if w.transparent {
+		glfw.WindowHint(glfw.TransparentFramebuffer, glfw.True)
+	} else {
+		glfw.WindowHint(glfw.TransparentFramebuffer, glfw.False)
 	}
 	glfw.WindowHint(glfw.AutoIconify, glfw.False)
 	initWindowHints()

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -902,6 +902,7 @@ func (w *window) create() {
 
 	// Initialize accessibility support
 	w.initAccessibilityForWindow()
+	w.created = true
 }
 
 func (w *window) view() *glfw.Window {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -88,19 +88,6 @@ func TestGLDriver_CreateSplashWindow(t *testing.T) {
 	assert.True(t, w.centered)
 }
 
-func TestGLDriver_TransparentWindow(t *testing.T) {
-	var w *window
-	runOnMain(func() { // tests launch in a different context
-		w = d.createWindow("", true).(*window)
-		w.SetTransparent(true)
-		w.create()
-	})
-	assert.Equal(t, 1, w.viewport.GetAttrib(glfw.TransparentFramebuffer))
-
-	w1 := createWindow("")
-	assert.Equal(t, 0, w1.window.viewport.GetAttrib(glfw.TransparentFramebuffer))
-}
-
 func TestWindow_MinSize_Fixed(t *testing.T) {
 	w := createWindowWithResizeCallback("Test")
 	r := canvas.NewRectangle(color.White)
@@ -1931,6 +1918,18 @@ func TestWindow_RescaleContext(t *testing.T) {
 		w.RescaleContext()
 		assert.Equal(t, initialWidth, w.width)
 	})
+}
+
+func TestWindow_Transparent(t *testing.T) {
+	runOnMain(func() { // tests launch in a different context
+		w := d.CreateWindow("Transparent").(*window)
+		w.SetTransparent(true)
+		w.create()
+		assert.Equal(t, 1, w.viewport.GetAttrib(glfw.TransparentFramebuffer))
+	})
+
+	w1 := createWindow("")
+	assert.Equal(t, 0, w1.window.viewport.GetAttrib(glfw.TransparentFramebuffer))
 }
 
 func TestWindow_Opacity(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -1921,15 +1922,38 @@ func TestWindow_RescaleContext(t *testing.T) {
 }
 
 func TestWindow_Transparent(t *testing.T) {
-	runOnMain(func() { // tests launch in a different context
-		w := d.CreateWindow("Transparent").(*window)
+	var w *window
+	var transparent bool
+	var frameBufferAttrib int
+
+	runOnMain(func() {
+		w = d.CreateWindow("Transparent").(*window)
 		w.SetTransparent(true)
 		w.create()
-		assert.Equal(t, 1, w.viewport.GetAttrib(glfw.TransparentFramebuffer))
+		transparent = w.Transparent()
+		frameBufferAttrib = w.viewport.GetAttrib(glfw.TransparentFramebuffer)
 	})
 
-	w1 := createWindow("")
-	assert.Equal(t, 0, w1.window.viewport.GetAttrib(glfw.TransparentFramebuffer))
+	assert.True(t, transparent)
+
+	// xvfb-run creates a cookie file usually matching /tmp/xvfb-run.XXXXXX/Xauthority
+	if runtime.GOOS == "linux" && strings.Contains(os.Getenv("XAUTHORITY"), "xvfb") {
+		t.Skip("Linux (xvfb) does not support transparent framebuffers")
+	}
+
+	assert.Equal(t, glfw.True, frameBufferAttrib)
+}
+
+func TestWindow_TransparentAfterCreate(t *testing.T) {
+	w := createWindow("Transparent")
+	assert.False(t, w.Transparent())
+	assert.Equal(t, glfw.False, w.window.viewport.GetAttrib(glfw.TransparentFramebuffer))
+
+	runOnMain(func() {
+		w.SetTransparent(true) // should not have an effect after creation
+		assert.False(t, w.Transparent())
+		assert.Equal(t, glfw.False, w.window.viewport.GetAttrib(glfw.TransparentFramebuffer))
+	})
 }
 
 func TestWindow_Opacity(t *testing.T) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -88,6 +88,19 @@ func TestGLDriver_CreateSplashWindow(t *testing.T) {
 	assert.True(t, w.centered)
 }
 
+func TestGLDriver_TransparentWindow(t *testing.T) {
+	var w *window
+	runOnMain(func() { // tests launch in a different context
+		w = d.createWindow("", true).(*window)
+		w.SetTransparent(true)
+		w.create()
+	})
+	assert.Equal(t, 1, w.viewport.GetAttrib(glfw.TransparentFramebuffer))
+
+	w1 := createWindow("")
+	assert.Equal(t, 0, w1.window.viewport.GetAttrib(glfw.TransparentFramebuffer))
+}
+
 func TestWindow_MinSize_Fixed(t *testing.T) {
 	w := createWindowWithResizeCallback("Test")
 	r := canvas.NewRectangle(color.White)
@@ -1917,6 +1930,16 @@ func TestWindow_RescaleContext(t *testing.T) {
 
 		w.RescaleContext()
 		assert.Equal(t, initialWidth, w.width)
+	})
+}
+
+func TestWindow_Opacity(t *testing.T) {
+	w := createWindow("Test")
+	assert.Equal(t, float32(1), w.Opacity())
+
+	runOnMain(func() {
+		w.SetOpacity(0.5)
+		assert.Equal(t, float32(0.5), w.Opacity())
 	})
 }
 

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -50,6 +50,7 @@ type window struct {
 	decorate  bool
 	closing   bool
 	fixedSize bool
+	transparent bool
 
 	cursor   desktop.Cursor
 	canvas   *glCanvas

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -45,11 +45,11 @@ const (
 var _ fyne.Window = (*window)(nil)
 
 type window struct {
-	viewport  *glfw.Window
-	created   bool
-	decorate  bool
-	closing   bool
-	fixedSize bool
+	viewport    *glfw.Window
+	created     bool
+	decorate    bool
+	closing     bool
+	fixedSize   bool
 	transparent bool
 
 	cursor   desktop.Cursor
@@ -122,6 +122,14 @@ func (w *window) SetIcon(icon fyne.Resource) {
 
 func (w *window) SetMaster() {
 	// FIXME: there could really only be one window
+}
+
+func (w *window) Opacity() float32 {
+	return 1.0
+}
+
+func (w *window) SetOpacity(opacity float32) {
+	// FIXME: no support for SetOpacity yet
 }
 
 func (w *window) fitContent() {
@@ -526,6 +534,7 @@ func (w *window) RescaleContext() {
 }
 
 func (w *window) create() {
+	// transparency doesn't seem to work in WebGL, so we'll ignore it for now
 	// we can't hide the window in webgl, so there might be some artifact
 	initWindowHints()
 

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -371,7 +371,12 @@ func (d *driver) paintWindow(window fyne.Window, size fyne.Size) {
 
 	c.Painter().SetOutputSize(d.currentSize.WidthPx, d.currentSize.HeightPx)
 
-	r, g, b, a := theme.Color(theme.ColorNameBackground).RGBA()
+	var r, g, b, a uint32
+	if window.Transparent() {
+		r, g, b, a = 0, 0, 0, 0
+	} else {
+		r, g, b, a = theme.Color(theme.ColorNameBackground).RGBA()
+	}
 	max16bit := float32(255 * 255)
 	d.glctx.ClearColor(float32(r)/max16bit, float32(g)/max16bit, float32(b)/max16bit, float32(a)/max16bit)
 	d.glctx.Clear(gl.ColorBufferBit)

--- a/internal/driver/mobile/window.go
+++ b/internal/driver/mobile/window.go
@@ -13,7 +13,6 @@ import (
 type window struct {
 	title              string
 	visible            bool
-	transparent        bool
 	onClosed           func()
 	onCloseIntercepted func()
 	isChild            bool
@@ -212,9 +211,17 @@ func (w *window) Context() any {
 }
 
 func (w *window) Transparent() bool {
-	return w.transparent
+	return false
 }
 
 func (w *window) SetTransparent(transparent bool) {
-	w.transparent = transparent
+	// no-op on mobile
+}
+
+func (w *window) Opacity() float32 {
+	return 1.0
+}
+
+func (w *window) SetOpacity(opacity float32) {
+	// no-op on mobile
 }

--- a/internal/driver/mobile/window.go
+++ b/internal/driver/mobile/window.go
@@ -13,6 +13,7 @@ import (
 type window struct {
 	title              string
 	visible            bool
+	transparent        bool
 	onClosed           func()
 	onCloseIntercepted func()
 	isChild            bool
@@ -208,4 +209,12 @@ func (w *window) RescaleContext() {
 
 func (w *window) Context() any {
 	return fyne.CurrentApp().Driver().(*driver).glctx
+}
+
+func (w *window) Transparent() bool {
+	return w.transparent
+}
+
+func (w *window) SetTransparent(transparent bool) {
+	w.transparent = transparent
 }

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -136,7 +136,7 @@ var _ Painter = (*painter)(nil)
 
 func (p *painter) Clear() {
 	var r, g, b, a uint32
-	if win, ok := p.contextProvider.(interface{ Transparent() bool }); ok && win.Transparent() {
+	if win, ok := p.contextProvider.(fyne.Window); ok && win.Transparent() {
 		r, g, b, a = 0, 0, 0, 0
 	} else {
 		r, g, b, a = theme.Color(theme.ColorNameBackground).RGBA()

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -135,7 +135,12 @@ func (p *painter) UpdateVertexArray(pState ProgramState, name string, size, stri
 var _ Painter = (*painter)(nil)
 
 func (p *painter) Clear() {
-	r, g, b, a := theme.Color(theme.ColorNameBackground).RGBA()
+	var r, g, b, a uint32
+	if win, ok := p.contextProvider.(interface{ Transparent() bool }); ok && win.Transparent() {
+		r, g, b, a = 0, 0, 0, 0
+	} else {
+		r, g, b, a = theme.Color(theme.ColorNameBackground).RGBA()
+	}
 	p.ctx.ClearColor(float32(r)/max16bit, float32(g)/max16bit, float32(b)/max16bit, float32(a)/max16bit)
 	p.ctx.Clear(bitColorBuffer | bitDepthBuffer)
 	p.logError()

--- a/test/window.go
+++ b/test/window.go
@@ -10,6 +10,7 @@ type window struct {
 	fixedSize          bool
 	focused            bool
 	transparent        bool
+	opacity            float32
 	onClosed           func()
 	onCloseIntercepted func()
 
@@ -146,4 +147,12 @@ func (w *window) Transparent() bool {
 
 func (w *window) SetTransparent(transparent bool) {
 	w.transparent = transparent
+}
+
+func (w *window) Opacity() float32 {
+	return w.opacity
+}
+
+func (w *window) SetOpacity(opacity float32) {
+	w.opacity = opacity
 }

--- a/test/window.go
+++ b/test/window.go
@@ -9,6 +9,7 @@ type window struct {
 	fullScreen         bool
 	fixedSize          bool
 	focused            bool
+	transparent        bool
 	onClosed           func()
 	onCloseIntercepted func()
 
@@ -137,4 +138,12 @@ func (w *window) ShowAndRun() {
 
 func (w *window) Title() string {
 	return w.title
+}
+
+func (w *window) Transparent() bool {
+	return w.transparent
+}
+
+func (w *window) SetTransparent(transparent bool) {
+	w.transparent = transparent
 }

--- a/window.go
+++ b/window.go
@@ -110,8 +110,18 @@ type Window interface {
 	// Since: 2.8
 	Transparent() bool
 	// SetTransparent sets whether the window background should be transparent.
-	// This must be set before Show() is called.
+	// This must be set before Show() or ShowAndRun() is called.
 	//
 	// Since: 2.8
 	SetTransparent(bool)
+
+	// Opacity returns the opacity of this window.
+	//
+	// Since: 2.8
+	Opacity() float32
+	// SetOpacity sets the opacity of this window.
+	// 0.0 - fully transparent, 1.0 - fully opaque
+	//
+	// Since: 2.8
+	SetOpacity(float32)
 }

--- a/window.go
+++ b/window.go
@@ -104,4 +104,14 @@ type Window interface {
 	//
 	// Deprecated: use App.Clipboard() instead.
 	Clipboard() Clipboard
+
+	// Transparent returns whether the window background is transparent.
+	//
+	// Since: 2.8
+	Transparent() bool
+	// SetTransparent sets whether the window background should be transparent.
+	// This must be set before Show() is called.
+	//
+	// Since: 2.8
+	SetTransparent(bool)
 }


### PR DESCRIPTION
### Description:
Fixes #181

This PR introduces window transparency (only background) and opacity (entire window: border and content) control to the Fyne framework. New methods are added to the `fyne.Window` interface:

#### Window Transparency:

`Transparent() bool` - Returns whether the window background is transparent
`SetTransparent(bool)` - Sets window transparency (must be called before Show() or ShowAndRun())

#### Window Opacity:

`Opacity() float32` - Returns the current window opacity
`SetOpacity(float32)` - Sets window opacity (0.0 = fully transparent, 1.0 = fully opaque)

#### Implementation Details:

Desktop (GLFW): Full support for both transparency and opacity
- Uses `glfw.TransparentFramebuffer` hint for transparency
- Calls `SetOpacity()` on the viewport window for opacity control
- Clear color set to transparent (0,0,0,0) when transparency is enabled

Mobile, WebAssembly, Embedded (no-OS): Stubbed implementation (no-effect)

Changes Included:

- Added transparent and opacity fields to window structs across all drivers
- Updated painter to respect transparency setting when clearing
- Update demo tutorial showing both features
- Unit tests for GLFW implementation
- Tested on: Windows and Ubuntu

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.
