### PR TITLE
rename GL shader variables to camel-cse

### DIFF
--- a/canvas/shader.go
+++ b/canvas/shader.go
@@ -17,8 +17,8 @@ var _ fyne.CanvasObject = (*Shader)(nil)
 // internal vector shaders. It is provided with the following uniforms:
 //
 //	uniform vec2 frame;   // the size of the output frame, in pixels
-//	uniform vec4 rectCoords;  // this object's bounds (x1, y1, x2, y2), in pixels
-//	uniform float time;       // elapsed animation time in seconds (see NewShaderAnimation)
+//	uniform vec4 bounds;  // this object's bounds (x1, y1, x2, y2), in pixels
+//	uniform float time;   // elapsed animation time in seconds (see NewShaderAnimation)
 //
 // and should compute its color from gl_FragCoord, as the built-in shapes do.
 // Any images set in Textures are additionally exposed as "uniform sampler2D"

--- a/canvas/shader.go
+++ b/canvas/shader.go
@@ -16,7 +16,7 @@ var _ fyne.CanvasObject = (*Shader)(nil)
 // The supplied fragment shader must follow the same conventions as Fyne's
 // internal vector shaders. It is provided with the following uniforms:
 //
-//	uniform vec2 frameSize;   // the size of the output frame, in pixels
+//	uniform vec2 frame;   // the size of the output frame, in pixels
 //	uniform vec4 rectCoords;  // this object's bounds (x1, y1, x2, y2), in pixels
 //	uniform float time;       // elapsed animation time in seconds (see NewShaderAnimation)
 //

--- a/canvas/shader.go
+++ b/canvas/shader.go
@@ -16,11 +16,11 @@ var _ fyne.CanvasObject = (*Shader)(nil)
 // The supplied fragment shader must follow the same conventions as Fyne's
 // internal vector shaders. It is provided with the following uniforms:
 //
-//	uniform vec2 frame_size;   // the size of the output frame, in pixels
-//	uniform vec4 rect_coords;  // this object's bounds (x1, y1, x2, y2), in pixels
-//	uniform float time;        // elapsed animation time in seconds (see NewShaderAnimation)
+//	uniform vec2 frame_size;  // the size of the output frame, in pixels
+//	uniform vec4 rectCoords;  // this object's bounds (x1, y1, x2, y2), in pixels
+//	uniform float time;       // elapsed animation time in seconds (see NewShaderAnimation)
 //
-// and should compute its colour from gl_FragCoord, as the built in shapes do.
+// and should compute its color from gl_FragCoord, as the built-in shapes do.
 // Any images set in Textures are additionally exposed as "uniform sampler2D"
 // values, and any values in Uniforms as "uniform float", named by their map key.
 //

--- a/canvas/shader.go
+++ b/canvas/shader.go
@@ -16,7 +16,7 @@ var _ fyne.CanvasObject = (*Shader)(nil)
 // The supplied fragment shader must follow the same conventions as Fyne's
 // internal vector shaders. It is provided with the following uniforms:
 //
-//	uniform vec2 frame_size;  // the size of the output frame, in pixels
+//	uniform vec2 frameSize;   // the size of the output frame, in pixels
 //	uniform vec4 rectCoords;  // this object's bounds (x1, y1, x2, y2), in pixels
 //	uniform float time;       // elapsed animation time in seconds (see NewShaderAnimation)
 //

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -281,7 +281,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.SetUniform2f(program, "startPoint", p1XScaled, p1YScaled)
 
 	p2XScaled, p2YScaled := roundToPixel(p2.X*p.pixScale, 1.0), roundToPixel(p2.Y*p.pixScale, 1.0)
-	p.SetUniform2f(program, "end_point", p2XScaled, p2YScaled)
+	p.SetUniform2f(program, "endPoint", p2XScaled, p2YScaled)
 
 	if len(cp) == 1 {
 		cpXScaled, cpYScaled := roundToPixel(cp[0].X*p.pixScale, 1.0), roundToPixel(cp[0].Y*p.pixScale, 1.0)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -198,7 +198,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
 		p.SetUniform2f(program, "shadow_offset", roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_spread", roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
+		p.SetUniform1f(program, "shadowSpread", roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(circle.Shadow.Variant))
 		addShadow = 1.0
 	}
@@ -623,7 +623,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
 		p.SetUniform2f(program, "shadow_offset", roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_spread", roundToPixel(shadow.Spread*p.pixScale, 1.0))
+		p.SetUniform1f(program, "shadowSpread", roundToPixel(shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(shadow.Variant))
 		addShadow = 1.0
 	}
@@ -822,7 +822,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
 		p.SetUniform2f(program, "shadow_offset", roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_spread", roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))
+		p.SetUniform1f(program, "shadowSpread", roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(ellipse.Shadow.Variant))
 		addShadow = 1.0
 	}

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -293,7 +293,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 		cp2XScaled, cp2YScaled := roundToPixel(cp[1].X*p.pixScale, 1.0), roundToPixel(cp[1].Y*p.pixScale, 1.0)
 		p.SetUniform2f(program, "controlPoint2", cp2XScaled, cp2YScaled)
 	}
-	p.SetUniform1f(program, "num_control_points", fyne.Min(float32(len(cp)), 2))
+	p.SetUniform1f(program, "numControlPoints", fyne.Min(float32(len(cp)), 2))
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -197,7 +197,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 		r, g, b, a = getFragmentColor(circle.Shadow.Color)
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
 		p.SetUniform2f(program, "shadow_offset", roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_blur_radius", roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
+		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_spread", roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(circle.Shadow.Variant))
 		addShadow = 1.0
@@ -622,7 +622,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		r, g, b, a = getFragmentColor(shadow.Color)
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
 		p.SetUniform2f(program, "shadow_offset", roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_blur_radius", roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
+		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_spread", roundToPixel(shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(shadow.Variant))
 		addShadow = 1.0
@@ -821,7 +821,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 		r, g, b, a = getFragmentColor(ellipse.Shadow.Color)
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
 		p.SetUniform2f(program, "shadow_offset", roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_blur_radius", roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
+		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_spread", roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(ellipse.Shadow.Variant))
 		addShadow = 1.0

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -195,7 +195,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	var addShadow float32
 	if paint.IsShadowVisible(circle.Shadow) {
 		r, g, b, a = getFragmentColor(circle.Shadow.Color)
-		p.SetUniform4f(program, "shadow_color", r, g, b, a)
+		p.SetUniform4f(program, "shadowColor", r, g, b, a)
 		p.SetUniform2f(program, "shadowOffset", roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
@@ -620,7 +620,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	var addShadow float32
 	if paint.IsShadowVisible(shadow) {
 		r, g, b, a = getFragmentColor(shadow.Color)
-		p.SetUniform4f(program, "shadow_color", r, g, b, a)
+		p.SetUniform4f(program, "shadowColor", r, g, b, a)
 		p.SetUniform2f(program, "shadowOffset", roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(shadow.Spread*p.pixScale, 1.0))
@@ -819,7 +819,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	var addShadow float32
 	if paint.IsShadowVisible(ellipse.Shadow) {
 		r, g, b, a = getFragmentColor(ellipse.Shadow.Color)
-		p.SetUniform4f(program, "shadow_color", r, g, b, a)
+		p.SetUniform4f(program, "shadowColor", r, g, b, a)
 		p.SetUniform2f(program, "shadowOffset", roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -167,7 +167,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(circle.StrokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)
@@ -265,7 +265,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
@@ -330,7 +330,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
@@ -483,7 +483,7 @@ func (p *painter) drawShader(shader *canvas.Shader, pos fyne.Position, frame fyn
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	for name, v := range shader.Uniforms {
 		p.SetUniform1f(program, name, v)
@@ -571,7 +571,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
 	if roundedCorners {
@@ -659,7 +659,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
@@ -717,7 +717,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
@@ -792,7 +792,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rect_coords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(ellipse.StrokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "stroke_width", strokeWidthScaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -732,7 +732,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 
 	startAngle, endAngle := paint.NormalizeArcAngles(arc.StartAngle, arc.EndAngle)
 	p.SetUniform1f(program, "startAngle", startAngle)
-	p.SetUniform1f(program, "end_angle", endAngle)
+	p.SetUniform1f(program, "endAngle", endAngle)
 
 	cornerRadius := fyne.Min(paint.GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)
 	cornerRadiusScaled := roundToPixel(cornerRadius*p.pixScale, 1.0)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -278,7 +278,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p1, p2, cp := paint.NormalizeBezierCurvePoints(bezierCurve.StartPoint, bezierCurve.EndPoint, bezierCurve.ControlPoints, bezierCurve.Size(), strokeWidth/2.0)
 
 	p1XScaled, p1YScaled := roundToPixel(p1.X*p.pixScale, 1.0), roundToPixel(p1.Y*p.pixScale, 1.0)
-	p.SetUniform2f(program, "start_point", p1XScaled, p1YScaled)
+	p.SetUniform2f(program, "startPoint", p1XScaled, p1YScaled)
 
 	p2XScaled, p2YScaled := roundToPixel(p2.X*p.pixScale, 1.0), roundToPixel(p2.Y*p.pixScale, 1.0)
 	p.SetUniform2f(program, "end_point", p2XScaled, p2YScaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -196,7 +196,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	if paint.IsShadowVisible(circle.Shadow) {
 		r, g, b, a = getFragmentColor(circle.Shadow.Color)
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
-		p.SetUniform2f(program, "shadow_offset", roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
+		p.SetUniform2f(program, "shadowOffset", roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(circle.Shadow.Variant))
@@ -621,7 +621,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	if paint.IsShadowVisible(shadow) {
 		r, g, b, a = getFragmentColor(shadow.Color)
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
-		p.SetUniform2f(program, "shadow_offset", roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
+		p.SetUniform2f(program, "shadowOffset", roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(shadow.Variant))
@@ -820,7 +820,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	if paint.IsShadowVisible(ellipse.Shadow) {
 		r, g, b, a = getFragmentColor(ellipse.Shadow.Color)
 		p.SetUniform4f(program, "shadow_color", r, g, b, a)
-		p.SetUniform2f(program, "shadow_offset", roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
+		p.SetUniform2f(program, "shadowOffset", roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadow_type", float32(ellipse.Shadow.Variant))

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -666,7 +666,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 
 	outerRadius := fyne.Min(size.Width, size.Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "outer_radius", outerRadiusScaled)
+	p.SetUniform1f(program, "outerRadius", outerRadiusScaled)
 
 	p.SetUniform1f(program, "angle", polygon.Angle)
 	p.SetUniform1f(program, "sides", float32(polygon.Sides))
@@ -724,7 +724,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 
 	outerRadius := fyne.Min(arc.Size().Width, arc.Size().Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "outer_radius", outerRadiusScaled)
+	p.SetUniform1f(program, "outerRadius", outerRadiusScaled)
 
 	innerRadius := outerRadius * float32(math.Min(1.0, math.Max(0.0, float64(arc.CutoutRatio))))
 	innerRadiusScaled := roundToPixel(innerRadius*p.pixScale, 1.0)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -673,7 +673,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 
 	cornerRadius := fyne.Min(paint.GetMaximumRadius(size), polygon.CornerRadius)
 	cornerRadiusScaled := roundToPixel(cornerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "corner_radius", cornerRadiusScaled)
+	p.SetUniform1f(program, "cornerRadius", cornerRadiusScaled)
 
 	strokeWidthScaled := roundToPixel(polygon.StrokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
@@ -736,7 +736,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 
 	cornerRadius := fyne.Min(paint.GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)
 	cornerRadiusScaled := roundToPixel(cornerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "corner_radius", cornerRadiusScaled)
+	p.SetUniform1f(program, "cornerRadius", cornerRadiusScaled)
 
 	strokeWidthScaled := roundToPixel(arc.StrokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -202,7 +202,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 		p.SetUniform1f(program, "shadow_type", float32(circle.Shadow.Variant))
 		addShadow = 1.0
 	}
-	p.SetUniform1f(program, "add_shadow", addShadow)
+	p.SetUniform1f(program, "addShadow", addShadow)
 
 	p.logError()
 	// Fragment: END
@@ -627,7 +627,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		p.SetUniform1f(program, "shadow_type", float32(shadow.Variant))
 		addShadow = 1.0
 	}
-	p.SetUniform1f(program, "add_shadow", addShadow)
+	p.SetUniform1f(program, "addShadow", addShadow)
 
 	p.logError()
 	// Fragment: END
@@ -826,7 +826,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 		p.SetUniform1f(program, "shadow_type", float32(ellipse.Shadow.Variant))
 		addShadow = 1.0
 	}
-	p.SetUniform1f(program, "add_shadow", addShadow)
+	p.SetUniform1f(program, "addShadow", addShadow)
 
 	p.logError()
 	// Fragment: END

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -164,7 +164,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -262,7 +262,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -327,7 +327,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -480,7 +480,7 @@ func (p *painter) drawShader(shader *canvas.Shader, pos fyne.Position, frame fyn
 
 	// Fragment: BEG - the standard uniform contract shared with the built in vector shaders
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -568,7 +568,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -656,7 +656,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -714,7 +714,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -789,7 +789,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame_size", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -728,7 +728,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 
 	innerRadius := outerRadius * float32(math.Min(1.0, math.Max(0.0, float64(arc.CutoutRatio))))
 	innerRadiusScaled := roundToPixel(innerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "inner_radius", innerRadiusScaled)
+	p.SetUniform1f(program, "innerRadius", innerRadiusScaled)
 
 	startAngle, endAngle := paint.NormalizeArcAngles(arc.StartAngle, arc.EndAngle)
 	p.SetUniform1f(program, "start_angle", startAngle)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -190,7 +190,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	p.SetUniform4f(program, "stroke_color", r, g, b, a)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
+	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 
 	var addShadow float32
 	if paint.IsShadowVisible(circle.Shadow) {
@@ -268,7 +268,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
+	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 
 	// ensure stroke width is not larger than the size of the object
 	strokeWidth := fyne.Min(bezierCurve.StrokeWidth, fyne.Min(bezierCurve.Size().Width, bezierCurve.Size().Height))
@@ -333,7 +333,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
+	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 
 	numPoints := int(fyne.Min(paint.ArbitraryPolygonVerticesMaximum, float32(len(polygon.Points))))
 	p.SetUniform1f(program, "vertex_count", float32(numPoints))
@@ -602,7 +602,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		p.SetUniform4f(program, "radius", topRightRadiusScaled, bottomRightRadiusScaled, topLeftRadiusScaled, bottomLeftRadiusScaled)
 
 		edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-		p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
+		p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 	} else {
 		p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
 	}
@@ -662,7 +662,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
+	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 
 	outerRadius := fyne.Min(size.Width, size.Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
@@ -720,7 +720,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
+	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 
 	outerRadius := fyne.Min(arc.Size().Width, arc.Size().Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
@@ -814,7 +814,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	p.SetUniform4f(program, "stroke_color", r, g, b, a)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edge_softness", edgeSoftnessScaled)
+	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 
 	var addShadow float32
 	if paint.IsShadowVisible(ellipse.Shadow) {

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -336,7 +336,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 
 	numPoints := int(fyne.Min(paint.ArbitraryPolygonVerticesMaximum, float32(len(polygon.Points))))
-	p.SetUniform1f(program, "vertex_count", float32(numPoints))
+	p.SetUniform1f(program, "vertexCount", float32(numPoints))
 
 	size := polygon.Size()
 	clampPoint := func(p fyne.Position) (float32, float32) {

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -174,7 +174,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 
 	rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 	rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled
-	p.SetUniform2f(program, "rect_size_half", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
+	p.SetUniform2f(program, "rectSizeHalf", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
 
 	radiusScaled := roundToPixel(radius*p.pixScale, 1.0)
 	p.SetUniform4f(program, "radius", radiusScaled, radiusScaled, radiusScaled, radiusScaled)
@@ -579,7 +579,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 
 		rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 		rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled
-		p.SetUniform2f(program, "rect_size_half", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
+		p.SetUniform2f(program, "rectSizeHalf", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
 
 		// the maximum possible corner radii for a circular shape, calculated taking into account the rect coords with aspect ratio
 		size := fyne.NewSize(bounds[2]-bounds[0], bounds[3]-bounds[1])

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -285,10 +285,10 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 
 	if len(cp) == 1 {
 		cpXScaled, cpYScaled := roundToPixel(cp[0].X*p.pixScale, 1.0), roundToPixel(cp[0].Y*p.pixScale, 1.0)
-		p.SetUniform2f(program, "control_point1", cpXScaled, cpYScaled)
+		p.SetUniform2f(program, "controlPoint1", cpXScaled, cpYScaled)
 	} else if len(cp) == 2 {
 		cp1XScaled, cp1YScaled := roundToPixel(cp[0].X*p.pixScale, 1.0), roundToPixel(cp[0].Y*p.pixScale, 1.0)
-		p.SetUniform2f(program, "control_point1", cp1XScaled, cp1YScaled)
+		p.SetUniform2f(program, "controlPoint1", cp1XScaled, cp1YScaled)
 
 		cp2XScaled, cp2YScaled := roundToPixel(cp[1].X*p.pixScale, 1.0), roundToPixel(cp[1].Y*p.pixScale, 1.0)
 		p.SetUniform2f(program, "control_point2", cp2XScaled, cp2YScaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -187,7 +187,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "stroke_color", r, g, b, a)
+	p.SetUniform4f(program, "strokeColor", r, g, b, a)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
@@ -299,7 +299,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)
 
 	r, g, b, a := getFragmentColor(bezierCurve.StrokeColor)
-	p.SetUniform4f(program, "stroke_color", r, g, b, a)
+	p.SetUniform4f(program, "strokeColor", r, g, b, a)
 
 	p.logError()
 	// Fragment: END
@@ -379,7 +379,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	p.SetUniform4f(program, "fillColor", r, g, b, a)
 
 	r, g, b, a = getFragmentColor(polygon.StrokeColor)
-	p.SetUniform4f(program, "stroke_color", r, g, b, a)
+	p.SetUniform4f(program, "strokeColor", r, g, b, a)
 
 	strokeWidthScaled := roundToPixel(polygon.StrokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
@@ -615,7 +615,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "stroke_color", r, g, b, a)
+	p.SetUniform4f(program, "strokeColor", r, g, b, a)
 
 	var addShadow float32
 	if paint.IsShadowVisible(shadow) {
@@ -686,7 +686,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "stroke_color", r, g, b, a)
+	p.SetUniform4f(program, "strokeColor", r, g, b, a)
 
 	p.logError()
 	// Fragment: END
@@ -749,7 +749,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "stroke_color", r, g, b, a)
+	p.SetUniform4f(program, "strokeColor", r, g, b, a)
 
 	p.logError()
 	// Fragment: END
@@ -811,7 +811,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "stroke_color", r, g, b, a)
+	p.SetUniform4f(program, "strokeColor", r, g, b, a)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -291,7 +291,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 		p.SetUniform2f(program, "controlPoint1", cp1XScaled, cp1YScaled)
 
 		cp2XScaled, cp2YScaled := roundToPixel(cp[1].X*p.pixScale, 1.0), roundToPixel(cp[1].Y*p.pixScale, 1.0)
-		p.SetUniform2f(program, "control_point2", cp2XScaled, cp2YScaled)
+		p.SetUniform2f(program, "controlPoint2", cp2XScaled, cp2YScaled)
 	}
 	p.SetUniform1f(program, "num_control_points", fyne.Min(float32(len(cp)), 2))
 

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -164,7 +164,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -262,7 +262,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -327,7 +327,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -480,7 +480,7 @@ func (p *painter) drawShader(shader *canvas.Shader, pos fyne.Position, frame fyn
 
 	// Fragment: BEG - the standard uniform contract shared with the built in vector shaders
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -568,7 +568,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -656,7 +656,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -714,7 +714,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
@@ -789,7 +789,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frameSize", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -731,7 +731,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.SetUniform1f(program, "innerRadius", innerRadiusScaled)
 
 	startAngle, endAngle := paint.NormalizeArcAngles(arc.StartAngle, arc.EndAngle)
-	p.SetUniform1f(program, "start_angle", startAngle)
+	p.SetUniform1f(program, "startAngle", startAngle)
 	p.SetUniform1f(program, "end_angle", endAngle)
 
 	cornerRadius := fyne.Min(paint.GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -180,7 +180,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	p.SetUniform4f(program, "radius", radiusScaled, radiusScaled, radiusScaled, radiusScaled)
 
 	r, g, b, a := getFragmentColor(circle.FillColor)
-	p.SetUniform4f(program, "fill_color", r, g, b, a)
+	p.SetUniform4f(program, "fillColor", r, g, b, a)
 
 	strokeColor := circle.StrokeColor
 	if strokeColor == nil {
@@ -376,7 +376,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 
 	// Colors and Stroke
 	r, g, b, a := getFragmentColor(polygon.FillColor)
-	p.SetUniform4f(program, "fill_color", r, g, b, a)
+	p.SetUniform4f(program, "fillColor", r, g, b, a)
 
 	r, g, b, a = getFragmentColor(polygon.StrokeColor)
 	p.SetUniform4f(program, "stroke_color", r, g, b, a)
@@ -608,7 +608,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	}
 
 	r, g, b, a := getFragmentColor(fill)
-	p.SetUniform4f(program, "fill_color", r, g, b, a)
+	p.SetUniform4f(program, "fillColor", r, g, b, a)
 
 	strokeColor := stroke
 	if strokeColor == nil {
@@ -679,7 +679,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 	p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
 
 	r, g, b, a := getFragmentColor(polygon.FillColor)
-	p.SetUniform4f(program, "fill_color", r, g, b, a)
+	p.SetUniform4f(program, "fillColor", r, g, b, a)
 
 	strokeColor := polygon.StrokeColor
 	if strokeColor == nil {
@@ -742,7 +742,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
 
 	r, g, b, a := getFragmentColor(arc.FillColor)
-	p.SetUniform4f(program, "fill_color", r, g, b, a)
+	p.SetUniform4f(program, "fillColor", r, g, b, a)
 
 	strokeColor := arc.StrokeColor
 	if strokeColor == nil {
@@ -804,7 +804,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	p.SetUniform1f(program, "angle", 0) // angle of ellipse, in degrees (positive means clockwise, negative means counter-clockwise direction), not yet supported in public API but reserved for future use
 
 	r, g, b, a := getFragmentColor(ellipse.FillColor)
-	p.SetUniform4f(program, "fill_color", r, g, b, a)
+	p.SetUniform4f(program, "fillColor", r, g, b, a)
 
 	strokeColor := ellipse.StrokeColor
 	if strokeColor == nil {

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -167,7 +167,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(circle.StrokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "strokeWidthHalf", strokeWidthScaled*0.5)
@@ -265,7 +265,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
@@ -330,7 +330,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
@@ -483,7 +483,7 @@ func (p *painter) drawShader(shader *canvas.Shader, pos fyne.Position, frame fyn
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	for name, v := range shader.Uniforms {
 		p.SetUniform1f(program, name, v)
@@ -571,7 +571,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
 	if roundedCorners {
@@ -659,7 +659,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
@@ -717,7 +717,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
@@ -792,7 +792,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
+	p.SetUniform4f(program, "bounds", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(ellipse.StrokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -170,7 +170,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(circle.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)
+	p.SetUniform1f(program, "strokeWidthHalf", strokeWidthScaled*0.5)
 
 	rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 	rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled
@@ -296,7 +296,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.SetUniform1f(program, "numControlPoints", fyne.Min(float32(len(cp)), 2))
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)
+	p.SetUniform1f(program, "strokeWidthHalf", strokeWidthScaled*0.5)
 
 	r, g, b, a := getFragmentColor(bezierCurve.StrokeColor)
 	p.SetUniform4f(program, "strokeColor", r, g, b, a)
@@ -575,7 +575,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
 	if roundedCorners {
-		p.SetUniform1f(program, "stroke_width_half", strokeWidthScaled*0.5)
+		p.SetUniform1f(program, "strokeWidthHalf", strokeWidthScaled*0.5)
 
 		rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 		rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -382,7 +382,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	p.SetUniform4f(program, "stroke_color", r, g, b, a)
 
 	strokeWidthScaled := roundToPixel(polygon.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
+	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
 
 	p.logError()
 	// Fragment: END
@@ -604,7 +604,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 		p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
 	} else {
-		p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
+		p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
 	}
 
 	r, g, b, a := getFragmentColor(fill)
@@ -676,7 +676,7 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 	p.SetUniform1f(program, "corner_radius", cornerRadiusScaled)
 
 	strokeWidthScaled := roundToPixel(polygon.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
+	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
 
 	r, g, b, a := getFragmentColor(polygon.FillColor)
 	p.SetUniform4f(program, "fillColor", r, g, b, a)
@@ -739,7 +739,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.SetUniform1f(program, "corner_radius", cornerRadiusScaled)
 
 	strokeWidthScaled := roundToPixel(arc.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
+	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
 
 	r, g, b, a := getFragmentColor(arc.FillColor)
 	p.SetUniform4f(program, "fillColor", r, g, b, a)
@@ -795,7 +795,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	p.SetUniform4f(program, "rectCoords", x1Scaled, x2Scaled, y1Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(ellipse.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "stroke_width", strokeWidthScaled)
+	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
 
 	radiusXScaled := roundToPixel(radiusX*p.pixScale, 1.0)
 	radiusYScaled := roundToPixel(radiusY*p.pixScale, 1.0)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -199,7 +199,7 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 		p.SetUniform2f(program, "shadowOffset", roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_type", float32(circle.Shadow.Variant))
+		p.SetUniform1f(program, "shadowType", float32(circle.Shadow.Variant))
 		addShadow = 1.0
 	}
 	p.SetUniform1f(program, "addShadow", addShadow)
@@ -624,7 +624,7 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 		p.SetUniform2f(program, "shadowOffset", roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(shadow.Spread*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_type", float32(shadow.Variant))
+		p.SetUniform1f(program, "shadowType", float32(shadow.Variant))
 		addShadow = 1.0
 	}
 	p.SetUniform1f(program, "addShadow", addShadow)
@@ -823,7 +823,7 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 		p.SetUniform2f(program, "shadowOffset", roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
 		p.SetUniform1f(program, "shadowSpread", roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadow_type", float32(ellipse.Shadow.Variant))
+		p.SetUniform1f(program, "shadowType", float32(ellipse.Shadow.Variant))
 		addShadow = 1.0
 	}
 	p.SetUniform1f(program, "addShadow", addShadow)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -372,7 +372,7 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	}
 
 	p.SetUniform2fv(program, "vertices", verticesScaled)
-	p.SetUniform1fv(program, "corner_radii", cornerRadiiScaled)
+	p.SetUniform1fv(program, "cornerRadii", cornerRadiiScaled)
 
 	// Colors and Stroke
 	r, g, b, a := getFragmentColor(polygon.FillColor)

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -7,7 +7,7 @@ uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
-uniform float corner_radii[MAX_VERTICES];
+uniform float cornerRadii[MAX_VERTICES];
 uniform float vertex_count;
 
 uniform vec4 fill_color;
@@ -43,7 +43,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
         vec2 point1 = vertices[i];
         vec2 point2 = vertices[j];
         vec2 point3 = vertices[k];
-        float radius = corner_radii[j];
+        float radius = cornerRadii[j];
 
         vec2 pos = p - point2;
         vec2 a = normalize(point1 - point2);

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -11,7 +11,7 @@ uniform float cornerRadii[MAX_VERTICES];
 uniform float vertexCount;
 
 uniform vec4 fillColor;
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec4 stroke_color;
 
 const float INF = 1e10;
@@ -137,10 +137,10 @@ void main()
     float dist = arbitrary_polygon_distance(p, num);
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
+        float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fillColor, fill_mask);

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -3,7 +3,7 @@
 #define MAX_VERTICES 32
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
@@ -131,7 +131,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - bounds.xz;
 
     int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -3,7 +3,7 @@
 #define MAX_VERTICES 32
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 
 uniform vec2 vertices[MAX_VERTICES];
@@ -131,7 +131,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rect_coords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
 
     int num = int(vertex_count);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -8,7 +8,7 @@ uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
 uniform float cornerRadii[MAX_VERTICES];
-uniform float vertex_count;
+uniform float vertexCount;
 
 uniform vec4 fill_color;
 uniform float stroke_width;
@@ -133,7 +133,7 @@ void main()
     // coordinates: (0.0) at rect top-left, +X right, +Y down
     vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
-    int num = int(vertex_count);
+    int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);
     vec4 final_color = fill_color;
 

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -10,7 +10,7 @@ uniform vec2 vertices[MAX_VERTICES];
 uniform float cornerRadii[MAX_VERTICES];
 uniform float vertexCount;
 
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform float stroke_width;
 uniform vec4 stroke_color;
 
@@ -135,7 +135,7 @@ void main()
 
     int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -143,7 +143,7 @@ void main()
         float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -4,7 +4,7 @@
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
 uniform float corner_radii[MAX_VERTICES];
@@ -140,14 +140,14 @@ void main()
     if (stroke_width > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edge_softness, -stroke_width - edge_softness, dist);
+        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fill_color, fill_mask);
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
 
     // apply the final alpha to the combined color
     gl_FragColor = vec4(final_color.rgb, final_color.a * final_alpha);

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -2,7 +2,7 @@
 
 #define MAX_VERTICES 32
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
@@ -131,7 +131,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
 
     int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -2,7 +2,7 @@
 
 #define MAX_VERTICES 32
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 
@@ -131,7 +131,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
     int num = int(vertex_count);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arbitrary_polygon.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon.frag
@@ -12,7 +12,7 @@ uniform float vertexCount;
 
 uniform vec4 fillColor;
 uniform float strokeWidth;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 const float INF = 1e10;
 const float EPS = 1e-3;
@@ -143,7 +143,7 @@ void main()
         float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -14,7 +14,7 @@ precision lowp sampler2D;
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
 uniform float corner_radii[MAX_VERTICES];
@@ -177,14 +177,14 @@ void main()
     if (stroke_width > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edge_softness, -stroke_width - edge_softness, dist);
+        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fill_color, fill_mask);
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
 
     // apply the final alpha to the combined color
     gl_FragColor = vec4(final_color.rgb, final_color.a * final_alpha);

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -17,7 +17,7 @@ uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
-uniform float corner_radii[MAX_VERTICES];
+uniform float cornerRadii[MAX_VERTICES];
 uniform float vertex_count;
 
 uniform vec4 fill_color;
@@ -51,7 +51,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
         if (m == num - 2) p_prev2 = vertices[m];
         if (m == num - 1) {
             p_prev1 = vertices[m];
-            r_prev = corner_radii[m];
+            r_prev = cornerRadii[m];
             break;
         }
     }
@@ -121,7 +121,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
         // Shift values for the next iteration
         p_prev2 = point2;
         p_prev1 = point3;
-        r_prev = corner_radii[k];
+        r_prev = cornerRadii[k];
     }
 
     // Phase 2: Distance to straight edge segments between tangent points

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -21,7 +21,7 @@ uniform float cornerRadii[MAX_VERTICES];
 uniform float vertexCount;
 
 uniform vec4 fillColor;
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec4 stroke_color;
 
 const float INF = 1e10;
@@ -174,10 +174,10 @@ void main()
     float dist = arbitrary_polygon_distance(p, num);
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
+        float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fillColor, fill_mask);

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -22,7 +22,7 @@ uniform float vertexCount;
 
 uniform vec4 fillColor;
 uniform float strokeWidth;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 const float INF = 1e10;
 const float EPS = 1e-3;
@@ -180,7 +180,7 @@ void main()
         float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -18,7 +18,7 @@ uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
 uniform float cornerRadii[MAX_VERTICES];
-uniform float vertex_count;
+uniform float vertexCount;
 
 uniform vec4 fill_color;
 uniform float stroke_width;
@@ -170,7 +170,7 @@ void main()
     // coordinates: (0.0) at rect top-left, +X right, +Y down
     vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
-    int num = int(vertex_count);
+    int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);
     vec4 final_color = fill_color;
 

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 #define MAX_VERTICES 32
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
@@ -168,7 +168,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
 
     int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -13,7 +13,7 @@ precision lowp sampler2D;
 #define MAX_VERTICES 32
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 
 uniform vec2 vertices[MAX_VERTICES];
@@ -168,7 +168,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - bounds.xz;
 
     int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -20,7 +20,7 @@ uniform vec2 vertices[MAX_VERTICES];
 uniform float cornerRadii[MAX_VERTICES];
 uniform float vertexCount;
 
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform float stroke_width;
 uniform vec4 stroke_color;
 
@@ -172,7 +172,7 @@ void main()
 
     int num = int(vertexCount);
     float dist = arbitrary_polygon_distance(p, num);
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -180,7 +180,7 @@ void main()
         float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -13,7 +13,7 @@ precision lowp sampler2D;
 #define MAX_VERTICES 32
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 
 uniform vec2 vertices[MAX_VERTICES];
@@ -168,7 +168,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rect_coords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
 
     int num = int(vertex_count);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arbitrary_polygon_es.frag
+++ b/internal/painter/gl/shaders/arbitrary_polygon_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 #define MAX_VERTICES 32
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 
@@ -168,7 +168,7 @@ float arbitrary_polygon_distance(vec2 p, int num)
 void main()
 {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
     int num = int(vertex_count);
     float dist = arbitrary_polygon_distance(p, num);

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -4,7 +4,7 @@
 // To adapt the arc orientation or coordinate system, adjust the startAngle and endAngle uniforms accordingly.
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 
 uniform float innerRadius;
@@ -67,7 +67,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(startAngle);
     float end_rad = radians(endAngle);

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -14,7 +14,7 @@ uniform float end_angle;
 uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float strokeWidth;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 const float PI = 3.141592653589793;
 
@@ -105,7 +105,7 @@ void main()
         float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + strokeWidth);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -8,7 +8,7 @@ uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
 uniform float innerRadius;
-uniform float outer_radius;
+uniform float outerRadius;
 uniform float start_angle;
 uniform float end_angle;
 uniform vec4 fillColor;
@@ -83,18 +83,18 @@ void main()
         if (innerRadius < 0.5)
         {
             // no inner radius
-            dist = r - outer_radius;
+            dist = r - outerRadius;
         }
         else
         {
-            float ring_center_radius = (innerRadius + outer_radius) * 0.5;
-            float ring_thickness = (outer_radius - innerRadius) * 0.5;
+            float ring_center_radius = (innerRadius + outerRadius) * 0.5;
+            float ring_thickness = (outerRadius - innerRadius) * 0.5;
             dist = abs(r - ring_center_radius) - ring_thickness;
         }
     }
     else
     {
-        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outer_radius, start_rad, end_rad, corner_radius);
+        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outerRadius, start_rad, end_rad, corner_radius);
     }
 
     vec4 final_color = fillColor;

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -5,7 +5,7 @@
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 
 uniform float inner_radius;
 uniform float outer_radius;
@@ -102,14 +102,14 @@ void main()
     if (stroke_width > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(edge_softness, -edge_softness, dist + stroke_width);
+        float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + stroke_width);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fill_color, fill_mask);
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
     
     // apply the final alpha to the combined color
     gl_FragColor = vec4(final_color.rgb, final_color.a * final_alpha);

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -4,7 +4,7 @@
 // To adapt the arc orientation or coordinate system, adjust the start_angle and end_angle uniforms accordingly.
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 
 uniform float inner_radius;
@@ -67,7 +67,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(start_angle);
     float end_rad = radians(end_angle);

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -1,7 +1,7 @@
 #version 110
 
 // Note: This shader operates in the unit circle coordinate system, where angles are measured from the positive X axis.
-// To adapt the arc orientation or coordinate system, adjust the startAngle and end_angle uniforms accordingly.
+// To adapt the arc orientation or coordinate system, adjust the startAngle and endAngle uniforms accordingly.
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
@@ -10,7 +10,7 @@ uniform float edgeSoftness;
 uniform float innerRadius;
 uniform float outerRadius;
 uniform float startAngle;
-uniform float end_angle;
+uniform float endAngle;
 uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float strokeWidth;
@@ -70,7 +70,7 @@ void main()
     vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(startAngle);
-    float end_rad = radians(end_angle);
+    float end_rad = radians(endAngle);
     
     // check if the arc is a full circle (360 degrees or more)
     // the sd_rounded_arc function creates segment at the start/end angle, which is undesirable for a complete circle

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -12,7 +12,7 @@ uniform float outerRadius;
 uniform float startAngle;
 uniform float endAngle;
 uniform vec4 fillColor;
-uniform float corner_radius;
+uniform float cornerRadius;
 uniform float strokeWidth;
 uniform vec4 strokeColor;
 
@@ -94,7 +94,7 @@ void main()
     }
     else
     {
-        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outerRadius, start_rad, end_rad, corner_radius);
+        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outerRadius, start_rad, end_rad, cornerRadius);
     }
 
     vec4 final_color = fillColor;

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -13,7 +13,7 @@ uniform float start_angle;
 uniform float end_angle;
 uniform vec4 fillColor;
 uniform float corner_radius;
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec4 stroke_color;
 
 const float PI = 3.141592653589793;
@@ -99,10 +99,10 @@ void main()
 
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + stroke_width);
+        float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + strokeWidth);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fillColor, fill_mask);

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -7,7 +7,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
-uniform float inner_radius;
+uniform float innerRadius;
 uniform float outer_radius;
 uniform float start_angle;
 uniform float end_angle;
@@ -80,21 +80,21 @@ void main()
         // full circle
         float r = length(vec_centered_pos);
         
-        if (inner_radius < 0.5)
+        if (innerRadius < 0.5)
         {
             // no inner radius
             dist = r - outer_radius;
         }
         else
         {
-            float ring_center_radius = (inner_radius + outer_radius) * 0.5;
-            float ring_thickness = (outer_radius - inner_radius) * 0.5;
+            float ring_center_radius = (innerRadius + outer_radius) * 0.5;
+            float ring_thickness = (outer_radius - innerRadius) * 0.5;
             dist = abs(r - ring_center_radius) - ring_thickness;
         }
     }
     else
     {
-        dist = sd_rounded_arc(vec_centered_pos, inner_radius, outer_radius, start_rad, end_rad, corner_radius);
+        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outer_radius, start_rad, end_rad, corner_radius);
     }
 
     vec4 final_color = fillColor;

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -1,7 +1,7 @@
 #version 110
 
 // Note: This shader operates in the unit circle coordinate system, where angles are measured from the positive X axis.
-// To adapt the arc orientation or coordinate system, adjust the start_angle and end_angle uniforms accordingly.
+// To adapt the arc orientation or coordinate system, adjust the startAngle and end_angle uniforms accordingly.
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
@@ -9,7 +9,7 @@ uniform float edgeSoftness;
 
 uniform float innerRadius;
 uniform float outerRadius;
-uniform float start_angle;
+uniform float startAngle;
 uniform float end_angle;
 uniform vec4 fillColor;
 uniform float corner_radius;
@@ -69,7 +69,7 @@ void main()
 {
     vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
-    float start_rad = radians(start_angle);
+    float start_rad = radians(startAngle);
     float end_rad = radians(end_angle);
     
     // check if the arc is a full circle (360 degrees or more)

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -3,7 +3,7 @@
 // Note: This shader operates in the unit circle coordinate system, where angles are measured from the positive X axis.
 // To adapt the arc orientation or coordinate system, adjust the startAngle and endAngle uniforms accordingly.
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
@@ -67,7 +67,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(startAngle);
     float end_rad = radians(endAngle);

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -11,7 +11,7 @@ uniform float inner_radius;
 uniform float outer_radius;
 uniform float start_angle;
 uniform float end_angle;
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float stroke_width;
 uniform vec4 stroke_color;
@@ -97,7 +97,7 @@ void main()
         dist = sd_rounded_arc(vec_centered_pos, inner_radius, outer_radius, start_rad, end_rad, corner_radius);
     }
 
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -105,7 +105,7 @@ void main()
         float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + stroke_width);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arc.frag
+++ b/internal/painter/gl/shaders/arc.frag
@@ -3,7 +3,7 @@
 // Note: This shader operates in the unit circle coordinate system, where angles are measured from the positive X axis.
 // To adapt the arc orientation or coordinate system, adjust the start_angle and end_angle uniforms accordingly.
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 
@@ -67,7 +67,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(start_angle);
     float end_rad = radians(end_angle);

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -14,7 +14,7 @@ precision lowp sampler2D;
 #endif
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 
 uniform float inner_radius;
@@ -77,7 +77,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(start_angle);
     float end_rad = radians(end_angle);

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -1,7 +1,7 @@
 #version 100
 
 // Note: This shader operates in the unit circle coordinate system, where angles are measured from the positive X axis.
-// To adapt the arc orientation or coordinate system, adjust the startAngle and end_angle uniforms accordingly.
+// To adapt the arc orientation or coordinate system, adjust the startAngle and endAngle uniforms accordingly.
 
 #ifdef GL_ES
 # ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -20,7 +20,7 @@ uniform float edgeSoftness;
 uniform float innerRadius;
 uniform float outerRadius;
 uniform float startAngle;
-uniform float end_angle;
+uniform float endAngle;
 uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float strokeWidth;
@@ -80,7 +80,7 @@ void main()
     vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(startAngle);
-    float end_rad = radians(end_angle);
+    float end_rad = radians(endAngle);
     
     // check if the arc is a full circle (360 degrees or more)
     // the sd_rounded_arc function creates segment at the start/end angle, which is undesirable for a complete circle

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -23,7 +23,7 @@ uniform float start_angle;
 uniform float end_angle;
 uniform vec4 fillColor;
 uniform float corner_radius;
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec4 stroke_color;
 
 const float PI = 3.141592653589793;
@@ -109,10 +109,10 @@ void main()
 
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + stroke_width);
+        float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + strokeWidth);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fillColor, fill_mask);

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -21,7 +21,7 @@ uniform float inner_radius;
 uniform float outer_radius;
 uniform float start_angle;
 uniform float end_angle;
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float stroke_width;
 uniform vec4 stroke_color;
@@ -107,7 +107,7 @@ void main()
         dist = sd_rounded_arc(vec_centered_pos, inner_radius, outer_radius, start_rad, end_rad, corner_radius);
     }
 
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -115,7 +115,7 @@ void main()
         float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + stroke_width);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -24,7 +24,7 @@ uniform float end_angle;
 uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float strokeWidth;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 const float PI = 3.141592653589793;
 
@@ -115,7 +115,7 @@ void main()
         float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + strokeWidth);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -14,7 +14,7 @@ precision lowp sampler2D;
 #endif
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 
 uniform float innerRadius;
@@ -77,7 +77,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(startAngle);
     float end_rad = radians(endAngle);

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -13,7 +13,7 @@ precision mediump int;
 precision lowp sampler2D;
 #endif
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 
@@ -77,7 +77,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(start_angle);
     float end_rad = radians(end_angle);

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -1,7 +1,7 @@
 #version 100
 
 // Note: This shader operates in the unit circle coordinate system, where angles are measured from the positive X axis.
-// To adapt the arc orientation or coordinate system, adjust the start_angle and end_angle uniforms accordingly.
+// To adapt the arc orientation or coordinate system, adjust the startAngle and end_angle uniforms accordingly.
 
 #ifdef GL_ES
 # ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -19,7 +19,7 @@ uniform float edgeSoftness;
 
 uniform float innerRadius;
 uniform float outerRadius;
-uniform float start_angle;
+uniform float startAngle;
 uniform float end_angle;
 uniform vec4 fillColor;
 uniform float corner_radius;
@@ -79,7 +79,7 @@ void main()
 {
     vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
-    float start_rad = radians(start_angle);
+    float start_rad = radians(startAngle);
     float end_rad = radians(end_angle);
     
     // check if the arc is a full circle (360 degrees or more)

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -15,7 +15,7 @@ precision lowp sampler2D;
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 
 uniform float inner_radius;
 uniform float outer_radius;
@@ -112,14 +112,14 @@ void main()
     if (stroke_width > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(edge_softness, -edge_softness, dist + stroke_width);
+        float fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist + stroke_width);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fill_color, fill_mask);
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
     
     // apply the final alpha to the combined color
     gl_FragColor = vec4(final_color.rgb, final_color.a * final_alpha);

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -13,7 +13,7 @@ precision mediump int;
 precision lowp sampler2D;
 #endif
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
@@ -77,7 +77,7 @@ float sd_rounded_arc(vec2 p, float r1, float r2, float a0, float a1, float cr)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
     float start_rad = radians(startAngle);
     float end_rad = radians(endAngle);

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -17,7 +17,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
-uniform float inner_radius;
+uniform float innerRadius;
 uniform float outer_radius;
 uniform float start_angle;
 uniform float end_angle;
@@ -90,21 +90,21 @@ void main()
         // full circle
         float r = length(vec_centered_pos);
         
-        if (inner_radius < 0.5)
+        if (innerRadius < 0.5)
         {
             // no inner radius
             dist = r - outer_radius;
         }
         else
         {
-            float ring_center_radius = (inner_radius + outer_radius) * 0.5;
-            float ring_thickness = (outer_radius - inner_radius) * 0.5;
+            float ring_center_radius = (innerRadius + outer_radius) * 0.5;
+            float ring_thickness = (outer_radius - innerRadius) * 0.5;
             dist = abs(r - ring_center_radius) - ring_thickness;
         }
     }
     else
     {
-        dist = sd_rounded_arc(vec_centered_pos, inner_radius, outer_radius, start_rad, end_rad, corner_radius);
+        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outer_radius, start_rad, end_rad, corner_radius);
     }
 
     vec4 final_color = fillColor;

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -22,7 +22,7 @@ uniform float outerRadius;
 uniform float startAngle;
 uniform float endAngle;
 uniform vec4 fillColor;
-uniform float corner_radius;
+uniform float cornerRadius;
 uniform float strokeWidth;
 uniform vec4 strokeColor;
 
@@ -104,7 +104,7 @@ void main()
     }
     else
     {
-        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outerRadius, start_rad, end_rad, corner_radius);
+        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outerRadius, start_rad, end_rad, cornerRadius);
     }
 
     vec4 final_color = fillColor;

--- a/internal/painter/gl/shaders/arc_es.frag
+++ b/internal/painter/gl/shaders/arc_es.frag
@@ -18,7 +18,7 @@ uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
 uniform float innerRadius;
-uniform float outer_radius;
+uniform float outerRadius;
 uniform float start_angle;
 uniform float end_angle;
 uniform vec4 fillColor;
@@ -93,18 +93,18 @@ void main()
         if (innerRadius < 0.5)
         {
             // no inner radius
-            dist = r - outer_radius;
+            dist = r - outerRadius;
         }
         else
         {
-            float ring_center_radius = (innerRadius + outer_radius) * 0.5;
-            float ring_thickness = (outer_radius - innerRadius) * 0.5;
+            float ring_center_radius = (innerRadius + outerRadius) * 0.5;
+            float ring_thickness = (outerRadius - innerRadius) * 0.5;
             dist = abs(r - ring_center_radius) - ring_thickness;
         }
     }
     else
     {
-        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outer_radius, start_rad, end_rad, corner_radius);
+        dist = sd_rounded_arc(vec_centered_pos, innerRadius, outerRadius, start_rad, end_rad, corner_radius);
     }
 
     vec4 final_color = fillColor;

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -1,6 +1,6 @@
 #version 110
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 uniform float strokeWidthHalf;
@@ -132,7 +132,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
     if (int(numControlPoints) == 1) {

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -1,6 +1,6 @@
 #version 110
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 uniform float stroke_width_half;
@@ -132,7 +132,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
     if (int(num_control_points) == 1) {

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -7,7 +7,7 @@ uniform float stroke_width_half;
 uniform vec4 strokeColor;
 
 uniform vec2 startPoint;
-uniform vec2 end_point;
+uniform vec2 endPoint;
 uniform vec2 control_point1; // used for quadratic and cubic
 uniform vec2 control_point2; // used for cubic only
 uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
@@ -136,11 +136,11 @@ void main() {
 
     float dist;
     if (int(num_control_points) == 1) {
-        dist = quadratic_distance(p, startPoint, control_point1, end_point);
+        dist = quadratic_distance(p, startPoint, control_point1, endPoint);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, startPoint, control_point1, control_point2, end_point);
+        dist = cubic_distance(p, startPoint, control_point1, control_point2, endPoint);
     } else {
-        dist = linear_distance(p, startPoint, end_point);
+        dist = linear_distance(p, startPoint, endPoint);
     }
 
     float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -1,7 +1,7 @@
 #version 110
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 uniform float strokeWidthHalf;
 uniform vec4 strokeColor;
@@ -132,7 +132,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - bounds.xz;
 
     float dist;
     if (int(numControlPoints) == 1) {

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -8,7 +8,7 @@ uniform vec4 strokeColor;
 
 uniform vec2 startPoint;
 uniform vec2 endPoint;
-uniform vec2 control_point1; // used for quadratic and cubic
+uniform vec2 controlPoint1; // used for quadratic and cubic
 uniform vec2 control_point2; // used for cubic only
 uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
 
@@ -136,9 +136,9 @@ void main() {
 
     float dist;
     if (int(num_control_points) == 1) {
-        dist = quadratic_distance(p, startPoint, control_point1, endPoint);
+        dist = quadratic_distance(p, startPoint, controlPoint1, endPoint);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, startPoint, control_point1, control_point2, endPoint);
+        dist = cubic_distance(p, startPoint, controlPoint1, control_point2, endPoint);
     } else {
         dist = linear_distance(p, startPoint, endPoint);
     }

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -2,7 +2,7 @@
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 uniform float stroke_width_half;
 uniform vec4 stroke_color;
 
@@ -143,6 +143,6 @@ void main() {
         dist = linear_distance(p, start_point, end_point);
     }
 
-    float alpha = 1.0 - smoothstep(stroke_width_half - edge_softness, stroke_width_half + edge_softness, dist);
+    float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);
     gl_FragColor = vec4(stroke_color.rgb, stroke_color.a * alpha);
 }

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -9,7 +9,7 @@ uniform vec4 strokeColor;
 uniform vec2 startPoint;
 uniform vec2 endPoint;
 uniform vec2 controlPoint1; // used for quadratic and cubic
-uniform vec2 control_point2; // used for cubic only
+uniform vec2 controlPoint2; // used for cubic only
 uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
 
 const float EPS = 1e-3;
@@ -138,7 +138,7 @@ void main() {
     if (int(num_control_points) == 1) {
         dist = quadratic_distance(p, startPoint, controlPoint1, endPoint);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, startPoint, controlPoint1, control_point2, endPoint);
+        dist = cubic_distance(p, startPoint, controlPoint1, controlPoint2, endPoint);
     } else {
         dist = linear_distance(p, startPoint, endPoint);
     }

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -10,7 +10,7 @@ uniform vec2 startPoint;
 uniform vec2 endPoint;
 uniform vec2 controlPoint1; // used for quadratic and cubic
 uniform vec2 controlPoint2; // used for cubic only
-uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
+uniform float numControlPoints; // 0: linear, 1: quadratic, 2: cubic
 
 const float EPS = 1e-3;
 
@@ -135,9 +135,9 @@ void main() {
     vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
-    if (int(num_control_points) == 1) {
+    if (int(numControlPoints) == 1) {
         dist = quadratic_distance(p, startPoint, controlPoint1, endPoint);
-    } else if (int(num_control_points) == 2) {
+    } else if (int(numControlPoints) == 2) {
         dist = cubic_distance(p, startPoint, controlPoint1, controlPoint2, endPoint);
     } else {
         dist = linear_distance(p, startPoint, endPoint);

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -6,7 +6,7 @@ uniform float edgeSoftness;
 uniform float stroke_width_half;
 uniform vec4 strokeColor;
 
-uniform vec2 start_point;
+uniform vec2 startPoint;
 uniform vec2 end_point;
 uniform vec2 control_point1; // used for quadratic and cubic
 uniform vec2 control_point2; // used for cubic only
@@ -136,11 +136,11 @@ void main() {
 
     float dist;
     if (int(num_control_points) == 1) {
-        dist = quadratic_distance(p, start_point, control_point1, end_point);
+        dist = quadratic_distance(p, startPoint, control_point1, end_point);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, start_point, control_point1, control_point2, end_point);
+        dist = cubic_distance(p, startPoint, control_point1, control_point2, end_point);
     } else {
-        dist = linear_distance(p, start_point, end_point);
+        dist = linear_distance(p, startPoint, end_point);
     }
 
     float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -1,7 +1,7 @@
 #version 110
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 uniform float stroke_width_half;
 uniform vec4 stroke_color;
@@ -132,7 +132,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rect_coords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
     if (int(num_control_points) == 1) {

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -3,7 +3,7 @@
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
-uniform float stroke_width_half;
+uniform float strokeWidthHalf;
 uniform vec4 strokeColor;
 
 uniform vec2 startPoint;
@@ -143,6 +143,6 @@ void main() {
         dist = linear_distance(p, startPoint, endPoint);
     }
 
-    float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);
+    float alpha = 1.0 - smoothstep(strokeWidthHalf - edgeSoftness, strokeWidthHalf + edgeSoftness, dist);
     gl_FragColor = vec4(strokeColor.rgb, strokeColor.a * alpha);
 }

--- a/internal/painter/gl/shaders/bezier_curve.frag
+++ b/internal/painter/gl/shaders/bezier_curve.frag
@@ -4,7 +4,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 uniform float stroke_width_half;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 uniform vec2 start_point;
 uniform vec2 end_point;
@@ -144,5 +144,5 @@ void main() {
     }
 
     float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);
-    gl_FragColor = vec4(stroke_color.rgb, stroke_color.a * alpha);
+    gl_FragColor = vec4(strokeColor.rgb, strokeColor.a * alpha);
 }

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -17,7 +17,7 @@ uniform float stroke_width_half;
 uniform vec4 strokeColor;
 
 uniform vec2 startPoint;
-uniform vec2 end_point;
+uniform vec2 endPoint;
 uniform vec2 control_point1; // used for quadratic and cubic
 uniform vec2 control_point2; // used for cubic only
 uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
@@ -149,11 +149,11 @@ void main() {
 
     float dist;
     if (int(num_control_points) == 1) {
-        dist = quadratic_distance(p, startPoint, control_point1, end_point);
+        dist = quadratic_distance(p, startPoint, control_point1, endPoint);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, startPoint, control_point1, control_point2, end_point);
+        dist = cubic_distance(p, startPoint, control_point1, control_point2, endPoint);
     } else {
-        dist = linear_distance(p, startPoint, end_point);
+        dist = linear_distance(p, startPoint, endPoint);
     }
 
     float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -19,7 +19,7 @@ uniform vec4 strokeColor;
 uniform vec2 startPoint;
 uniform vec2 endPoint;
 uniform vec2 controlPoint1; // used for quadratic and cubic
-uniform vec2 control_point2; // used for cubic only
+uniform vec2 controlPoint2; // used for cubic only
 uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
 
 const float EPS = 1e-3;
@@ -151,7 +151,7 @@ void main() {
     if (int(num_control_points) == 1) {
         dist = quadratic_distance(p, startPoint, controlPoint1, endPoint);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, startPoint, controlPoint1, control_point2, endPoint);
+        dist = cubic_distance(p, startPoint, controlPoint1, controlPoint2, endPoint);
     } else {
         dist = linear_distance(p, startPoint, endPoint);
     }

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -16,7 +16,7 @@ uniform float edgeSoftness;
 uniform float stroke_width_half;
 uniform vec4 strokeColor;
 
-uniform vec2 start_point;
+uniform vec2 startPoint;
 uniform vec2 end_point;
 uniform vec2 control_point1; // used for quadratic and cubic
 uniform vec2 control_point2; // used for cubic only
@@ -149,11 +149,11 @@ void main() {
 
     float dist;
     if (int(num_control_points) == 1) {
-        dist = quadratic_distance(p, start_point, control_point1, end_point);
+        dist = quadratic_distance(p, startPoint, control_point1, end_point);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, start_point, control_point1, control_point2, end_point);
+        dist = cubic_distance(p, startPoint, control_point1, control_point2, end_point);
     } else {
-        dist = linear_distance(p, start_point, end_point);
+        dist = linear_distance(p, startPoint, end_point);
     }
 
     float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -20,7 +20,7 @@ uniform vec2 startPoint;
 uniform vec2 endPoint;
 uniform vec2 controlPoint1; // used for quadratic and cubic
 uniform vec2 controlPoint2; // used for cubic only
-uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
+uniform float numControlPoints; // 0: linear, 1: quadratic, 2: cubic
 
 const float EPS = 1e-3;
 
@@ -148,9 +148,9 @@ void main() {
     vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
-    if (int(num_control_points) == 1) {
+    if (int(numControlPoints) == 1) {
         dist = quadratic_distance(p, startPoint, controlPoint1, endPoint);
-    } else if (int(num_control_points) == 2) {
+    } else if (int(numControlPoints) == 2) {
         dist = cubic_distance(p, startPoint, controlPoint1, controlPoint2, endPoint);
     } else {
         dist = linear_distance(p, startPoint, endPoint);

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 uniform float stroke_width_half;
 uniform vec4 stroke_color;
@@ -145,7 +145,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rect_coords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
     if (int(num_control_points) == 1) {

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 uniform float strokeWidthHalf;
 uniform vec4 strokeColor;
@@ -145,7 +145,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - bounds.xz;
 
     float dist;
     if (int(numControlPoints) == 1) {

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -18,7 +18,7 @@ uniform vec4 strokeColor;
 
 uniform vec2 startPoint;
 uniform vec2 endPoint;
-uniform vec2 control_point1; // used for quadratic and cubic
+uniform vec2 controlPoint1; // used for quadratic and cubic
 uniform vec2 control_point2; // used for cubic only
 uniform float num_control_points; // 0: linear, 1: quadratic, 2: cubic
 
@@ -149,9 +149,9 @@ void main() {
 
     float dist;
     if (int(num_control_points) == 1) {
-        dist = quadratic_distance(p, startPoint, control_point1, endPoint);
+        dist = quadratic_distance(p, startPoint, controlPoint1, endPoint);
     } else if (int(num_control_points) == 2) {
-        dist = cubic_distance(p, startPoint, control_point1, control_point2, endPoint);
+        dist = cubic_distance(p, startPoint, controlPoint1, control_point2, endPoint);
     } else {
         dist = linear_distance(p, startPoint, endPoint);
     }

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -14,7 +14,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 uniform float stroke_width_half;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 uniform vec2 start_point;
 uniform vec2 end_point;
@@ -157,5 +157,5 @@ void main() {
     }
 
     float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);
-    gl_FragColor = vec4(stroke_color.rgb, stroke_color.a * alpha);
+    gl_FragColor = vec4(strokeColor.rgb, strokeColor.a * alpha);
 }

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 uniform float stroke_width_half;
 uniform vec4 stroke_color;
 
@@ -156,6 +156,6 @@ void main() {
         dist = linear_distance(p, start_point, end_point);
     }
 
-    float alpha = 1.0 - smoothstep(stroke_width_half - edge_softness, stroke_width_half + edge_softness, dist);
+    float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);
     gl_FragColor = vec4(stroke_color.rgb, stroke_color.a * alpha);
 }

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -10,7 +10,7 @@ precision mediump int;
 precision lowp sampler2D;
 #endif
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 uniform float stroke_width_half;
@@ -145,7 +145,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frame_size.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
     if (int(num_control_points) == 1) {

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -13,7 +13,7 @@ precision lowp sampler2D;
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
-uniform float stroke_width_half;
+uniform float strokeWidthHalf;
 uniform vec4 strokeColor;
 
 uniform vec2 startPoint;
@@ -156,6 +156,6 @@ void main() {
         dist = linear_distance(p, startPoint, endPoint);
     }
 
-    float alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, dist);
+    float alpha = 1.0 - smoothstep(strokeWidthHalf - edgeSoftness, strokeWidthHalf + edgeSoftness, dist);
     gl_FragColor = vec4(strokeColor.rgb, strokeColor.a * alpha);
 }

--- a/internal/painter/gl/shaders/bezier_curve_es.frag
+++ b/internal/painter/gl/shaders/bezier_curve_es.frag
@@ -10,7 +10,7 @@ precision mediump int;
 precision lowp sampler2D;
 #endif
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 uniform float strokeWidthHalf;
@@ -145,7 +145,7 @@ float cubic_distance(vec2 p, vec2 v0, vec2 v1, vec2 v2, vec2 v3)
 
 void main() {
     // coordinates: (0.0) at rect top-left, +X right, +Y down
-    vec2 p = vec2(gl_FragCoord.x, frameSize.y - gl_FragCoord.y) - rectCoords.xz;
+    vec2 p = vec2(gl_FragCoord.x, frame.y - gl_FragCoord.y) - rectCoords.xz;
 
     float dist;
     if (int(numControlPoints) == 1) {

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -8,7 +8,7 @@ uniform vec2 radius;
 uniform float edgeSoftness;
 uniform float angle;
 /* colors params*/
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform vec4 stroke_color;
 /* shadow params*/
 uniform float add_shadow;
@@ -50,7 +50,7 @@ void main()
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
 
     float dist = calc_distance(vec_centered_pos, radius);
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -64,7 +64,7 @@ void main()
         }
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -11,7 +11,7 @@ uniform float angle;
 uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
-uniform float add_shadow;
+uniform float addShadow;
 uniform float shadow_blur_radius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
@@ -73,7 +73,7 @@ void main()
     // apply the final alpha to the combined color
     final_color = vec4(final_color.rgb, final_color.a * final_alpha);
 
-    if (add_shadow == 1.0)
+    if (addShadow == 1.0)
     {
         // use ellipse radii by default, expand/contract by spread
         vec2 shadow_radius = radius;

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -12,7 +12,7 @@ uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
-uniform float shadow_blur_radius;
+uniform float shadowBlurRadius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
@@ -82,14 +82,14 @@ void main()
             shadow_radius = max(radius + shadow_spread, 0.0);
         }
 
-        float blur_inset = shadow_blur_radius * 0.5;
+        float blur_inset = shadowBlurRadius * 0.5;
         shadow_radius = max(shadow_radius - blur_inset, 0.0);
 
         // flip the shadow offset to get the correct shadow position
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
         vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -3,7 +3,7 @@
 /* scaled params */
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec2 radius;
 uniform float edgeSoftness;
 uniform float angle;
@@ -52,9 +52,9 @@ void main()
     float dist = calc_distance(vec_centered_pos, radius);
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
-        vec2 inner_radius = radius - stroke_width;
+        vec2 inner_radius = radius - strokeWidth;
         float fill_mask = 0.0;
         if (inner_radius.x > 1.0 && inner_radius.y > 1.0)
         {

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -54,12 +54,12 @@ void main()
 
     if (strokeWidth > 0.0)
     {
-        vec2 inner_radius = radius - strokeWidth;
+        vec2 innerRadius = radius - strokeWidth;
         float fill_mask = 0.0;
-        if (inner_radius.x > 1.0 && inner_radius.y > 1.0)
+        if (innerRadius.x > 1.0 && innerRadius.y > 1.0)
         {
             // create a mask for the fill area (inside, shrunk by stroke width)
-            float dist_inner = calc_distance(vec_centered_pos, inner_radius);
+            float dist_inner = calc_distance(vec_centered_pos, innerRadius);
             fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist_inner);
         }
 

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -15,7 +15,7 @@ uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
-uniform vec4 shadow_color;
+uniform vec4 shadowColor;
 uniform float shadow_type;
 
 mat2 rotate(float a)
@@ -89,7 +89,7 @@ void main()
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
         vec2 shadow_offset_corrected = vec2(-shadowOffset.x, shadowOffset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
@@ -98,7 +98,7 @@ void main()
             shadow_alpha *= mask;
         }
 
-        final_color = blend_shadow(final_color, vec4(shadow_color.rgb, shadow_alpha));
+        final_color = blend_shadow(final_color, vec4(shadowColor.rgb, shadow_alpha));
     }
 
     gl_FragColor = final_color;

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -16,7 +16,7 @@ uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
 uniform vec4 shadowColor;
-uniform float shadow_type;
+uniform float shadowType;
 
 mat2 rotate(float a)
 {
@@ -91,7 +91,7 @@ void main()
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
         float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
-        if (shadow_type == 0.0)
+        if (shadowType == 0.0)
         {
             // remove shadow inside the ellipse
             float mask = smoothstep(-2.0 * edgeSoftness, 0.0, dist);

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -9,7 +9,7 @@ uniform float edgeSoftness;
 uniform float angle;
 /* colors params*/
 uniform vec4 fillColor;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 /* shadow params*/
 uniform float add_shadow;
 uniform float shadow_blur_radius;
@@ -64,7 +64,7 @@ void main()
         }
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -1,7 +1,7 @@
 #version 110
 
 /* scaled params */
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 uniform vec2 radius;
@@ -44,7 +44,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -2,7 +2,7 @@
 
 /* scaled params */
 uniform vec2 frame_size;
-uniform vec4 rect_coords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 uniform vec2 radius;
 uniform float edge_softness;
@@ -44,7 +44,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -14,7 +14,7 @@ uniform vec4 strokeColor;
 uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
-uniform vec2 shadow_offset;
+uniform vec2 shadowOffset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
 
@@ -87,7 +87,7 @@ void main()
 
         // flip the shadow offset to get the correct shadow position
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
-        vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
+        vec2 shadow_offset_corrected = vec2(-shadowOffset.x, shadowOffset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
         float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -1,7 +1,7 @@
 #version 110
 
 /* scaled params */
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 uniform vec2 radius;
@@ -44,7 +44,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -5,7 +5,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 uniform vec2 radius;
-uniform float edge_softness;
+uniform float edgeSoftness;
 uniform float angle;
 /* colors params*/
 uniform vec4 fill_color;
@@ -60,7 +60,7 @@ void main()
         {
             // create a mask for the fill area (inside, shrunk by stroke width)
             float dist_inner = calc_distance(vec_centered_pos, inner_radius);
-            fill_mask = smoothstep(edge_softness, -edge_softness, dist_inner);
+            fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist_inner);
         }
 
         // combine fill mask and colors (fill + stroke)
@@ -68,7 +68,7 @@ void main()
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
 
     // apply the final alpha to the combined color
     final_color = vec4(final_color.rgb, final_color.a * final_alpha);
@@ -89,12 +89,12 @@ void main()
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
         vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edge_softness, shadow_blur_radius + edge_softness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
             // remove shadow inside the ellipse
-            float mask = smoothstep(-2.0 * edge_softness, 0.0, dist);
+            float mask = smoothstep(-2.0 * edgeSoftness, 0.0, dist);
             shadow_alpha *= mask;
         }
 

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -2,7 +2,7 @@
 
 /* scaled params */
 uniform vec2 frame;
-uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 bounds; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 uniform vec2 radius;
 uniform float edgeSoftness;
@@ -44,7 +44,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/ellipse.frag
+++ b/internal/painter/gl/shaders/ellipse.frag
@@ -13,7 +13,7 @@ uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
 uniform float shadowBlurRadius;
-uniform float shadow_spread;
+uniform float shadowSpread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
@@ -77,9 +77,9 @@ void main()
     {
         // use ellipse radii by default, expand/contract by spread
         vec2 shadow_radius = radius;
-        if (shadow_spread != 0.0)
+        if (shadowSpread != 0.0)
         {
-            shadow_radius = max(radius + shadow_spread, 0.0);
+            shadow_radius = max(radius + shadowSpread, 0.0);
         }
 
         float blur_inset = shadowBlurRadius * 0.5;

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 /* scaled params */
 uniform vec2 frame_size;
-uniform vec4 rect_coords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 uniform vec2 radius;
 uniform float edge_softness;
@@ -54,7 +54,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -25,7 +25,7 @@ uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
-uniform vec4 shadow_color;
+uniform vec4 shadowColor;
 uniform float shadow_type;
 
 mat2 rotate(float a)
@@ -99,7 +99,7 @@ void main()
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
         vec2 shadow_offset_corrected = vec2(-shadowOffset.x, shadowOffset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
@@ -108,7 +108,7 @@ void main()
             shadow_alpha *= mask;
         }
 
-        final_color = blend_shadow(final_color, vec4(shadow_color.rgb, shadow_alpha));
+        final_color = blend_shadow(final_color, vec4(shadowColor.rgb, shadow_alpha));
     }
 
     gl_FragColor = final_color;

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -15,7 +15,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 uniform vec2 radius;
-uniform float edge_softness;
+uniform float edgeSoftness;
 uniform float angle;
 /* colors params*/
 uniform vec4 fill_color;
@@ -70,7 +70,7 @@ void main()
         {
             // create a mask for the fill area (inside, shrunk by stroke width)
             float dist_inner = calc_distance(vec_centered_pos, inner_radius);
-            fill_mask = smoothstep(edge_softness, -edge_softness, dist_inner);
+            fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist_inner);
         }
 
         // combine fill mask and colors (fill + stroke)
@@ -78,7 +78,7 @@ void main()
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
 
     // apply the final alpha to the combined color
     final_color = vec4(final_color.rgb, final_color.a * final_alpha);
@@ -99,12 +99,12 @@ void main()
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
         vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edge_softness, shadow_blur_radius + edge_softness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
             // remove shadow inside the ellipse
-            float mask = smoothstep(-2.0 * edge_softness, 0.0, dist);
+            float mask = smoothstep(-2.0 * edgeSoftness, 0.0, dist);
             shadow_alpha *= mask;
         }
 

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -26,7 +26,7 @@ uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
 uniform vec4 shadowColor;
-uniform float shadow_type;
+uniform float shadowType;
 
 mat2 rotate(float a)
 {
@@ -101,7 +101,7 @@ void main()
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
         float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
-        if (shadow_type == 0.0)
+        if (shadowType == 0.0)
         {
             // remove shadow inside the ellipse
             float mask = smoothstep(-2.0 * edgeSoftness, 0.0, dist);

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -22,7 +22,7 @@ uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
-uniform float shadow_blur_radius;
+uniform float shadowBlurRadius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
@@ -92,14 +92,14 @@ void main()
             shadow_radius = max(radius + shadow_spread, 0.0);
         }
 
-        float blur_inset = shadow_blur_radius * 0.5;
+        float blur_inset = shadowBlurRadius * 0.5;
         shadow_radius = max(shadow_radius - blur_inset, 0.0);
 
         // flip the shadow offset to get the correct shadow position
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
         vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 /* scaled params */
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 uniform vec2 radius;
@@ -54,7 +54,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -19,7 +19,7 @@ uniform float edgeSoftness;
 uniform float angle;
 /* colors params*/
 uniform vec4 fillColor;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 /* shadow params*/
 uniform float add_shadow;
 uniform float shadow_blur_radius;
@@ -74,7 +74,7 @@ void main()
         }
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -13,7 +13,7 @@ precision lowp sampler2D;
 /* scaled params */
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec2 radius;
 uniform float edgeSoftness;
 uniform float angle;
@@ -62,9 +62,9 @@ void main()
     float dist = calc_distance(vec_centered_pos, radius);
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
-        vec2 inner_radius = radius - stroke_width;
+        vec2 inner_radius = radius - strokeWidth;
         float fill_mask = 0.0;
         if (inner_radius.x > 1.0 && inner_radius.y > 1.0)
         {

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -24,7 +24,7 @@ uniform vec4 strokeColor;
 uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
-uniform vec2 shadow_offset;
+uniform vec2 shadowOffset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
 
@@ -97,7 +97,7 @@ void main()
 
         // flip the shadow offset to get the correct shadow position
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
-        vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
+        vec2 shadow_offset_corrected = vec2(-shadowOffset.x, shadowOffset.y);
         float distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_radius);
         float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 /* scaled params */
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 uniform vec2 radius;
@@ -54,7 +54,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -18,7 +18,7 @@ uniform vec2 radius;
 uniform float edgeSoftness;
 uniform float angle;
 /* colors params*/
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform vec4 stroke_color;
 /* shadow params*/
 uniform float add_shadow;
@@ -60,7 +60,7 @@ void main()
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
 
     float dist = calc_distance(vec_centered_pos, radius);
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -74,7 +74,7 @@ void main()
         }
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -21,7 +21,7 @@ uniform float angle;
 uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
-uniform float add_shadow;
+uniform float addShadow;
 uniform float shadow_blur_radius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
@@ -83,7 +83,7 @@ void main()
     // apply the final alpha to the combined color
     final_color = vec4(final_color.rgb, final_color.a * final_alpha);
 
-    if (add_shadow == 1.0)
+    if (addShadow == 1.0)
     {
         // use ellipse radii by default, expand/contract by spread
         vec2 shadow_radius = radius;

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -64,12 +64,12 @@ void main()
 
     if (strokeWidth > 0.0)
     {
-        vec2 inner_radius = radius - strokeWidth;
+        vec2 innerRadius = radius - strokeWidth;
         float fill_mask = 0.0;
-        if (inner_radius.x > 1.0 && inner_radius.y > 1.0)
+        if (innerRadius.x > 1.0 && innerRadius.y > 1.0)
         {
             // create a mask for the fill area (inside, shrunk by stroke width)
-            float dist_inner = calc_distance(vec_centered_pos, inner_radius);
+            float dist_inner = calc_distance(vec_centered_pos, innerRadius);
             fill_mask = smoothstep(edgeSoftness, -edgeSoftness, dist_inner);
         }
 

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -23,7 +23,7 @@ uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
 uniform float shadowBlurRadius;
-uniform float shadow_spread;
+uniform float shadowSpread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
@@ -87,9 +87,9 @@ void main()
     {
         // use ellipse radii by default, expand/contract by spread
         vec2 shadow_radius = radius;
-        if (shadow_spread != 0.0)
+        if (shadowSpread != 0.0)
         {
-            shadow_radius = max(radius + shadow_spread, 0.0);
+            shadow_radius = max(radius + shadowSpread, 0.0);
         }
 
         float blur_inset = shadowBlurRadius * 0.5;

--- a/internal/painter/gl/shaders/ellipse_es.frag
+++ b/internal/painter/gl/shaders/ellipse_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 /* scaled params */
 uniform vec2 frame;
-uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 bounds; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 uniform vec2 radius;
 uniform float edgeSoftness;
@@ -54,7 +54,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -6,7 +6,7 @@ uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_fr
 uniform float strokeWidth;
 /* colors params*/
 uniform vec4 fillColor;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 /* shadow params*/
 uniform float add_shadow;
 uniform float shadow_blur_radius;
@@ -74,19 +74,19 @@ void main()
     {
         if (gl_FragCoord.x >= rectCoords[1] - strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
         else if (gl_FragCoord.x <= rectCoords[0] + strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
         else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
         else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
     }
 

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -12,7 +12,7 @@ uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
-uniform vec4 shadow_color;
+uniform vec4 shadowColor;
 uniform float shadow_type;
 
 vec4 blend_shadow(vec4 color, vec4 shadow)
@@ -37,7 +37,7 @@ void main()
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
-        float shadow_alpha = shadow_color.a * (1.0 - distance_shadow);
+        float shadow_alpha = shadowColor.a * (1.0 - distance_shadow);
 
         if (shadow_type == 0.0)
         {
@@ -59,7 +59,7 @@ void main()
             color[3] = 0.0;
         }
 
-        color = blend_shadow(color, vec4(shadow_color.rgb, shadow_alpha));
+        color = blend_shadow(color, vec4(shadowColor.rgb, shadow_alpha));
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -3,7 +3,7 @@
 /* scaled params */
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
-uniform float stroke_width;
+uniform float strokeWidth;
 /* colors params*/
 uniform vec4 fillColor;
 uniform vec4 stroke_color;
@@ -72,19 +72,19 @@ void main()
     }
     else
     {
-        if (gl_FragCoord.x >= rectCoords[1] - stroke_width)
+        if (gl_FragCoord.x >= rectCoords[1] - strokeWidth)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.x <= rectCoords[0] + stroke_width)
+        else if (gl_FragCoord.x <= rectCoords[0] + strokeWidth)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + stroke_width)
+        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + strokeWidth)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - stroke_width)
+        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - strokeWidth)
         {
             color = stroke_color;
         }

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -9,7 +9,7 @@ uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
-uniform float shadow_blur_radius;
+uniform float shadowBlurRadius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
@@ -36,7 +36,7 @@ void main()
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
 
         vec2 d = abs(frag_pos - center) - half_size;
-        float distance_shadow = smoothstep(-shadow_blur_radius * 0.5, shadow_blur_radius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
+        float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
         float shadow_alpha = shadow_color.a * (1.0 - distance_shadow);
 
         if (shadow_type == 0.0)

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -11,7 +11,7 @@ uniform vec4 strokeColor;
 uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
-uniform vec2 shadow_offset;
+uniform vec2 shadowOffset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
 
@@ -30,7 +30,7 @@ void main()
 
     if (addShadow == 1.0)
     {
-        vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
+        vec2 frag_pos = gl_FragCoord.xy + vec2(-shadowOffset.x, shadowOffset.y);
         vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -10,7 +10,7 @@ uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
 uniform float shadowBlurRadius;
-uniform float shadow_spread;
+uniform float shadowSpread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
@@ -33,7 +33,7 @@ void main()
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
         vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
-        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
+        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -5,7 +5,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 /* colors params*/
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform vec4 stroke_color;
 /* shadow params*/
 uniform float add_shadow;
@@ -26,7 +26,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 color = fill_color;
+    vec4 color = fillColor;
 
     if (add_shadow == 1.0)
     {

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -13,7 +13,7 @@ uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
 uniform vec4 shadowColor;
-uniform float shadow_type;
+uniform float shadowType;
 
 vec4 blend_shadow(vec4 color, vec4 shadow)
 {
@@ -39,7 +39,7 @@ void main()
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
         float shadow_alpha = shadowColor.a * (1.0 - distance_shadow);
 
-        if (shadow_type == 0.0)
+        if (shadowType == 0.0)
         {
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -2,7 +2,7 @@
 
 /* scaled params */
 uniform vec2 frame_size;
-uniform vec4 rect_coords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 /* colors params*/
 uniform vec4 fill_color;
@@ -31,9 +31,9 @@ void main()
     if (add_shadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
-        vec2 center = vec2((rect_coords[0] + rect_coords[1]) * 0.5, frame_size.y - (rect_coords[2] + rect_coords[3]) * 0.5);
+        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame_size.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
-        vec2 half_size = vec2(rect_coords[1] - rect_coords[0], rect_coords[3] - rect_coords[2]) * 0.5 + vec2(shadow_spread);
+        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadow_blur_radius * 0.5, shadow_blur_radius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
@@ -43,19 +43,19 @@ void main()
         {
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
-            float d_h = min(frag_pos.x - rect_coords[0], rect_coords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frame_size.y + rect_coords[3], frame_size.y - rect_coords[2] - frag_pos.y);
+            float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
+            float d_v = min(frag_pos.y - frame_size.y + rectCoords[3], frame_size.y - rectCoords[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
 
-        if (gl_FragCoord.x > rect_coords[1]){
+        if (gl_FragCoord.x > rectCoords[1]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.x < rect_coords[0]){
+        } else if (gl_FragCoord.x < rectCoords[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frame_size.y - rect_coords[3]){
+        } else if (gl_FragCoord.y < frame_size.y - rectCoords[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frame_size.y - rect_coords[2]){
+        } else if (gl_FragCoord.y > frame_size.y - rectCoords[2]){
             color[3] = 0.0;
         }
 
@@ -63,7 +63,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rect_coords[0] || gl_FragCoord.x > rect_coords[1] || gl_FragCoord.y < frame_size.y - rect_coords[3] || gl_FragCoord.y > frame_size.y - rect_coords[2])
+    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame_size.y - rectCoords[3] || gl_FragCoord.y > frame_size.y - rectCoords[2])
     {
         if (add_shadow == 0.0)
         {
@@ -72,19 +72,19 @@ void main()
     }
     else
     {
-        if (gl_FragCoord.x >= rect_coords[1] - stroke_width)
+        if (gl_FragCoord.x >= rectCoords[1] - stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.x <= rect_coords[0] + stroke_width)
+        else if (gl_FragCoord.x <= rectCoords[0] + stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y <= frame_size.y - rect_coords[3] + stroke_width)
+        else if (gl_FragCoord.y <= frame_size.y - rectCoords[3] + stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y >= frame_size.y - rect_coords[2] - stroke_width)
+        else if (gl_FragCoord.y >= frame_size.y - rectCoords[2] - stroke_width)
         {
             color = stroke_color;
         }

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -1,7 +1,7 @@
 #version 110
 
 /* scaled params */
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 /* colors params*/
@@ -31,7 +31,7 @@ void main()
     if (add_shadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
-        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame_size.y - (rectCoords[2] + rectCoords[3]) * 0.5);
+        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
 
@@ -44,7 +44,7 @@ void main()
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
             float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frame_size.y + rectCoords[3], frame_size.y - rectCoords[2] - frag_pos.y);
+            float d_v = min(frag_pos.y - frameSize.y + rectCoords[3], frameSize.y - rectCoords[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
@@ -53,9 +53,9 @@ void main()
             color[3] = 0.0;
         } else if (gl_FragCoord.x < rectCoords[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frame_size.y - rectCoords[3]){
+        } else if (gl_FragCoord.y < frameSize.y - rectCoords[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frame_size.y - rectCoords[2]){
+        } else if (gl_FragCoord.y > frameSize.y - rectCoords[2]){
             color[3] = 0.0;
         }
 
@@ -63,7 +63,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame_size.y - rectCoords[3] || gl_FragCoord.y > frame_size.y - rectCoords[2])
+    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frameSize.y - rectCoords[3] || gl_FragCoord.y > frameSize.y - rectCoords[2])
     {
         if (add_shadow == 0.0)
         {
@@ -80,11 +80,11 @@ void main()
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y <= frame_size.y - rectCoords[3] + stroke_width)
+        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y >= frame_size.y - rectCoords[2] - stroke_width)
+        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - stroke_width)
         {
             color = stroke_color;
         }

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -8,7 +8,7 @@ uniform float strokeWidth;
 uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
-uniform float add_shadow;
+uniform float addShadow;
 uniform float shadow_blur_radius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
@@ -28,7 +28,7 @@ void main()
 {
     vec4 color = fillColor;
 
-    if (add_shadow == 1.0)
+    if (addShadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
         vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
@@ -65,7 +65,7 @@ void main()
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
     if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frameSize.y - rectCoords[3] || gl_FragCoord.y > frameSize.y - rectCoords[2])
     {
-        if (add_shadow == 0.0)
+        if (addShadow == 0.0)
         {
             discard;
         }

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -1,7 +1,7 @@
 #version 110
 
 /* scaled params */
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 /* colors params*/
@@ -31,7 +31,7 @@ void main()
     if (addShadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadowOffset.x, shadowOffset.y);
-        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
+        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);
 
@@ -44,7 +44,7 @@ void main()
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
             float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frameSize.y + rectCoords[3], frameSize.y - rectCoords[2] - frag_pos.y);
+            float d_v = min(frag_pos.y - frame.y + rectCoords[3], frame.y - rectCoords[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
@@ -53,9 +53,9 @@ void main()
             color[3] = 0.0;
         } else if (gl_FragCoord.x < rectCoords[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frameSize.y - rectCoords[3]){
+        } else if (gl_FragCoord.y < frame.y - rectCoords[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frameSize.y - rectCoords[2]){
+        } else if (gl_FragCoord.y > frame.y - rectCoords[2]){
             color[3] = 0.0;
         }
 
@@ -63,7 +63,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frameSize.y - rectCoords[3] || gl_FragCoord.y > frameSize.y - rectCoords[2])
+    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame.y - rectCoords[3] || gl_FragCoord.y > frame.y - rectCoords[2])
     {
         if (addShadow == 0.0)
         {
@@ -80,11 +80,11 @@ void main()
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + strokeWidth)
+        else if (gl_FragCoord.y <= frame.y - rectCoords[3] + strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - strokeWidth)
+        else if (gl_FragCoord.y >= frame.y - rectCoords[2] - strokeWidth)
         {
             color = strokeColor;
         }

--- a/internal/painter/gl/shaders/rectangle.frag
+++ b/internal/painter/gl/shaders/rectangle.frag
@@ -2,7 +2,7 @@
 
 /* scaled params */
 uniform vec2 frame;
-uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 bounds; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 /* colors params*/
 uniform vec4 fillColor;
@@ -31,9 +31,9 @@ void main()
     if (addShadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadowOffset.x, shadowOffset.y);
-        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame.y - (rectCoords[2] + rectCoords[3]) * 0.5);
+        vec2 center = vec2((bounds[0] + bounds[1]) * 0.5, frame.y - (bounds[2] + bounds[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
-        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);
+        vec2 half_size = vec2(bounds[1] - bounds[0], bounds[3] - bounds[2]) * 0.5 + vec2(shadowSpread);
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
@@ -43,19 +43,19 @@ void main()
         {
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
-            float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frame.y + rectCoords[3], frame.y - rectCoords[2] - frag_pos.y);
+            float d_h = min(frag_pos.x - bounds[0], bounds[1] - frag_pos.x);
+            float d_v = min(frag_pos.y - frame.y + bounds[3], frame.y - bounds[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
 
-        if (gl_FragCoord.x > rectCoords[1]){
+        if (gl_FragCoord.x > bounds[1]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.x < rectCoords[0]){
+        } else if (gl_FragCoord.x < bounds[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frame.y - rectCoords[3]){
+        } else if (gl_FragCoord.y < frame.y - bounds[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frame.y - rectCoords[2]){
+        } else if (gl_FragCoord.y > frame.y - bounds[2]){
             color[3] = 0.0;
         }
 
@@ -63,7 +63,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame.y - rectCoords[3] || gl_FragCoord.y > frame.y - rectCoords[2])
+    if (gl_FragCoord.x < bounds[0] || gl_FragCoord.x > bounds[1] || gl_FragCoord.y < frame.y - bounds[3] || gl_FragCoord.y > frame.y - bounds[2])
     {
         if (addShadow == 0.0)
         {
@@ -72,19 +72,19 @@ void main()
     }
     else
     {
-        if (gl_FragCoord.x >= rectCoords[1] - strokeWidth)
+        if (gl_FragCoord.x >= bounds[1] - strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.x <= rectCoords[0] + strokeWidth)
+        else if (gl_FragCoord.x <= bounds[0] + strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y <= frame.y - rectCoords[3] + strokeWidth)
+        else if (gl_FragCoord.y <= frame.y - bounds[3] + strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y >= frame.y - rectCoords[2] - strokeWidth)
+        else if (gl_FragCoord.y >= frame.y - bounds[2] - strokeWidth)
         {
             color = strokeColor;
         }

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -20,7 +20,7 @@ uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
 uniform float shadowBlurRadius;
-uniform float shadow_spread;
+uniform float shadowSpread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
@@ -43,7 +43,7 @@ void main()
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
         vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
-        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
+        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 /* scaled params */
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 /* colors params*/
@@ -41,7 +41,7 @@ void main()
     if (add_shadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
-        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame_size.y - (rectCoords[2] + rectCoords[3]) * 0.5);
+        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
 
@@ -54,7 +54,7 @@ void main()
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
             float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frame_size.y + rectCoords[3], frame_size.y - rectCoords[2] - frag_pos.y);
+            float d_v = min(frag_pos.y - frameSize.y + rectCoords[3], frameSize.y - rectCoords[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
@@ -63,9 +63,9 @@ void main()
             color[3] = 0.0;
         } else if (gl_FragCoord.x < rectCoords[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frame_size.y - rectCoords[3]){
+        } else if (gl_FragCoord.y < frameSize.y - rectCoords[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frame_size.y - rectCoords[2]){
+        } else if (gl_FragCoord.y > frameSize.y - rectCoords[2]){
             color[3] = 0.0;
         }
 
@@ -73,7 +73,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame_size.y - rectCoords[3] || gl_FragCoord.y > frame_size.y - rectCoords[2])
+    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frameSize.y - rectCoords[3] || gl_FragCoord.y > frameSize.y - rectCoords[2])
     {
         if (add_shadow == 0.0)
         {
@@ -90,11 +90,11 @@ void main()
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y <= frame_size.y - rectCoords[3] + stroke_width)
+        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y >= frame_size.y - rectCoords[2] - stroke_width)
+        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - stroke_width)
         {
             color = stroke_color;
         }

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -23,7 +23,7 @@ uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
 uniform vec4 shadowColor;
-uniform float shadow_type;
+uniform float shadowType;
 
 vec4 blend_shadow(vec4 color, vec4 shadow)
 {
@@ -49,7 +49,7 @@ void main()
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
         float shadow_alpha = shadowColor.a * (1.0 - distance_shadow);
 
-        if (shadow_type == 0.0)
+        if (shadowType == 0.0)
         {
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -13,7 +13,7 @@ precision lowp sampler2D;
 /* scaled params */
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
-uniform float stroke_width;
+uniform float strokeWidth;
 /* colors params*/
 uniform vec4 fillColor;
 uniform vec4 stroke_color;
@@ -82,19 +82,19 @@ void main()
     }
     else
     {
-        if (gl_FragCoord.x >= rectCoords[1] - stroke_width)
+        if (gl_FragCoord.x >= rectCoords[1] - strokeWidth)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.x <= rectCoords[0] + stroke_width)
+        else if (gl_FragCoord.x <= rectCoords[0] + strokeWidth)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + stroke_width)
+        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + strokeWidth)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - stroke_width)
+        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - strokeWidth)
         {
             color = stroke_color;
         }

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 /* scaled params */
 uniform vec2 frame;
-uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 bounds; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 /* colors params*/
 uniform vec4 fillColor;
@@ -41,9 +41,9 @@ void main()
     if (addShadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadowOffset.x, shadowOffset.y);
-        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame.y - (rectCoords[2] + rectCoords[3]) * 0.5);
+        vec2 center = vec2((bounds[0] + bounds[1]) * 0.5, frame.y - (bounds[2] + bounds[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
-        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);
+        vec2 half_size = vec2(bounds[1] - bounds[0], bounds[3] - bounds[2]) * 0.5 + vec2(shadowSpread);
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
@@ -53,19 +53,19 @@ void main()
         {
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
-            float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frame.y + rectCoords[3], frame.y - rectCoords[2] - frag_pos.y);
+            float d_h = min(frag_pos.x - bounds[0], bounds[1] - frag_pos.x);
+            float d_v = min(frag_pos.y - frame.y + bounds[3], frame.y - bounds[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
 
-        if (gl_FragCoord.x > rectCoords[1]){
+        if (gl_FragCoord.x > bounds[1]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.x < rectCoords[0]){
+        } else if (gl_FragCoord.x < bounds[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frame.y - rectCoords[3]){
+        } else if (gl_FragCoord.y < frame.y - bounds[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frame.y - rectCoords[2]){
+        } else if (gl_FragCoord.y > frame.y - bounds[2]){
             color[3] = 0.0;
         }
 
@@ -73,7 +73,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame.y - rectCoords[3] || gl_FragCoord.y > frame.y - rectCoords[2])
+    if (gl_FragCoord.x < bounds[0] || gl_FragCoord.x > bounds[1] || gl_FragCoord.y < frame.y - bounds[3] || gl_FragCoord.y > frame.y - bounds[2])
     {
         if (addShadow == 0.0)
         {
@@ -82,19 +82,19 @@ void main()
     }
     else
     {
-        if (gl_FragCoord.x >= rectCoords[1] - strokeWidth)
+        if (gl_FragCoord.x >= bounds[1] - strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.x <= rectCoords[0] + strokeWidth)
+        else if (gl_FragCoord.x <= bounds[0] + strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y <= frame.y - rectCoords[3] + strokeWidth)
+        else if (gl_FragCoord.y <= frame.y - bounds[3] + strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y >= frame.y - rectCoords[2] - strokeWidth)
+        else if (gl_FragCoord.y >= frame.y - bounds[2] - strokeWidth)
         {
             color = strokeColor;
         }

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -18,7 +18,7 @@ uniform float strokeWidth;
 uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
-uniform float add_shadow;
+uniform float addShadow;
 uniform float shadow_blur_radius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
@@ -38,7 +38,7 @@ void main()
 {
     vec4 color = fillColor;
 
-    if (add_shadow == 1.0)
+    if (addShadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
         vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
@@ -75,7 +75,7 @@ void main()
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
     if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frameSize.y - rectCoords[3] || gl_FragCoord.y > frameSize.y - rectCoords[2])
     {
-        if (add_shadow == 0.0)
+        if (addShadow == 0.0)
         {
             discard;
         }

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -16,7 +16,7 @@ uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_fr
 uniform float strokeWidth;
 /* colors params*/
 uniform vec4 fillColor;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 /* shadow params*/
 uniform float add_shadow;
 uniform float shadow_blur_radius;
@@ -84,19 +84,19 @@ void main()
     {
         if (gl_FragCoord.x >= rectCoords[1] - strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
         else if (gl_FragCoord.x <= rectCoords[0] + strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
         else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
         else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - strokeWidth)
         {
-            color = stroke_color;
+            color = strokeColor;
         }
     }
 

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 /* scaled params */
 uniform vec2 frame_size;
-uniform vec4 rect_coords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 /* colors params*/
 uniform vec4 fill_color;
@@ -41,9 +41,9 @@ void main()
     if (add_shadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
-        vec2 center = vec2((rect_coords[0] + rect_coords[1]) * 0.5, frame_size.y - (rect_coords[2] + rect_coords[3]) * 0.5);
+        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame_size.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
-        vec2 half_size = vec2(rect_coords[1] - rect_coords[0], rect_coords[3] - rect_coords[2]) * 0.5 + vec2(shadow_spread);
+        vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadow_blur_radius * 0.5, shadow_blur_radius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
@@ -53,19 +53,19 @@ void main()
         {
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
-            float d_h = min(frag_pos.x - rect_coords[0], rect_coords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frame_size.y + rect_coords[3], frame_size.y - rect_coords[2] - frag_pos.y);
+            float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
+            float d_v = min(frag_pos.y - frame_size.y + rectCoords[3], frame_size.y - rectCoords[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
 
-        if (gl_FragCoord.x > rect_coords[1]){
+        if (gl_FragCoord.x > rectCoords[1]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.x < rect_coords[0]){
+        } else if (gl_FragCoord.x < rectCoords[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frame_size.y - rect_coords[3]){
+        } else if (gl_FragCoord.y < frame_size.y - rectCoords[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frame_size.y - rect_coords[2]){
+        } else if (gl_FragCoord.y > frame_size.y - rectCoords[2]){
             color[3] = 0.0;
         }
 
@@ -73,7 +73,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rect_coords[0] || gl_FragCoord.x > rect_coords[1] || gl_FragCoord.y < frame_size.y - rect_coords[3] || gl_FragCoord.y > frame_size.y - rect_coords[2])
+    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame_size.y - rectCoords[3] || gl_FragCoord.y > frame_size.y - rectCoords[2])
     {
         if (add_shadow == 0.0)
         {
@@ -82,19 +82,19 @@ void main()
     }
     else
     {
-        if (gl_FragCoord.x >= rect_coords[1] - stroke_width)
+        if (gl_FragCoord.x >= rectCoords[1] - stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.x <= rect_coords[0] + stroke_width)
+        else if (gl_FragCoord.x <= rectCoords[0] + stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y <= frame_size.y - rect_coords[3] + stroke_width)
+        else if (gl_FragCoord.y <= frame_size.y - rectCoords[3] + stroke_width)
         {
             color = stroke_color;
         }
-        else if (gl_FragCoord.y >= frame_size.y - rect_coords[2] - stroke_width)
+        else if (gl_FragCoord.y >= frame_size.y - rectCoords[2] - stroke_width)
         {
             color = stroke_color;
         }

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -21,7 +21,7 @@ uniform vec4 strokeColor;
 uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
-uniform vec2 shadow_offset;
+uniform vec2 shadowOffset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
 
@@ -40,7 +40,7 @@ void main()
 
     if (addShadow == 1.0)
     {
-        vec2 frag_pos = gl_FragCoord.xy + vec2(-shadow_offset.x, shadow_offset.y);
+        vec2 frag_pos = gl_FragCoord.xy + vec2(-shadowOffset.x, shadowOffset.y);
         vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -22,7 +22,7 @@ uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
-uniform vec4 shadow_color;
+uniform vec4 shadowColor;
 uniform float shadow_type;
 
 vec4 blend_shadow(vec4 color, vec4 shadow)
@@ -47,7 +47,7 @@ void main()
 
         vec2 d = abs(frag_pos - center) - half_size;
         float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
-        float shadow_alpha = shadow_color.a * (1.0 - distance_shadow);
+        float shadow_alpha = shadowColor.a * (1.0 - distance_shadow);
 
         if (shadow_type == 0.0)
         {
@@ -69,7 +69,7 @@ void main()
             color[3] = 0.0;
         }
 
-        color = blend_shadow(color, vec4(shadow_color.rgb, shadow_alpha));
+        color = blend_shadow(color, vec4(shadowColor.rgb, shadow_alpha));
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -19,7 +19,7 @@ uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
-uniform float shadow_blur_radius;
+uniform float shadowBlurRadius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
@@ -46,7 +46,7 @@ void main()
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadow_spread);
 
         vec2 d = abs(frag_pos - center) - half_size;
-        float distance_shadow = smoothstep(-shadow_blur_radius * 0.5, shadow_blur_radius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
+        float distance_shadow = smoothstep(-shadowBlurRadius * 0.5, shadowBlurRadius * 0.5, length(max(d, 0.0)) + min(max(d.x, d.y), 0.0));
         float shadow_alpha = shadow_color.a * (1.0 - distance_shadow);
 
         if (shadow_type == 0.0)

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 /* scaled params */
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidth;
 /* colors params*/
@@ -41,7 +41,7 @@ void main()
     if (addShadow == 1.0)
     {
         vec2 frag_pos = gl_FragCoord.xy + vec2(-shadowOffset.x, shadowOffset.y);
-        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frameSize.y - (rectCoords[2] + rectCoords[3]) * 0.5);
+        vec2 center = vec2((rectCoords[0] + rectCoords[1]) * 0.5, frame.y - (rectCoords[2] + rectCoords[3]) * 0.5);
         // expand/contract rectangle bounds by spread on all sides
         vec2 half_size = vec2(rectCoords[1] - rectCoords[0], rectCoords[3] - rectCoords[2]) * 0.5 + vec2(shadowSpread);
 
@@ -54,7 +54,7 @@ void main()
             // remove shadow inside rectangle (uses original rect, not spread rect)
             vec2 frag_pos = gl_FragCoord.xy;
             float d_h = min(frag_pos.x - rectCoords[0], rectCoords[1] - frag_pos.x);
-            float d_v = min(frag_pos.y - frameSize.y + rectCoords[3], frameSize.y - rectCoords[2] - frag_pos.y);
+            float d_v = min(frag_pos.y - frame.y + rectCoords[3], frame.y - rectCoords[2] - frag_pos.y);
             float mask = smoothstep(0.0, -0.5, min(d_h, d_v));
             shadow_alpha *= mask;
         }
@@ -63,9 +63,9 @@ void main()
             color[3] = 0.0;
         } else if (gl_FragCoord.x < rectCoords[0]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y < frameSize.y - rectCoords[3]){
+        } else if (gl_FragCoord.y < frame.y - rectCoords[3]){
             color[3] = 0.0;
-        } else if (gl_FragCoord.y > frameSize.y - rectCoords[2]){
+        } else if (gl_FragCoord.y > frame.y - rectCoords[2]){
             color[3] = 0.0;
         }
 
@@ -73,7 +73,7 @@ void main()
     }
 
     // discard if outside rectangle coords, necessary to draw thin stroke and mitigate inconsistent borders issue
-    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frameSize.y - rectCoords[3] || gl_FragCoord.y > frameSize.y - rectCoords[2])
+    if (gl_FragCoord.x < rectCoords[0] || gl_FragCoord.x > rectCoords[1] || gl_FragCoord.y < frame.y - rectCoords[3] || gl_FragCoord.y > frame.y - rectCoords[2])
     {
         if (addShadow == 0.0)
         {
@@ -90,11 +90,11 @@ void main()
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y <= frameSize.y - rectCoords[3] + strokeWidth)
+        else if (gl_FragCoord.y <= frame.y - rectCoords[3] + strokeWidth)
         {
             color = strokeColor;
         }
-        else if (gl_FragCoord.y >= frameSize.y - rectCoords[2] - strokeWidth)
+        else if (gl_FragCoord.y >= frame.y - rectCoords[2] - strokeWidth)
         {
             color = strokeColor;
         }

--- a/internal/painter/gl/shaders/rectangle_es.frag
+++ b/internal/painter/gl/shaders/rectangle_es.frag
@@ -15,7 +15,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width;
 /* colors params*/
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform vec4 stroke_color;
 /* shadow params*/
 uniform float add_shadow;
@@ -36,7 +36,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 color = fill_color;
+    vec4 color = fillColor;
 
     if (add_shadow == 1.0)
     {

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -1,7 +1,7 @@
 #version 110
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 
 uniform float outer_radius;
@@ -35,7 +35,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -1,6 +1,6 @@
 #version 110
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 
@@ -35,7 +35,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -10,7 +10,7 @@ uniform float sides;
 
 uniform vec4 fillColor;
 uniform float corner_radius;
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec4 stroke_color;
 
 const float PI = 3.141592653589793;
@@ -42,10 +42,10 @@ void main()
     float dist = regular_distance(vec_centered_pos, outer_radius - corner_radius, int(sides)) - corner_radius;
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
+        float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fillColor, fill_mask);

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -2,7 +2,7 @@
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 
 uniform float outer_radius;
 uniform float angle;
@@ -45,14 +45,14 @@ void main()
     if (stroke_width > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edge_softness, -stroke_width - edge_softness, dist);
+        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fill_color, fill_mask);
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
 
     // apply the final alpha to the combined color
     gl_FragColor = vec4(final_color.rgb, final_color.a * final_alpha);

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -8,7 +8,7 @@ uniform float outer_radius;
 uniform float angle;
 uniform float sides;
 
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float stroke_width;
 uniform vec4 stroke_color;
@@ -40,7 +40,7 @@ void main()
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
     float dist = regular_distance(vec_centered_pos, outer_radius - corner_radius, int(sides)) - corner_radius;
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -48,7 +48,7 @@ void main()
         float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -1,6 +1,6 @@
 #version 110
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
@@ -35,7 +35,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -4,7 +4,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
-uniform float outer_radius;
+uniform float outerRadius;
 uniform float angle;
 uniform float sides;
 
@@ -39,7 +39,7 @@ void main()
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
-    float dist = regular_distance(vec_centered_pos, outer_radius - corner_radius, int(sides)) - corner_radius;
+    float dist = regular_distance(vec_centered_pos, outerRadius - corner_radius, int(sides)) - corner_radius;
     vec4 final_color = fillColor;
 
     if (strokeWidth > 0.0)

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -11,7 +11,7 @@ uniform float sides;
 uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float strokeWidth;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 const float PI = 3.141592653589793;
 
@@ -48,7 +48,7 @@ void main()
         float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -1,7 +1,7 @@
 #version 110
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 
 uniform float outerRadius;
@@ -35,7 +35,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon.frag
+++ b/internal/painter/gl/shaders/regular_polygon.frag
@@ -9,7 +9,7 @@ uniform float angle;
 uniform float sides;
 
 uniform vec4 fillColor;
-uniform float corner_radius;
+uniform float cornerRadius;
 uniform float strokeWidth;
 uniform vec4 strokeColor;
 
@@ -39,7 +39,7 @@ void main()
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
-    float dist = regular_distance(vec_centered_pos, outerRadius - corner_radius, int(sides)) - corner_radius;
+    float dist = regular_distance(vec_centered_pos, outerRadius - cornerRadius, int(sides)) - cornerRadius;
     vec4 final_color = fillColor;
 
     if (strokeWidth > 0.0)

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -14,7 +14,7 @@ uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
-uniform float outer_radius;
+uniform float outerRadius;
 uniform float angle;
 uniform float sides;
 
@@ -49,7 +49,7 @@ void main()
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
-    float dist = regular_distance(vec_centered_pos, outer_radius - corner_radius, int(sides)) - corner_radius;
+    float dist = regular_distance(vec_centered_pos, outerRadius - corner_radius, int(sides)) - corner_radius;
     vec4 final_color = fillColor;
 
     if (strokeWidth > 0.0)

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 uniform vec2 frame_size;
-uniform vec4 rect_coords;
+uniform vec4 rectCoords;
 uniform float edge_softness;
 
 uniform float outer_radius;
@@ -45,7 +45,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -20,7 +20,7 @@ uniform float sides;
 
 uniform vec4 fillColor;
 uniform float corner_radius;
-uniform float stroke_width;
+uniform float strokeWidth;
 uniform vec4 stroke_color;
 
 const float PI = 3.141592653589793;
@@ -52,10 +52,10 @@ void main()
     float dist = regular_distance(vec_centered_pos, outer_radius - corner_radius, int(sides)) - corner_radius;
     vec4 final_color = fillColor;
 
-    if (stroke_width > 0.0)
+    if (strokeWidth > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
+        float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fillColor, fill_mask);

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 uniform vec2 frameSize;
 uniform vec4 rectCoords;
-uniform float edge_softness;
+uniform float edgeSoftness;
 
 uniform float outer_radius;
 uniform float angle;
@@ -55,14 +55,14 @@ void main()
     if (stroke_width > 0.0)
     {
         // create a mask for the fill area (inside, shrunk by stroke width)
-        float fill_mask = smoothstep(-stroke_width + edge_softness, -stroke_width - edge_softness, dist);
+        float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
         final_color = mix(stroke_color, fill_color, fill_mask);
     }
 
     // smooth edges
-    float final_alpha = smoothstep(edge_softness, -edge_softness, dist);
+    float final_alpha = smoothstep(edgeSoftness, -edgeSoftness, dist);
 
     // apply the final alpha to the combined color
     gl_FragColor = vec4(final_color.rgb, final_color.a * final_alpha);

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 uniform vec2 frame;
-uniform vec4 rectCoords;
+uniform vec4 bounds;
 uniform float edgeSoftness;
 
 uniform float outerRadius;
@@ -45,7 +45,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -10,7 +10,7 @@ precision mediump int;
 precision lowp sampler2D;
 #endif
 
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords;
 uniform float edgeSoftness;
 
@@ -45,7 +45,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -10,7 +10,7 @@ precision mediump int;
 precision lowp sampler2D;
 #endif
 
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords;
 uniform float edge_softness;
 
@@ -45,7 +45,7 @@ float regular_distance(vec2 p, float r, int s)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -21,7 +21,7 @@ uniform float sides;
 uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float strokeWidth;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 
 const float PI = 3.141592653589793;
 
@@ -58,7 +58,7 @@ void main()
         float fill_mask = smoothstep(-strokeWidth + edgeSoftness, -strokeWidth - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fillColor, fill_mask);
+        final_color = mix(strokeColor, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -18,7 +18,7 @@ uniform float outer_radius;
 uniform float angle;
 uniform float sides;
 
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform float corner_radius;
 uniform float stroke_width;
 uniform vec4 stroke_color;
@@ -50,7 +50,7 @@ void main()
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
     float dist = regular_distance(vec_centered_pos, outer_radius - corner_radius, int(sides)) - corner_radius;
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
 
     if (stroke_width > 0.0)
     {
@@ -58,7 +58,7 @@ void main()
         float fill_mask = smoothstep(-stroke_width + edgeSoftness, -stroke_width - edgeSoftness, dist);
 
         // combine fill mask and colors (fill + stroke)
-        final_color = mix(stroke_color, fill_color, fill_mask);
+        final_color = mix(stroke_color, fillColor, fill_mask);
     }
 
     // smooth edges

--- a/internal/painter/gl/shaders/regular_polygon_es.frag
+++ b/internal/painter/gl/shaders/regular_polygon_es.frag
@@ -19,7 +19,7 @@ uniform float angle;
 uniform float sides;
 
 uniform vec4 fillColor;
-uniform float corner_radius;
+uniform float cornerRadius;
 uniform float strokeWidth;
 uniform vec4 strokeColor;
 
@@ -49,7 +49,7 @@ void main()
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     vec_centered_pos = rotate(radians(angle)) * vec_centered_pos;
-    float dist = regular_distance(vec_centered_pos, outerRadius - corner_radius, int(sides)) - corner_radius;
+    float dist = regular_distance(vec_centered_pos, outerRadius - cornerRadius, int(sides)) - cornerRadius;
     vec4 final_color = fillColor;
 
     if (strokeWidth > 0.0)

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -4,7 +4,7 @@
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidthHalf;
-uniform vec2 rect_size_half;
+uniform vec2 rectSizeHalf;
 uniform vec4 radius;
 uniform float edgeSoftness;
 /* colors params*/
@@ -75,11 +75,11 @@ void main()
     float final_alpha;
 
     // subtract a small threshold value to avoid calling calc_distance_all_quadrants when the largest corner radius is very close to half the length of the rectangle's shortest edge
-    bool calc_all_quadrants = max_radius - 0.9 > min(rect_size_half.x, rect_size_half.y) + strokeWidthHalf;
+    bool calc_all_quadrants = max_radius - 0.9 > min(rectSizeHalf.x, rectSizeHalf.y) + strokeWidthHalf;
     if (calc_all_quadrants)
     {
         // at least one corner radius is larger than half of the shorter edge
-        distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
+        distance = calc_distance_all_quadrants(vec_centered_pos, rectSizeHalf + strokeWidthHalf, radius);
         final_alpha = 1.0 - smoothstep(-edgeSoftness, edgeSoftness, distance);
 
         if (strokeWidthHalf > 0.0)
@@ -90,7 +90,7 @@ void main()
     }
     else
     {
-        distance = calc_distance(vec_centered_pos, rect_size_half, radius - strokeWidthHalf);
+        distance = calc_distance(vec_centered_pos, rectSizeHalf, radius - strokeWidthHalf);
         final_alpha = 1.0 - smoothstep(strokeWidthHalf - edgeSoftness, strokeWidthHalf + edgeSoftness, distance);
 
         if (strokeWidthHalf > 0.0)
@@ -106,7 +106,7 @@ void main()
     if (addShadow == 1.0)
     {
         // use rectangle size by default
-        vec2 shadow_size = rect_size_half + strokeWidthHalf;
+        vec2 shadow_size = rectSizeHalf + strokeWidthHalf;
         vec4 shadow_radius = radius;
 
         if (shadowSpread != 0.0)
@@ -150,7 +150,7 @@ void main()
             }
             else
             {
-                d_shape = calc_distance(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
+                d_shape = calc_distance(vec_centered_pos, rectSizeHalf + strokeWidthHalf, radius);
             }
             float mask = smoothstep(-2.0 * edgeSoftness, 0.0, d_shape);
             shadow_alpha *= mask;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -1,7 +1,7 @@
 #version 110
 
 /* scaled params */
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width_half;
 uniform vec2 rect_size_half;
@@ -66,7 +66,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -6,7 +6,7 @@ uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_fr
 uniform float stroke_width_half;
 uniform vec2 rect_size_half;
 uniform vec4 radius;
-uniform float edge_softness;
+uniform float edgeSoftness;
 /* colors params*/
 uniform vec4 fill_color;
 uniform vec4 stroke_color;
@@ -80,22 +80,22 @@ void main()
     {
         // at least one corner radius is larger than half of the shorter edge
         distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + stroke_width_half, radius);
-        final_alpha = 1.0 - smoothstep(-edge_softness, edge_softness, distance);
+        final_alpha = 1.0 - smoothstep(-edgeSoftness, edgeSoftness, distance);
 
         if (stroke_width_half > 0.0)
         {
-            float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edge_softness, stroke_width_half * 2.0 + edge_softness, abs(distance));
+            float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
             final_color = mix(fill_color, stroke_color, color_blend);
         }
     }
     else
     {
         distance = calc_distance(vec_centered_pos, rect_size_half, radius - stroke_width_half);
-        final_alpha = 1.0 - smoothstep(stroke_width_half - edge_softness, stroke_width_half + edge_softness, distance);
+        final_alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, distance);
 
         if (stroke_width_half > 0.0)
         {
-            float color_blend = smoothstep(-stroke_width_half - edge_softness, -stroke_width_half + edge_softness, distance);
+            float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
             final_color = mix(fill_color, stroke_color, color_blend);
         }
     }
@@ -137,7 +137,7 @@ void main()
         {
             distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);
         }
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edge_softness, shadow_blur_radius + edge_softness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
@@ -152,7 +152,7 @@ void main()
             {
                 d_shape = calc_distance(vec_centered_pos, rect_size_half + stroke_width_half, radius);
             }
-            float mask = smoothstep(-2.0 * edge_softness, 0.0, d_shape);
+            float mask = smoothstep(-2.0 * edgeSoftness, 0.0, d_shape);
             shadow_alpha *= mask;
         }
 

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -2,7 +2,7 @@
 
 /* scaled params */
 uniform vec2 frame_size;
-uniform vec4 rect_coords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width_half;
 uniform vec2 rect_size_half;
 uniform vec4 radius;
@@ -66,7 +66,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -9,7 +9,7 @@ uniform vec4 radius;
 uniform float edgeSoftness;
 /* colors params*/
 uniform vec4 fillColor;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 /* shadow params*/
 uniform float add_shadow;
 uniform float shadow_blur_radius;
@@ -85,7 +85,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
-            final_color = mix(fillColor, stroke_color, color_blend);
+            final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
     else
@@ -96,7 +96,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
-            final_color = mix(fillColor, stroke_color, color_blend);
+            final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
 

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -3,7 +3,7 @@
 /* scaled params */
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
-uniform float stroke_width_half;
+uniform float strokeWidthHalf;
 uniform vec2 rect_size_half;
 uniform vec4 radius;
 uniform float edgeSoftness;
@@ -75,27 +75,27 @@ void main()
     float final_alpha;
 
     // subtract a small threshold value to avoid calling calc_distance_all_quadrants when the largest corner radius is very close to half the length of the rectangle's shortest edge
-    bool calc_all_quadrants = max_radius - 0.9 > min(rect_size_half.x, rect_size_half.y) + stroke_width_half;
+    bool calc_all_quadrants = max_radius - 0.9 > min(rect_size_half.x, rect_size_half.y) + strokeWidthHalf;
     if (calc_all_quadrants)
     {
         // at least one corner radius is larger than half of the shorter edge
-        distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + stroke_width_half, radius);
+        distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
         final_alpha = 1.0 - smoothstep(-edgeSoftness, edgeSoftness, distance);
 
-        if (stroke_width_half > 0.0)
+        if (strokeWidthHalf > 0.0)
         {
-            float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
+            float color_blend = 1.0 - smoothstep(strokeWidthHalf * 2.0 - edgeSoftness, strokeWidthHalf * 2.0 + edgeSoftness, abs(distance));
             final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
     else
     {
-        distance = calc_distance(vec_centered_pos, rect_size_half, radius - stroke_width_half);
-        final_alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, distance);
+        distance = calc_distance(vec_centered_pos, rect_size_half, radius - strokeWidthHalf);
+        final_alpha = 1.0 - smoothstep(strokeWidthHalf - edgeSoftness, strokeWidthHalf + edgeSoftness, distance);
 
-        if (stroke_width_half > 0.0)
+        if (strokeWidthHalf > 0.0)
         {
-            float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
+            float color_blend = smoothstep(-strokeWidthHalf - edgeSoftness, -strokeWidthHalf + edgeSoftness, distance);
             final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
@@ -106,7 +106,7 @@ void main()
     if (add_shadow == 1.0)
     {
         // use rectangle size by default
-        vec2 shadow_size = rect_size_half + stroke_width_half;
+        vec2 shadow_size = rect_size_half + strokeWidthHalf;
         vec4 shadow_radius = radius;
 
         if (shadow_spread != 0.0)
@@ -150,7 +150,7 @@ void main()
             }
             else
             {
-                d_shape = calc_distance(vec_centered_pos, rect_size_half + stroke_width_half, radius);
+                d_shape = calc_distance(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
             }
             float mask = smoothstep(-2.0 * edgeSoftness, 0.0, d_shape);
             shadow_alpha *= mask;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -12,7 +12,7 @@ uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
-uniform float shadow_blur_radius;
+uniform float shadowBlurRadius;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
@@ -120,7 +120,7 @@ void main()
             shadow_radius = max(radius * min(ratio_x, ratio_y), 0.0);
         }
 
-        float blur_inset = shadow_blur_radius * 0.5;
+        float blur_inset = shadowBlurRadius * 0.5;
         shadow_size = max(shadow_size - blur_inset, 0.0);
         shadow_radius = max(shadow_radius - blur_inset, 0.0);
 
@@ -137,7 +137,7 @@ void main()
         {
             distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);
         }
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -11,7 +11,7 @@ uniform float edgeSoftness;
 uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
-uniform float add_shadow;
+uniform float addShadow;
 uniform float shadow_blur_radius;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
@@ -103,7 +103,7 @@ void main()
     // final color
     final_color = vec4(final_color.rgb, final_color.a * final_alpha);
 
-    if (add_shadow == 1.0)
+    if (addShadow == 1.0)
     {
         // use rectangle size by default
         vec2 shadow_size = rect_size_half + strokeWidthHalf;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -8,7 +8,7 @@ uniform vec2 rect_size_half;
 uniform vec4 radius;
 uniform float edgeSoftness;
 /* colors params*/
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform vec4 stroke_color;
 /* shadow params*/
 uniform float add_shadow;
@@ -71,7 +71,7 @@ void main()
 
     float distance;
     float max_radius = max(max(radius.x, radius.y), max(radius.z, radius.w));
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
     float final_alpha;
 
     // subtract a small threshold value to avoid calling calc_distance_all_quadrants when the largest corner radius is very close to half the length of the rectangle's shortest edge
@@ -85,7 +85,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
-            final_color = mix(fill_color, stroke_color, color_blend);
+            final_color = mix(fillColor, stroke_color, color_blend);
         }
     }
     else
@@ -96,7 +96,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
-            final_color = mix(fill_color, stroke_color, color_blend);
+            final_color = mix(fillColor, stroke_color, color_blend);
         }
     }
 

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -14,7 +14,7 @@ uniform vec4 strokeColor;
 uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform vec2 shadowOffset;
-uniform vec4 shadow_color;
+uniform vec4 shadowColor;
 uniform float shadow_type;
 uniform float shadowSpread;
 
@@ -137,7 +137,7 @@ void main()
         {
             distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);
         }
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
@@ -156,7 +156,7 @@ void main()
             shadow_alpha *= mask;
         }
 
-        final_color = blend_shadow(final_color, vec4(shadow_color.rgb, shadow_alpha));
+        final_color = blend_shadow(final_color, vec4(shadowColor.rgb, shadow_alpha));
     }
 
     gl_FragColor = final_color;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -2,7 +2,7 @@
 
 /* scaled params */
 uniform vec2 frame;
-uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 bounds; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidthHalf;
 uniform vec2 rectSizeHalf;
 uniform vec4 radius;
@@ -66,7 +66,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -1,7 +1,7 @@
 #version 110
 
 /* scaled params */
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidthHalf;
 uniform vec2 rectSizeHalf;
@@ -66,7 +66,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -15,7 +15,7 @@ uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform vec2 shadowOffset;
 uniform vec4 shadowColor;
-uniform float shadow_type;
+uniform float shadowType;
 uniform float shadowSpread;
 
 // distance is calculated for a single quadrant
@@ -139,7 +139,7 @@ void main()
         }
         float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
-        if (shadow_type == 0.0)
+        if (shadowType == 0.0)
         {
             // remove shadow inside rectangle
             float d_shape;

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -13,7 +13,7 @@ uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
 uniform float shadowBlurRadius;
-uniform vec2 shadow_offset;
+uniform vec2 shadowOffset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
 uniform float shadowSpread;
@@ -128,7 +128,7 @@ void main()
         float distance_shadow;
         // flip the shadow offset to get the correct shadow position
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
-        vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
+        vec2 shadow_offset_corrected = vec2(-shadowOffset.x, shadowOffset.y);
         if (calc_all_quadrants)
         {
             distance_shadow = calc_distance_all_quadrants(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);

--- a/internal/painter/gl/shaders/round_rectangle.frag
+++ b/internal/painter/gl/shaders/round_rectangle.frag
@@ -16,7 +16,7 @@ uniform float shadowBlurRadius;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
-uniform float shadow_spread;
+uniform float shadowSpread;
 
 // distance is calculated for a single quadrant
 // returns invalid output if corner radius exceed half of the shorter edge
@@ -109,11 +109,11 @@ void main()
         vec2 shadow_size = rect_size_half + strokeWidthHalf;
         vec4 shadow_radius = radius;
 
-        if (shadow_spread != 0.0)
+        if (shadowSpread != 0.0)
         {
             // expand/contract by spread, adjust radii to match
             vec2 original_size = shadow_size;
-            shadow_size = max(original_size + shadow_spread, 0.0);
+            shadow_size = max(original_size + shadowSpread, 0.0);
             float ratio_x = (original_size.x > 0.0) ? (shadow_size.x / original_size.x) : 1.0;
             float ratio_y = (original_size.y > 0.0) ? (shadow_size.y / original_size.y) : 1.0;
             // scale all corner radii proportionally, use minimum ratio so radius never exceeds the shorter adjacent edge

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -24,7 +24,7 @@ uniform vec4 strokeColor;
 uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
-uniform vec2 shadow_offset;
+uniform vec2 shadowOffset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
 
@@ -138,7 +138,7 @@ void main()
         float distance_shadow;
         // flip the shadow offset to get the correct shadow position
         // negative offset-x value places the shadow to the left of the element. Negative offset-y value places the shadow above the element
-        vec2 shadow_offset_corrected = vec2(-shadow_offset.x, shadow_offset.y);
+        vec2 shadow_offset_corrected = vec2(-shadowOffset.x, shadowOffset.y);
         if (calc_all_quadrants)
         {
             distance_shadow = calc_distance_all_quadrants(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 /* scaled params */
-uniform vec2 frameSize;
+uniform vec2 frame;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidthHalf;
 uniform vec2 rectSizeHalf;
@@ -76,7 +76,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -23,7 +23,7 @@ uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
 uniform float shadowBlurRadius;
-uniform float shadow_spread;
+uniform float shadowSpread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
 uniform float shadow_type;
@@ -119,11 +119,11 @@ void main()
         vec2 shadow_size = rect_size_half + strokeWidthHalf;
         vec4 shadow_radius = radius;
 
-        if (shadow_spread != 0.0)
+        if (shadowSpread != 0.0)
         {
             // expand/contract by spread, adjust radii to match
             vec2 original_size = shadow_size;
-            shadow_size = max(original_size + shadow_spread, 0.0);
+            shadow_size = max(original_size + shadowSpread, 0.0);
             float ratio_x = (original_size.x > 0.0) ? (shadow_size.x / original_size.x) : 1.0;
             float ratio_y = (original_size.y > 0.0) ? (shadow_size.y / original_size.y) : 1.0;
             // scale all corner radii proportionally, use minimum ratio so radius never exceeds the shorter adjacent edge

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 /* scaled params */
 uniform vec2 frame_size;
-uniform vec4 rect_coords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width_half;
 uniform vec2 rect_size_half;
 uniform vec4 radius;
@@ -76,7 +76,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rect_coords[0], rect_coords[1], frame_size.y - rect_coords[3], frame_size.y - rect_coords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -22,7 +22,7 @@ uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
 uniform float addShadow;
-uniform float shadow_blur_radius;
+uniform float shadowBlurRadius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
 uniform vec4 shadow_color;
@@ -130,7 +130,7 @@ void main()
             shadow_radius = max(radius * min(ratio_x, ratio_y), 0.0);
         }
 
-        float blur_inset = shadow_blur_radius * 0.5;
+        float blur_inset = shadowBlurRadius * 0.5;
         shadow_size = max(shadow_size - blur_inset, 0.0);
         shadow_radius = max(shadow_radius - blur_inset, 0.0);
 
@@ -147,7 +147,7 @@ void main()
         {
             distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);
         }
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -21,7 +21,7 @@ uniform float edgeSoftness;
 uniform vec4 fillColor;
 uniform vec4 strokeColor;
 /* shadow params*/
-uniform float add_shadow;
+uniform float addShadow;
 uniform float shadow_blur_radius;
 uniform float shadow_spread;
 uniform vec2 shadow_offset;
@@ -113,7 +113,7 @@ void main()
     // final color
     final_color = vec4(final_color.rgb, final_color.a * final_alpha);
 
-    if (add_shadow == 1.0)
+    if (addShadow == 1.0)
     {
         // use rectangle size by default
         vec2 shadow_size = rect_size_half + strokeWidthHalf;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -25,7 +25,7 @@ uniform float addShadow;
 uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
-uniform vec4 shadow_color;
+uniform vec4 shadowColor;
 uniform float shadow_type;
 
 // distance is calculated for a single quadrant
@@ -147,7 +147,7 @@ void main()
         {
             distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);
         }
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
+        float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
@@ -166,7 +166,7 @@ void main()
             shadow_alpha *= mask;
         }
 
-        final_color = blend_shadow(final_color, vec4(shadow_color.rgb, shadow_alpha));
+        final_color = blend_shadow(final_color, vec4(shadowColor.rgb, shadow_alpha));
     }
 
     gl_FragColor = final_color;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -19,7 +19,7 @@ uniform vec4 radius;
 uniform float edgeSoftness;
 /* colors params*/
 uniform vec4 fillColor;
-uniform vec4 stroke_color;
+uniform vec4 strokeColor;
 /* shadow params*/
 uniform float add_shadow;
 uniform float shadow_blur_radius;
@@ -95,7 +95,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
-            final_color = mix(fillColor, stroke_color, color_blend);
+            final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
     else
@@ -106,7 +106,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
-            final_color = mix(fillColor, stroke_color, color_blend);
+            final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
 

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -26,7 +26,7 @@ uniform float shadowBlurRadius;
 uniform float shadowSpread;
 uniform vec2 shadowOffset;
 uniform vec4 shadowColor;
-uniform float shadow_type;
+uniform float shadowType;
 
 // distance is calculated for a single quadrant
 // returns invalid output if corner radius exceed half of the shorter edge
@@ -149,7 +149,7 @@ void main()
         }
         float shadow_alpha = shadowColor.a * (1.0 - smoothstep(-edgeSoftness, shadowBlurRadius + edgeSoftness, distance_shadow));
 
-        if (shadow_type == 0.0)
+        if (shadowType == 0.0)
         {
             // remove shadow inside rectangle
             float d_shape;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -16,7 +16,7 @@ uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_fr
 uniform float stroke_width_half;
 uniform vec2 rect_size_half;
 uniform vec4 radius;
-uniform float edge_softness;
+uniform float edgeSoftness;
 /* colors params*/
 uniform vec4 fill_color;
 uniform vec4 stroke_color;
@@ -90,22 +90,22 @@ void main()
     {
         // at least one corner radius is larger than half of the shorter edge
         distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + stroke_width_half, radius);
-        final_alpha = 1.0 - smoothstep(-edge_softness, edge_softness, distance);
+        final_alpha = 1.0 - smoothstep(-edgeSoftness, edgeSoftness, distance);
 
         if (stroke_width_half > 0.0)
         {
-            float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edge_softness, stroke_width_half * 2.0 + edge_softness, abs(distance));
+            float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
             final_color = mix(fill_color, stroke_color, color_blend);
         }
     }
     else
     {
         distance = calc_distance(vec_centered_pos, rect_size_half, radius - stroke_width_half);
-        final_alpha = 1.0 - smoothstep(stroke_width_half - edge_softness, stroke_width_half + edge_softness, distance);
+        final_alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, distance);
 
         if (stroke_width_half > 0.0)
         {
-            float color_blend = smoothstep(-stroke_width_half - edge_softness, -stroke_width_half + edge_softness, distance);
+            float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
             final_color = mix(fill_color, stroke_color, color_blend);
         }
     }
@@ -147,7 +147,7 @@ void main()
         {
             distance_shadow = calc_distance(vec_centered_pos + shadow_offset_corrected, shadow_size, shadow_radius);
         }
-        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edge_softness, shadow_blur_radius + edge_softness, distance_shadow));
+        float shadow_alpha = shadow_color.a * (1.0 - smoothstep(-edgeSoftness, shadow_blur_radius + edgeSoftness, distance_shadow));
 
         if (shadow_type == 0.0)
         {
@@ -162,7 +162,7 @@ void main()
             {
                 d_shape = calc_distance(vec_centered_pos, rect_size_half + stroke_width_half, radius);
             }
-            float mask = smoothstep(-2.0 * edge_softness, 0.0, d_shape);
+            float mask = smoothstep(-2.0 * edgeSoftness, 0.0, d_shape);
             shadow_alpha *= mask;
         }
 

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 /* scaled params */
-uniform vec2 frame_size;
+uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float stroke_width_half;
 uniform vec2 rect_size_half;
@@ -76,7 +76,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame_size.y - rectCoords[3], frame_size.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frameSize.y - rectCoords[3], frameSize.y - rectCoords[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -18,7 +18,7 @@ uniform vec2 rect_size_half;
 uniform vec4 radius;
 uniform float edgeSoftness;
 /* colors params*/
-uniform vec4 fill_color;
+uniform vec4 fillColor;
 uniform vec4 stroke_color;
 /* shadow params*/
 uniform float add_shadow;
@@ -81,7 +81,7 @@ void main()
 
     float distance;
     float max_radius = max(max(radius.x, radius.y), max(radius.z, radius.w));
-    vec4 final_color = fill_color;
+    vec4 final_color = fillColor;
     float final_alpha;
 
     // subtract a small threshold value to avoid calling calc_distance_all_quadrants when the largest corner radius is very close to half the length of the rectangle's shortest edge
@@ -95,7 +95,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
-            final_color = mix(fill_color, stroke_color, color_blend);
+            final_color = mix(fillColor, stroke_color, color_blend);
         }
     }
     else
@@ -106,7 +106,7 @@ void main()
         if (stroke_width_half > 0.0)
         {
             float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
-            final_color = mix(fill_color, stroke_color, color_blend);
+            final_color = mix(fillColor, stroke_color, color_blend);
         }
     }
 

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -12,7 +12,7 @@ precision lowp sampler2D;
 
 /* scaled params */
 uniform vec2 frame;
-uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
+uniform vec4 bounds; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidthHalf;
 uniform vec2 rectSizeHalf;
 uniform vec4 radius;
@@ -76,7 +76,7 @@ vec4 blend_shadow(vec4 color, vec4 shadow)
 
 void main()
 {
-    vec4 frag_rect_coords = vec4(rectCoords[0], rectCoords[1], frame.y - rectCoords[3], frame.y - rectCoords[2]);
+    vec4 frag_rect_coords = vec4(bounds[0], bounds[1], frame.y - bounds[3], frame.y - bounds[2]);
     vec2 vec_centered_pos = (gl_FragCoord.xy - vec2(frag_rect_coords[0] + frag_rect_coords[1], frag_rect_coords[2] + frag_rect_coords[3]) * 0.5);
 
     float distance;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -13,7 +13,7 @@ precision lowp sampler2D;
 /* scaled params */
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
-uniform float stroke_width_half;
+uniform float strokeWidthHalf;
 uniform vec2 rect_size_half;
 uniform vec4 radius;
 uniform float edgeSoftness;
@@ -85,27 +85,27 @@ void main()
     float final_alpha;
 
     // subtract a small threshold value to avoid calling calc_distance_all_quadrants when the largest corner radius is very close to half the length of the rectangle's shortest edge
-    bool calc_all_quadrants = max_radius - 0.9 > min(rect_size_half.x, rect_size_half.y) + stroke_width_half;
+    bool calc_all_quadrants = max_radius - 0.9 > min(rect_size_half.x, rect_size_half.y) + strokeWidthHalf;
     if (calc_all_quadrants)
     {
         // at least one corner radius is larger than half of the shorter edge
-        distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + stroke_width_half, radius);
+        distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
         final_alpha = 1.0 - smoothstep(-edgeSoftness, edgeSoftness, distance);
 
-        if (stroke_width_half > 0.0)
+        if (strokeWidthHalf > 0.0)
         {
-            float color_blend = 1.0 - smoothstep(stroke_width_half * 2.0 - edgeSoftness, stroke_width_half * 2.0 + edgeSoftness, abs(distance));
+            float color_blend = 1.0 - smoothstep(strokeWidthHalf * 2.0 - edgeSoftness, strokeWidthHalf * 2.0 + edgeSoftness, abs(distance));
             final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
     else
     {
-        distance = calc_distance(vec_centered_pos, rect_size_half, radius - stroke_width_half);
-        final_alpha = 1.0 - smoothstep(stroke_width_half - edgeSoftness, stroke_width_half + edgeSoftness, distance);
+        distance = calc_distance(vec_centered_pos, rect_size_half, radius - strokeWidthHalf);
+        final_alpha = 1.0 - smoothstep(strokeWidthHalf - edgeSoftness, strokeWidthHalf + edgeSoftness, distance);
 
-        if (stroke_width_half > 0.0)
+        if (strokeWidthHalf > 0.0)
         {
-            float color_blend = smoothstep(-stroke_width_half - edgeSoftness, -stroke_width_half + edgeSoftness, distance);
+            float color_blend = smoothstep(-strokeWidthHalf - edgeSoftness, -strokeWidthHalf + edgeSoftness, distance);
             final_color = mix(fillColor, strokeColor, color_blend);
         }
     }
@@ -116,7 +116,7 @@ void main()
     if (add_shadow == 1.0)
     {
         // use rectangle size by default
-        vec2 shadow_size = rect_size_half + stroke_width_half;
+        vec2 shadow_size = rect_size_half + strokeWidthHalf;
         vec4 shadow_radius = radius;
 
         if (shadow_spread != 0.0)
@@ -160,7 +160,7 @@ void main()
             }
             else
             {
-                d_shape = calc_distance(vec_centered_pos, rect_size_half + stroke_width_half, radius);
+                d_shape = calc_distance(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
             }
             float mask = smoothstep(-2.0 * edgeSoftness, 0.0, d_shape);
             shadow_alpha *= mask;

--- a/internal/painter/gl/shaders/round_rectangle_es.frag
+++ b/internal/painter/gl/shaders/round_rectangle_es.frag
@@ -14,7 +14,7 @@ precision lowp sampler2D;
 uniform vec2 frameSize;
 uniform vec4 rectCoords; //x1 [0], x2 [1], y1 [2], y2 [3]; coords of the rect_frame
 uniform float strokeWidthHalf;
-uniform vec2 rect_size_half;
+uniform vec2 rectSizeHalf;
 uniform vec4 radius;
 uniform float edgeSoftness;
 /* colors params*/
@@ -85,11 +85,11 @@ void main()
     float final_alpha;
 
     // subtract a small threshold value to avoid calling calc_distance_all_quadrants when the largest corner radius is very close to half the length of the rectangle's shortest edge
-    bool calc_all_quadrants = max_radius - 0.9 > min(rect_size_half.x, rect_size_half.y) + strokeWidthHalf;
+    bool calc_all_quadrants = max_radius - 0.9 > min(rectSizeHalf.x, rectSizeHalf.y) + strokeWidthHalf;
     if (calc_all_quadrants)
     {
         // at least one corner radius is larger than half of the shorter edge
-        distance = calc_distance_all_quadrants(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
+        distance = calc_distance_all_quadrants(vec_centered_pos, rectSizeHalf + strokeWidthHalf, radius);
         final_alpha = 1.0 - smoothstep(-edgeSoftness, edgeSoftness, distance);
 
         if (strokeWidthHalf > 0.0)
@@ -100,7 +100,7 @@ void main()
     }
     else
     {
-        distance = calc_distance(vec_centered_pos, rect_size_half, radius - strokeWidthHalf);
+        distance = calc_distance(vec_centered_pos, rectSizeHalf, radius - strokeWidthHalf);
         final_alpha = 1.0 - smoothstep(strokeWidthHalf - edgeSoftness, strokeWidthHalf + edgeSoftness, distance);
 
         if (strokeWidthHalf > 0.0)
@@ -116,7 +116,7 @@ void main()
     if (addShadow == 1.0)
     {
         // use rectangle size by default
-        vec2 shadow_size = rect_size_half + strokeWidthHalf;
+        vec2 shadow_size = rectSizeHalf + strokeWidthHalf;
         vec4 shadow_radius = radius;
 
         if (shadowSpread != 0.0)
@@ -160,7 +160,7 @@ void main()
             }
             else
             {
-                d_shape = calc_distance(vec_centered_pos, rect_size_half + strokeWidthHalf, radius);
+                d_shape = calc_distance(vec_centered_pos, rectSizeHalf + strokeWidthHalf, radius);
             }
             float mask = smoothstep(-2.0 * edgeSoftness, 0.0, d_shape);
             shadow_alpha *= mask;


### PR DESCRIPTION
### Description:

This PR renames all (global) GL shader variables to camel-case.
Local variables function names and other are not touched.

This also renames `frame_size` to `frame` and `rect_coords` to `bounds` to improve the new Shader API.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
