### PR TITLE
lang: avoid resolving unrelated languages by script similarity

### DIFF
--- a/lang/locale.go
+++ b/lang/locale.go
@@ -36,7 +36,13 @@ func closestSupportedLocale(locs []string) fyne.Locale {
 		}
 		tags[i] = tag
 	}
-	best, _, _ := matcher.Match(tags...)
+	best, _, conf := matcher.Match(tags...)
+	// When confidence is No the matcher may pick a language that shares only a script
+	// (for example Serbian Cyrillic resolving to Russian). Prefer the default fallback
+	// in that case rather than presenting an unrelated language.
+	if conf == language.No && len(translated) > 0 {
+		best = translated[0]
+	}
 	return localeFromTag(best)
 }
 

--- a/lang/locale_test.go
+++ b/lang/locale_test.go
@@ -5,7 +5,32 @@ import (
 
 	"github.com/jeandeaual/go-locale"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
+
+func TestClosestSupportedLocale_FallsBackForUnrelatedScript(t *testing.T) {
+	// Save and restore the translated list.
+	orig := translated
+	t.Cleanup(func() { translated = orig })
+
+	translated = []language.Tag{
+		language.Make("en"),
+		language.Make("ru"),
+		language.Make("uk"),
+	}
+
+	// Serbian Cyrillic shares its script with Russian but is otherwise unrelated;
+	// previously the matcher would resolve it to Russian. It should now fall back to English.
+	got := closestSupportedLocale([]string{"sr-Cyrl"})
+	assert.Equal(t, "en", got.LanguageString())
+
+	// Confirm that exact and high-confidence matches still resolve normally.
+	got = closestSupportedLocale([]string{"ru"})
+	assert.Equal(t, "ru", got.LanguageString())
+
+	got = closestSupportedLocale([]string{"uk-UA"})
+	assert.Equal(t, "uk", got.LanguageString())
+}
 
 func TestSystemLocale(t *testing.T) {
 	info, err := locale.GetLocale()


### PR DESCRIPTION
## Summary

When the locale matcher returns a match with `language.No` confidence, fall back to the default translated language (English) instead of using the match.

The matcher currently resolves Serbian Cyrillic (`sr-Cyrl`) to Russian because they share the Cyrillic script, even though the two languages aren't mutually intelligible. The confidence in that case is `No`, so treating it as a real match is misleading — falling back to English is more useful.

Fixes #6176

## Test plan
- [x] Added `TestClosestSupportedLocale_FallsBackForUnrelatedScript` covering `sr-Cyrl` fallback and confirming exact / high-confidence matches (`ru`, `uk-UA`) still resolve normally
- [x] `go test ./lang/...` passes