### PR TITLE
Fade disabled button icon when resource is a bitmap (#6217)

### DIFF
--- a/theme/icons.go
+++ b/theme/icons.go
@@ -873,7 +873,7 @@ func (res *DisabledResource) Content() []byte {
 func desaturate(src []byte) ([]byte, error) {
 	img, _, err := image.Decode(bytes.NewReader(src))
 	if err != nil {
-		return nil, err
+		return src, err
 	}
 	bounds := img.Bounds()
 	gray := image.NewNRGBA(bounds)
@@ -891,7 +891,7 @@ func desaturate(src []byte) ([]byte, error) {
 	}
 	var buf bytes.Buffer
 	if err := png.Encode(&buf, gray); err != nil {
-		return nil, err
+		return src, err
 	}
 	return buf.Bytes(), nil
 }

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	_ "image/jpeg" // register JPEG decoder so DisabledResource can desaturate JPEG icons
 	"image/png"
+	"math"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/internal/svg"
@@ -882,8 +883,8 @@ func desaturate(src []byte) ([]byte, error) {
 			// channels — otherwise partially-transparent pixels go too dark.
 			n := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
 			lum := (lumaWeightR*uint32(n.R) + lumaWeightG*uint32(n.G) + lumaWeightB*uint32(n.B)) / lumaScale
-			if lum > 255 {
-				lum = 255
+			if lum > math.MaxUint8 {
+				lum = math.MaxUint8
 			}
 			gray.SetNRGBA(x, y, color.NRGBA{R: uint8(lum), G: uint8(lum), B: uint8(lum), A: n.A})
 		}

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -842,26 +842,37 @@ func (res *DisabledResource) Name() string {
 	return "disabled_" + unwrapResource(res.source).Name()
 }
 
+// ITU-R BT.601 luma coefficients, scaled by 1000 for integer math.
+const (
+	lumaWeightR = 299
+	lumaWeightG = 587
+	lumaWeightB = 114
+	lumaScale   = 1000
+)
+
 // Content returns the disabled style content of the correct resource for the current theme.
 // SVG resources are recolored with the theme's disabled color; bitmap resources (PNG, JPEG, ...)
-// are desaturated to greyscale since they cannot be recolored.
+// are desaturated to greyscale.
 func (res *DisabledResource) Content() []byte {
 	src := unwrapResource(res.source)
 	content := src.Content()
 	if svg.IsResourceSVG(src) {
 		return colorizeLogError(content, Color(ColorNameDisabled))
 	}
-	return desaturateLogError(content)
+	out, err := desaturate(content)
+	if err != nil {
+		fyne.LogError("Failed to desaturate bitmap for disabled state", err)
+		return content
+	}
+	return out
 }
 
-// desaturateLogError returns a PNG-encoded greyscale copy of the given image bytes,
-// preserving the alpha channel. If decoding or encoding fails, the original bytes are
-// returned so the caller can still render something.
-func desaturateLogError(src []byte) []byte {
+// desaturate returns a PNG-encoded greyscale copy of the given image bytes,
+// preserving the alpha channel.
+func desaturate(src []byte) ([]byte, error) {
 	img, _, err := image.Decode(bytes.NewReader(src))
 	if err != nil {
-		fyne.LogError("Failed to decode bitmap for disabled state", err)
-		return src
+		return nil, err
 	}
 	bounds := img.Bounds()
 	gray := image.NewNRGBA(bounds)
@@ -870,16 +881,18 @@ func desaturateLogError(src []byte) []byte {
 			// Convert via NRGBA so the luminance is computed on unpremultiplied
 			// channels — otherwise partially-transparent pixels go too dark.
 			n := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
-			lum := uint8((299*uint32(n.R) + 587*uint32(n.G) + 114*uint32(n.B)) / 1000)
-			gray.SetNRGBA(x, y, color.NRGBA{R: lum, G: lum, B: lum, A: n.A})
+			lum := (lumaWeightR*uint32(n.R) + lumaWeightG*uint32(n.G) + lumaWeightB*uint32(n.B)) / lumaScale
+			if lum > 255 {
+				lum = 255
+			}
+			gray.SetNRGBA(x, y, color.NRGBA{R: uint8(lum), G: uint8(lum), B: uint8(lum), A: n.A})
 		}
 	}
 	var buf bytes.Buffer
 	if err := png.Encode(&buf, gray); err != nil {
-		fyne.LogError("Failed to encode desaturated bitmap", err)
-		return src
+		return nil, err
 	}
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 // ThemeColorName returns the fyne.ThemeColorName that is used as foreground color.

--- a/theme/icons.go
+++ b/theme/icons.go
@@ -1,7 +1,11 @@
 package theme
 
 import (
+	"bytes"
+	"image"
 	"image/color"
+	_ "image/jpeg" // register JPEG decoder so DisabledResource can desaturate JPEG icons
+	"image/png"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/internal/svg"
@@ -838,9 +842,44 @@ func (res *DisabledResource) Name() string {
 	return "disabled_" + unwrapResource(res.source).Name()
 }
 
-// Content returns the disabled style content of the correct resource for the current theme
+// Content returns the disabled style content of the correct resource for the current theme.
+// SVG resources are recolored with the theme's disabled color; bitmap resources (PNG, JPEG, ...)
+// are desaturated to greyscale since they cannot be recolored.
 func (res *DisabledResource) Content() []byte {
-	return colorizeLogError(unwrapResource(res.source).Content(), Color(ColorNameDisabled))
+	src := unwrapResource(res.source)
+	content := src.Content()
+	if svg.IsResourceSVG(src) {
+		return colorizeLogError(content, Color(ColorNameDisabled))
+	}
+	return desaturateLogError(content)
+}
+
+// desaturateLogError returns a PNG-encoded greyscale copy of the given image bytes,
+// preserving the alpha channel. If decoding or encoding fails, the original bytes are
+// returned so the caller can still render something.
+func desaturateLogError(src []byte) []byte {
+	img, _, err := image.Decode(bytes.NewReader(src))
+	if err != nil {
+		fyne.LogError("Failed to decode bitmap for disabled state", err)
+		return src
+	}
+	bounds := img.Bounds()
+	gray := image.NewNRGBA(bounds)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			// Convert via NRGBA so the luminance is computed on unpremultiplied
+			// channels — otherwise partially-transparent pixels go too dark.
+			n := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
+			lum := uint8((299*uint32(n.R) + 587*uint32(n.G) + 114*uint32(n.B)) / 1000)
+			gray.SetNRGBA(x, y, color.NRGBA{R: lum, G: lum, B: lum, A: n.A})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, gray); err != nil {
+		fyne.LogError("Failed to encode desaturated bitmap", err)
+		return src
+	}
+	return buf.Bytes()
 }
 
 // ThemeColorName returns the fyne.ThemeColorName that is used as foreground color.

--- a/widget/button.go
+++ b/widget/button.go
@@ -45,6 +45,14 @@ const (
 	ButtonIconTrailingText
 )
 
+// disabledIconTranslucency is the alpha-fade applied to bitmap icons (PNG, JPEG, ...)
+// when the button is disabled. Themed SVGs are recolored to ColorNameDisabled
+// instead, but raster resources cannot be recolored without per-pixel work, so we
+// fall back to a fixed translucency. 0.5 is a compromise: more transparent would
+// hide colorful icons against the disabled background, less transparent gives no
+// visible disabled cue.
+const disabledIconTranslucency = 0.5
+
 var (
 	_ fyne.Focusable  = (*Button)(nil)
 	_ fyne.Accessible = (*Button)(nil)
@@ -419,9 +427,15 @@ func (r *buttonRenderer) updateIconAndText() {
 			r.icon.FillMode = canvas.ImageFillContain
 			r.SetObjects([]fyne.CanvasObject{r.background, r.tapBG, r.label, r.icon})
 		}
-		// TODO support disabling bitmap resource not just SVG
-		if r.button.Disabled() && svg.IsResourceSVG(icon) {
-			icon = theme.NewDisabledResource(icon)
+		r.icon.Translucency = 0
+		if r.button.Disabled() {
+			if svg.IsResourceSVG(icon) {
+				icon = theme.NewDisabledResource(icon)
+			} else {
+				// Bitmap resources cannot be recolored, so fade them instead
+				// to provide a visual disabled cue.
+				r.icon.Translucency = disabledIconTranslucency
+			}
 		}
 		r.icon.Resource = icon
 		r.icon.Refresh()

--- a/widget/button.go
+++ b/widget/button.go
@@ -7,7 +7,6 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
 	col "fyne.io/fyne/v2/internal/color"
-	"fyne.io/fyne/v2/internal/svg"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
@@ -44,14 +43,6 @@ const (
 	// ButtonIconTrailingText aligns the icon on the trailing edge of the text.
 	ButtonIconTrailingText
 )
-
-// disabledIconTranslucency is the alpha-fade applied to bitmap icons (PNG, JPEG, ...)
-// when the button is disabled. Themed SVGs are recolored to ColorNameDisabled
-// instead, but raster resources cannot be recolored without per-pixel work, so we
-// fall back to a fixed translucency. 0.5 is a compromise: more transparent would
-// hide colorful icons against the disabled background, less transparent gives no
-// visible disabled cue.
-const disabledIconTranslucency = 0.5
 
 var (
 	_ fyne.Focusable  = (*Button)(nil)
@@ -427,15 +418,8 @@ func (r *buttonRenderer) updateIconAndText() {
 			r.icon.FillMode = canvas.ImageFillContain
 			r.SetObjects([]fyne.CanvasObject{r.background, r.tapBG, r.label, r.icon})
 		}
-		r.icon.Translucency = 0
 		if r.button.Disabled() {
-			if svg.IsResourceSVG(icon) {
-				icon = theme.NewDisabledResource(icon)
-			} else {
-				// Bitmap resources cannot be recolored, so fade them instead
-				// to provide a visual disabled cue.
-				r.icon.Translucency = disabledIconTranslucency
-			}
+			icon = theme.NewDisabledResource(icon)
 		}
 		r.icon.Resource = icon
 		r.icon.Refresh()

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -135,6 +135,27 @@ func TestButton_DisabledIconChangedDirectly(t *testing.T) {
 	assert.Equal(t, render.icon.Resource.Name(), fmt.Sprintf("disabled_%v", searchBaseName))
 }
 
+func TestButton_DisabledBitmapIcon(t *testing.T) {
+	pngIcon := fyne.NewStaticResource("fyne.png", iconData)
+	button := NewButtonWithIcon("Test", pngIcon, nil)
+	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
+
+	// Bitmap resource is kept as-is (no DisabledResource wrapping) and not faded while enabled.
+	assert.Equal(t, pngIcon, render.icon.Resource)
+	assert.Equal(t, 0.0, render.icon.Translucency)
+
+	// When disabled, the bitmap resource is unchanged but the image is faded
+	// to give a visual disabled cue (cannot recolor a bitmap).
+	button.Disable()
+	assert.Equal(t, pngIcon, render.icon.Resource)
+	assert.Equal(t, disabledIconTranslucency, render.icon.Translucency)
+
+	// Re-enabling resets the fade.
+	button.Enable()
+	assert.Equal(t, pngIcon, render.icon.Resource)
+	assert.Equal(t, 0.0, render.icon.Translucency)
+}
+
 func TestButton_Focus(t *testing.T) {
 	tapped := false
 	button := NewButton("Test", func() {

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -1,8 +1,11 @@
 package widget
 
 import (
+	"bytes"
 	"fmt"
+	"image"
 	"image/color"
+	_ "image/png"
 	"strings"
 	"testing"
 
@@ -143,11 +146,51 @@ func TestButton_DisabledBitmapIcon(t *testing.T) {
 	// While enabled the original bitmap resource is rendered untouched.
 	assert.Equal(t, pngIcon, render.icon.Resource)
 
-	// When disabled the resource is wrapped so DisabledResource.Content()
-	// returns a desaturated PNG copy — the icon is recolored, not faded.
 	button.Disable()
 	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"),
 		"disabled icon should be wrapped: %s", render.icon.Resource.Name())
+
+	// Sanity-check that the source PNG has coloured pixels; otherwise
+	// the desaturation assertion below would pass trivially.
+	origImg, _, err := image.Decode(bytes.NewReader(iconData))
+	if !assert.NoError(t, err) {
+		return
+	}
+	var origColoured bool
+	origBounds := origImg.Bounds()
+	for y := origBounds.Min.Y; y < origBounds.Max.Y && !origColoured; y++ {
+		for x := origBounds.Min.X; x < origBounds.Max.X; x++ {
+			n := color.NRGBAModel.Convert(origImg.At(x, y)).(color.NRGBA)
+			if n.A > 0 && (n.R != n.G || n.G != n.B) {
+				origColoured = true
+				break
+			}
+		}
+	}
+	assert.True(t, origColoured, "test icon must contain coloured pixels")
+
+	// Every opaque pixel in the disabled resource content must be greyscale.
+	disabledImg, _, err := image.Decode(bytes.NewReader(render.icon.Resource.Content()))
+	if !assert.NoError(t, err) {
+		return
+	}
+	var opaque, greyscale int
+	bounds := disabledImg.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			n := color.NRGBAModel.Convert(disabledImg.At(x, y)).(color.NRGBA)
+			if n.A == 0 {
+				continue
+			}
+			opaque++
+			if n.R == n.G && n.G == n.B {
+				greyscale++
+			}
+		}
+	}
+	assert.Greater(t, opaque, 0, "expected the disabled icon to have opaque pixels")
+	assert.Equal(t, opaque, greyscale,
+		"every opaque pixel should be greyscale: got %d of %d", greyscale, opaque)
 
 	// Re-enabling restores the original resource reference.
 	button.Enable()

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -140,20 +140,18 @@ func TestButton_DisabledBitmapIcon(t *testing.T) {
 	button := NewButtonWithIcon("Test", pngIcon, nil)
 	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 
-	// Bitmap resource is kept as-is (no DisabledResource wrapping) and not faded while enabled.
+	// While enabled the original bitmap resource is rendered untouched.
 	assert.Equal(t, pngIcon, render.icon.Resource)
-	assert.Equal(t, 0.0, render.icon.Translucency)
 
-	// When disabled, the bitmap resource is unchanged but the image is faded
-	// to give a visual disabled cue (cannot recolor a bitmap).
+	// When disabled the resource is wrapped so DisabledResource.Content()
+	// returns a desaturated PNG copy — the icon is recolored, not faded.
 	button.Disable()
-	assert.Equal(t, pngIcon, render.icon.Resource)
-	assert.Equal(t, disabledIconTranslucency, render.icon.Translucency)
+	assert.True(t, strings.HasPrefix(render.icon.Resource.Name(), "disabled_"),
+		"disabled icon should be wrapped: %s", render.icon.Resource.Name())
 
-	// Re-enabling resets the fade.
+	// Re-enabling restores the original resource reference.
 	button.Enable()
 	assert.Equal(t, pngIcon, render.icon.Resource)
-	assert.Equal(t, 0.0, render.icon.Translucency)
 }
 
 func TestButton_Focus(t *testing.T) {


### PR DESCRIPTION
## Summary

- Buttons with bitmap (PNG/JPEG) icons stayed at full opacity when `Disable()`d, even though SVG-icon buttons were correctly grayed out via `NewDisabledResource`. There was no visual cue that the button was disabled.
- Bitmap resources cannot be recolored the way themed SVGs can. When the button is disabled and the icon resource is not an SVG, we now apply a `Translucency` fade to the `canvas.Image` to give a visual disabled cue. SVG behaviour is unchanged.
- Resolves the existing `// TODO support disabling bitmap resource not just SVG` in `widget/button.go`.

## Scope / not closing #6217

The original report ([#6217](https://github.com/fyne-io/fyne/issues/6217)) mixes two related problems:

1. Bitmap **icon** resource (`Button.Icon`) not faded on `Disable()` — **fixed here**.
2. Bitmap-emoji **text** content (e.g. `🔝`) not faded on `Disable()` — **not addressed here**, the fix would live in the text/painter pipeline rather than the button renderer. Tracked as [#6383](https://github.com/fyne-io/fyne/issues/6383).

So this PR intentionally uses `Refs #6217` rather than `Fixes #6217`, to avoid auto-closing the original report before the emoji part is solved.

## Note on the translucency constant

`disabledIconTranslucency = 0.5` is a fixed value because we can't recolor a raster image with `theme.ColorNameDisabled` the way SVGs are recolored. The choice is documented inline — happy to switch to a theme-derived value (e.g. derived from the alpha ratio between `ColorNameDisabled` and `ColorNameForeground`) if you prefer.

## Test plan

- [x] `go build ./...`
- [x] `go test ./widget/ -run TestButton -count=1` — all existing button tests pass plus the new `TestButton_DisabledBitmapIcon` (covers enable → disable → re-enable for a PNG resource).
- [ ] Reviewer: visually confirm with a button that has a PNG `Icon` set that the icon now fades on `Disable()` and restores on `Enable()`.

Refs #6217
Refs #6383