### PR TITLE
clean up painter/gl

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -377,7 +377,7 @@ func (p *painter) shaderProgram(shader *canvas.Shader) (*shaderState, bool) {
 		program: programState{
 			ref:        ref,
 			buff:       p.createBuffer(16),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		},
 		valid: true,

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -374,7 +374,7 @@ func (p *painter) shaderProgram(shader *canvas.Shader) (*shaderState, bool) {
 	}
 
 	state := &shaderState{
-		program: ProgramState{
+		program: programState{
 			ref:        ref,
 			buff:       p.createBuffer(16),
 			uniforms:   make(map[string]*UniformState),
@@ -474,7 +474,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	}
 
 	roundedCorners := topRightRadius != 0 || topLeftRadius != 0 || bottomRightRadius != 0 || bottomLeftRadius != 0
-	var program ProgramState
+	var program programState
 	if roundedCorners {
 		program = p.roundRectangleProgram
 	} else {

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -77,63 +77,63 @@ func (p *painter) Init() {
 	p.program = programState{
 		ref:        p.createProgram("simple"),
 		buff:       p.createBuffer(20),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.blurProgram = programState{
 		ref:        p.createProgram("blur"),
 		buff:       p.createBuffer(20),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.lineProgram = programState{
 		ref:        p.createProgram("line"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.rectangleProgram = programState{
 		ref:        p.createProgram("rectangle"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.roundRectangleProgram = programState{
 		ref:        p.createProgram("round_rectangle"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.polygonProgram = programState{
 		ref:        p.createProgram("polygon"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arcProgram = programState{
 		ref:        p.createProgram("arc"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.bezierCurveProgram = programState{
 		ref:        p.createProgram("bezier_curve"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arbitraryPolygonProgram = programState{
 		ref:        p.createProgram("arbitrary_polygon"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 }

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -74,63 +74,63 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = ProgramState{
+	p.program = programState{
 		ref:        p.createProgram("simple"),
 		buff:       p.createBuffer(20),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.blurProgram = ProgramState{
+	p.blurProgram = programState{
 		ref:        p.createProgram("blur"),
 		buff:       p.createBuffer(20),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.lineProgram = ProgramState{
+	p.lineProgram = programState{
 		ref:        p.createProgram("line"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.rectangleProgram = ProgramState{
+	p.rectangleProgram = programState{
 		ref:        p.createProgram("rectangle"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.roundRectangleProgram = ProgramState{
+	p.roundRectangleProgram = programState{
 		ref:        p.createProgram("round_rectangle"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.polygonProgram = ProgramState{
+	p.polygonProgram = programState{
 		ref:        p.createProgram("polygon"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.arcProgram = ProgramState{
+	p.arcProgram = programState{
 		ref:        p.createProgram("arc"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.bezierCurveProgram = ProgramState{
+	p.bezierCurveProgram = programState{
 		ref:        p.createProgram("bezier_curve"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.arbitraryPolygonProgram = ProgramState{
+	p.arbitraryPolygonProgram = programState{
 		ref:        p.createProgram("arbitrary_polygon"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -77,63 +77,63 @@ func (p *painter) Init() {
 	p.program = programState{
 		ref:        p.createProgram("simple_es"),
 		buff:       p.createBuffer(20),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.blurProgram = programState{
 		ref:        p.createProgram("blur_es"),
 		buff:       p.createBuffer(20),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.lineProgram = programState{
 		ref:        p.createProgram("line_es"),
 		buff:       p.createBuffer(24),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.rectangleProgram = programState{
 		ref:        p.createProgram("rectangle_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.roundRectangleProgram = programState{
 		ref:        p.createProgram("round_rectangle_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.polygonProgram = programState{
 		ref:        p.createProgram("polygon_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arcProgram = programState{
 		ref:        p.createProgram("arc_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.bezierCurveProgram = programState{
 		ref:        p.createProgram("bezier_curve_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arbitraryPolygonProgram = programState{
 		ref:        p.createProgram("arbitrary_polygon_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 }

--- a/internal/painter/gl/gl_es.go
+++ b/internal/painter/gl/gl_es.go
@@ -74,63 +74,63 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = ProgramState{
+	p.program = programState{
 		ref:        p.createProgram("simple_es"),
 		buff:       p.createBuffer(20),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.blurProgram = ProgramState{
+	p.blurProgram = programState{
 		ref:        p.createProgram("blur_es"),
 		buff:       p.createBuffer(20),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.lineProgram = ProgramState{
+	p.lineProgram = programState{
 		ref:        p.createProgram("line_es"),
 		buff:       p.createBuffer(24),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.rectangleProgram = ProgramState{
+	p.rectangleProgram = programState{
 		ref:        p.createProgram("rectangle_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.roundRectangleProgram = ProgramState{
+	p.roundRectangleProgram = programState{
 		ref:        p.createProgram("round_rectangle_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.polygonProgram = ProgramState{
+	p.polygonProgram = programState{
 		ref:        p.createProgram("polygon_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.arcProgram = ProgramState{
+	p.arcProgram = programState{
 		ref:        p.createProgram("arc_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.bezierCurveProgram = ProgramState{
+	p.bezierCurveProgram = programState{
 		ref:        p.createProgram("bezier_curve_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.arbitraryPolygonProgram = ProgramState{
+	p.arbitraryPolygonProgram = programState{
 		ref:        p.createProgram("arbitrary_polygon_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -53,7 +53,7 @@ type (
 )
 
 var (
-	compiled          []ProgramState // avoid multiple compilations with the re-used mobile GUI context
+	compiled          []programState // avoid multiple compilations with the re-used mobile GUI context
 	noBuffer          = Buffer{}
 	noProgram         = Program{}
 	noShader          = Shader{}
@@ -70,69 +70,69 @@ func (p *painter) Init() {
 	p.glctx().Disable(gl.DepthTest)
 	p.glctx().Enable(gl.Blend)
 	if compiled == nil {
-		p.program = ProgramState{
+		p.program = programState{
 			ref:        p.createProgram("simple_es"),
 			buff:       p.createBuffer(20),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.blurProgram = ProgramState{
+		p.blurProgram = programState{
 			ref:        p.createProgram("blur_es"),
 			buff:       p.createBuffer(20),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.lineProgram = ProgramState{
+		p.lineProgram = programState{
 			ref:        p.createProgram("line_es"),
 			buff:       p.createBuffer(24),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.rectangleProgram = ProgramState{
+		p.rectangleProgram = programState{
 			ref:        p.createProgram("rectangle_es"),
 			buff:       p.createBuffer(16),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.roundRectangleProgram = ProgramState{
+		p.roundRectangleProgram = programState{
 			ref:        p.createProgram("round_rectangle_es"),
 			buff:       p.createBuffer(16),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.polygonProgram = ProgramState{
+		p.polygonProgram = programState{
 			ref:        p.createProgram("polygon_es"),
 			buff:       p.createBuffer(16),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.arcProgram = ProgramState{
+		p.arcProgram = programState{
 			ref:        p.createProgram("arc_es"),
 			buff:       p.createBuffer(16),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.bezierCurveProgram = ProgramState{
+		p.bezierCurveProgram = programState{
 			ref:        p.createProgram("bezier_curve_es"),
 			buff:       p.createBuffer(16),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
 
-		p.arbitraryPolygonProgram = ProgramState{
+		p.arbitraryPolygonProgram = programState{
 			ref:        p.createProgram("arbitrary_polygon_es"),
 			buff:       p.createBuffer(16),
 			uniforms:   make(map[string]*UniformState),
 			attributes: make(map[string]Attribute),
 		}
-		compiled = []ProgramState{
+		compiled = []programState{
 			p.program,
 			p.blurProgram,
 			p.lineProgram,

--- a/internal/painter/gl/gl_gomobile.go
+++ b/internal/painter/gl/gl_gomobile.go
@@ -73,63 +73,63 @@ func (p *painter) Init() {
 		p.program = programState{
 			ref:        p.createProgram("simple_es"),
 			buff:       p.createBuffer(20),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.blurProgram = programState{
 			ref:        p.createProgram("blur_es"),
 			buff:       p.createBuffer(20),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.lineProgram = programState{
 			ref:        p.createProgram("line_es"),
 			buff:       p.createBuffer(24),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.rectangleProgram = programState{
 			ref:        p.createProgram("rectangle_es"),
 			buff:       p.createBuffer(16),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.roundRectangleProgram = programState{
 			ref:        p.createProgram("round_rectangle_es"),
 			buff:       p.createBuffer(16),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.polygonProgram = programState{
 			ref:        p.createProgram("polygon_es"),
 			buff:       p.createBuffer(16),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.arcProgram = programState{
 			ref:        p.createProgram("arc_es"),
 			buff:       p.createBuffer(16),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.bezierCurveProgram = programState{
 			ref:        p.createProgram("bezier_curve_es"),
 			buff:       p.createBuffer(16),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 
 		p.arbitraryPolygonProgram = programState{
 			ref:        p.createProgram("arbitrary_polygon_es"),
 			buff:       p.createBuffer(16),
-			uniforms:   make(map[string]*UniformState),
+			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		}
 		compiled = []programState{

--- a/internal/painter/gl/gl_wasm.go
+++ b/internal/painter/gl/gl_wasm.go
@@ -64,63 +64,63 @@ func (p *painter) Init() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Enable(gl.BLEND)
 	p.logError()
-	p.program = ProgramState{
+	p.program = programState{
 		ref:        p.createProgram("simple_es"),
 		buff:       p.createBuffer(20),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.blurProgram = ProgramState{
+	p.blurProgram = programState{
 		ref:        p.createProgram("blur_es"),
 		buff:       p.createBuffer(20),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.lineProgram = ProgramState{
+	p.lineProgram = programState{
 		ref:        p.createProgram("line_es"),
 		buff:       p.createBuffer(24),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.rectangleProgram = ProgramState{
+	p.rectangleProgram = programState{
 		ref:        p.createProgram("rectangle_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.roundRectangleProgram = ProgramState{
+	p.roundRectangleProgram = programState{
 		ref:        p.createProgram("round_rectangle_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.polygonProgram = ProgramState{
+	p.polygonProgram = programState{
 		ref:        p.createProgram("polygon_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.arcProgram = ProgramState{
+	p.arcProgram = programState{
 		ref:        p.createProgram("arc_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.bezierCurveProgram = ProgramState{
+	p.bezierCurveProgram = programState{
 		ref:        p.createProgram("bezier_curve_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),
 		attributes: make(map[string]Attribute),
 	}
 
-	p.arbitraryPolygonProgram = ProgramState{
+	p.arbitraryPolygonProgram = programState{
 		ref:        p.createProgram("arbitrary_polygon_es"),
 		buff:       p.createBuffer(16),
 		uniforms:   make(map[string]*UniformState),

--- a/internal/painter/gl/gl_wasm.go
+++ b/internal/painter/gl/gl_wasm.go
@@ -67,63 +67,63 @@ func (p *painter) Init() {
 	p.program = programState{
 		ref:        p.createProgram("simple_es"),
 		buff:       p.createBuffer(20),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.blurProgram = programState{
 		ref:        p.createProgram("blur_es"),
 		buff:       p.createBuffer(20),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.lineProgram = programState{
 		ref:        p.createProgram("line_es"),
 		buff:       p.createBuffer(24),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.rectangleProgram = programState{
 		ref:        p.createProgram("rectangle_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.roundRectangleProgram = programState{
 		ref:        p.createProgram("round_rectangle_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.polygonProgram = programState{
 		ref:        p.createProgram("polygon_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arcProgram = programState{
 		ref:        p.createProgram("arc_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.bezierCurveProgram = programState{
 		ref:        p.createProgram("bezier_curve_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arbitraryPolygonProgram = programState{
 		ref:        p.createProgram("arbitrary_polygon_es"),
 		buff:       p.createBuffer(16),
-		uniforms:   make(map[string]*UniformState),
+		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 }

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -66,7 +66,7 @@ type painter struct {
 type programState struct {
 	ref        Program
 	buff       Buffer
-	uniforms   map[string]*UniformState
+	uniforms   map[string]*uniformState
 	attributes map[string]Attribute
 }
 
@@ -86,7 +86,7 @@ type shaderTexture struct {
 	src image.Image
 }
 
-type UniformState struct {
+type uniformState struct {
 	ref   Uniform
 	prev  [4]float32
 	prevv []float32
@@ -297,10 +297,10 @@ func (p *painter) enableAttribArray(pState programState, name string) Attribute 
 	return a
 }
 
-func (p *painter) getUniformLocation(pState programState, name string) *UniformState {
+func (p *painter) getUniformLocation(pState programState, name string) *uniformState {
 	u, ok := pState.uniforms[name]
 	if !ok {
-		u = &UniformState{ref: p.ctx.GetUniformLocation(pState.ref, name)}
+		u = &uniformState{ref: p.ctx.GetUniformLocation(pState.ref, name)}
 		pState.uniforms[name] = u
 	}
 

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -63,35 +63,6 @@ type painter struct {
 	fbHeight                int     // current framebuffer height in pixels
 }
 
-type programState struct {
-	ref        Program
-	buff       Buffer
-	uniforms   map[string]*uniformState
-	attributes map[string]Attribute
-}
-
-// shaderState caches a user shader's compiled program and uploaded textures.
-// valid is false when the source failed to compile, so we can record the
-// failure without comparing the (not always comparable) program reference.
-type shaderState struct {
-	program  programState
-	valid    bool
-	textures map[string]*shaderTexture // uploaded textures, keyed by uniform name
-}
-
-// shaderTexture is a GPU texture uploaded for a shader, remembering the source
-// image so we only re-upload when it is replaced.
-type shaderTexture struct {
-	tex Texture
-	src image.Image
-}
-
-type uniformState struct {
-	ref   Uniform
-	prev  [4]float32
-	prevv []float32
-}
-
 func (p *painter) SetUniform1f(pState programState, name string, v float32) {
 	u := p.getUniformLocation(pState, name)
 	if u.prev[0] == v {
@@ -309,6 +280,35 @@ func (p *painter) getUniformLocation(pState programState, name string) *uniformS
 
 func (p *painter) logError() {
 	logGLError(p.ctx.GetError)
+}
+
+type programState struct {
+	ref        Program
+	buff       Buffer
+	uniforms   map[string]*uniformState
+	attributes map[string]Attribute
+}
+
+// shaderState caches a user shader's compiled program and uploaded textures.
+// valid is false when the source failed to compile, so we can record the
+// failure without comparing the (not always comparable) program reference.
+type shaderState struct {
+	program  programState
+	valid    bool
+	textures map[string]*shaderTexture // uploaded textures, keyed by uniform name
+}
+
+// shaderTexture is a GPU texture uploaded for a shader, remembering the source
+// image so we only re-upload when it is replaced.
+type shaderTexture struct {
+	tex Texture
+	src image.Image
+}
+
+type uniformState struct {
+	ref   Uniform
+	prev  [4]float32
+	prevv []float32
 }
 
 func float32SlicesEqual(a, b []float32) bool {

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -63,6 +63,42 @@ type painter struct {
 	fbHeight                int     // current framebuffer height in pixels
 }
 
+// Declare conformity to Painter interface
+var _ Painter = (*painter)(nil)
+
+func (p *painter) Clear() {
+	r, g, b, a := theme.Color(theme.ColorNameBackground).RGBA()
+	p.ctx.ClearColor(float32(r)/max16bit, float32(g)/max16bit, float32(b)/max16bit, float32(a)/max16bit)
+	p.ctx.Clear(bitColorBuffer | bitDepthBuffer)
+	p.logError()
+}
+
+func (p *painter) Free(obj fyne.CanvasObject) {
+	// Shader programs are immutable and compiled once per Shader.Name, living for
+	// the lifetime of the GL context like the built in shader programs. They are
+	// deliberately not freed here: Free is also called for every object on each
+	// Refresh (see Canvas.FreeDirtyTextures), so freeing would recompile the
+	// program - and reset its animation clock - every single frame.
+	p.freeTexture(obj)
+}
+
+func (p *painter) Paint(obj fyne.CanvasObject, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
+	if obj.Visible() {
+		p.drawObject(obj, pos, frame, clip)
+	}
+}
+
+func (p *painter) SetFrameBufferScale(scale float32) {
+	p.texScale = scale
+	p.pixScale = p.canvas.Scale() * p.texScale
+}
+
+func (p *painter) SetOutputSize(width, height int) {
+	p.ctx.Viewport(0, 0, width, height)
+	p.fbHeight = height
+	p.logError()
+}
+
 func (p *painter) SetUniform1f(pState programState, name string, v float32) {
 	u := p.getUniformLocation(pState, name)
 	if u.prev[0] == v {
@@ -122,49 +158,6 @@ func (p *painter) SetUniform4f(pState programState, name string, v0, v1, v2, v3 
 	p.ctx.Uniform4f(u.ref, v0, v1, v2, v3)
 }
 
-func (p *painter) UpdateVertexArray(pState programState, name string, size, stride, offset int) {
-	a := p.enableAttribArray(pState, name)
-
-	p.ctx.VertexAttribPointerWithOffset(a, size, float, false, stride*floatSize, offset*floatSize)
-	p.logError()
-}
-
-// Declare conformity to Painter interface
-var _ Painter = (*painter)(nil)
-
-func (p *painter) Clear() {
-	r, g, b, a := theme.Color(theme.ColorNameBackground).RGBA()
-	p.ctx.ClearColor(float32(r)/max16bit, float32(g)/max16bit, float32(b)/max16bit, float32(a)/max16bit)
-	p.ctx.Clear(bitColorBuffer | bitDepthBuffer)
-	p.logError()
-}
-
-func (p *painter) Free(obj fyne.CanvasObject) {
-	// Shader programs are immutable and compiled once per Shader.Name, living for
-	// the lifetime of the GL context like the built in shader programs. They are
-	// deliberately not freed here: Free is also called for every object on each
-	// Refresh (see Canvas.FreeDirtyTextures), so freeing would recompile the
-	// program - and reset its animation clock - every single frame.
-	p.freeTexture(obj)
-}
-
-func (p *painter) Paint(obj fyne.CanvasObject, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
-	if obj.Visible() {
-		p.drawObject(obj, pos, frame, clip)
-	}
-}
-
-func (p *painter) SetFrameBufferScale(scale float32) {
-	p.texScale = scale
-	p.pixScale = p.canvas.Scale() * p.texScale
-}
-
-func (p *painter) SetOutputSize(width, height int) {
-	p.ctx.Viewport(0, 0, width, height)
-	p.fbHeight = height
-	p.logError()
-}
-
 func (p *painter) StartClipping(pos fyne.Position, size fyne.Size) {
 	x := p.textureScale(pos.X)
 	y := p.textureScale(p.canvas.Size().Height - pos.Y - size.Height)
@@ -177,6 +170,13 @@ func (p *painter) StartClipping(pos fyne.Position, size fyne.Size) {
 
 func (p *painter) StopClipping() {
 	p.ctx.Disable(scissorTest)
+	p.logError()
+}
+
+func (p *painter) UpdateVertexArray(pState programState, name string, size, stride, offset int) {
+	a := p.enableAttribArray(pState, name)
+
+	p.ctx.VertexAttribPointerWithOffset(a, size, float, false, stride*floatSize, offset*floatSize)
 	p.logError()
 }
 

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -13,7 +13,7 @@ import (
 
 // Painter defines the functionality of our OpenGL based renderer
 type Painter interface {
-	// Init tell a new painter to initialise, usually called after a context is available
+	// Init tell a new painter to initialize, usually called after a context is available
 	Init()
 	// Capture requests that the specified canvas be drawn to an in-memory image
 	Capture(fyne.Canvas) image.Image
@@ -34,7 +34,7 @@ type Painter interface {
 }
 
 // NewPainter creates a new GL based renderer for the provided canvas.
-// If it is a master painter it will also initialise OpenGL
+// If it is a master painter it will also initialize OpenGL
 func NewPainter(c fyne.Canvas, ctx driver.WithContext) Painter {
 	p := &painter{canvas: c, contextProvider: ctx}
 	p.SetFrameBufferScale(1.0)
@@ -75,7 +75,7 @@ func (p *painter) Clear() {
 
 func (p *painter) Free(obj fyne.CanvasObject) {
 	// Shader programs are immutable and compiled once per Shader.Name, living for
-	// the lifetime of the GL context like the built in shader programs. They are
+	// the lifetime of the GL context like the built-in shader programs. They are
 	// deliberately not freed here: Free is also called for every object on each
 	// Refresh (see Canvas.FreeDirtyTextures), so freeing would recompile the
 	// program - and reset its animation clock - every single frame.

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -45,15 +45,15 @@ type painter struct {
 	canvas                  fyne.Canvas
 	ctx                     context
 	contextProvider         driver.WithContext
-	program                 ProgramState
-	blurProgram             ProgramState
-	lineProgram             ProgramState
-	rectangleProgram        ProgramState
-	roundRectangleProgram   ProgramState
-	polygonProgram          ProgramState
-	arcProgram              ProgramState
-	bezierCurveProgram      ProgramState
-	arbitraryPolygonProgram ProgramState
+	program                 programState
+	blurProgram             programState
+	lineProgram             programState
+	rectangleProgram        programState
+	roundRectangleProgram   programState
+	polygonProgram          programState
+	arcProgram              programState
+	bezierCurveProgram      programState
+	arbitraryPolygonProgram programState
 	shaderPrograms          map[string]*shaderState // lazily compiled programs for user shaders, keyed by Shader.Name
 	texScale                float32
 	pixScale                float32 // pre-calculate scale*texScale for each draw
@@ -63,7 +63,7 @@ type painter struct {
 	fbHeight                int     // current framebuffer height in pixels
 }
 
-type ProgramState struct {
+type programState struct {
 	ref        Program
 	buff       Buffer
 	uniforms   map[string]*UniformState
@@ -74,7 +74,7 @@ type ProgramState struct {
 // valid is false when the source failed to compile, so we can record the
 // failure without comparing the (not always comparable) program reference.
 type shaderState struct {
-	program  ProgramState
+	program  programState
 	valid    bool
 	textures map[string]*shaderTexture // uploaded textures, keyed by uniform name
 }
@@ -92,7 +92,7 @@ type UniformState struct {
 	prevv []float32
 }
 
-func (p *painter) SetUniform1f(pState ProgramState, name string, v float32) {
+func (p *painter) SetUniform1f(pState programState, name string, v float32) {
 	u := p.getUniformLocation(pState, name)
 	if u.prev[0] == v {
 		return
@@ -101,7 +101,7 @@ func (p *painter) SetUniform1f(pState ProgramState, name string, v float32) {
 	p.ctx.Uniform1f(u.ref, v)
 }
 
-func (p *painter) SetUniform1i(pState ProgramState, name string, v int32) {
+func (p *painter) SetUniform1i(pState programState, name string, v int32) {
 	u := p.getUniformLocation(pState, name)
 	fv := float32(v)
 	if u.prev[0] == fv {
@@ -111,7 +111,7 @@ func (p *painter) SetUniform1i(pState ProgramState, name string, v int32) {
 	p.ctx.Uniform1i(u.ref, v)
 }
 
-func (p *painter) SetUniform1fv(pState ProgramState, name string, v []float32) {
+func (p *painter) SetUniform1fv(pState programState, name string, v []float32) {
 	u := p.getUniformLocation(pState, name)
 	if float32SlicesEqual(u.prevv, v) {
 		return
@@ -120,7 +120,7 @@ func (p *painter) SetUniform1fv(pState ProgramState, name string, v []float32) {
 	p.ctx.Uniform1fv(u.ref, v)
 }
 
-func (p *painter) SetUniform2f(pState ProgramState, name string, v0, v1 float32) {
+func (p *painter) SetUniform2f(pState programState, name string, v0, v1 float32) {
 	u := p.getUniformLocation(pState, name)
 	if u.prev[0] == v0 && u.prev[1] == v1 {
 		return
@@ -130,7 +130,7 @@ func (p *painter) SetUniform2f(pState ProgramState, name string, v0, v1 float32)
 	p.ctx.Uniform2f(u.ref, v0, v1)
 }
 
-func (p *painter) SetUniform2fv(pState ProgramState, name string, v []float32) {
+func (p *painter) SetUniform2fv(pState programState, name string, v []float32) {
 	u := p.getUniformLocation(pState, name)
 	if float32SlicesEqual(u.prevv, v) {
 		return
@@ -139,7 +139,7 @@ func (p *painter) SetUniform2fv(pState ProgramState, name string, v []float32) {
 	p.ctx.Uniform2fv(u.ref, v)
 }
 
-func (p *painter) SetUniform4f(pState ProgramState, name string, v0, v1, v2, v3 float32) {
+func (p *painter) SetUniform4f(pState programState, name string, v0, v1, v2, v3 float32) {
 	u := p.getUniformLocation(pState, name)
 	if u.prev[0] == v0 && u.prev[1] == v1 && u.prev[2] == v2 && u.prev[3] == v3 {
 		return
@@ -151,7 +151,7 @@ func (p *painter) SetUniform4f(pState ProgramState, name string, v0, v1, v2, v3 
 	p.ctx.Uniform4f(u.ref, v0, v1, v2, v3)
 }
 
-func (p *painter) UpdateVertexArray(pState ProgramState, name string, size, stride, offset int) {
+func (p *painter) UpdateVertexArray(pState programState, name string, size, stride, offset int) {
 	a := p.enableAttribArray(pState, name)
 
 	p.ctx.VertexAttribPointerWithOffset(a, size, float, false, stride*floatSize, offset*floatSize)
@@ -286,7 +286,7 @@ func (p *painter) createProgramFromSource(vertexSrc, fragmentSrc []byte) (Progra
 	return prog, nil
 }
 
-func (p *painter) enableAttribArray(pState ProgramState, name string) Attribute {
+func (p *painter) enableAttribArray(pState programState, name string) Attribute {
 	a, ok := pState.attributes[name]
 	if !ok {
 		a = p.ctx.GetAttribLocation(pState.ref, name)
@@ -297,7 +297,7 @@ func (p *painter) enableAttribArray(pState ProgramState, name string) Attribute 
 	return a
 }
 
-func (p *painter) getUniformLocation(pState ProgramState, name string) *UniformState {
+func (p *painter) getUniformLocation(pState programState, name string) *UniformState {
 	u, ok := pState.uniforms[name]
 	if !ok {
 		u = &UniformState{ref: p.ctx.GetUniformLocation(pState.ref, name)}


### PR DESCRIPTION
This PR unexports two internal data types and re-orders some code.
It also fixes typo/style in comments.