### PR TITLE
widget/list: add IsScrolledToTop and IsScrolledToBottom

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -334,6 +334,31 @@ func (l *List) GetScrollOffset() float32 {
 	return l.offsetY
 }
 
+// IsScrolledToTop reports whether the list is currently scrolled to the top.
+//
+// Since: 2.7
+func (l *List) IsScrolledToTop() bool {
+	if l.scroller == nil {
+		return true
+	}
+	return l.scroller.Offset.Y <= 0
+}
+
+// IsScrolledToBottom reports whether the list is currently scrolled to the bottom.
+//
+// Since: 2.7
+func (l *List) IsScrolledToBottom() bool {
+	if l.scroller == nil {
+		return true
+	}
+	viewHeight := l.scroller.Size().Height
+	contentHeight := l.contentMinSize().Height
+	if viewHeight >= contentHeight {
+		return true
+	}
+	return l.scroller.Offset.Y+viewHeight >= contentHeight
+}
+
 // TypedKey is called if a key event happens while this List is focused.
 func (l *List) TypedKey(event *fyne.KeyEvent) {
 	oldFocus := l.currentHighlight

--- a/widget/list_internal_test.go
+++ b/widget/list_internal_test.go
@@ -251,6 +251,26 @@ func TestList_ScrollToTop(t *testing.T) {
 	assert.Equal(t, offset, list.scroller.Offset.Y)
 }
 
+func TestList_IsScrolledToTopAndBottom(t *testing.T) {
+	list := createList(1000)
+
+	assert.True(t, list.IsScrolledToTop())
+	assert.False(t, list.IsScrolledToBottom())
+
+	list.ScrollToBottom()
+	assert.False(t, list.IsScrolledToTop())
+	assert.True(t, list.IsScrolledToBottom())
+
+	list.ScrollToTop()
+	assert.True(t, list.IsScrolledToTop())
+	assert.False(t, list.IsScrolledToBottom())
+
+	small := createList(1)
+	small.Resize(fyne.NewSize(200, 500))
+	assert.True(t, small.IsScrolledToTop())
+	assert.True(t, small.IsScrolledToBottom())
+}
+
 func TestList_ScrollOffset(t *testing.T) {
 	list := createList(10)
 	list.Resize(fyne.NewSize(20, 15))


### PR DESCRIPTION
## Summary

Adds two helpers to `widget.List` so callers can tell whether the list is parked at either scroll extreme without having to compare `GetScrollOffset` against the content height themselves.

- `IsScrolledToTop() bool`
- `IsScrolledToBottom() bool`

Lists whose content fits entirely in the viewport report `true` for both.

Useful for patterns like "keep tailing the list when new items are appended only if the user is already at the bottom".

Fixes #6306

## Test plan
- [x] Added `TestList_IsScrolledToTopAndBottom` covering: initial state, after `ScrollToBottom`, after `ScrollToTop`, and the case where the viewport is larger than the content
- [x] `go test ./widget/... -run "TestList_IsScrolled|TestList_ScrollTo"` passes