### PR TITLE
Markdown: horizontally scrollable tables

### DIFF
--- a/widget/markdown_test.go
+++ b/widget/markdown_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
+	internalWidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
@@ -213,6 +214,17 @@ func TestRichTextMarkdown_TableAlignmentAppliedThroughVisual(t *testing.T) {
 
 	assert.Equal(t, fyne.TextAlignLeading, table.Rows[0][0][0].(*TextSegment).Style.Alignment)
 	assert.Equal(t, fyne.TextAlignTrailing, table.Rows[0][1][0].(*TextSegment).Style.Alignment)
+}
+
+func TestRichTextMarkdown_TableScrollsHorizontally(t *testing.T) {
+	r := NewRichTextFromMarkdown("| Feature | Value |\n| :--- | ---: |\n| " + strings.Repeat("wide", 50) + " | value |")
+	table := r.Segments[0].(*TableSegment)
+
+	visual, ok := table.Visual().(*internalWidget.Scroll)
+	if !ok {
+		t.Fatalf("table visual = %T, want *widget.Scroll", table.Visual())
+	}
+	assert.Equal(t, internalWidget.ScrollHorizontalOnly, visual.Direction)
 }
 
 func TestRichTextMarkdown_Code_Incomplete(t *testing.T) {

--- a/widget/richtext_objects.go
+++ b/widget/richtext_objects.go
@@ -624,7 +624,7 @@ func (t *TableSegment) Visual() fyne.CanvasObject {
 
 	grid := &fyne.Container{Layout: &tableSegmentLayout{cols: cols}, Objects: objects}
 	border := canvas.NewRectangle(theme.Color(theme.ColorNameInputBorder))
-	return &fyne.Container{Layout: layout.NewStackLayout(), Objects: []fyne.CanvasObject{border, grid}}
+	return widget.NewHScroll(&fyne.Container{Layout: layout.NewStackLayout(), Objects: []fyne.CanvasObject{border, grid}})
 }
 
 // Update does nothing; a table visual is rebuilt rather than updated.


### PR DESCRIPTION
### Description:

This PR adds horizontal scroll to `HScroll` to GTM Markdown tables allowing wide tables to be scrollable.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
- [x] Any breaking changes have a deprecation path or have been discussed.
- [x] Check for binary size increases when importing new modules.

### Testing:

Added test passes; other tests aren't broken.

### References

Relevant PR https://github.com/fyne-io/fyne/pull/6256.