### PR TITLE
Keep GridWrap highlight visible after scroll

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -612,6 +612,27 @@ func (l *gridWrapLayout) offsetUpdated(pos fyne.Position) {
 	}
 	l.gw.offsetY = pos.Y
 	l.updateGrid(true)
+	l.keepHighlightVisible()
+}
+
+func (l *gridWrapLayout) keepHighlightVisible() {
+	if len(l.visible) == 0 {
+		return
+	}
+
+	current := l.gw.currentHighlight
+	first := l.visible[0].id
+	last := l.visible[len(l.visible)-1].id
+	if current < first {
+		l.gw.currentHighlight = first
+	} else if current > last {
+		l.gw.currentHighlight = last
+	}
+
+	if current != l.gw.currentHighlight {
+		l.gw.RefreshItem(current)
+		l.gw.RefreshItem(l.gw.currentHighlight)
+	}
 }
 
 func (l *gridWrapLayout) setupGridItem(li *gridWrapItem, id GridWrapItemID, focus bool) {

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGridWrap_Focus(t *testing.T) {
@@ -97,6 +98,25 @@ func TestGridWrap_ScrollTo(t *testing.T) {
 
 	g.ScrollToBottom()
 	assert.Equal(t, greatest, GridWrapItemID(999))
+}
+
+func TestGridWrap_ScrollKeepsHighlightVisible(t *testing.T) {
+	g := createGridWrap(1000)
+	window := test.NewWindow(g)
+	defer window.Close()
+	window.Resize(fyne.NewSize(80, 100))
+
+	canvas := window.Canvas().(test.WindowlessCanvas)
+	canvas.FocusNext()
+	assert.Equal(t, GridWrapItemID(0), g.currentHighlight)
+
+	g.ScrollToBottom()
+
+	visible := g.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).visible
+	require.NotEmpty(t, visible)
+
+	assert.GreaterOrEqual(t, g.currentHighlight, visible[0].id)
+	assert.LessOrEqual(t, g.currentHighlight, visible[len(visible)-1].id)
 }
 
 func TestGridWrap_ScrollToOffset(t *testing.T) {


### PR DESCRIPTION
### Description:

Fixes #5992

Keeps the GridWrap keyboard highlight clamped to the visible item range after scrolling. This lets subsequent arrow-key navigation continue from the current viewport instead of jumping back to a stale off-screen highlighted item.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [ ] Tests all pass.

### Testing:

- `go test ./widget -run '^TestGridWrap_ScrollKeepsHighlightVisible$' -count=1`\n- `go test ./widget -run '^TestGridWrap' -count=1`\n- `go test ./widget -run '^Test(GridWrap|List|Tree)_(ScrollTo|TypedKey|Highlight)' -count=1`\n- `go vet ./widget`\n- `go run golang.org/x/tools/cmd/goimports@latest -e -d widget/gridwrap.go widget/gridwrap_test.go`\n- `go run mvdan.cc/gofumpt@latest -l widget/gridwrap.go widget/gridwrap_test.go`\n- `git diff --check`\n\n`go test ./widget -count=1` hit unrelated local golden-render differences in `List`/`Tree` scrollbars/images on macOS; the focused GridWrap and nearby scroll/highlight tests above passed.