### PR TITLE
Don't call drawObject for objects outside the window

### DIFF
--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -7,7 +7,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
-	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/cache"
 	paint "fyne.io/fyne/v2/internal/painter"
 )
@@ -319,7 +318,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	p.logError()
 }
 
-func (p *painter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
+func (p *painter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.Size) {
 	switch obj := o.(type) {
 	case *canvas.Blur:
 		p.drawBlur(obj, pos, frame)
@@ -334,7 +333,7 @@ func (p *painter) drawObject(o fyne.CanvasObject, pos fyne.Position, frame fyne.
 	case *canvas.Rectangle:
 		p.drawRectangle(obj, pos, frame)
 	case *canvas.Text:
-		p.drawText(obj, pos, frame, clip)
+		p.drawText(obj, pos, frame)
 	case *canvas.LinearGradient:
 		p.drawGradient(obj, p.newGlLinearGradientTexture, pos, frame)
 	case *canvas.RadialGradient:
@@ -671,7 +670,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.logError()
 }
 
-func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
+func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size) {
 	if text.Text == "" {
 		return
 	}
@@ -691,18 +690,6 @@ func (p *painter) drawText(text *canvas.Text, pos fyne.Position, frame fyne.Size
 
 	if containerSize.Height > size.Height {
 		pos = fyne.NewPos(pos.X, pos.Y+(containerSize.Height-size.Height)/2)
-	}
-
-	var clipPos fyne.Position
-	var clipSize fyne.Size
-	if clip != nil {
-		clipPos, clipSize = clip.Rect()
-	} else {
-		clipSize = frame
-	}
-	if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
-		pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
-		return
 	}
 
 	// text size is sensitive to position on screen

--- a/internal/painter/gl/painter.go
+++ b/internal/painter/gl/painter.go
@@ -83,9 +83,24 @@ func (p *painter) Free(obj fyne.CanvasObject) {
 }
 
 func (p *painter) Paint(obj fyne.CanvasObject, pos fyne.Position, frame fyne.Size, clip *internal.ClipItem) {
-	if obj.Visible() {
-		p.drawObject(obj, pos, frame, clip)
+	if !obj.Visible() {
+		return
 	}
+
+	size := obj.Size()
+	var clipPos fyne.Position
+	var clipSize fyne.Size
+	if clip != nil {
+		clipPos, clipSize = clip.Rect()
+	} else {
+		clipSize = frame
+	}
+	if pos.Y > clipPos.Y+clipSize.Height || pos.Y+size.Height < clipPos.Y ||
+		pos.X > clipPos.X+clipSize.Width || pos.X+size.Width < clipPos.X {
+		return
+	}
+
+	p.drawObject(obj, pos, frame)
 }
 
 func (p *painter) SetFrameBufferScale(scale float32) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
Followup to #6122, generalized for all objects, not just text.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.