### PR TITLE
Add support for Wrapping for RadioGroup option strings

### DIFF
--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -56,7 +56,7 @@ func (r *RadioGroup) CreateRenderer() fyne.WidgetRenderer {
 	items := make([]fyne.CanvasObject, len(r.Options))
 	for i, option := range r.Options {
 		idx := i
-		items[idx] = newRadioItem(option, r.Wrapping, func(item *radioItem) {
+		items[idx] = newRadioItem(option, &r.Wrapping, func(item *radioItem) {
 			r.itemTapped(item, idx)
 		})
 	}
@@ -158,19 +158,18 @@ type radioGroupRenderer struct {
 }
 
 // Layout the components of the radio widget
-func (r *radioGroupRenderer) Layout(s fyne.Size) {
+func (r *radioGroupRenderer) Layout(size fyne.Size) {
 	count := 1
 	if len(r.items) > 0 {
 		count = len(r.items)
 	}
 	var itemHeight, itemWidth float32
-	minSize := s
 	if r.radio.Horizontal {
-		itemHeight = minSize.Height
-		itemWidth = minSize.Width / float32(count)
+		itemHeight = size.Height
+		itemWidth = size.Width / float32(count)
 	} else {
-		itemHeight = minSize.Height / float32(count)
-		itemWidth = minSize.Width
+		itemHeight = size.Height / float32(count)
+		itemWidth = size.Width
 	}
 
 	itemSize := fyne.NewSize(itemWidth, itemHeight)
@@ -217,7 +216,7 @@ func (r *radioGroupRenderer) updateItems(refresh bool) {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
 			idx := i
-			item := newRadioItem(r.radio.Options[idx], r.radio.Wrapping, func(item *radioItem) {
+			item := newRadioItem(r.radio.Options[idx], &r.radio.Wrapping, func(item *radioItem) {
 				r.radio.itemTapped(item, idx)
 			})
 			r.items = append(r.items, item)

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -17,6 +17,7 @@ type RadioGroup struct {
 	OnChanged  func(string) `json:"-"`
 	Options    []string
 	Selected   string
+	Wrapping   fyne.TextWrap
 
 	// this index is ONE-BASED so the default zero-value is unselected
 	// use r.selectedIndex(), r.setSelectedIndex(int) to maniupulate this field
@@ -52,7 +53,7 @@ func (r *RadioGroup) CreateRenderer() fyne.WidgetRenderer {
 	items := make([]fyne.CanvasObject, len(r.Options))
 	for i, option := range r.Options {
 		idx := i
-		items[idx] = newRadioItem(option, func(item *radioItem) {
+		items[idx] = newRadioItem(option, r.Wrapping, func(item *radioItem) {
 			r.itemTapped(item, idx)
 		})
 	}
@@ -154,13 +155,13 @@ type radioGroupRenderer struct {
 }
 
 // Layout the components of the radio widget
-func (r *radioGroupRenderer) Layout(_ fyne.Size) {
+func (r *radioGroupRenderer) Layout(s fyne.Size) {
 	count := 1
 	if len(r.items) > 0 {
 		count = len(r.items)
 	}
 	var itemHeight, itemWidth float32
-	minSize := r.radio.MinSize()
+	minSize := s
 	if r.radio.Horizontal {
 		itemHeight = minSize.Height
 		itemWidth = minSize.Width / float32(count)
@@ -213,7 +214,7 @@ func (r *radioGroupRenderer) updateItems(refresh bool) {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
 			idx := i
-			item := newRadioItem(r.radio.Options[idx], func(item *radioItem) {
+			item := newRadioItem(r.radio.Options[idx], r.radio.Wrapping, func(item *radioItem) {
 				r.radio.itemTapped(item, idx)
 			})
 			r.items = append(r.items, item)

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -17,7 +17,10 @@ type RadioGroup struct {
 	OnChanged  func(string) `json:"-"`
 	Options    []string
 	Selected   string
-	Wrapping   fyne.TextWrap
+	// The wrapping of the Options Text
+	//
+	// Since: 2.8
+	Wrapping fyne.TextWrap
 
 	// this index is ONE-BASED so the default zero-value is unselected
 	// use r.selectedIndex(), r.setSelectedIndex(int) to maniupulate this field

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -19,7 +19,7 @@ type RadioGroup struct {
 	Selected   string
 	// The wrapping of the Options Text
 	//
-	// Since: 2.8
+	// Since: 2.9
 	Wrapping fyne.TextWrap
 
 	// this index is ONE-BASED so the default zero-value is unselected

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -56,7 +56,7 @@ func (r *RadioGroup) CreateRenderer() fyne.WidgetRenderer {
 	items := make([]fyne.CanvasObject, len(r.Options))
 	for i, option := range r.Options {
 		idx := i
-		items[idx] = newRadioItem(option, &r.Wrapping, func(item *radioItem) {
+		items[idx] = newRadioItem(option, r, func(item *radioItem) {
 			r.itemTapped(item, idx)
 		})
 	}
@@ -216,7 +216,7 @@ func (r *radioGroupRenderer) updateItems(refresh bool) {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
 			idx := i
-			item := newRadioItem(r.radio.Options[idx], &r.radio.Wrapping, func(item *radioItem) {
+			item := newRadioItem(r.radio.Options[idx], r.radio, func(item *radioItem) {
 				r.radio.itemTapped(item, idx)
 			})
 			r.items = append(r.items, item)

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -1,7 +1,6 @@
 package widget
 
 import (
-	"fmt"
 	"image/color"
 	"testing"
 
@@ -174,7 +173,6 @@ func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 		render.Refresh()
 		customTextSize = render.label.Theme()
 	})
-	fmt.Println(textSize, customTextSize)
 	assert.NotEqual(t, textSize, customTextSize)
 }
 

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -1,6 +1,7 @@
 package widget
 
 import (
+	"fmt"
 	"image/color"
 	"testing"
 
@@ -167,13 +168,13 @@ func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 	radio := newextendedRadioGroup([]string{"Test"}, func(string) {})
 	render := cache.Renderer(test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)).(*radioItemRenderer)
 
-	textSize := render.label.Size()
+	textSize := render.label.Theme()
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.Size()
+		customTextSize = render.label.Theme()
 	})
-
+	fmt.Println(textSize, customTextSize)
 	assert.NotEqual(t, textSize, customTextSize)
 }
 

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -167,11 +167,11 @@ func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 	radio := newextendedRadioGroup([]string{"Test"}, func(string) {})
 	render := cache.Renderer(test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)).(*radioItemRenderer)
 
-	textSize := render.label.TextSize
+	textSize := render.label.Size()
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.TextSize
+		customTextSize = render.label.Size()
 	})
 
 	assert.NotEqual(t, textSize, customTextSize)

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/test"
@@ -167,11 +168,11 @@ func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 	radio := newextendedRadioGroup([]string{"Test"}, func(string) {})
 	render := cache.Renderer(test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)).(*radioItemRenderer)
 
-	textSize := render.label.Theme()
+	textSize := test.TempWidgetRenderer(t, render.label).Objects()[0].(*canvas.Text).TextSize
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.Theme()
+		customTextSize = test.TempWidgetRenderer(t, render.label).Objects()[0].(*canvas.Text).TextSize
 	})
 	assert.NotEqual(t, textSize, customTextSize)
 }

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -174,6 +174,7 @@ func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 		render.Refresh()
 		customTextSize = test.TempWidgetRenderer(t, render.label).Objects()[0].(*canvas.Text).TextSize
 	})
+
 	assert.NotEqual(t, textSize, customTextSize)
 }
 

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -298,11 +298,11 @@ func TestRadioGroupRenderer_ApplyTheme(t *testing.T) {
 	radio := NewRadioGroup([]string{"Test"}, func(string) {})
 	render := radioGroupTestItemRenderer(t, radio, 0)
 
-	textSize := render.label.Size()
+	textSize := render.label.Theme()
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.Size()
+		customTextSize = render.label.Theme()
 	})
 
 	assert.NotEqual(t, textSize, customTextSize)

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -298,11 +298,11 @@ func TestRadioGroupRenderer_ApplyTheme(t *testing.T) {
 	radio := NewRadioGroup([]string{"Test"}, func(string) {})
 	render := radioGroupTestItemRenderer(t, radio, 0)
 
-	textSize := render.label.TextSize
+	textSize := render.label.Size()
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.TextSize
+		customTextSize = render.label.Size()
 	})
 
 	assert.NotEqual(t, textSize, customTextSize)

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/test"
@@ -298,11 +299,11 @@ func TestRadioGroupRenderer_ApplyTheme(t *testing.T) {
 	radio := NewRadioGroup([]string{"Test"}, func(string) {})
 	render := radioGroupTestItemRenderer(t, radio, 0)
 
-	textSize := render.label.Theme()
+	textSize := test.TempWidgetRenderer(t, render.label).Objects()[0].(*canvas.Text).TextSize
 	customTextSize := textSize
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.Theme()
+		customTextSize = test.TempWidgetRenderer(t, render.label).Objects()[0].(*canvas.Text).TextSize
 	})
 
 	assert.NotEqual(t, textSize, customTextSize)

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -39,7 +39,7 @@ type radioItem struct {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
 	txt := NewRichTextWithText(i.Label)
-	txt.Wrapping = *&i.radio.Wrapping
+	txt.Wrapping = i.radio.Wrapping
 	r := &radioItemRenderer{item: i, label: txt}
 	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, txt})
 	r.update()

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -17,8 +17,8 @@ var (
 	_ fyne.Focusable    = (*radioItem)(nil)
 )
 
-func newRadioItem(label string, onTap func(*radioItem)) *radioItem {
-	i := &radioItem{Label: label, onTap: onTap}
+func newRadioItem(label string, Wrapping fyne.TextWrap, onTap func(*radioItem)) *radioItem {
+	i := &radioItem{Label: label, onTap: onTap, Wrapping: Wrapping}
 	i.ExtendBaseWidget(i)
 	return i
 }
@@ -29,6 +29,7 @@ type radioItem struct {
 
 	Label    string
 	Selected bool
+	Wrapping fyne.TextWrap
 
 	focused bool
 	hovered bool
@@ -37,10 +38,10 @@ type radioItem struct {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
-	txt := canvas.Text{Alignment: fyne.TextAlignLeading}
-	txt.TextSize = i.Theme().Size(theme.SizeNameText)
-	r := &radioItemRenderer{item: i, label: &txt}
-	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, &txt})
+	txt := NewRichTextWithText(i.Label)
+	txt.Wrapping = i.Wrapping
+	r := &radioItemRenderer{item: i, label: txt}
+	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, txt})
 	r.update()
 	return r
 }
@@ -124,7 +125,7 @@ type radioItemRenderer struct {
 
 	focusIndicator canvas.Circle
 	icon, over     canvas.Image
-	label          *canvas.Text
+	label          *RichText
 }
 
 func (r *radioItemRenderer) Layout(size fyne.Size) {
@@ -137,7 +138,7 @@ func (r *radioItemRenderer) Layout(size fyne.Size) {
 	r.focusIndicator.Resize(focusIndicatorSize)
 	r.focusIndicator.Move(fyne.NewPos(borderSize, (size.Height-focusIndicatorSize.Height)/2))
 
-	labelSize := fyne.NewSize(size.Width, size.Height)
+	labelSize := fyne.NewSize(size.Width-iconInlineSize, size.Height-iconInlineSize)
 	r.label.Resize(labelSize)
 	r.label.Move(fyne.NewPos(focusIndicatorSize.Width+th.Size(theme.SizeNamePadding), 0))
 
@@ -166,12 +167,13 @@ func (r *radioItemRenderer) update() {
 	th := r.item.Theme()
 	v := fyne.CurrentApp().Settings().ThemeVariant()
 
-	r.label.Text = r.item.Label
-	r.label.TextSize = th.Size(theme.SizeNameText)
+	r.label.Segments[0].(*TextSegment).Text = r.item.Label
+	r.label.Segments[0].(*TextSegment).Style.SizeName = theme.SizeNameText
+	r.label.Wrapping = r.item.Wrapping
 	if r.item.Disabled() {
-		r.label.Color = th.Color(theme.ColorNameDisabled, v)
+		r.label.Segments[0].(*TextSegment).Style.ColorName = theme.ColorNameDisabled
 	} else {
-		r.label.Color = th.Color(theme.ColorNameForeground, v)
+		r.label.Segments[0].(*TextSegment).Style.ColorName = theme.ColorNameForeground
 	}
 
 	out := theme.NewThemedResource(th.Icon(theme.IconNameRadioButton))

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -17,7 +17,7 @@ var (
 	_ fyne.Focusable    = (*radioItem)(nil)
 )
 
-func newRadioItem(label string, Wrapping fyne.TextWrap, onTap func(*radioItem)) *radioItem {
+func newRadioItem(label string, Wrapping *fyne.TextWrap, onTap func(*radioItem)) *radioItem {
 	i := &radioItem{Label: label, onTap: onTap, Wrapping: Wrapping}
 	i.ExtendBaseWidget(i)
 	return i
@@ -29,7 +29,7 @@ type radioItem struct {
 
 	Label    string
 	Selected bool
-	Wrapping fyne.TextWrap
+	Wrapping *fyne.TextWrap
 
 	focused bool
 	hovered bool
@@ -39,7 +39,7 @@ type radioItem struct {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
 	txt := NewRichTextWithText(i.Label)
-	txt.Wrapping = i.Wrapping
+	txt.Wrapping = *i.Wrapping
 	r := &radioItemRenderer{item: i, label: txt}
 	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, txt})
 	r.update()
@@ -169,12 +169,13 @@ func (r *radioItemRenderer) update() {
 
 	r.label.Segments[0].(*TextSegment).Text = r.item.Label
 	r.label.Segments[0].(*TextSegment).Style.SizeName = theme.SizeNameText
-	r.label.Wrapping = r.item.Wrapping
+	r.label.Wrapping = *r.item.Wrapping
 	if r.item.Disabled() {
 		r.label.Segments[0].(*TextSegment).Style.ColorName = theme.ColorNameDisabled
 	} else {
 		r.label.Segments[0].(*TextSegment).Style.ColorName = theme.ColorNameForeground
 	}
+	r.label.Refresh()
 
 	out := theme.NewThemedResource(th.Icon(theme.IconNameRadioButton))
 	out.ColorName = theme.ColorNameInputBorder

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -17,8 +17,8 @@ var (
 	_ fyne.Focusable    = (*radioItem)(nil)
 )
 
-func newRadioItem(label string, Wrapping *fyne.TextWrap, onTap func(*radioItem)) *radioItem {
-	i := &radioItem{Label: label, onTap: onTap, Wrapping: Wrapping}
+func newRadioItem(label string, radio *RadioGroup, onTap func(*radioItem)) *radioItem {
+	i := &radioItem{Label: label, onTap: onTap, radio: radio}
 	i.ExtendBaseWidget(i)
 	return i
 }
@@ -29,7 +29,7 @@ type radioItem struct {
 
 	Label    string
 	Selected bool
-	Wrapping *fyne.TextWrap
+	radio    *RadioGroup
 
 	focused bool
 	hovered bool
@@ -39,7 +39,7 @@ type radioItem struct {
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
 	txt := NewRichTextWithText(i.Label)
-	txt.Wrapping = *i.Wrapping
+	txt.Wrapping = *&i.radio.Wrapping
 	r := &radioItemRenderer{item: i, label: txt}
 	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, txt})
 	r.update()
@@ -169,7 +169,7 @@ func (r *radioItemRenderer) update() {
 
 	r.label.Segments[0].(*TextSegment).Text = r.item.Label
 	r.label.Segments[0].(*TextSegment).Style.SizeName = theme.SizeNameText
-	r.label.Wrapping = *r.item.Wrapping
+	r.label.Wrapping = r.item.radio.Wrapping
 	if r.item.Disabled() {
 		r.label.Segments[0].(*TextSegment).Style.ColorName = theme.ColorNameDisabled
 	} else {

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -26,7 +26,9 @@ func BenchmarkRadioCreateRenderer(b *testing.B) {
 }
 
 func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
-	item := newRadioItem("Hello", fyne.TextWrapOff, nil)
+	p := new(fyne.TextWrap)
+	*p = fyne.TextWrapOff
+	item := newRadioItem("Hello", p, nil)
 	render := test.TempWidgetRenderer(t, item).(*radioItemRenderer)
 	render.Layout(fyne.NewSize(200, 100))
 

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -26,7 +26,7 @@ func BenchmarkRadioCreateRenderer(b *testing.B) {
 }
 
 func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
-	item := newRadioItem("Hello", nil)
+	item := newRadioItem("Hello", fyne.TextWrapOff, nil)
 	render := test.TempWidgetRenderer(t, item).(*radioItemRenderer)
 	render.Layout(fyne.NewSize(200, 100))
 

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -26,9 +26,7 @@ func BenchmarkRadioCreateRenderer(b *testing.B) {
 }
 
 func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
-	p := new(fyne.TextWrap)
-	*p = fyne.TextWrapOff
-	item := newRadioItem("Hello", p, nil)
+	item := newRadioItem("Hello", new(RadioGroup), nil)
 	render := test.TempWidgetRenderer(t, item).(*radioItemRenderer)
 	render.Layout(fyne.NewSize(200, 100))
 

--- a/widget/testdata/radio_group/disabled_append_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_append_none_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,60" size="98x70" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
+			<widget pos="13,44" size="114x102" type="*widget.RadioGroup">
+				<widget size="114x34" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="94x14" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
+				<widget pos="0,34" size="114x34" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="94x14" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
+				<widget pos="0,68" size="114x34" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="94x14" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/disabled_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_none_selected.xml
@@ -7,7 +7,7 @@
 					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<widget pos="32,0" size="94x31" type="*widget.RichText">
-						<text pos="8,8" size="57x19">Option A</text>
+						<text color="disabled" pos="8,8" size="57x19">Option A</text>
 					</widget>
 				</widget>
 				<widget pos="0,51" size="114x51" type="*widget.radioItem">
@@ -15,7 +15,7 @@
 					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<widget pos="32,0" size="94x31" type="*widget.RichText">
-						<text pos="8,8" size="58x19">Option B</text>
+						<text color="disabled" pos="8,8" size="58x19">Option B</text>
 					</widget>
 				</widget>
 			</widget>

--- a/widget/testdata/radio_group/disabled_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_none_selected.xml
@@ -1,18 +1,22 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,60" size="98x70" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,44" size="114x102" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_a_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_b_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,19" size="114x153" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle fillColor="focus" pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+				<widget pos="0,102" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_a_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_none_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,19" size="114x153" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle fillColor="focus" pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+				<widget pos="0,102" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_b_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_b_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,19" size="114x153" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle fillColor="focus" pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+				<widget pos="0,102" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_b_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_none_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,19" size="114x153" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle fillColor="focus" pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle fillColor="focus" pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+				<widget pos="0,102" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_disabled_none_selected.xml
+++ b/widget/testdata/radio_group/focus_disabled_none_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,19" size="114x153" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option C</text>
+				<widget pos="0,102" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_disabled_none_selected.xml
+++ b/widget/testdata/radio_group/focus_disabled_none_selected.xml
@@ -7,7 +7,7 @@
 					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<widget pos="32,0" size="94x31" type="*widget.RichText">
-						<text pos="8,8" size="57x19">Option A</text>
+						<text color="disabled" pos="8,8" size="57x19">Option A</text>
 					</widget>
 				</widget>
 				<widget pos="0,51" size="114x51" type="*widget.radioItem">
@@ -15,7 +15,7 @@
 					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<widget pos="32,0" size="94x31" type="*widget.RichText">
-						<text pos="8,8" size="58x19">Option B</text>
+						<text color="disabled" pos="8,8" size="58x19">Option B</text>
 					</widget>
 				</widget>
 				<widget pos="0,102" size="114x51" type="*widget.radioItem">
@@ -23,7 +23,7 @@
 					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
 					<widget pos="32,0" size="94x31" type="*widget.RichText">
-						<text pos="8,8" size="57x19">Option C</text>
+						<text color="disabled" pos="8,8" size="57x19">Option C</text>
 					</widget>
 				</widget>
 			</widget>

--- a/widget/testdata/radio_group/focus_none_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_b_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,19" size="114x153" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+				<widget pos="0,102" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_none_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_none_selected.xml
@@ -1,24 +1,30 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="21,43" size="98x105" type="*widget.RadioGroup">
-				<widget size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+			<widget pos="13,19" size="114x153" type="*widget.RadioGroup">
+				<widget size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option A</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option B</text>
+				<widget pos="0,51" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="58x19">Option B</text>
+					</widget>
 				</widget>
-				<widget pos="0,70" size="98x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+				<widget pos="0,102" size="114x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="94x31" type="*widget.RichText">
+						<text pos="8,8" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple.xml
+++ b/widget/testdata/radio_group/layout_multiple.xml
@@ -1,18 +1,22 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
-				<widget size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Foo</text>
+			<widget pos="30,44" size="80x102" type="*widget.RadioGroup">
+				<widget size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Bar</text>
+				<widget pos="0,51" size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text pos="8,8" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_disabled.xml
@@ -1,18 +1,22 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
-				<widget size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Foo</text>
+			<widget pos="30,44" size="80x102" type="*widget.RadioGroup">
+				<widget size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Bar</text>
+				<widget pos="0,51" size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal.xml
@@ -1,18 +1,22 @@
-<canvas padded size="162x200">
+<canvas padded size="194x200">
 	<content>
-		<container pos="4,4" size="154x192">
-			<widget pos="-4,78" size="162x35" type="*widget.RadioGroup">
-				<widget size="81x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="81x35">Foo</text>
+		<container pos="4,4" size="186x192">
+			<widget pos="-4,70" size="194x51" type="*widget.RadioGroup">
+				<widget size="97x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="77x31" type="*widget.RichText">
+						<text pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="81,0" size="81x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="81x35">Barley</text>
+				<widget pos="97,0" size="97x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="77x31" type="*widget.RichText">
+						<text pos="8,8" size="41x19">Barley</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
@@ -1,18 +1,22 @@
-<canvas padded size="162x200">
+<canvas padded size="194x200">
 	<content>
-		<container pos="4,4" size="154x192">
-			<widget pos="-4,78" size="162x35" type="*widget.RadioGroup">
-				<widget size="81x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="81x35">Foo</text>
+		<container pos="4,4" size="186x192">
+			<widget pos="-4,70" size="194x51" type="*widget.RadioGroup">
+				<widget size="97x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="77x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="81,0" size="81x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="81x35">Barley</text>
+				<widget pos="97,0" size="97x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="77x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="41x19">Barley</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected.xml
@@ -1,18 +1,22 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
-				<widget size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="64x35">Foo</text>
+			<widget pos="30,44" size="80x102" type="*widget.RadioGroup">
+				<widget size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Bar</text>
+				<widget pos="0,51" size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text pos="8,8" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
@@ -1,18 +1,22 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="38,60" size="64x70" type="*widget.RadioGroup">
-				<widget size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Foo</text>
+			<widget pos="30,44" size="80x102" type="*widget.RadioGroup">
+				<widget size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="0,35" size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Bar</text>
+				<widget pos="0,51" size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
@@ -1,18 +1,22 @@
-<canvas padded size="150x200">
+<canvas padded size="160x200">
 	<content>
-		<container pos="4,4" size="142x192">
-			<widget pos="6,78" size="128x35" type="*widget.RadioGroup">
-				<widget size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="64x35">Foo</text>
+		<container pos="4,4" size="152x192">
+			<widget pos="-4,70" size="160x51" type="*widget.RadioGroup">
+				<widget size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="64,0" size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Bar</text>
+				<widget pos="80,0" size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text pos="8,8" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
@@ -1,18 +1,22 @@
-<canvas padded size="150x200">
+<canvas padded size="160x200">
 	<content>
-		<container pos="4,4" size="142x192">
-			<widget pos="6,78" size="128x35" type="*widget.RadioGroup">
-				<widget size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Foo</text>
+		<container pos="4,4" size="152x192">
+			<widget pos="-4,70" size="160x51" type="*widget.RadioGroup">
+				<widget size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="24x19">Foo</text>
+					</widget>
 				</widget>
-				<widget pos="64,0" size="64x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Bar</text>
+				<widget pos="80,0" size="80x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="60x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single.xml
+++ b/widget/testdata/radio_group/layout_single.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_disabled.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected.xml
+++ b/widget/testdata/radio_group/layout_single_selected.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_disabled.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
@@ -1,12 +1,14 @@
 <canvas padded size="150x200">
 	<content>
 		<container pos="4,4" size="142x192">
-			<widget pos="37,78" size="66x35" type="*widget.RadioGroup">
-				<widget size="66x35" type="*widget.radioItem">
-					<circle pos="2,3" size="28x28"/>
-					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
-					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+			<widget pos="29,70" size="82x51" type="*widget.RadioGroup">
+				<widget size="82x51" type="*widget.radioItem">
+					<circle pos="2,11" size="28x28"/>
+					<image pos="6,15" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
+					<image pos="6,15" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
+					<widget pos="32,0" size="62x31" type="*widget.RichText">
+						<text color="disabled" pos="8,8" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>


### PR DESCRIPTION
add field Wrapping to RadioGroup.
In order to enable word wrapping
for text exceeding the screen
when creating a single choice question UI,
similar to the TextWrapBreak for widget.Label

Fixes #5656

