### PR TITLE
Fix some tests on MacOS

### DIFF
--- a/.github/workflows/mobile_tests.yml
+++ b/.github/workflows/mobile_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-          go-version-file: "go.mod"
+          go-version-file: ${{ matrix.go-version == '' && 'go.mod' || '' }}
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-          go-version-file: "go.mod"
+          go-version-file: ${{ matrix.go-version == '' && 'go.mod' || '' }}
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1624,10 +1624,10 @@ func TestWindow_CaptureTypedShortcutClipboard(t *testing.T) {
 
 	w.Canvas().Focus(content)
 
-	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Press, glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyV, 0, glfw.Press, glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Release, glfw.ModControl)
-	w.keyPressed(nil, glfw.KeyV, 0, glfw.Release, glfw.ModControl)
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Press, ctrlMod())
+	w.keyPressed(nil, glfw.KeyV, 0, glfw.Press, ctrlMod())
+	w.keyPressed(nil, glfw.KeyLeftControl, 0, glfw.Release, ctrlMod())
+	w.keyPressed(nil, glfw.KeyV, 0, glfw.Release, ctrlMod())
 
 	assert.Equal(t, 1, len(content.capturedShortcuts))
 	paste, ok := content.capturedShortcuts[0].(*fyne.ShortcutPaste)

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1762,11 +1762,7 @@ func TestWindow_ClipboardCopy_DisabledEntry(t *testing.T) {
 	e.DoubleTapped(nil)
 	assert.Equal(t, "Testing", e.SelectedText())
 
-	ctrlMod := glfw.ModControl
-	if isMacOSRuntime() {
-		ctrlMod = glfw.ModSuper
-	}
-	w.keyPressed(nil, glfw.KeyC, 0, glfw.Repeat, ctrlMod)
+	w.keyPressed(nil, glfw.KeyC, 0, glfw.Repeat, ctrlMod())
 
 	assert.Equal(t, "Testing", NewClipboard().Content())
 
@@ -1775,13 +1771,13 @@ func TestWindow_ClipboardCopy_DisabledEntry(t *testing.T) {
 	assert.Equal(t, "Testing2", e.SelectedText())
 
 	// any other shortcut should be forbidden (Cut)
-	w.keyPressed(nil, glfw.KeyX, 0, glfw.Repeat, ctrlMod)
+	w.keyPressed(nil, glfw.KeyX, 0, glfw.Repeat, ctrlMod())
 
 	assert.Equal(t, "Testing2", e.Text)
 	assert.Equal(t, "Testing", NewClipboard().Content())
 
 	// any other shortcut should be forbidden (Paste)
-	w.keyPressed(nil, glfw.KeyV, 0, glfw.Repeat, ctrlMod)
+	w.keyPressed(nil, glfw.KeyV, 0, glfw.Repeat, ctrlMod())
 
 	assert.Equal(t, "Testing2", e.Text)
 	assert.Equal(t, "Testing", NewClipboard().Content())
@@ -1966,6 +1962,14 @@ func createWindowWithResizeCallback(title string) *safeWindow {
 		w.create()
 	})
 	return &safeWindow{window: w}
+}
+
+func ctrlMod() glfw.ModifierKey {
+	if isMacOSRuntime() {
+		return glfw.ModSuper
+	}
+
+	return glfw.ModControl
 }
 
 //

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1631,8 +1631,9 @@ func TestWindow_CaptureTypedShortcutClipboard(t *testing.T) {
 
 	assert.Equal(t, 1, len(content.capturedShortcuts))
 	paste, ok := content.capturedShortcuts[0].(*fyne.ShortcutPaste)
-	assert.True(t, ok)
-	assert.False(t, paste.Secondary)
+	if assert.True(t, ok) {
+		assert.False(t, paste.Secondary)
+	}
 
 	w.keyPressed(nil, glfw.KeyLeftShift, 0, glfw.Press, glfw.ModShift)
 	w.keyPressed(nil, glfw.KeyInsert, 0, glfw.Press, glfw.ModShift)
@@ -1641,8 +1642,9 @@ func TestWindow_CaptureTypedShortcutClipboard(t *testing.T) {
 
 	assert.Equal(t, 2, len(content.capturedShortcuts))
 	paste, ok = content.capturedShortcuts[1].(*fyne.ShortcutPaste)
-	assert.True(t, ok)
-	assert.True(t, paste.Secondary)
+	if assert.True(t, ok) {
+		assert.True(t, paste.Secondary)
+	}
 }
 
 func TestWindow_OnlyTabAndShiftTabToCapturesTab(t *testing.T) {


### PR DESCRIPTION
This PR fixes the internal GLFW window test on MacOS.
It also avoids a GitHub Action warning for the platform tests.