### PR TITLE
Fix data race in glfw.TestMenuBar_Toggle

### DIFF
--- a/internal/driver/glfw/menu_bar_test.go
+++ b/internal/driver/glfw/menu_bar_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestMenuBar(t *testing.T) {
-	test.NewTempApp(t)
+	runOnMain(func() {
+		test.NewTempApp(t)
+	})
 
 	var lastAction string
 
@@ -475,7 +477,9 @@ func TestMenuBar(t *testing.T) {
 }
 
 func TestMenuBar_Toggle(t *testing.T) {
-	test.NewTempApp(t)
+	runOnMain(func() {
+		test.NewTempApp(t)
+	})
 
 	m1i1 := fyne.NewMenuItem("New", nil)
 	m1i2 := fyne.NewMenuItem("Open", nil)


### PR DESCRIPTION
### Description:

There is a data race in `glfw.TestMenuBar_Toggle` (and possibly `glfw.TestMenuBar`) because the tests run in goroutines and access different caches from there. `TestMain(m *testing.M)` in `internal/driver/glfw/window_test.go` runs and creates a `gLDriver` on the main thread and accesses the same caches from there.

This can be fixed by wrapping `test.NewTempApp(t)` in `runOnMain` which ensures that all cache access happens on the main thread.

Fixes #6346.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.