### PR TITLE
Add Wrapping field to RadioGroup for long option strings (#5656)

### DIFF
--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -22,6 +22,10 @@ type RadioGroup struct {
 	// The default value, fyne.TextWrapOff, preserves the previous behaviour: text that
 	// is wider than the radio group will not be wrapped and may be clipped.
 	//
+	// When wrapping is enabled the group's height grows with the content; if the parent
+	// container does not give it enough room, items may extend beyond its bounds. Wrap
+	// the RadioGroup in a container.Scroll if scrolling is needed.
+	//
 	// Since: 2.9
 	Wrapping fyne.TextWrap
 
@@ -225,7 +229,8 @@ func (r *radioGroupRenderer) Layout(size fyne.Size) {
 
 // MinSize calculates the minimum size of a radio item.
 // This is based on the contained text, the radio icon and a standard amount of padding
-// between each item.
+// between each item. When Wrapping is enabled the per-item MinSize shrinks to roughly a
+// single character, matching widget.Label's behaviour with wrapping.
 func (r *radioGroupRenderer) MinSize() fyne.Size {
 	width := float32(0)
 	height := float32(0)

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -18,6 +18,13 @@ type RadioGroup struct {
 	Options    []string
 	Selected   string
 
+	// Wrapping controls how option text that does not fit the available width is wrapped.
+	// The default value, fyne.TextWrapOff, preserves the previous behaviour: text that
+	// is wider than the radio group will not be wrapped and may be clipped.
+	//
+	// Since: 2.9
+	Wrapping fyne.TextWrap
+
 	// this index is ONE-BASED so the default zero-value is unselected
 	// use r.selectedIndex(), r.setSelectedIndex(int) to maniupulate this field
 	// as if it were a zero-based index (with -1 == nothing selected)
@@ -52,7 +59,7 @@ func (r *RadioGroup) CreateRenderer() fyne.WidgetRenderer {
 	items := make([]fyne.CanvasObject, len(r.Options))
 	for i, option := range r.Options {
 		idx := i
-		items[idx] = newRadioItem(option, func(item *radioItem) {
+		items[idx] = newRadioItem(option, r.Wrapping, func(item *radioItem) {
 			r.itemTapped(item, idx)
 		})
 	}
@@ -154,31 +161,65 @@ type radioGroupRenderer struct {
 }
 
 // Layout the components of the radio widget
-func (r *radioGroupRenderer) Layout(_ fyne.Size) {
+func (r *radioGroupRenderer) Layout(size fyne.Size) {
 	count := 1
 	if len(r.items) > 0 {
 		count = len(r.items)
 	}
-	var itemHeight, itemWidth float32
-	minSize := r.radio.MinSize()
-	if r.radio.Horizontal {
-		itemHeight = minSize.Height
-		itemWidth = minSize.Width / float32(count)
-	} else {
-		itemHeight = minSize.Height / float32(count)
-		itemWidth = minSize.Width
+
+	if r.radio.Wrapping == fyne.TextWrapOff {
+		var itemHeight, itemWidth float32
+		minSize := r.radio.MinSize()
+		if r.radio.Horizontal {
+			itemHeight = minSize.Height
+			itemWidth = minSize.Width / float32(count)
+		} else {
+			itemHeight = minSize.Height / float32(count)
+			itemWidth = minSize.Width
+		}
+
+		itemSize := fyne.NewSize(itemWidth, itemHeight)
+		x, y := float32(0), float32(0)
+		for _, item := range r.items {
+			item.Resize(itemSize)
+			item.Move(fyne.NewPos(x, y))
+			if r.radio.Horizontal {
+				x += itemWidth
+			} else {
+				y += itemHeight
+			}
+		}
+		return
 	}
 
-	itemSize := fyne.NewSize(itemWidth, itemHeight)
-	x, y := float32(0), float32(0)
-	for _, item := range r.items {
-		item.Resize(itemSize)
-		item.Move(fyne.NewPos(x, y))
-		if r.radio.Horizontal {
-			x += itemWidth
-		} else {
-			y += itemHeight
+	// When wrapping is enabled each item's height depends on its width, so we
+	// resize the item to the available width first and then read its content
+	// height before placing it.
+	if r.radio.Horizontal {
+		itemWidth := size.Width / float32(count)
+		var maxHeight float32
+		for _, item := range r.items {
+			item.Resize(fyne.NewSize(itemWidth, 0))
+			if h := item.MinSize().Height; h > maxHeight {
+				maxHeight = h
+			}
 		}
+		x := float32(0)
+		for _, item := range r.items {
+			item.Resize(fyne.NewSize(itemWidth, maxHeight))
+			item.Move(fyne.NewPos(x, 0))
+			x += itemWidth
+		}
+		return
+	}
+
+	y := float32(0)
+	for _, item := range r.items {
+		item.Resize(fyne.NewSize(size.Width, 0))
+		h := item.MinSize().Height
+		item.Resize(fyne.NewSize(size.Width, h))
+		item.Move(fyne.NewPos(0, y))
+		y += h
 	}
 }
 
@@ -213,7 +254,7 @@ func (r *radioGroupRenderer) updateItems(refresh bool) {
 	if len(r.items) < len(r.radio.Options) {
 		for i := len(r.items); i < len(r.radio.Options); i++ {
 			idx := i
-			item := newRadioItem(r.radio.Options[idx], func(item *radioItem) {
+			item := newRadioItem(r.radio.Options[idx], r.radio.Wrapping, func(item *radioItem) {
 				r.radio.itemTapped(item, idx)
 			})
 			r.items = append(r.items, item)
@@ -238,6 +279,10 @@ func (r *radioGroupRenderer) updateItems(refresh bool) {
 		}
 		if d := r.radio.Disabled(); d != item.Disabled() {
 			item.disabled = d
+			changed = true
+		}
+		if w := r.radio.Wrapping; w != item.wrapping {
+			item.wrapping = w
 			changed = true
 		}
 

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -18,13 +18,7 @@ type RadioGroup struct {
 	Options    []string
 	Selected   string
 
-	// Wrapping controls how option text that does not fit the available width is wrapped.
-	// The default value, fyne.TextWrapOff, preserves the previous behaviour: text that
-	// is wider than the radio group will not be wrapped and may be clipped.
-	//
-	// When wrapping is enabled the group's height grows with the content; if the parent
-	// container does not give it enough room, items may extend beyond its bounds. Wrap
-	// the RadioGroup in a container.Scroll if scrolling is needed.
+	// Wrapping is the wrapping of the option text.
 	//
 	// Since: 2.9
 	Wrapping fyne.TextWrap

--- a/widget/radio_group_extended_test.go
+++ b/widget/radio_group_extended_test.go
@@ -167,14 +167,14 @@ func TestRadioGroupRenderer_Extended_ApplyTheme(t *testing.T) {
 	radio := newextendedRadioGroup([]string{"Test"}, func(string) {})
 	render := cache.Renderer(test.TempWidgetRenderer(t, radio).Objects()[0].(*radioItem)).(*radioItemRenderer)
 
-	textSize := render.label.TextSize
-	customTextSize := textSize
+	textMin := render.label.MinSize()
+	customMin := textMin
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.TextSize
+		customMin = render.label.MinSize()
 	})
 
-	assert.NotEqual(t, textSize, customTextSize)
+	assert.NotEqual(t, textMin, customMin)
 }
 
 func extendedRadioGroupTestTapItem(t *testing.T, radio *extendedRadioGroup, item int) {

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -294,18 +294,48 @@ func TestRadioGroup_Required(t *testing.T) {
 	assert.Equal(t, "There", radio.Selected)
 }
 
+func TestRadioGroup_Wrapping_PropagatesToItems(t *testing.T) {
+	radio := NewRadioGroup([]string{"A", "B"}, nil)
+	radio.Wrapping = fyne.TextWrapBreak
+	render := test.TempWidgetRenderer(t, radio).(*radioGroupRenderer)
+
+	for _, obj := range render.items {
+		assert.Equal(t, fyne.TextWrapBreak, obj.(*radioItem).wrapping)
+	}
+
+	radio.Wrapping = fyne.TextWrapOff
+	radio.Refresh()
+	for _, obj := range render.items {
+		assert.Equal(t, fyne.TextWrapOff, obj.(*radioItem).wrapping)
+	}
+}
+
+func TestRadioGroup_Wrapping_WrapsLongOption(t *testing.T) {
+	const longText = "this is a deliberately long radio option label that should wrap"
+	radio := NewRadioGroup([]string{longText}, nil)
+	noWrapHeight := radio.MinSize().Height
+
+	radio.Wrapping = fyne.TextWrapBreak
+	radio.Refresh()
+	radio.Resize(fyne.NewSize(80, radio.MinSize().Height))
+
+	itemRender := radioGroupTestItemRenderer(t, radio, 0)
+	wrappedHeight := itemRender.MinSize().Height
+	assert.Greater(t, wrappedHeight, noWrapHeight, "wrapped item should be taller than a single-line option")
+}
+
 func TestRadioGroupRenderer_ApplyTheme(t *testing.T) {
 	radio := NewRadioGroup([]string{"Test"}, func(string) {})
 	render := radioGroupTestItemRenderer(t, radio, 0)
 
-	textSize := render.label.TextSize
-	customTextSize := textSize
+	textMin := render.label.MinSize()
+	customMin := textMin
 	test.WithTestTheme(t, func() {
 		render.Refresh()
-		customTextSize = render.label.TextSize
+		customMin = render.label.MinSize()
 	})
 
-	assert.NotEqual(t, textSize, customTextSize)
+	assert.NotEqual(t, textMin, customMin)
 }
 
 func radioGroupTestTapItem(t *testing.T, radio *RadioGroup, item int) {

--- a/widget/radio_group_internal_test.go
+++ b/widget/radio_group_internal_test.go
@@ -310,6 +310,25 @@ func TestRadioGroup_Wrapping_PropagatesToItems(t *testing.T) {
 	}
 }
 
+func TestRadioGroup_Wrapping_Horizontal(t *testing.T) {
+	const longText = "this is a deliberately long radio option label that should wrap"
+	radio := NewRadioGroup([]string{longText, longText}, nil)
+	radio.Horizontal = true
+	radio.Wrapping = fyne.TextWrapBreak
+	render := test.TempWidgetRenderer(t, radio).(*radioGroupRenderer)
+
+	radio.Resize(fyne.NewSize(200, 200))
+
+	item0 := render.items[0].(*radioItem)
+	item1 := render.items[1].(*radioItem)
+
+	assert.Equal(t, float32(100), item0.Size().Width)
+	assert.Equal(t, item0.Size().Width, item1.Size().Width)
+	assert.Equal(t, item0.Size().Height, item1.Size().Height, "horizontal wrap should align item heights")
+	assert.Equal(t, fyne.NewPos(0, 0), item0.Position())
+	assert.Equal(t, fyne.NewPos(100, 0), item1.Position())
+}
+
 func TestRadioGroup_Wrapping_WrapsLongOption(t *testing.T) {
 	const longText = "this is a deliberately long radio option label that should wrap"
 	radio := NewRadioGroup([]string{longText}, nil)

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -39,10 +39,8 @@ type radioItem struct {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
-	th := i.Theme()
 	label := NewRichTextWithText(i.Label)
 	label.Wrapping = i.wrapping
-	label.inset = fyne.NewSquareSize(th.Size(theme.SizeNameInnerPadding))
 	r := &radioItemRenderer{item: i, label: label}
 	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, label})
 	r.update()
@@ -194,6 +192,8 @@ func (r *radioItemRenderer) update() {
 		seg.Style.ColorName = theme.ColorNameForeground
 	}
 	r.label.Wrapping = r.item.wrapping
+	// Negate RichText's built-in inner padding so the label keeps the same
+	// position and MinSize that the previous canvas.Text-based renderer had.
 	r.label.inset = fyne.NewSquareSize(th.Size(theme.SizeNameInnerPadding))
 	r.label.Refresh()
 

--- a/widget/radio_item.go
+++ b/widget/radio_item.go
@@ -17,8 +17,8 @@ var (
 	_ fyne.Focusable    = (*radioItem)(nil)
 )
 
-func newRadioItem(label string, onTap func(*radioItem)) *radioItem {
-	i := &radioItem{Label: label, onTap: onTap}
+func newRadioItem(label string, wrap fyne.TextWrap, onTap func(*radioItem)) *radioItem {
+	i := &radioItem{Label: label, wrapping: wrap, onTap: onTap}
 	i.ExtendBaseWidget(i)
 	return i
 }
@@ -30,6 +30,8 @@ type radioItem struct {
 	Label    string
 	Selected bool
 
+	wrapping fyne.TextWrap
+
 	focused bool
 	hovered bool
 	onTap   func(item *radioItem)
@@ -37,10 +39,12 @@ type radioItem struct {
 
 // CreateRenderer is a private method to Fyne which links this widget to its renderer.
 func (i *radioItem) CreateRenderer() fyne.WidgetRenderer {
-	txt := canvas.Text{Alignment: fyne.TextAlignLeading}
-	txt.TextSize = i.Theme().Size(theme.SizeNameText)
-	r := &radioItemRenderer{item: i, label: &txt}
-	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, &txt})
+	th := i.Theme()
+	label := NewRichTextWithText(i.Label)
+	label.Wrapping = i.wrapping
+	label.inset = fyne.NewSquareSize(th.Size(theme.SizeNameInnerPadding))
+	r := &radioItemRenderer{item: i, label: label}
+	r.SetObjects([]fyne.CanvasObject{&r.focusIndicator, &r.icon, &r.over, label})
 	r.update()
 	return r
 }
@@ -124,7 +128,14 @@ type radioItemRenderer struct {
 
 	focusIndicator canvas.Circle
 	icon, over     canvas.Image
-	label          *canvas.Text
+	label          *RichText
+}
+
+// labelOffset returns the x offset of the label inside the radio item.
+func (r *radioItemRenderer) labelOffset() float32 {
+	th := r.item.Theme()
+	focusIndicatorWidth := th.Size(theme.SizeNameInlineIcon) + th.Size(theme.SizeNameInnerPadding)
+	return focusIndicatorWidth + th.Size(theme.SizeNamePadding)
 }
 
 func (r *radioItemRenderer) Layout(size fyne.Size) {
@@ -137,9 +148,17 @@ func (r *radioItemRenderer) Layout(size fyne.Size) {
 	r.focusIndicator.Resize(focusIndicatorSize)
 	r.focusIndicator.Move(fyne.NewPos(borderSize, (size.Height-focusIndicatorSize.Height)/2))
 
-	labelSize := fyne.NewSize(size.Width, size.Height)
-	r.label.Resize(labelSize)
-	r.label.Move(fyne.NewPos(focusIndicatorSize.Width+th.Size(theme.SizeNamePadding), 0))
+	labelX := r.labelOffset()
+	labelWidth := size.Width
+	if r.item.wrapping != fyne.TextWrapOff {
+		// constrain wrap to the space remaining after the icon column
+		labelWidth = size.Width - labelX
+		if labelWidth < 0 {
+			labelWidth = 0
+		}
+	}
+	r.label.Resize(fyne.NewSize(labelWidth, size.Height))
+	r.label.Move(fyne.NewPos(labelX, 0))
 
 	iconPos := fyne.NewPos(innerPadding/2+borderSize, (size.Height-iconInlineSize)/2)
 	iconSize := fyne.NewSquareSize(iconInlineSize)
@@ -166,13 +185,17 @@ func (r *radioItemRenderer) update() {
 	th := r.item.Theme()
 	v := fyne.CurrentApp().Settings().ThemeVariant()
 
-	r.label.Text = r.item.Label
-	r.label.TextSize = th.Size(theme.SizeNameText)
+	seg := r.label.Segments[0].(*TextSegment)
+	seg.Text = r.item.Label
+	seg.Style.SizeName = theme.SizeNameText
 	if r.item.Disabled() {
-		r.label.Color = th.Color(theme.ColorNameDisabled, v)
+		seg.Style.ColorName = theme.ColorNameDisabled
 	} else {
-		r.label.Color = th.Color(theme.ColorNameForeground, v)
+		seg.Style.ColorName = theme.ColorNameForeground
 	}
+	r.label.Wrapping = r.item.wrapping
+	r.label.inset = fyne.NewSquareSize(th.Size(theme.SizeNameInnerPadding))
+	r.label.Refresh()
 
 	out := theme.NewThemedResource(th.Icon(theme.IconNameRadioButton))
 	out.ColorName = theme.ColorNameInputBorder

--- a/widget/radio_item_test.go
+++ b/widget/radio_item_test.go
@@ -26,7 +26,7 @@ func BenchmarkRadioCreateRenderer(b *testing.B) {
 }
 
 func TestRadioItem_FocusIndicator_Centered_Vertically(t *testing.T) {
-	item := newRadioItem("Hello", nil)
+	item := newRadioItem("Hello", fyne.TextWrapOff, nil)
 	render := test.TempWidgetRenderer(t, item).(*radioItemRenderer)
 	render.Layout(fyne.NewSize(200, 100))
 

--- a/widget/testdata/radio_group/disabled_append_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_append_none_selected.xml
@@ -6,19 +6,25 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/disabled_none_selected.xml
+++ b/widget/testdata/radio_group/disabled_none_selected.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="58x19">Option B</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_a_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_b_selected.xml
@@ -6,19 +6,25 @@
 					<circle fillColor="focus" pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_a_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_a_focused_none_selected.xml
@@ -6,19 +6,25 @@
 					<circle fillColor="focus" pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_b_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_b_selected.xml
@@ -6,19 +6,25 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle fillColor="focus" pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_b_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_b_focused_none_selected.xml
@@ -6,19 +6,25 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle fillColor="focus" pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_disabled_none_selected.xml
+++ b/widget/testdata/radio_group/focus_disabled_none_selected.xml
@@ -6,19 +6,25 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text color="disabled" size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_none_focused_b_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_b_selected.xml
@@ -6,19 +6,25 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/focus_none_focused_none_selected.xml
+++ b/widget/testdata/radio_group/focus_none_focused_none_selected.xml
@@ -6,19 +6,25 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option A</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option A</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option B</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="58x19">Option B</text>
+					</widget>
 				</widget>
 				<widget pos="0,70" size="98x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="98x35">Option C</text>
+					<widget pos="32,0" size="98x35" type="*widget.RichText">
+						<text size="57x19">Option C</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple.xml
+++ b/widget/testdata/radio_group/layout_multiple.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Foo</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Bar</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_disabled.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Foo</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text color="disabled" size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Bar</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text color="disabled" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="81x35">Foo</text>
+					<widget pos="32,0" size="81x35" type="*widget.RichText">
+						<text size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="81,0" size="81x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="81x35">Barley</text>
+					<widget pos="32,0" size="81x35" type="*widget.RichText">
+						<text size="41x19">Barley</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_horizontal_disabled.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="81x35">Foo</text>
+					<widget pos="32,0" size="81x35" type="*widget.RichText">
+						<text color="disabled" size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="81,0" size="81x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="81x35">Barley</text>
+					<widget pos="32,0" size="81x35" type="*widget.RichText">
+						<text color="disabled" size="41x19">Barley</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="64x35">Foo</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Bar</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_disabled.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Foo</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text color="disabled" size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="0,35" size="64x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Bar</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text color="disabled" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="64x35">Foo</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="64,0" size="64x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="64x35">Bar</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_multiple_selected_horizontal_disabled.xml
@@ -6,13 +6,17 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Foo</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text color="disabled" size="24x19">Foo</text>
+					</widget>
 				</widget>
 				<widget pos="64,0" size="64x35" type="*widget.radioItem">
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="64x35">Bar</text>
+					<widget pos="32,0" size="64x35" type="*widget.RichText">
+						<text color="disabled" size="22x19">Bar</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single.xml
+++ b/widget/testdata/radio_group/layout_single.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_disabled.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text color="disabled" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="inputBackground"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="inputBorder"/>
-					<text pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_horizontal_disabled.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="background"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text color="disabled" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected.xml
+++ b/widget/testdata/radio_group/layout_single_selected.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_disabled.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text color="disabled" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="primary"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="foreground"/>
-					<text pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>

--- a/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
+++ b/widget/testdata/radio_group/layout_single_selected_horizontal_disabled.xml
@@ -6,7 +6,9 @@
 					<circle pos="2,3" size="28x28"/>
 					<image pos="6,7" rsc="radioButtonFillIcon" size="iconInlineSize" themed="disabled"/>
 					<image pos="6,7" rsc="radioButtonIcon" size="iconInlineSize" themed="disabled"/>
-					<text color="disabled" pos="32,0" size="66x35">Test</text>
+					<widget pos="32,0" size="66x35" type="*widget.RichText">
+						<text color="disabled" size="26x19">Test</text>
+					</widget>
 				</widget>
 			</widget>
 		</container>


### PR DESCRIPTION
## Summary

Adds a `Wrapping fyne.TextWrap` field on `RadioGroup` (since 2.9) so a long
option string can wrap to a new line instead of being clipped.

Fixes #5656

Example from the issue now wraps at the right edge of the group:
```go
widget.NewRadioGroup([]string{"long string: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, nil)
```

## Approach

* The `radioItem` label is converted from `canvas.Text` to `RichText` so
  the existing wrap implementation can be reused. `RichText.inset` is
  set to `InnerPadding` so the geometry the renderer produces is the
  same as before.
* `RadioGroup.Wrapping` is propagated to each `radioItem.wrapping` and
  forwarded to the label inside `Refresh`, so changes after creation
  apply immediately.
* When wrapping is enabled, `radioGroupRenderer.Layout` uses the
  assigned size as the available width and reads each item's height
  back from `MinSize` so wrapped lines stay inside the group. With the
  default `TextWrapOff`, the previous layout path is kept unchanged,
  so existing apps are not affected.

## Notes for review

* The public API is plain `fyne.TextWrap`, matching `widget.Label`.
* The XML markup fixtures are regenerated because the label is now a
  `*widget.RichText` node wrapping a `<text>` child. Positions and
  sizes did not change.
* There is an existing PR (#6369) targeting the same issue. This PR
  takes a smaller approach: it keeps the no-wrap layout path bit-for-
  bit identical and only adds a separate wrap-aware path, instead of
  rewriting the existing one.

## Test plan

- [x] `go test ./widget/ -run TestRadio` (all radio tests pass)
- [x] New `TestRadioGroup_Wrapping_PropagatesToItems` verifies the
      field is forwarded to each item on create and on `Refresh`.
- [x] New `TestRadioGroup_Wrapping_WrapsLongOption` verifies that a
      long option is taller with `TextWrapBreak` than without.