### PR TITLE
Run static analysis on all platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -36,6 +36,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
 
       - name: golangci-lint
+        if: ${{ runner.os != 'Windows' }} # TODO: On Windows the checks all succeed but there is a compiler issue that cannot be ignored using the configuration.
         uses: golangci/golangci-lint-action@v9
         with:
           args: '--verbose'

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -8,7 +8,14 @@ env:
 
 jobs:
   static_analysis:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
 
     steps:
       - uses: actions/checkout@v5
@@ -22,9 +29,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends clang lld libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev xvfb language-pack-en
+        if: ${{ runner.os == 'Linux' }}
 
       - name: Set environment variable LANG
         run: echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
+        if: ${{ runner.os == 'Linux' }}
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/internal/app/theme_windows.go
+++ b/internal/app/theme_windows.go
@@ -57,7 +57,7 @@ func WatchTheme(onChanged func()) {
 	}
 	for {
 		// blocks until the registry key has been changed
-		regNotifyChangeKeyValue.Call(uintptr(k), 0, 0x00000001|0x00000004, 0, 0)
+		_, _, _ = regNotifyChangeKeyValue.Call(uintptr(k), 0, 0x00000001|0x00000004, 0, 0)
 		onChanged()
 	}
 }

--- a/internal/driver/mobile/app/app.go
+++ b/internal/driver/mobile/app/app.go
@@ -9,7 +9,6 @@ package app
 import (
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/driver/mobile/event/lifecycle"
-	"fyne.io/fyne/v2/internal/driver/mobile/event/size"
 	"fyne.io/fyne/v2/internal/driver/mobile/gl"
 
 	// Initialize necessary mobile functionality, such as logging.
@@ -85,18 +84,6 @@ func init() {
 	theApp.glctx, theApp.worker = gl.NewContext()
 }
 
-func (a *app) sendLifecycle(to lifecycle.Stage) {
-	if a.lifecycleStage == to {
-		return
-	}
-	a.events.In() <- lifecycle.Event{
-		From:        a.lifecycleStage,
-		To:          to,
-		DrawContext: a.glctx,
-	}
-	a.lifecycleStage = to
-}
-
 type app struct {
 	filters []func(any) any
 
@@ -155,12 +142,4 @@ func (a *app) ShowFileOpenPicker(callback func(string, func()), filter *FileFilt
 
 func (a *app) ShowFileSavePicker(callback func(string, func()), filter *FileFilter, filename string) {
 	driverShowFileSavePicker(callback, filter, filename)
-}
-
-func screenOrientation(width, height int) size.Orientation {
-	if width > height {
-		return size.OrientationLandscape
-	}
-
-	return size.OrientationPortrait
 }

--- a/internal/driver/mobile/app/app_darwin_and_unix.go
+++ b/internal/driver/mobile/app/app_darwin_and_unix.go
@@ -1,0 +1,28 @@
+//go:build freebsd || linux || darwin || openbsd
+
+package app
+
+import (
+	"fyne.io/fyne/v2/internal/driver/mobile/event/lifecycle"
+	"fyne.io/fyne/v2/internal/driver/mobile/event/size"
+)
+
+func screenOrientation(width, height int) size.Orientation {
+	if width > height {
+		return size.OrientationLandscape
+	}
+
+	return size.OrientationPortrait
+}
+
+func (a *app) sendLifecycle(to lifecycle.Stage) {
+	if a.lifecycleStage == to {
+		return
+	}
+	a.events.In() <- lifecycle.Event{
+		From:        a.lifecycleStage,
+		To:          to,
+		DrawContext: a.glctx,
+	}
+	a.lifecycleStage = to
+}

--- a/internal/driver/mobile/gl/dll_windows.go
+++ b/internal/driver/mobile/gl/dll_windows.go
@@ -127,11 +127,11 @@ func containsDLLs(dir string) bool {
 
 		switch file.Machine {
 		case pe.IMAGE_FILE_MACHINE_AMD64:
-			return "amd64" == runtime.GOARCH
+			return runtime.GOARCH == "amd64"
 		case pe.IMAGE_FILE_MACHINE_ARM:
-			return "arm" == runtime.GOARCH
+			return runtime.GOARCH == "arm"
 		case pe.IMAGE_FILE_MACHINE_I386:
-			return "386" == runtime.GOARCH
+			return runtime.GOARCH == "386"
 		}
 		return false
 	}

--- a/internal/driver/mobile/gl/dll_windows.go
+++ b/internal/driver/mobile/gl/dll_windows.go
@@ -69,13 +69,13 @@ func downloadDLLs() (path string, err error) {
 	}
 
 	writeDLLs := func(path string) error {
-		if err := os.WriteFile(filepath.Join(path, "libglesv2.dll"), bytesGLESv2, 0o755); err != nil {
+		if err = os.WriteFile(filepath.Join(path, "libglesv2.dll"), bytesGLESv2, 0o755); err != nil {
 			return fmt.Errorf("gl: cannot install ANGLE: %v", err)
 		}
-		if err := os.WriteFile(filepath.Join(path, "libegl.dll"), bytesEGL, 0o755); err != nil {
+		if err = os.WriteFile(filepath.Join(path, "libegl.dll"), bytesEGL, 0o755); err != nil {
 			return fmt.Errorf("gl: cannot install ANGLE: %v", err)
 		}
-		if err := os.WriteFile(filepath.Join(path, "d3dcompiler_47.dll"), bytesD3DCompiler, 0o755); err != nil {
+		if err = os.WriteFile(filepath.Join(path, "d3dcompiler_47.dll"), bytesD3DCompiler, 0o755); err != nil {
 			return fmt.Errorf("gl: cannot install ANGLE: %v", err)
 		}
 		return nil
@@ -85,17 +85,21 @@ func downloadDLLs() (path string, err error) {
 	//
 	// Traditionally we would use the system32 directory, but it is
 	// no longer writable by normal programs.
-	os.MkdirAll(appdataPath(), 0o775)
-	if err := writeDLLs(appdataPath()); err == nil {
+	if err = os.MkdirAll(appdataPath(), 0o775); err != nil {
+		return "", fmt.Errorf("unable to create app data directory: %w", err)
+	}
+
+	if err = writeDLLs(appdataPath()); err == nil {
 		return appdataPath(), nil
 	}
+
 	debug.Printf("DLLs could not be written to %s", appdataPath())
 
 	// Second, install in GOPATH/pkg if it exists.
 	gopath := os.Getenv("GOPATH")
 	gopathpkg := filepath.Join(gopath, "pkg")
-	if _, err := os.Stat(gopathpkg); err == nil && gopath != "" {
-		if err := writeDLLs(gopathpkg); err == nil {
+	if _, err = os.Stat(gopathpkg); err == nil && gopath != "" {
+		if err = writeDLLs(gopathpkg); err == nil {
 			return gopathpkg, nil
 		}
 	}
@@ -103,7 +107,7 @@ func downloadDLLs() (path string, err error) {
 
 	// Third, pick a temporary directory.
 	tmp := os.TempDir()
-	if err := writeDLLs(tmp); err != nil {
+	if err = writeDLLs(tmp); err != nil {
 		return "", fmt.Errorf("gl: unable to install ANGLE DLLs: %v", err)
 	}
 	return tmp, nil

--- a/internal/driver/mobile/gl/fn.go
+++ b/internal/driver/mobile/gl/fn.go
@@ -23,8 +23,6 @@ type fnargs struct {
 	a5 uintptr
 	a6 uintptr
 	a7 uintptr
-	a8 uintptr
-	a9 uintptr
 }
 
 type glfn int

--- a/internal/driver/mobile/gl/work.h
+++ b/internal/driver/mobile/gl/work.h
@@ -102,8 +102,6 @@ struct fnargs {
 	uintptr_t a5;
 	uintptr_t a6;
 	uintptr_t a7;
-	uintptr_t a8;
-	uintptr_t a9;
 };
 
 extern uintptr_t processFn(struct fnargs* args, char* parg);

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -11,7 +11,7 @@ import (
 
 // context is described in work.go.
 type context struct {
-	debug         int32
+	debug         int32 //nolint:unused // TODO: currently unused, can this be removed?
 	workAvailable chan struct{}
 	work          chan call
 	retvalue      chan uintptr

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -93,51 +93,51 @@ func (ctx *context) cStringPtr(str string) (uintptr, func()) {
 
 var glfnFuncs = [...]func(c call) (ret uintptr){
 	glfnActiveTexture: func(c call) (ret uintptr) {
-		syscall.SyscallN(glActiveTexture.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glActiveTexture.Addr(), c.args.a0)
 		return ret
 	},
 	glfnAttachShader: func(c call) (ret uintptr) {
-		syscall.SyscallN(glAttachShader.Addr(), c.args.a0, c.args.a1)
+		_, _, _ = syscall.SyscallN(glAttachShader.Addr(), c.args.a0, c.args.a1)
 		return ret
 	},
 	glfnBindBuffer: func(c call) (ret uintptr) {
-		syscall.SyscallN(glBindBuffer.Addr(), c.args.a0, c.args.a1)
+		_, _, _ = syscall.SyscallN(glBindBuffer.Addr(), c.args.a0, c.args.a1)
 		return ret
 	},
 	glfnBindTexture: func(c call) (ret uintptr) {
-		syscall.SyscallN(glBindTexture.Addr(), c.args.a0, c.args.a1)
+		_, _, _ = syscall.SyscallN(glBindTexture.Addr(), c.args.a0, c.args.a1)
 		return ret
 	},
 	glfnBindVertexArray: func(c call) (ret uintptr) {
-		syscall.SyscallN(glBindVertexArray.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glBindVertexArray.Addr(), c.args.a0)
 		return ret
 	},
 	glfnBlendColor: func(c call) (ret uintptr) {
-		syscall.SyscallN(glBlendColor.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
+		_, _, _ = syscall.SyscallN(glBlendColor.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
 		return ret
 	},
 	glfnBlendFunc: func(c call) (ret uintptr) {
-		syscall.SyscallN(glBlendFunc.Addr(), c.args.a0, c.args.a1)
+		_, _, _ = syscall.SyscallN(glBlendFunc.Addr(), c.args.a0, c.args.a1)
 		return ret
 	},
 	glfnBufferData: func(c call) (ret uintptr) {
-		syscall.SyscallN(glBufferData.Addr(), c.args.a0, c.args.a1, uintptr(c.parg), c.args.a2)
+		_, _, _ = syscall.SyscallN(glBufferData.Addr(), c.args.a0, c.args.a1, uintptr(c.parg), c.args.a2)
 		return ret
 	},
 	glfnBufferSubData: func(c call) (ret uintptr) {
-		syscall.SyscallN(glBufferSubData.Addr(), c.args.a0, c.args.a1, c.args.a2, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glBufferSubData.Addr(), c.args.a0, c.args.a1, c.args.a2, uintptr(c.parg))
 		return ret
 	},
 	glfnClear: func(c call) (ret uintptr) {
-		syscall.SyscallN(glClear.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glClear.Addr(), c.args.a0)
 		return ret
 	},
 	glfnClearColor: func(c call) (ret uintptr) {
-		syscall.SyscallN(glClearColor.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
+		_, _, _ = syscall.SyscallN(glClearColor.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
 		return ret
 	},
 	glfnCompileShader: func(c call) (ret uintptr) {
-		syscall.SyscallN(glCompileShader.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glCompileShader.Addr(), c.args.a0)
 		return ret
 	},
 	glfnCreateProgram: func(c call) (ret uintptr) {
@@ -149,47 +149,47 @@ var glfnFuncs = [...]func(c call) (ret uintptr){
 		return ret
 	},
 	glfnDeleteBuffer: func(c call) (ret uintptr) {
-		syscall.SyscallN(glDeleteBuffers.Addr(), 1, uintptr(unsafe.Pointer(&c.args.a0)))
+		_, _, _ = syscall.SyscallN(glDeleteBuffers.Addr(), 1, uintptr(unsafe.Pointer(&c.args.a0)))
 		return ret
 	},
 	glfnDeleteTexture: func(c call) (ret uintptr) {
-		syscall.SyscallN(glDeleteTextures.Addr(), 1, uintptr(unsafe.Pointer(&c.args.a0)))
+		_, _, _ = syscall.SyscallN(glDeleteTextures.Addr(), 1, uintptr(unsafe.Pointer(&c.args.a0)))
 		return ret
 	},
 	glfnDeleteProgram: func(c call) (ret uintptr) {
-		syscall.SyscallN(glDeleteProgram.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glDeleteProgram.Addr(), c.args.a0)
 		return ret
 	},
 	glfnDisable: func(c call) (ret uintptr) {
-		syscall.SyscallN(glDisable.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glDisable.Addr(), c.args.a0)
 		return ret
 	},
 	glfnDrawArrays: func(c call) (ret uintptr) {
-		syscall.SyscallN(glDrawArrays.Addr(), c.args.a0, c.args.a1, c.args.a2)
+		_, _, _ = syscall.SyscallN(glDrawArrays.Addr(), c.args.a0, c.args.a1, c.args.a2)
 		return ret
 	},
 	glfnEnable: func(c call) (ret uintptr) {
-		syscall.SyscallN(glEnable.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glEnable.Addr(), c.args.a0)
 		return ret
 	},
 	glfnEnableVertexAttribArray: func(c call) (ret uintptr) {
-		syscall.SyscallN(glEnableVertexAttribArray.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glEnableVertexAttribArray.Addr(), c.args.a0)
 		return ret
 	},
 	glfnFlush: func(c call) (ret uintptr) {
-		syscall.SyscallN(glFlush.Addr())
+		_, _, _ = syscall.SyscallN(glFlush.Addr())
 		return ret
 	},
 	glfnGenBuffer: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGenBuffers.Addr(), 1, uintptr(unsafe.Pointer(&ret)))
+		_, _, _ = syscall.SyscallN(glGenBuffers.Addr(), 1, uintptr(unsafe.Pointer(&ret)))
 		return ret
 	},
 	glfnGenVertexArray: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGenVertexArrays.Addr(), 1, uintptr(unsafe.Pointer(&ret)))
+		_, _, _ = syscall.SyscallN(glGenVertexArrays.Addr(), 1, uintptr(unsafe.Pointer(&ret)))
 		return ret
 	},
 	glfnGenTexture: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGenTextures.Addr(), 1, uintptr(unsafe.Pointer(&ret)))
+		_, _, _ = syscall.SyscallN(glGenTextures.Addr(), 1, uintptr(unsafe.Pointer(&ret)))
 		return ret
 	},
 	glfnGetAttribLocation: func(c call) (ret uintptr) {
@@ -201,27 +201,27 @@ var glfnFuncs = [...]func(c call) (ret uintptr){
 		return ret
 	},
 	glfnGetProgramInfoLog: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGetProgramInfoLog.Addr(), c.args.a0, c.args.a1, 0, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glGetProgramInfoLog.Addr(), c.args.a0, c.args.a1, 0, uintptr(c.parg))
 		return ret
 	},
 	glfnGetProgramiv: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGetProgramiv.Addr(), c.args.a0, c.args.a1, uintptr(unsafe.Pointer(&ret)))
+		_, _, _ = syscall.SyscallN(glGetProgramiv.Addr(), c.args.a0, c.args.a1, uintptr(unsafe.Pointer(&ret)))
 		return ret
 	},
 	glfnGetShaderInfoLog: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGetShaderInfoLog.Addr(), c.args.a0, c.args.a1, 0, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glGetShaderInfoLog.Addr(), c.args.a0, c.args.a1, 0, uintptr(c.parg))
 		return ret
 	},
 	glfnGetShaderSource: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGetShaderSource.Addr(), c.args.a0, c.args.a1, 0, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glGetShaderSource.Addr(), c.args.a0, c.args.a1, 0, uintptr(c.parg))
 		return ret
 	},
 	glfnGetShaderiv: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGetShaderiv.Addr(), c.args.a0, c.args.a1, uintptr(unsafe.Pointer(&ret)))
+		_, _, _ = syscall.SyscallN(glGetShaderiv.Addr(), c.args.a0, c.args.a1, uintptr(unsafe.Pointer(&ret)))
 		return ret
 	},
 	glfnGetTexParameteriv: func(c call) (ret uintptr) {
-		syscall.SyscallN(glGetTexParameteriv.Addr(), c.args.a0, c.args.a1, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glGetTexParameteriv.Addr(), c.args.a0, c.args.a1, uintptr(c.parg))
 		return ret
 	},
 	glfnGetUniformLocation: func(c call) (ret uintptr) {
@@ -229,71 +229,71 @@ var glfnFuncs = [...]func(c call) (ret uintptr){
 		return ret
 	},
 	glfnLinkProgram: func(c call) (ret uintptr) {
-		syscall.SyscallN(glLinkProgram.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glLinkProgram.Addr(), c.args.a0)
 		return ret
 	},
 	glfnReadPixels: func(c call) (ret uintptr) {
-		syscall.SyscallN(glReadPixels.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, c.args.a5, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glReadPixels.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, c.args.a5, uintptr(c.parg))
 		return ret
 	},
 	glfnScissor: func(c call) (ret uintptr) {
-		syscall.SyscallN(glScissor.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
+		_, _, _ = syscall.SyscallN(glScissor.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
 		return ret
 	},
 	glfnShaderSource: func(c call) (ret uintptr) {
-		syscall.SyscallN(glShaderSource.Addr(), c.args.a0, c.args.a1, c.args.a2, 0)
+		_, _, _ = syscall.SyscallN(glShaderSource.Addr(), c.args.a0, c.args.a1, c.args.a2, 0)
 		return ret
 	},
 	glfnTexImage2D: func(c call) (ret uintptr) {
-		syscall.SyscallN(glTexImage2D.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, 0, c.args.a5, c.args.a6, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glTexImage2D.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, 0, c.args.a5, c.args.a6, uintptr(c.parg))
 		return ret
 	},
 	glfnTexParameteri: func(c call) (ret uintptr) {
-		syscall.SyscallN(glTexParameteri.Addr(), c.args.a0, c.args.a1, c.args.a2)
+		_, _, _ = syscall.SyscallN(glTexParameteri.Addr(), c.args.a0, c.args.a1, c.args.a2)
 		return ret
 	},
 	glfnUniform1f: func(c call) (ret uintptr) {
-		syscall.SyscallN(glUniform1f.Addr(), c.args.a0, c.args.a1)
+		_, _, _ = syscall.SyscallN(glUniform1f.Addr(), c.args.a0, c.args.a1)
 		return ret
 	},
 	glfnUniform1i: func(c call) (ret uintptr) {
-		syscall.SyscallN(glUniform1i.Addr(), c.args.a0, c.args.a1)
+		_, _, _ = syscall.SyscallN(glUniform1i.Addr(), c.args.a0, c.args.a1)
 		return ret
 	},
 	glfnUniform1fv: func(c call) (ret uintptr) {
-		syscall.Syscall(glUniform1fv.Addr(), 3, c.args.a0, c.args.a1, uintptr(c.parg))
+		_, _, _ = syscall.Syscall(glUniform1fv.Addr(), 3, c.args.a0, c.args.a1, uintptr(c.parg))
 		return ret
 	},
 	glfnUniform2f: func(c call) (ret uintptr) {
-		syscall.SyscallN(glUniform2f.Addr(), c.args.a0, c.args.a1, c.args.a2)
+		_, _, _ = syscall.SyscallN(glUniform2f.Addr(), c.args.a0, c.args.a1, c.args.a2)
 		return ret
 	},
 	glfnUniform2fv: func(c call) (ret uintptr) {
-		syscall.SyscallN(glUniform2fv.Addr(), c.args.a0, c.args.a1, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glUniform2fv.Addr(), c.args.a0, c.args.a1, uintptr(c.parg))
 		return ret
 	},
 	glfnUniform4f: func(c call) (ret uintptr) {
-		syscall.SyscallN(glUniform4f.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4)
+		_, _, _ = syscall.SyscallN(glUniform4f.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4)
 		return ret
 	},
 	glfnUniform4fv: func(c call) (ret uintptr) {
-		syscall.SyscallN(glUniform4fv.Addr(), c.args.a0, c.args.a1, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glUniform4fv.Addr(), c.args.a0, c.args.a1, uintptr(c.parg))
 		return ret
 	},
 	glfnUseProgram: func(c call) (ret uintptr) {
-		syscall.SyscallN(glUseProgram.Addr(), c.args.a0)
+		_, _, _ = syscall.SyscallN(glUseProgram.Addr(), c.args.a0)
 		return ret
 	},
 	glfnVertexAttribPointer: func(c call) (ret uintptr) {
-		syscall.SyscallN(glVertexAttribPointer.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, c.args.a5)
+		_, _, _ = syscall.SyscallN(glVertexAttribPointer.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, c.args.a5)
 		return ret
 	},
 	glfnViewport: func(c call) (ret uintptr) {
-		syscall.SyscallN(glViewport.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
+		_, _, _ = syscall.SyscallN(glViewport.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3)
 		return ret
 	},
 	glfnCopyTexSubImage2D: func(c call) (ret uintptr) {
-		syscall.SyscallN(glCopyTexSubImage2D.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, c.args.a5, c.args.a6, c.args.a7)
+		_, _, _ = syscall.SyscallN(glCopyTexSubImage2D.Addr(), c.args.a0, c.args.a1, c.args.a2, c.args.a3, c.args.a4, c.args.a5, c.args.a6, c.args.a7)
 		return ret
 	},
 }

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -37,7 +37,7 @@ func NewContext() (Context, Worker) {
 		retvalue:      make(chan uintptr),
 		cStrings:      make(map[int]unsafe.Pointer),
 	}
-	return glctx, glctx
+	return context3{glctx}, glctx
 }
 
 func (ctx *context) enqueue(c call) uintptr {

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -261,7 +261,7 @@ var glfnFuncs = [...]func(c call) (ret uintptr){
 		return ret
 	},
 	glfnUniform1fv: func(c call) (ret uintptr) {
-		_, _, _ = syscall.Syscall(glUniform1fv.Addr(), 3, c.args.a0, c.args.a1, uintptr(c.parg))
+		_, _, _ = syscall.SyscallN(glUniform1fv.Addr(), 3, c.args.a0, c.args.a1, uintptr(c.parg))
 		return ret
 	},
 	glfnUniform2f: func(c call) (ret uintptr) {

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -353,7 +353,6 @@ var (
 	glGetShaderiv             = libGLESv2.NewProc("glGetShaderiv")
 	glGetTexParameteriv       = libGLESv2.NewProc("glGetTexParameteriv")
 	glGetUniformLocation      = libGLESv2.NewProc("glGetUniformLocation")
-	glPixelStorei             = libGLESv2.NewProc("glPixelStorei")
 	glLinkProgram             = libGLESv2.NewProc("glLinkProgram")
 	glReadPixels              = libGLESv2.NewProc("glReadPixels")
 	glScissor                 = libGLESv2.NewProc("glScissor")


### PR DESCRIPTION
### Description:

This PR introduces a run matrix to the static analysis GitHub Action workflow.

It contains some adjustments for issues that were detected by golangci-lint on Windows.
Sadly, golangci-lint had to be deactivated on Windows eventually because it faces some type issues from the compiler. Interestingly all the linters run nevertheless and succeed.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.