### PR TITLE
Markdown: render inline and block code on a background fill

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -548,6 +548,23 @@ type textRenderer struct {
 	obj *RichText
 }
 
+// codeInlineText returns the text inside an inline-code [background, text]
+// container, or a bare *canvas.Text as-is. It returns false for anything else,
+// including the single-child hyperlink container (hence the len == 2 check).
+func codeInlineText(obj fyne.CanvasObject) (*canvas.Text, bool) {
+	switch o := obj.(type) {
+	case *canvas.Text:
+		return o, true
+	case *fyne.Container:
+		if len(o.Objects) == 2 {
+			if t, ok := o.Objects[1].(*canvas.Text); ok {
+				return t, true
+			}
+		}
+	}
+	return nil, false
+}
+
 func (r *textRenderer) Layout(size fyne.Size) {
 	th := r.obj.Theme()
 	bounds := r.obj.rowBounds
@@ -579,7 +596,7 @@ func (r *textRenderer) Layout(size fyne.Size) {
 			inline := segI < len(bound.segments)-1
 			obj := objs[i]
 			i++
-			_, isText := obj.(*canvas.Text)
+			_, isText := codeInlineText(obj) // code-inline containers are text-like, not blocks
 			if !isText && !inline {
 				if len(rowItems) != 0 {
 					width, _ := r.layoutRow(rowItems, rowAlign, left+leftPad, yPos, lineWidth-leftPad)
@@ -763,7 +780,8 @@ func (r *textRenderer) Refresh() {
 			}
 
 			if isText {
-				obj.(*canvas.Text).Text = txt
+				to, _ := codeInlineText(obj)
+				to.Text = txt
 			} else if isHyperlink {
 				hl := obj.(*fyne.Container).Objects[0].(*Hyperlink)
 				hl.Text = txt
@@ -804,7 +822,7 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	initialX := xPos
 	if len(texts) == 1 {
 		min := texts[0].MinSize()
-		if text, ok := texts[0].(*canvas.Text); ok {
+		if text, ok := codeInlineText(texts[0]); ok {
 			texts[0].Resize(min)
 			xPad := float32(0)
 			switch text.Alignment {
@@ -830,6 +848,16 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	for i, text := range texts {
 		var size fyne.Size
 		if txt, ok := text.(*canvas.Text); ok {
+			s, base := driver.RenderedTextSize(txt.Text, txt.TextSize, txt.TextStyle, txt.FontSource)
+			if base > tallestBaseline {
+				if tallestBaseline > 0 {
+					realign = true
+				}
+				tallestBaseline = base
+			}
+			size = s
+			baselines[i] = base
+		} else if txt, ok := codeInlineText(text); ok {
 			s, base := driver.RenderedTextSize(txt.Text, txt.TextSize, txt.TextStyle, txt.FontSource)
 			if base > tallestBaseline {
 				if tallestBaseline > 0 {
@@ -1171,7 +1199,7 @@ func truncateLines(t *RichText, seg RichTextSegment, trunc fyne.TextTruncation, 
 			var textObj *canvas.Text
 			switch s := seg.(type) {
 			case *TextSegment:
-				textObj = seg.Visual().(*canvas.Text)
+				textObj, _ = codeInlineText(seg.Visual())
 			case *HyperlinkSegment:
 				textObj = canvas.NewText(string(txt), color.Black)
 				textObj.TextStyle = s.TextStyle

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -548,18 +548,16 @@ type textRenderer struct {
 	obj *RichText
 }
 
-// codeInlineText returns the text inside an inline-code [background, text]
-// container, or a bare *canvas.Text as-is. It returns false for anything else,
-// including the single-child hyperlink container (hence the len == 2 check).
+// codeInlineText returns the text inside an inline-code container, identified by
+// its codeInlineLayout, or a bare *canvas.Text as-is. It returns false for any
+// other object.
 func codeInlineText(obj fyne.CanvasObject) (*canvas.Text, bool) {
 	switch o := obj.(type) {
 	case *canvas.Text:
 		return o, true
 	case *fyne.Container:
-		if len(o.Objects) == 2 {
-			if t, ok := o.Objects[1].(*canvas.Text); ok {
-				return t, true
-			}
+		if _, ok := o.Layout.(*codeInlineLayout); ok {
+			return o.Objects[1].(*canvas.Text), true
 		}
 	}
 	return nil, false
@@ -847,17 +845,7 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	driver := fyne.CurrentApp().Driver()
 	for i, text := range texts {
 		var size fyne.Size
-		if txt, ok := text.(*canvas.Text); ok {
-			s, base := driver.RenderedTextSize(txt.Text, txt.TextSize, txt.TextStyle, txt.FontSource)
-			if base > tallestBaseline {
-				if tallestBaseline > 0 {
-					realign = true
-				}
-				tallestBaseline = base
-			}
-			size = s
-			baselines[i] = base
-		} else if txt, ok := codeInlineText(text); ok {
+		if txt, ok := codeInlineText(text); ok { // bare text or an inline-code container
 			s, base := driver.RenderedTextSize(txt.Text, txt.TextSize, txt.TextStyle, txt.FontSource)
 			if base > tallestBaseline {
 				if tallestBaseline > 0 {

--- a/widget/richtext_codeinline_test.go
+++ b/widget/richtext_codeinline_test.go
@@ -31,7 +31,7 @@ func TestTextSegment_InlineCodeVisualHasBackground(t *testing.T) {
 	if !ok {
 		t.Fatalf("first object should be the background rectangle, got %T", c.Objects[0])
 	}
-	assert.Equal(t, theme.Color(theme.ColorNameBackground), bg.FillColor)
+	assert.Equal(t, theme.Color(theme.ColorNameInputBackground), bg.FillColor)
 
 	txt, ok := c.Objects[1].(*canvas.Text)
 	if !ok {
@@ -73,7 +73,16 @@ func TestTextSegment_InlineCodeUpdate(t *testing.T) {
 
 	c := vis.(*fyne.Container)
 	assert.Equal(t, "y", c.Objects[1].(*canvas.Text).Text)
-	assert.Equal(t, theme.Color(theme.ColorNameBackground), c.Objects[0].(*canvas.Rectangle).FillColor)
+	assert.Equal(t, theme.Color(theme.ColorNameInputBackground), c.Objects[0].(*canvas.Rectangle).FillColor)
+}
+
+// The fenced code block shares the inline code background colour.
+func TestRichCodeBlock_BackgroundColour(t *testing.T) {
+	test.NewTempApp(t)
+
+	cb := newRichCodeBlock("x")
+	test.TempWidgetRenderer(t, cb)
+	assert.Equal(t, theme.Color(theme.ColorNameInputBackground), cb.bg.FillColor)
 }
 
 // A rendered document with inline code lays out without panicking and the code

--- a/widget/richtext_codeinline_test.go
+++ b/widget/richtext_codeinline_test.go
@@ -76,6 +76,29 @@ func TestTextSegment_InlineCodeUpdate(t *testing.T) {
 	assert.Equal(t, theme.Color(theme.ColorNameInputBackground), c.Objects[0].(*canvas.Rectangle).FillColor)
 }
 
+// Emphasised inline code (e.g. **`x`**) keeps its background. Emphasis mutates
+// the segment's TextStyle (sets Bold), so its Style no longer equals the
+// RichTextStyleCodeInline var — a struct-equality check would miss it, but the
+// codeInline marker survives the mutation.
+func TestTextSegment_EmphasisedInlineCodeHasBackground(t *testing.T) {
+	test.NewTempApp(t)
+
+	r := NewRichTextFromMarkdown("**`code`**")
+	var seg *TextSegment
+	for _, s := range r.Segments {
+		if ts, ok := s.(*TextSegment); ok && ts.Style.TextStyle.Monospace {
+			seg = ts
+		}
+	}
+	if seg == nil {
+		t.Fatal("no monospace inline-code segment found")
+	}
+	assert.True(t, seg.Style.TextStyle.Bold, "precondition: emphasis set Bold on the code segment")
+	assert.NotEqual(t, RichTextStyleCodeInline, seg.Style, "precondition: style differs from the var once Bold is set")
+	_, ok := seg.Visual().(*fyne.Container)
+	assert.True(t, ok, "emphasised inline code should still get a background")
+}
+
 // The fenced code block shares the inline code background colour.
 func TestRichCodeBlock_BackgroundColour(t *testing.T) {
 	test.NewTempApp(t)

--- a/widget/richtext_codeinline_test.go
+++ b/widget/richtext_codeinline_test.go
@@ -1,0 +1,100 @@
+package widget
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/cache"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+)
+
+// Inline code (inline + monospace) renders its text on a background fill using
+// the same colour name as the code block, reusing RichTextStyleCodeInline with
+// no new style, segment type or field.
+func TestTextSegment_InlineCodeVisualHasBackground(t *testing.T) {
+	test.NewTempApp(t)
+
+	seg := &TextSegment{Style: RichTextStyleCodeInline, Text: "code"}
+	vis := seg.Visual()
+
+	c, ok := vis.(*fyne.Container)
+	if !ok {
+		t.Fatalf("inline code visual should be a container, got %T", vis)
+	}
+	assert.Len(t, c.Objects, 2)
+
+	bg, ok := c.Objects[0].(*canvas.Rectangle)
+	if !ok {
+		t.Fatalf("first object should be the background rectangle, got %T", c.Objects[0])
+	}
+	assert.Equal(t, theme.Color(theme.ColorNameBackground), bg.FillColor)
+
+	txt, ok := c.Objects[1].(*canvas.Text)
+	if !ok {
+		t.Fatalf("second object should be the text, got %T", c.Objects[1])
+	}
+	assert.Equal(t, "code", txt.Text)
+	assert.True(t, txt.TextStyle.Monospace)
+}
+
+// Ordinary inline text is unchanged: a bare canvas.Text with no background.
+func TestTextSegment_PlainInlineVisualUnchanged(t *testing.T) {
+	test.NewTempApp(t)
+
+	seg := &TextSegment{Style: RichTextStyleInline, Text: "plain"}
+	_, ok := seg.Visual().(*canvas.Text)
+	assert.True(t, ok, "plain inline text should remain a bare canvas.Text")
+}
+
+// Monospace inline text that is not code (e.g. a monospace Entry) must NOT get a
+// background: the marker, not the monospace style, drives the backdrop.
+func TestTextSegment_MonospaceInlineNotCodeUnchanged(t *testing.T) {
+	test.NewTempApp(t)
+
+	style := RichTextStyleInline
+	style.TextStyle.Monospace = true
+	seg := &TextSegment{Style: style, Text: "mono"}
+	_, ok := seg.Visual().(*canvas.Text)
+	assert.True(t, ok, "monospace non-code inline text should remain a bare canvas.Text")
+}
+
+// Update recolours the backdrop and refreshes the text of an inline code container.
+func TestTextSegment_InlineCodeUpdate(t *testing.T) {
+	test.NewTempApp(t)
+
+	seg := &TextSegment{Style: RichTextStyleCodeInline, Text: "x"}
+	vis := seg.Visual()
+	seg.Text = "y"
+	seg.Update(vis)
+
+	c := vis.(*fyne.Container)
+	assert.Equal(t, "y", c.Objects[1].(*canvas.Text).Text)
+	assert.Equal(t, theme.Color(theme.ColorNameBackground), c.Objects[0].(*canvas.Rectangle).FillColor)
+}
+
+// A rendered document with inline code lays out without panicking and the code
+// fragment appears as a backed container in the renderer's objects.
+func TestRichText_InlineCodeRenders(t *testing.T) {
+	test.NewTempApp(t)
+
+	r := NewRichTextFromMarkdown("a `code` b")
+	w := test.NewTempWindow(t, r)
+	w.Resize(fyne.NewSize(200, 100))
+
+	renderer := cache.Renderer(r).(*textRenderer)
+	found := false
+	for _, o := range renderer.Objects() {
+		c, ok := o.(*fyne.Container)
+		if !ok || len(c.Objects) != 2 {
+			continue
+		}
+		if _, ok := c.Objects[0].(*canvas.Rectangle); ok {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected an inline-code background container among render objects")
+}

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -36,10 +36,11 @@ var (
 	//
 	// Since: 2.1
 	RichTextStyleCodeInline = RichTextStyle{
-		ColorName: theme.ColorNameForeground,
-		Inline:    true,
-		SizeName:  theme.SizeNameText,
-		TextStyle: fyne.TextStyle{Monospace: true},
+		ColorName:  theme.ColorNameForeground,
+		Inline:     true,
+		SizeName:   theme.SizeNameText,
+		TextStyle:  fyne.TextStyle{Monospace: true},
+		codeInline: true,
 	}
 	// RichTextStyleEmphasis represents regular text with emphasis.
 	//
@@ -551,6 +552,9 @@ type RichTextStyle struct {
 
 	// an internal detail where we obscure password fields
 	concealed bool
+
+	// an internal detail marking inline code, which renders on a background fill
+	codeInline bool
 }
 
 // RichTextSegment describes any element that can be rendered in a RichText widget.
@@ -589,21 +593,51 @@ func (t *TextSegment) Textual() string {
 
 // Visual returns a new instance of a graphical element required to render this segment.
 func (t *TextSegment) Visual() fyne.CanvasObject {
-	obj := canvas.NewText(t.Text, t.color())
+	text := canvas.NewText(t.Text, t.color())
+	if t.Style.codeInline {
+		bg := canvas.NewRectangle(theme.ColorForWidget(theme.ColorNameBackground, t.parent))
+		c := &fyne.Container{Layout: &codeInlineLayout{}, Objects: []fyne.CanvasObject{bg, text}}
+		t.Update(c)
+		return c
+	}
 
-	t.Update(obj)
-	return obj
+	t.Update(text)
+	return text
 }
 
 // Update applies the current state of this text segment to an existing visual.
 func (t *TextSegment) Update(o fyne.CanvasObject) {
-	obj := o.(*canvas.Text)
+	obj, ok := o.(*canvas.Text)
+	if !ok { // inline code container: [background, text]
+		c := o.(*fyne.Container)
+		bg := c.Objects[0].(*canvas.Rectangle)
+		bg.FillColor = theme.ColorForWidget(theme.ColorNameBackground, t.parent)
+		bg.Refresh()
+		obj = c.Objects[1].(*canvas.Text)
+	}
 	obj.Text = t.Text
 	obj.Color = t.color()
 	obj.Alignment = t.Style.Alignment
 	obj.TextStyle = t.Style.TextStyle
 	obj.TextSize = t.size()
 	obj.Refresh()
+}
+
+// codeInlineLayout keeps the inline-code background tight to the text, so when
+// the row layout stretches the container to fill trailing space the fill does
+// not stretch with it.
+type codeInlineLayout struct{}
+
+func (codeInlineLayout) MinSize(o []fyne.CanvasObject) fyne.Size {
+	return o[1].MinSize()
+}
+
+func (codeInlineLayout) Layout(o []fyne.CanvasObject, _ fyne.Size) {
+	size := o[1].MinSize()
+	for _, obj := range o {
+		obj.Resize(size)
+		obj.Move(fyne.NewPos(0, 0))
+	}
 }
 
 // Select tells the segment that the user is selecting the content between the two positions.

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -468,7 +468,7 @@ func (c *richCodeBlock) setText(text string) {
 }
 
 func (c *richCodeBlock) CreateRenderer() fyne.WidgetRenderer {
-	c.bg = canvas.NewRectangle(theme.Color(theme.ColorNameBackground))
+	c.bg = canvas.NewRectangle(theme.Color(theme.ColorNameInputBackground))
 	c.bg.StrokeColor = theme.Color(theme.ColorNameInputBorder)
 	c.bg.StrokeWidth = 1
 	c.bg.CornerRadius = theme.Size(theme.SizeNameInputRadius)
@@ -595,7 +595,7 @@ func (t *TextSegment) Textual() string {
 func (t *TextSegment) Visual() fyne.CanvasObject {
 	text := canvas.NewText(t.Text, t.color())
 	if t.Style.codeInline {
-		bg := canvas.NewRectangle(theme.ColorForWidget(theme.ColorNameBackground, t.parent))
+		bg := canvas.NewRectangle(theme.ColorForWidget(theme.ColorNameInputBackground, t.parent))
 		c := &fyne.Container{Layout: &codeInlineLayout{}, Objects: []fyne.CanvasObject{bg, text}}
 		t.Update(c)
 		return c
@@ -611,7 +611,7 @@ func (t *TextSegment) Update(o fyne.CanvasObject) {
 	if !ok { // inline code container: [background, text]
 		c := o.(*fyne.Container)
 		bg := c.Objects[0].(*canvas.Rectangle)
-		bg.FillColor = theme.ColorForWidget(theme.ColorNameBackground, t.parent)
+		bg.FillColor = theme.ColorForWidget(theme.ColorNameInputBackground, t.parent)
 		bg.Refresh()
 		obj = c.Objects[1].(*canvas.Text)
 	}


### PR DESCRIPTION
## Description

Follow-up to #6330 and closes #6041. After the fenced code block style landed in #6335, @andydotxyz asked that inline code be styled consistently with it.

Inline code (`` `x` ``) now renders as monospace text on a background fill, and the fenced **block** is recoloured to the same fill, so the two match. Following GitHub-flavored markdown, inline code gets a fill only (no border/rounded corners); the block keeps its border.

**Colour:** `theme.ColorNameInputBackground` for both. The first revision used `ColorNameBackground` (the block's original fill), but as @MaxGyver83 pointed out in review it renders invisibly — it *is* the window surface, and inline code has no border to define it. `ColorNameInputBackground` is theme-aware and stays visible against the default window background in both light and dark themes. (A fixed translucent overlay such as `ColorNameShadow` looks fine in light theme but is near-invisible in dark, so a themed surface colour is preferable.)

## Approach

- **Reuses the existing `RichTextStyleCodeInline`** — no new style, segment type, public field or theme constant.
- Detection uses an **unexported `codeInline` marker** on `RichTextStyle`, set only on the `RichTextStyleCodeInline` var. This mirrors the existing unexported `concealed` flag (passwords). Keying on `Monospace` alone would be wrong: a monospace `Entry`/`Label` is not code and must not get a background.
- Inline code stays a `*TextSegment`, so wrapping is unchanged. `TextSegment.Visual()` returns a `[background, text]` container for code (each wrapped fragment gets its own, via the existing per-fragment visual cache); the renderer unwraps it through a small `codeInlineText` helper at the same spots that already special-case the hyperlink container.

## Tests

`widget/richtext_codeinline_test.go`: the inline-code visual carries an `InputBackground` rectangle behind monospace text; plain and monospace-but-not-code inline text stay bare `*canvas.Text`; `Update` recolours the backdrop; the fenced block uses the same colour; a rendered document with inline code lays out without panicking.