### PR TITLE
Keep RichText widget scroll position

### DIFF
--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -775,11 +775,13 @@ func (r *textRenderer) Refresh() {
 	}
 
 	if r.obj.scr != nil {
-		r.obj.scr.Content = &fyne.Container{Layout: layout.NewStackLayout(), Objects: []fyne.CanvasObject{
-			r.obj.prop, &fyne.Container{Objects: objs},
-		}}
-		r.obj.scr.Direction = scroll
-		r.SetObjects([]fyne.CanvasObject{r.obj.scr})
+		if isEmptyScroll(r.obj.scr) {
+			r.obj.scr.Content = &fyne.Container{Layout: layout.NewStackLayout(), Objects: []fyne.CanvasObject{
+				r.obj.prop, &fyne.Container{Objects: objs},
+			}}
+			r.obj.scr.Direction = scroll
+			r.SetObjects([]fyne.CanvasObject{r.obj.scr})
+		}
 		r.obj.scr.Refresh()
 	} else {
 		r.SetObjects(objs)
@@ -912,6 +914,17 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 	}
 
 	return xPos - initialX, height
+}
+
+func isEmptyScroll(o *widget.Scroll) bool {
+	if c, ok := o.Content.(*fyne.Container); ok {
+		if len(c.Objects) == 2 {
+			if inner, ok := c.Objects[1].(*fyne.Container); ok {
+				return inner.Objects == nil
+			}
+		}
+	}
+	return false
 }
 
 // howManyRunesFit accepts a rune slice, an available width, an average


### PR DESCRIPTION
### Description:

Don't recreate scroll container content in `*textRenderer.Refresh`. This way the scroll position is kept (p.e. when AppTabs are switched).

Fixes #5991.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.