### PR TITLE
desktop: Ignore system settings if FYNE_THEME is set

### DIFF
--- a/app/settings.go
+++ b/app/settings.go
@@ -30,6 +30,11 @@ func (sc *SettingsSchema) StoragePath() string {
 // Declare conformity with Settings interface
 var _ fyne.Settings = (*settings)(nil)
 
+const (
+	themeVariantNameDark  = "dark"
+	themeVariantNameLight = "light"
+)
+
 type settings struct {
 	theme          fyne.Theme
 	themeSpecified bool
@@ -130,9 +135,9 @@ func (s *settings) setupTheme() {
 		effectiveTheme = theme.DefaultTheme()
 	}
 	switch name {
-	case "light":
+	case themeVariantNameLight:
 		variant = theme.VariantLight
-	case "dark":
+	case themeVariantNameDark:
 		variant = theme.VariantDark
 	}
 

--- a/app/settings.go
+++ b/app/settings.go
@@ -123,11 +123,7 @@ func (s *settings) fileChanged() {
 }
 
 func (s *settings) setupTheme() {
-	name := s.schema.ThemeName
-	if env := os.Getenv("FYNE_THEME"); env != "" {
-		name = env
-	}
-
+	name := s.explicitThemeVariantName()
 	variant := app.DefaultVariant()
 	effectiveTheme := s.theme
 	if !s.themeSpecified {
@@ -141,6 +137,14 @@ func (s *settings) setupTheme() {
 	}
 
 	s.applyTheme(effectiveTheme, variant)
+}
+
+func (s *settings) explicitThemeVariantName() string {
+	if name := os.Getenv("FYNE_THEME"); name != "" {
+		return name
+	}
+
+	return s.schema.ThemeName
 }
 
 func loadSettings() *settings {

--- a/app/settings_desktop.go
+++ b/app/settings_desktop.go
@@ -62,7 +62,7 @@ func watchFile(path string, callback func()) *fsnotify.Watcher {
 func (s *settings) watchSettings() {
 	s.watcher = watchFile(s.schema.StoragePath(), s.fileChanged)
 
-	if env := os.Getenv("FYNE_THEME"); env == "" {
+	if s.explicitThemeVariantName() == "" {
 		a := fyne.CurrentApp()
 		if a != nil && s != nil && a.Settings() == s { // ignore if testing
 			watchTheme(s)

--- a/app/settings_desktop.go
+++ b/app/settings_desktop.go
@@ -62,9 +62,11 @@ func watchFile(path string, callback func()) *fsnotify.Watcher {
 func (s *settings) watchSettings() {
 	s.watcher = watchFile(s.schema.StoragePath(), s.fileChanged)
 
-	a := fyne.CurrentApp()
-	if a != nil && s != nil && a.Settings() == s { // ignore if testing
-		watchTheme(s)
+	if env := os.Getenv("FYNE_THEME"); env == "" {
+		a := fyne.CurrentApp()
+		if a != nil && s != nil && a.Settings() == s { // ignore if testing
+			watchTheme(s)
+		}
 	}
 }
 

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -28,10 +28,10 @@ func TestSettingsLoad(t *testing.T) {
 	settings := &settings{}
 
 	require.NoError(t, settings.loadFromFile(filepath.Join("testdata", "light-theme.json")))
-	assert.Equal(t, "light", settings.schema.ThemeName)
+	assert.Equal(t, themeVariantNameLight, settings.schema.ThemeName)
 
 	require.NoError(t, settings.loadFromFile(filepath.Join("testdata", "dark-theme.json")))
-	assert.Equal(t, "dark", settings.schema.ThemeName)
+	assert.Equal(t, themeVariantNameDark, settings.schema.ThemeName)
 }
 
 func TestOverrideTheme(t *testing.T) {
@@ -40,12 +40,12 @@ func TestOverrideTheme(t *testing.T) {
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
 
-	set.schema.ThemeName = "light"
+	set.schema.ThemeName = themeVariantNameLight
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
 
-	set.schema.ThemeName = "dark"
+	set.schema.ThemeName = themeVariantNameDark
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())
@@ -54,7 +54,7 @@ func TestOverrideTheme(t *testing.T) {
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
 
-	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
+	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameLight))
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
@@ -65,7 +65,7 @@ func TestOverrideTheme(t *testing.T) {
 func TestOverrideTheme_IgnoresSettingsChange(t *testing.T) {
 	// check that a file-load does not overwrite our value
 	set := &settings{}
-	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
+	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameLight))
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
@@ -99,12 +99,12 @@ func TestCustomTheme(t *testing.T) {
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())
 
-	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
+	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameLight))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
 
-	require.NoError(t, os.Setenv("FYNE_THEME", "dark"))
+	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameDark))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSettingsBuildType(t *testing.T) {
@@ -26,26 +27,15 @@ func TestSettingsBuildType(t *testing.T) {
 func TestSettingsLoad(t *testing.T) {
 	settings := &settings{}
 
-	err := settings.loadFromFile(filepath.Join("testdata", "light-theme.json"))
-	if err != nil {
-		t.Error(err)
-	}
-
+	require.NoError(t, settings.loadFromFile(filepath.Join("testdata", "light-theme.json")))
 	assert.Equal(t, "light", settings.schema.ThemeName)
 
-	err = settings.loadFromFile(filepath.Join("testdata", "dark-theme.json"))
-	if err != nil {
-		t.Error(err)
-	}
-
+	require.NoError(t, settings.loadFromFile(filepath.Join("testdata", "dark-theme.json")))
 	assert.Equal(t, "dark", settings.schema.ThemeName)
 }
 
 func TestOverrideTheme(t *testing.T) {
-	err := os.Setenv("FYNE_THEME", "")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, os.Setenv("FYNE_THEME", ""))
 	set := &settings{}
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
@@ -64,41 +54,27 @@ func TestOverrideTheme(t *testing.T) {
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
 
-	err = os.Setenv("FYNE_THEME", "light")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
-	err = os.Setenv("FYNE_THEME", "")
-	if err != nil {
-		t.Error(err)
-	}
+
+	require.NoError(t, os.Setenv("FYNE_THEME", ""))
 }
 
 func TestOverrideTheme_IgnoresSettingsChange(t *testing.T) {
 	// check that a file-load does not overwrite our value
 	set := &settings{}
-	err := os.Setenv("FYNE_THEME", "light")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
 
-	err = set.loadFromFile(filepath.Join("testdata", "dark-theme.json"))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, set.loadFromFile(filepath.Join("testdata", "dark-theme.json")))
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
-	err = os.Setenv("FYNE_THEME", "")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, os.Setenv("FYNE_THEME", ""))
 }
 
 func TestCustomTheme(t *testing.T) {
@@ -113,42 +89,27 @@ func TestCustomTheme(t *testing.T) {
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
 
-	err := set.loadFromFile(filepath.Join("testdata", "light-theme.json"))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, set.loadFromFile(filepath.Join("testdata", "light-theme.json")))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
 
-	err = set.loadFromFile(filepath.Join("testdata", "dark-theme.json"))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, set.loadFromFile(filepath.Join("testdata", "dark-theme.json")))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())
 
-	err = os.Setenv("FYNE_THEME", "light")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
 
-	err = os.Setenv("FYNE_THEME", "dark")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, os.Setenv("FYNE_THEME", "dark"))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())
 
-	err = os.Setenv("FYNE_THEME", "")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, os.Setenv("FYNE_THEME", ""))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -42,6 +42,10 @@ func TestSettingsLoad(t *testing.T) {
 }
 
 func TestOverrideTheme(t *testing.T) {
+	err := os.Setenv("FYNE_THEME", "")
+	if err != nil {
+		t.Error(err)
+	}
 	set := &settings{}
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
@@ -60,7 +64,7 @@ func TestOverrideTheme(t *testing.T) {
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
 
-	err := os.Setenv("FYNE_THEME", "light")
+	err = os.Setenv("FYNE_THEME", "light")
 	if err != nil {
 		t.Error(err)
 	}

--- a/app/settings_test.go
+++ b/app/settings_test.go
@@ -28,10 +28,10 @@ func TestSettingsLoad(t *testing.T) {
 	settings := &settings{}
 
 	require.NoError(t, settings.loadFromFile(filepath.Join("testdata", "light-theme.json")))
-	assert.Equal(t, themeVariantNameLight, settings.schema.ThemeName)
+	assert.Equal(t, "light", settings.schema.ThemeName)
 
 	require.NoError(t, settings.loadFromFile(filepath.Join("testdata", "dark-theme.json")))
-	assert.Equal(t, themeVariantNameDark, settings.schema.ThemeName)
+	assert.Equal(t, "dark", settings.schema.ThemeName)
 }
 
 func TestOverrideTheme(t *testing.T) {
@@ -40,12 +40,12 @@ func TestOverrideTheme(t *testing.T) {
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
 
-	set.schema.ThemeName = themeVariantNameLight
+	set.schema.ThemeName = "light"
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
 
-	set.schema.ThemeName = themeVariantNameDark
+	set.schema.ThemeName = "dark"
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())
@@ -54,7 +54,7 @@ func TestOverrideTheme(t *testing.T) {
 	set.setupTheme()
 	assert.Equal(t, internalapp.DefaultVariant(), set.ThemeVariant())
 
-	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameLight))
+	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
@@ -65,7 +65,7 @@ func TestOverrideTheme(t *testing.T) {
 func TestOverrideTheme_IgnoresSettingsChange(t *testing.T) {
 	// check that a file-load does not overwrite our value
 	set := &settings{}
-	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameLight))
+	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
 	set.setupTheme()
 	assert.Equal(t, theme.DefaultTheme(), set.Theme())
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
@@ -99,12 +99,12 @@ func TestCustomTheme(t *testing.T) {
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())
 
-	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameLight))
+	require.NoError(t, os.Setenv("FYNE_THEME", "light"))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantLight, set.ThemeVariant())
 
-	require.NoError(t, os.Setenv("FYNE_THEME", themeVariantNameDark))
+	require.NoError(t, os.Setenv("FYNE_THEME", "dark"))
 	set.setupTheme()
 	assert.Equal(t, set.Theme(), ctheme)
 	assert.Equal(t, theme.VariantDark, set.ThemeVariant())


### PR DESCRIPTION
### Description:

#### dark/light mode on desktop:

- Ignore system settings (DBus) if either `FYNE_THEME` or `s.schema.ThemeName` is set (→ skipping the `watchTheme` call).
- Introduce constants for `"dark"` and `"light"` strings.

#### app/settings_test.go:

- Update `TestOverrideTheme` to not depend on the actual `FYNE_THEME` value (this test simulates different values of `FYNE_THEME`).
- Abort test if test set-up fails (setting `FYNE_THEME` or reading testdata json file).

Fixes #6342.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.