### PR TITLE
Bugfix/cursor animation

### DIFF
--- a/test/driver.go
+++ b/test/driver.go
@@ -114,7 +114,11 @@ func (d *driver) Run() {
 
 func (d *driver) StartAnimation(a *fyne.Animation) {
 	// currently no animations in test app, we just initialise it and leave
-	a.Tick(1.0)
+	if a.AutoReverse {
+		a.Tick(0.0)
+	} else {
+		a.Tick(1.0)
+	}
 }
 
 func (d *driver) StopAnimation(a *fyne.Animation) {

--- a/widget/entry_cursor_anim.go
+++ b/widget/entry_cursor_anim.go
@@ -48,8 +48,7 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 
 	interrupted := false
 	anim := fyne.NewAnimation(time.Second/2, func(f float32) {
-		shouldBeInterrupted := timeNow().Sub(a.lastInterruptTime) <= cursorInterruptDuration
-		if shouldBeInterrupted {
+		if timeNow().Sub(a.lastInterruptTime) < cursorInterruptDuration {
 			if !interrupted {
 				a.cursor.FillColor = opaqueColor
 				a.cursor.Refresh()

--- a/widget/entry_cursor_anim.go
+++ b/widget/entry_cursor_anim.go
@@ -13,9 +13,9 @@ import (
 var timeNow = time.Now // used in tests
 
 const (
-	cursorInterruptTime = 300 * time.Millisecond
-	cursorFadeAlpha     = uint8(0x16)
-	cursorFadeRatio     = 0.1
+	cursorInterruptDuration = 300 * time.Millisecond
+	cursorFadeAlpha         = uint8(0x16)
+	cursorFadeRatio         = 0.1
 )
 
 type entryCursorAnimation struct {
@@ -51,8 +51,8 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 
 	interrupted := false
 	anim := fyne.NewAnimation(time.Second/2, func(f float32) {
-		shouldInterrupt := timeNow().Sub(a.lastInterruptTime) <= cursorInterruptTime
-		if shouldInterrupt {
+		shouldBeInterrupted := timeNow().Sub(a.lastInterruptTime) <= cursorInterruptDuration
+		if shouldBeInterrupted {
 			if !interrupted {
 				a.cursor.FillColor = cursorOpaque
 				a.cursor.Refresh()
@@ -60,6 +60,7 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 			}
 			return
 		}
+
 		if interrupted {
 			a.anim.Stop()
 			if !inverted {
@@ -109,12 +110,12 @@ func (a *entryCursorAnimation) start() {
 	}
 }
 
-// temporarily stops the animation by "cursorInterruptTime".
+// Stops the animation for cursorInterruptDuration.
+// This is used to keep the cursor visible while typing.
 func (a *entryCursorAnimation) interrupt() {
 	a.lastInterruptTime = timeNow()
 }
 
-// stops cursor animation.
 func (a *entryCursorAnimation) stop() {
 	if a.anim != nil {
 		a.anim.Stop()

--- a/widget/entry_cursor_anim.go
+++ b/widget/entry_cursor_anim.go
@@ -32,17 +32,14 @@ func newEntryCursorAnimation(cursor *canvas.Rectangle) *entryCursorAnimation {
 }
 
 // creates fyne animation
-func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
+func (a *entryCursorAnimation) createAnim() *fyne.Animation {
 	ri, gi, bi, ai := col.ToNRGBA(theme.Color(theme.ColorNamePrimary))
 	r := uint8(ri)
 	g := uint8(gi)
 	b := uint8(bi)
 	opaqueColor := color.NRGBA{R: r, G: g, B: b, A: uint8(ai)}
-	startColor := color.NRGBA{R: r, G: g, B: b, A: cursorFadeAlpha}
-	endColor := opaqueColor
-	if inverted {
-		startColor, endColor = endColor, startColor
-	}
+	endColor := color.NRGBA{R: r, G: g, B: b, A: cursorFadeAlpha}
+	startColor := opaqueColor
 	a.cursor.FillColor = startColor
 
 	deltaA := float32(int(endColor.A) - int(startColor.A))
@@ -59,8 +56,8 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 
 		if interrupted {
 			interrupted = false
+			// stop and start effectively restarts animation from the beginning
 			a.anim.Stop()
-			a.anim = a.createAnim(true)
 			a.anim.Start()
 			return
 		}
@@ -94,9 +91,8 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 
 // starts cursor animation.
 func (a *entryCursorAnimation) start() {
-	isStopped := a.anim == nil
-	if isStopped {
-		a.anim = a.createAnim(false)
+	if a.anim == nil {
+		a.anim = a.createAnim()
 		a.anim.Start()
 	}
 }

--- a/widget/entry_cursor_anim.go
+++ b/widget/entry_cursor_anim.go
@@ -15,7 +15,10 @@ var timeNow = time.Now // used in tests
 const (
 	cursorInterruptDuration = 300 * time.Millisecond
 	cursorFadeAlpha         = uint8(0x16)
-	cursorFadeRatio         = 0.2
+	cursorFadeRatio         = float32(0.2)
+
+	fadeStart = 0.5 - cursorFadeRatio/2
+	fadeStop  = 0.5 + cursorFadeRatio/2
 )
 
 type entryCursorAnimation struct {
@@ -42,10 +45,7 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 	}
 	a.cursor.FillColor = startColor
 
-	deltaA := int(endColor.A) - int(startColor.A)
-	fadeStart := float32(0.5 - cursorFadeRatio/2)
-	fadeStop := float32(0.5 + cursorFadeRatio/2)
-
+	deltaA := float32(int(endColor.A) - int(startColor.A))
 	interrupted := false
 	anim := fyne.NewAnimation(time.Second/2, func(f float32) {
 		if timeNow().Sub(a.lastInterruptTime) < cursorInterruptDuration {
@@ -80,7 +80,7 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 			a.cursor.FillColor = endColor
 		} else {
 			fade := (f - fadeStart) / cursorFadeRatio
-			alpha = startColor.A + uint8(float32(deltaA)*fade)
+			alpha = startColor.A + uint8(deltaA*fade)
 			a.cursor.FillColor = color.NRGBA{R: r, G: g, B: b, A: alpha}
 		}
 

--- a/widget/entry_cursor_anim.go
+++ b/widget/entry_cursor_anim.go
@@ -15,7 +15,7 @@ var timeNow = time.Now // used in tests
 const (
 	cursorInterruptDuration = 300 * time.Millisecond
 	cursorFadeAlpha         = uint8(0x16)
-	cursorFadeRatio         = 0.1
+	cursorFadeRatio         = 0.2
 )
 
 type entryCursorAnimation struct {
@@ -30,31 +30,28 @@ func newEntryCursorAnimation(cursor *canvas.Rectangle) *entryCursorAnimation {
 
 // creates fyne animation
 func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
-	cursorOpaque := theme.Color(theme.ColorNamePrimary)
-	ri, gi, bi, ai := col.ToNRGBA(cursorOpaque)
-	r := uint8(ri >> 8)
-	g := uint8(gi >> 8)
-	b := uint8(bi >> 8)
-	endA := uint8(ai >> 8)
-	startA := cursorFadeAlpha
-	cursorDim := color.NRGBA{R: r, G: g, B: b, A: cursorFadeAlpha}
+	ri, gi, bi, ai := col.ToNRGBA(theme.Color(theme.ColorNamePrimary))
+	r := uint8(ri)
+	g := uint8(gi)
+	b := uint8(bi)
+	opaqueColor := color.NRGBA{R: r, G: g, B: b, A: uint8(ai)}
+	startColor := color.NRGBA{R: r, G: g, B: b, A: cursorFadeAlpha}
+	endColor := opaqueColor
 	if inverted {
-		a.cursor.FillColor = cursorOpaque
-		startA, endA = endA, startA
-	} else {
-		a.cursor.FillColor = cursorDim
+		startColor, endColor = endColor, startColor
 	}
+	a.cursor.FillColor = startColor
 
-	deltaA := endA - startA
-	fadeStart := float32(0.5 - cursorFadeRatio)
-	fadeStop := float32(0.5 + cursorFadeRatio)
+	deltaA := int(endColor.A) - int(startColor.A)
+	fadeStart := float32(0.5 - cursorFadeRatio/2)
+	fadeStop := float32(0.5 + cursorFadeRatio/2)
 
 	interrupted := false
 	anim := fyne.NewAnimation(time.Second/2, func(f float32) {
 		shouldBeInterrupted := timeNow().Sub(a.lastInterruptTime) <= cursorInterruptDuration
 		if shouldBeInterrupted {
 			if !interrupted {
-				a.cursor.FillColor = cursorOpaque
+				a.cursor.FillColor = opaqueColor
 				a.cursor.Refresh()
 				interrupted = true
 			}
@@ -62,34 +59,29 @@ func (a *entryCursorAnimation) createAnim(inverted bool) *fyne.Animation {
 		}
 
 		if interrupted {
-			a.anim.Stop()
-			if !inverted {
-				a.anim = a.createAnim(true)
-			}
 			interrupted = false
-			canStart := a.anim != nil
-			if canStart {
-				a.anim.Start()
-			}
+			a.anim.Stop()
+			a.anim = a.createAnim(true)
+			a.anim.Start()
 			return
 		}
 
-		alpha := uint8(0)
+		var alpha uint8
 		if f < fadeStart {
-			if _, _, _, al := a.cursor.FillColor.RGBA(); uint8(al>>8) == cursorFadeAlpha {
+			if a.cursor.FillColor == startColor {
 				return
 			}
 
-			a.cursor.FillColor = cursorDim
-		} else if f >= fadeStop {
-			if _, _, _, al := a.cursor.FillColor.RGBA(); al == 0xffff {
+			a.cursor.FillColor = startColor
+		} else if f > fadeStop {
+			if a.cursor.FillColor == endColor {
 				return
 			}
 
-			a.cursor.FillColor = cursorOpaque
+			a.cursor.FillColor = endColor
 		} else {
-			fade := (f + cursorFadeRatio - 0.5) * (1 / (cursorFadeRatio * 2))
-			alpha = uint8(float32(deltaA) * fade)
+			fade := (f - fadeStart) / cursorFadeRatio
+			alpha = startColor.A + uint8(float32(deltaA)*fade)
 			a.cursor.FillColor = color.NRGBA{R: r, G: g, B: b, A: alpha}
 		}
 

--- a/widget/entry_cursor_anim_test.go
+++ b/widget/entry_cursor_anim_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	col "fyne.io/fyne/v2/internal/color"
 	_ "fyne.io/fyne/v2/test"
@@ -25,19 +26,22 @@ func TestEntryCursorAnim(t *testing.T) {
 
 	cursor := canvas.NewRectangle(color.Black)
 	a := newEntryCursorAnimation(cursor)
+	a.start()
 
-	t.Run("animation changes from dimmed to opaque fading only a small time in between", func(t *testing.T) {
-		a.start()
+	assert.True(t, a.anim.AutoReverse)
+	assert.Equal(t, fyne.AnimationRepeatForever, a.anim.RepeatCount)
+
+	t.Run("animation changes from opaque to dimmed fading only a small time in between", func(t *testing.T) {
 		a.anim.Tick(0.0)
-		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 		a.anim.Tick(0.4)
-		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 		a.anim.Tick(0.5)
 		assert.InDelta(t, (alpha(cursorOpaque)-alpha(cursorDim))/2+alpha(cursorDim), alpha(a.cursor.FillColor), 1)
 		a.anim.Tick(0.6)
-		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
 		a.anim.Tick(1.0)
-		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
 	})
 
 	t.Run("interrupted animation is always opaque", func(t *testing.T) {

--- a/widget/entry_cursor_anim_test.go
+++ b/widget/entry_cursor_anim_test.go
@@ -2,7 +2,6 @@ package widget
 
 import (
 	"image/color"
-	"runtime"
 	"testing"
 	"time"
 
@@ -56,9 +55,7 @@ func TestEntryCursorAnim(t *testing.T) {
 			return time.Now().Add(300 * time.Millisecond)
 		}
 		a.anim.Tick(0.0)
-		runtime.Gosched()
-		time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
-		a.anim.Tick(0.0)
+		a.anim.Tick(0.0) // first tick after interruption period creates a new animation which is ticked by the test driver to 1.0 directly
 		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 		a.anim.Tick(0.4)
 		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
@@ -80,9 +77,7 @@ func TestEntryCursorAnim(t *testing.T) {
 			return time.Now().Add(300 * time.Millisecond)
 		}
 		a.anim.Tick(0.0)
-		runtime.Gosched()
-		time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
-		a.anim.Tick(0.0)
+		a.anim.Tick(0.0) // first tick after interruption period creates a new animation which is ticked by the test driver to 1.0 directly
 		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 		a.anim.Tick(1.0)
 		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))

--- a/widget/entry_cursor_anim_test.go
+++ b/widget/entry_cursor_anim_test.go
@@ -19,10 +19,9 @@ func TestEntryCursorAnim(t *testing.T) {
 	r, g, b, _ := col.ToNRGBA(cursorOpaque)
 	cursorDim := color.NRGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: 0x16}
 
-	alphaEquals := func(color1, color2 color.Color) bool {
-		_, _, _, a1 := col.ToNRGBA(color1)
-		_, _, _, a2 := col.ToNRGBA(color2)
-		return uint8(a1>>8) == uint8(a2>>8) // only check 8bit colour channels
+	alpha := func(c color.Color) uint8 {
+		_, _, _, a := col.ToNRGBA(c)
+		return uint8(a >> 8) // only check 8bit colour channels
 	}
 
 	cursor := canvas.NewRectangle(color.Black)
@@ -30,17 +29,17 @@ func TestEntryCursorAnim(t *testing.T) {
 
 	a.start()
 	a.anim.Tick(0.0)
-	assert.True(t, alphaEquals(cursorDim, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
 	a.anim.Tick(1.0)
-	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 
 	a.interrupt()
 	a.anim.Tick(0.0)
-	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 	a.anim.Tick(0.5)
-	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 	a.anim.Tick(1.0)
-	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 
 	timeNow = func() time.Time {
 		return time.Now().Add(cursorInterruptTime)
@@ -50,14 +49,14 @@ func TestEntryCursorAnim(t *testing.T) {
 	runtime.Gosched()
 	time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
 	a.anim.Tick(0.0)
-	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 	a.anim.Tick(1.0)
-	assert.True(t, alphaEquals(cursorDim, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
 
 	timeNow = time.Now
 	a.interrupt()
 	a.anim.Tick(0.0)
-	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 
 	timeNow = func() time.Time {
 		return time.Now().Add(cursorInterruptTime)
@@ -66,9 +65,9 @@ func TestEntryCursorAnim(t *testing.T) {
 	runtime.Gosched()
 	time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
 	a.anim.Tick(0.0)
-	assert.True(t, alphaEquals(cursorOpaque, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 	a.anim.Tick(1.0)
-	assert.True(t, alphaEquals(cursorDim, a.cursor.FillColor))
+	assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
 
 	a.stop()
 	assert.Nil(t, a.anim)

--- a/widget/entry_cursor_anim_test.go
+++ b/widget/entry_cursor_anim_test.go
@@ -27,47 +27,54 @@ func TestEntryCursorAnim(t *testing.T) {
 	cursor := canvas.NewRectangle(color.Black)
 	a := newEntryCursorAnimation(cursor)
 
-	a.start()
-	a.anim.Tick(0.0)
-	assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
-	a.anim.Tick(1.0)
-	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+	t.Run("animation changes from faded to opaque", func(t *testing.T) {
+		a.start()
+		a.anim.Tick(0.0)
+		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+		a.anim.Tick(1.0)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+	})
 
-	a.interrupt()
-	a.anim.Tick(0.0)
-	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
-	a.anim.Tick(0.5)
-	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
-	a.anim.Tick(1.0)
-	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+	t.Run("interrupted animation is always opaque", func(t *testing.T) {
+		a.interrupt()
+		a.anim.Tick(0.0)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		a.anim.Tick(0.5)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		a.anim.Tick(1.0)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+	})
 
-	timeNow = func() time.Time {
-		return time.Now().Add(cursorInterruptTime)
-	}
-	// animation should be restarted inverting the colors
-	a.anim.Tick(0.0)
-	runtime.Gosched()
-	time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
-	a.anim.Tick(0.0)
-	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
-	a.anim.Tick(1.0)
-	assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+	t.Run("animation starts fading out again 300ms after interruption", func(t *testing.T) {
+		timeNow = func() time.Time {
+			return time.Now().Add(300 * time.Millisecond)
+		}
+		a.anim.Tick(0.0)
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
+		a.anim.Tick(0.0)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		a.anim.Tick(1.0)
+		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+	})
 
-	timeNow = time.Now
-	a.interrupt()
-	a.anim.Tick(0.0)
-	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+	t.Run("subsequent interruption works", func(t *testing.T) {
+		timeNow = time.Now
+		a.interrupt()
+		a.anim.Tick(0.0)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 
-	timeNow = func() time.Time {
-		return time.Now().Add(cursorInterruptTime)
-	}
-	a.anim.Tick(0.0)
-	runtime.Gosched()
-	time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
-	a.anim.Tick(0.0)
-	assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
-	a.anim.Tick(1.0)
-	assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+		timeNow = func() time.Time {
+			return time.Now().Add(300 * time.Millisecond)
+		}
+		a.anim.Tick(0.0)
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
+		a.anim.Tick(0.0)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		a.anim.Tick(1.0)
+		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+	})
 
 	a.stop()
 	assert.Nil(t, a.anim)

--- a/widget/entry_cursor_anim_test.go
+++ b/widget/entry_cursor_anim_test.go
@@ -21,16 +21,22 @@ func TestEntryCursorAnim(t *testing.T) {
 
 	alpha := func(c color.Color) uint8 {
 		_, _, _, a := col.ToNRGBA(c)
-		return uint8(a >> 8) // only check 8bit colour channels
+		return uint8(a)
 	}
 
 	cursor := canvas.NewRectangle(color.Black)
 	a := newEntryCursorAnimation(cursor)
 
-	t.Run("animation changes from faded to opaque", func(t *testing.T) {
+	t.Run("animation changes from dimmed to opaque fading only a small time in between", func(t *testing.T) {
 		a.start()
 		a.anim.Tick(0.0)
 		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+		a.anim.Tick(0.4)
+		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
+		a.anim.Tick(0.5)
+		assert.InDelta(t, (alpha(cursorOpaque)-alpha(cursorDim))/2+alpha(cursorDim), alpha(a.cursor.FillColor), 1)
+		a.anim.Tick(0.6)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 		a.anim.Tick(1.0)
 		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
 	})
@@ -54,6 +60,12 @@ func TestEntryCursorAnim(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // ensure go routine for restart animation is executed
 		a.anim.Tick(0.0)
 		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		a.anim.Tick(0.4)
+		assert.Equal(t, alpha(cursorOpaque), alpha(a.cursor.FillColor))
+		a.anim.Tick(0.5)
+		assert.InDelta(t, (alpha(cursorOpaque)-alpha(cursorDim))/2+alpha(cursorDim), alpha(a.cursor.FillColor), 1)
+		a.anim.Tick(0.6)
+		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
 		a.anim.Tick(1.0)
 		assert.Equal(t, alpha(cursorDim), alpha(a.cursor.FillColor))
 	})


### PR DESCRIPTION
### Description:

This PR fixes the cursor animation.

The animation was mostly broken but that went unnoticed by the tests because they were broken too.
It went unnoticed by the human eye because the actual fade is too short to be noticeable.

The issues were:
- An effective 8bit value was shifted 8 bits to the right resulting in zero.
- The same in the tests, thus neither this error nor any other was detected.
- Inverted animations changed the start/end alpha values and thus inverted
  the delta but the tick function did not use the correct start/end values.
- After interruption a new fade-out animation was only created if the
  current animation was not a fade-out. That would lead to unexpected
  flickering if the fading would be actually visible.
- The delta was wrong (always positive), so never fading out.
- The fading computation did not incorporate the start as offset and
  thus covered the wrong range.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.