### PR TITLE
Add ClearSelection method to Entry and Label

### DIFF
--- a/widget/entry.go
+++ b/widget/entry.go
@@ -468,6 +468,18 @@ func (e *Entry) SelectedText() string {
 	return e.sel.SelectedText()
 }
 
+// ClearSelection removes any active text selection in this Entry.
+// It has no effect if nothing is currently selected.
+//
+// Since: 2.7
+func (e *Entry) ClearSelection() {
+	if e.sel == nil || !e.sel.selecting {
+		return
+	}
+	e.sel.selecting = false
+	e.Refresh()
+}
+
 // SetIcon sets the leading icon resource for the entry.
 // The icon will be displayed at the outer left of the entry, but is not clickable.
 // This can be used to indicate the purpose of the entry, such as an email or password field.

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -471,7 +471,7 @@ func (e *Entry) SelectedText() string {
 // ClearSelection removes any active text selection in this Entry.
 // It has no effect if nothing is currently selected.
 //
-// Since: 2.7
+// Since: 2.9
 func (e *Entry) ClearSelection() {
 	if e.sel == nil || !e.sel.selecting {
 		return

--- a/widget/entry_test.go
+++ b/widget/entry_test.go
@@ -441,6 +441,21 @@ func TestEntry_EmptySelection(t *testing.T) {
 	assert.Equal(t, "", entry.SelectedText())
 }
 
+func TestEntry_ClearSelection(t *testing.T) {
+	entry := widget.NewEntry()
+	entry.SetText("Testing")
+
+	typeKeys(entry, fyne.KeyRight, fyne.KeyRight, keyShiftLeftDown, fyne.KeyRight, fyne.KeyRight, keyShiftLeftUp)
+	assert.Equal(t, "st", entry.SelectedText())
+
+	entry.ClearSelection()
+	assert.Equal(t, "", entry.SelectedText())
+
+	// calling again with nothing selected is a no-op
+	entry.ClearSelection()
+	assert.Equal(t, "", entry.SelectedText())
+}
+
 func TestEntry_Focus(t *testing.T) {
 	entry, window := setupImageTest(t, false)
 	c := window.Canvas()

--- a/widget/label.go
+++ b/widget/label.go
@@ -139,6 +139,18 @@ func (l *Label) SelectedText() string {
 	return l.selection.SelectedText()
 }
 
+// ClearSelection removes any active text selection in this Label.
+// It has no effect if the Label is not Selectable or nothing is currently selected.
+//
+// Since: 2.7
+func (l *Label) ClearSelection() {
+	if !l.Selectable || l.selection == nil || !l.selection.selecting {
+		return
+	}
+	l.selection.selecting = false
+	l.Refresh()
+}
+
 // SetText sets the text of the label
 func (l *Label) SetText(text string) {
 	l.Text = text

--- a/widget/label.go
+++ b/widget/label.go
@@ -142,7 +142,7 @@ func (l *Label) SelectedText() string {
 // ClearSelection removes any active text selection in this Label.
 // It has no effect if the Label is not Selectable or nothing is currently selected.
 //
-// Since: 2.7
+// Since: 2.9
 func (l *Label) ClearSelection() {
 	if !l.Selectable || l.selection == nil || !l.selection.selecting {
 		return

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -234,6 +234,34 @@ func TestLabel_Select(t *testing.T) {
 	assert.Empty(t, l.SelectedText())
 }
 
+func TestLabel_ClearSelection(t *testing.T) {
+	l := NewLabel("Hello")
+	l.Selectable = true
+
+	sel := test.WidgetRenderer(l).Objects()[0].(*focusSelectable)
+	sel.MouseDown(&desktop.MouseEvent{
+		Button:     desktop.MouseButtonPrimary,
+		PointEvent: fyne.PointEvent{Position: fyne.NewPos(15, 10)},
+	})
+	sel.Dragged(&fyne.DragEvent{
+		Dragged:    fyne.Delta{DX: 15, DY: 0},
+		PointEvent: fyne.PointEvent{Position: fyne.NewPos(30, 10)},
+	})
+	sel.DragEnd()
+	sel.MouseUp(&desktop.MouseEvent{
+		Button:     desktop.MouseButtonPrimary,
+		PointEvent: fyne.PointEvent{Position: fyne.NewPos(30, 10)},
+	})
+	assert.Equal(t, "el", l.SelectedText())
+
+	l.ClearSelection()
+	assert.Equal(t, "", l.SelectedText())
+
+	// calling again with nothing selected is a no-op
+	l.ClearSelection()
+	assert.Equal(t, "", l.SelectedText())
+}
+
 func TestLabel_SelectWord(t *testing.T) {
 	l := NewLabel("Hello")
 	l.Selectable = true


### PR DESCRIPTION
Fixes #6375.

Adds a `ClearSelection()` method to `widget.Entry` and `widget.Label` so callers can programmatically cancel an active text selection without needing knowledge of the internal selection state (the workaround previously was re-calling `SetText` with the same text).

- `Entry.ClearSelection()` and `Label.ClearSelection()` clear an active selection and refresh; both are no-ops when nothing is selected (or, for Label, when it isn't `Selectable`).
- Added tests `TestEntry_ClearSelection` and `TestLabel_ClearSelection` covering the selection-then-clear path and the no-op case.

Verified locally with `go test ./widget/` (both tests pass), `gofmt`, and `go vet ./widget/`.