### PR TITLE
Enable unconvert and revive linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - govet
     - nolintlint
     - staticcheck
+    - unconvert
     - unused
   exclusions:
     presets:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,11 +19,13 @@ linters:
         linters:
           - errcheck
           - gosec
+          - revive
           - staticcheck
       - path: cmd/fyne_demo/ # The whole tool is deprecated
         linters:
           - errcheck
           - gosec
+          - revive
       - path: test/ # In tests, the usage of deprecated stuff is valid to check for compatibility.
         linters:
           - staticcheck
@@ -45,7 +47,14 @@ linters:
       enable-all-rules: true
       rules:
         - name: add-constant
-          disabled: true # TODO
+          arguments:
+          - allowFloats: "0.0,0.25,0.5,0.75,1.0"
+            allowInts: "0,1,2,3,4,5,100,0xff,0xffff"
+            allowStrs: '""'
+            ignoreFuncs: "strconv\\.Format.*,strconv\\.Parse.*"
+          exclude:
+            - "**/*_test.go"
+            - "**/test/**"
         - name: argument-limit
           disabled: true # TODO
         - name: blank-imports
@@ -90,8 +99,6 @@ linters:
           disabled: true # TODO
         - name: identical-switch-branches
           disabled: true # TODO
-        - name: if-return
-          disabled: true # TODO
         - name: import-alias-naming
           disabled: true # TODO
         - name: import-shadowing
@@ -103,8 +110,6 @@ linters:
         - name: inefficient-map-lookup
           disabled: true # TODO
         - name: line-length-limit
-          disabled: true # TODO
-        - name: max-control-nesting
           disabled: true # TODO
         - name: max-public-structs
           disabled: true # TODO
@@ -132,13 +137,9 @@ linters:
           disabled: true # TODO
         - name: unnecessary-stmt
           disabled: true # TODO
-        - name: unsecure-url-scheme
-          disabled: true # TODO
         - name: unused-parameter
           disabled: true # TODO
         - name: unused-receiver
-          disabled: true # TODO
-        - name: use-errors-new
           disabled: true # TODO
         - name: var-declaration
           disabled: true # TODO

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - gosec
     - govet
     - nolintlint
+    - revive
     - staticcheck
     - unconvert
     - unused
@@ -39,6 +40,108 @@ linters:
         - G302
         - G304
         - G306
+    revive:
+      severity: error
+      enable-all-rules: true
+      rules:
+        - name: add-constant
+          disabled: true # TODO
+        - name: argument-limit
+          disabled: true # TODO
+        - name: blank-imports
+          disabled: true # TODO
+        - name: bool-literal-in-expr
+          disabled: true # TODO
+        - name: cognitive-complexity
+          disabled: true
+        - name: comment-spacings
+          disabled: true # TODO
+        - name: confusing-naming
+          disabled: true # TODO
+        - name: confusing-results
+          disabled: true # TODO
+        - name: cyclomatic
+          disabled: true
+        - name: deep-exit
+          disabled: true # TODO
+        - name: early-return
+          disabled: true # TODO
+        - name: empty-block
+          disabled: true # TODO
+        - name: empty-lines
+          disabled: true # TODO
+        - name: enforce-switch-style
+          disabled: true # TODO
+        - name: epoch-naming
+          disabled: true # TODO
+        - name: exported
+          disabled: true # TODO
+        - name: filename-format
+          disabled: true # TODO
+        - name: flag-parameter
+          disabled: true # TODO
+        - name: function-length
+          disabled: true # TODO
+        - name: function-result-limit
+          disabled: true # TODO
+        - name: get-return
+          disabled: true # TODO
+        - name: identical-ifelseif-branches
+          disabled: true # TODO
+        - name: identical-switch-branches
+          disabled: true # TODO
+        - name: if-return
+          disabled: true # TODO
+        - name: import-alias-naming
+          disabled: true # TODO
+        - name: import-shadowing
+          disabled: true # TODO
+        - name: increment-decrement
+          disabled: true # TODO
+        - name: indent-error-flow
+          disabled: true # TODO
+        - name: inefficient-map-lookup
+          disabled: true # TODO
+        - name: line-length-limit
+          disabled: true # TODO
+        - name: max-control-nesting
+          disabled: true # TODO
+        - name: max-public-structs
+          disabled: true # TODO
+        - name: nested-structs
+          disabled: true # TODO
+        - name: package-comments
+          disabled: true # TODO
+        - name: package-naming
+          disabled: true # TODO
+        - name: redefines-builtin-id
+          disabled: true # TODO
+        - name: redundant-test-main-exit
+          disabled: true # TODO
+        - name: struct-tag
+          disabled: true # TODO
+        - name: unchecked-type-assertion
+          disabled: true # TODO
+        - name: unexported-naming
+          disabled: true # TODO
+        - name: unexported-return
+          disabled: true # TODO
+        - name: unhandled-error
+          disabled: true # we rely on errcheck
+        - name: unnecessary-format
+          disabled: true # TODO
+        - name: unnecessary-stmt
+          disabled: true # TODO
+        - name: unsecure-url-scheme
+          disabled: true # TODO
+        - name: unused-parameter
+          disabled: true # TODO
+        - name: unused-receiver
+          disabled: true # TODO
+        - name: use-errors-new
+          disabled: true # TODO
+        - name: var-declaration
+          disabled: true # TODO
     staticcheck:
       checks:
         - all

--- a/app/app.go
+++ b/app/app.go
@@ -4,8 +4,8 @@
 package app // import "fyne.io/fyne/v2/app"
 
 import (
+	"fmt"
 	"log"
-	"strconv"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -64,7 +64,7 @@ func (a *fyneApp) UniqueID() string {
 	}
 
 	fyne.LogError("Preferences API requires a unique ID, use app.NewWithID() or the FyneApp.toml ID field", nil)
-	a.uniqueID = "missing-id-" + strconv.FormatInt(time.Now().Unix(), 10) // This is a fake unique - it just has to not be reused...
+	a.uniqueID = fmt.Sprintf("missing-id-%d", time.Now().Unix()) // This is a fake unique - it just has to not be reused...
 	return a.uniqueID
 }
 

--- a/app/app_mobile_desktop.go
+++ b/app/app_mobile_desktop.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 )
 
 func (a *fyneApp) OpenURL(url *url.URL) error {
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == goos.Darwin {
 		cmd := exec.Command("open", url.String())
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 		return cmd.Run()

--- a/app/icon_cache_file.go
+++ b/app/icon_cache_file.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/repository"
 )
 
 var once sync.Once
@@ -28,7 +29,7 @@ func (a *fyneApp) cachedIconPath() string {
 }
 
 func (a *fyneApp) saveIconToCache(dirPath, filePath string) error {
-	err := os.MkdirAll(dirPath, 0o700)
+	err := os.MkdirAll(dirPath, repository.PermUserReadWriteExec)
 	if err != nil {
 		fyne.LogError("Unable to create application cache directory", err)
 		return err

--- a/app/meta_development.go
+++ b/app/meta_development.go
@@ -34,15 +34,16 @@ func checkLocalMetadata() {
 	meta.Version = data.Details.Version
 	meta.Build = data.Details.Build
 
+	const iconBaseSize = 512
 	if data.Details.Icon != "" {
 		res, err := fyne.LoadResourceFromPath(data.Details.Icon)
 		if err == nil {
-			meta.Icon = metadata.ScaleIcon(res, 512)
+			meta.Icon = metadata.ScaleIcon(res, iconBaseSize)
 		}
 	} else { // Icon.png fallback
 		res, err := fyne.LoadResourceFromPath("Icon.png")
 		if err == nil {
-			meta.Icon = metadata.ScaleIcon(res, 512)
+			meta.Icon = metadata.ScaleIcon(res, iconBaseSize)
 		}
 	}
 

--- a/app/preferences_nonweb.go
+++ b/app/preferences_nonweb.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"fyne.io/fyne/v2/internal/repository"
 )
 
 func (p *preferences) storageWriter() (writeSyncCloser, error) {
@@ -17,7 +19,7 @@ func (p *preferences) storageReader() (io.ReadCloser, error) {
 }
 
 func (p *preferences) storageWriterForPath(path string) (writeSyncCloser, error) {
-	err := os.MkdirAll(filepath.Dir(path), 0o700)
+	err := os.MkdirAll(filepath.Dir(path), repository.PermUserReadWriteExec)
 	if err != nil { // this is not an exists error according to docs
 		return nil, err
 	}
@@ -38,7 +40,7 @@ func (p *preferences) storageReaderForPath(path string) (io.ReadCloser, error) {
 	file, err := os.Open(path) // #nosec
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			if err := os.MkdirAll(filepath.Dir(path), repository.PermUserReadWriteExec); err != nil {
 				return nil, err
 			}
 			return nil, errEmptyPreferencesStore

--- a/app/settings_desktop.go
+++ b/app/settings_desktop.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/repository"
 )
 
 func watchFileAddTarget(watcher *fsnotify.Watcher, path string) {
@@ -26,7 +27,7 @@ func ensureDirExists(dir string) {
 		return
 	}
 
-	err := os.MkdirAll(dir, 0o700)
+	err := os.MkdirAll(dir, repository.PermUserReadWriteExec)
 	if err != nil {
 		fyne.LogError("Unable to create settings storage:", err)
 	}

--- a/canvas/gradient.go
+++ b/canvas/gradient.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/painter/geom"
 )
 
 // LinearGradient defines a Gradient travelling straight at a given angle.
@@ -23,31 +24,31 @@ func (g *LinearGradient) Generate(iw, ih int) image.Image {
 	w, h := float64(iw), float64(ih)
 	var generator func(x, y float64) float64
 	switch g.Angle {
-	case 90, -270: // horizontal flipped
+	case geom.AngleQuarter, -geom.AngleThreeQuarter: // horizontal flipped
 		generator = func(x, _ float64) float64 {
 			return (w - x) / w
 		}
-	case 270, -90: // horizontal
+	case geom.AngleThreeQuarter, -geom.AngleQuarter: // horizontal
 		generator = func(x, _ float64) float64 {
 			return x / w
 		}
-	case 45, -315: // diagonal negative flipped
+	case geom.AngleEighth, -geom.AngleSevenEighth: // diagonal negative flipped
 		generator = func(x, y float64) float64 {
 			return math.Abs((w - x + y) / (w + h)) // ((w+h)-(x+h-y)) / (w+h)
 		}
-	case 225, -135: // diagonal negative
+	case geom.AngleFiveEighth, -geom.AngleThreeEighth: // diagonal negative
 		generator = func(x, y float64) float64 {
 			return math.Abs((x + h - y) / (w + h))
 		}
-	case 135, -225: // diagonal positive flipped
+	case geom.AngleThreeEighth, -geom.AngleFiveEighth: // diagonal positive flipped
 		generator = func(x, y float64) float64 {
 			return math.Abs((w + h - (x + y)) / (w + h))
 		}
-	case 315, -45: // diagonal positive
+	case geom.AngleSevenEighth, -geom.AngleEighth: // diagonal positive
 		generator = func(x, y float64) float64 {
 			return math.Abs((x + y) / (w + h))
 		}
-	case 180, -180: // vertical flipped
+	case geom.AngleHalf, -geom.AngleHalf: // vertical flipped
 		generator = func(_, y float64) float64 {
 			return (h - y) / h
 		}
@@ -213,7 +214,7 @@ func computeGradient(generator func(x, y float64) float64, w, h int, startColor,
 // The start color will be at the left of the gradient and the end color will be at the right.
 func NewHorizontalGradient(start, end color.Color) *LinearGradient {
 	g := &LinearGradient{StartColor: start, EndColor: end}
-	g.Angle = 270
+	g.Angle = geom.AngleThreeQuarter
 	return g
 }
 

--- a/canvas/image.go
+++ b/canvas/image.go
@@ -237,8 +237,8 @@ func NewImageFromFile(file string) *Image {
 //
 // Since: 2.0
 func NewImageFromURI(uri fyne.URI) *Image {
-	if uri.Scheme() == "file" && len(uri.String()) > 7 {
-		return NewImageFromFile(uri.Path())
+	if path := uri.Path(); path != "" && uri.Scheme() == fyne.URLSchemeFile {
+		return NewImageFromFile(path)
 	}
 
 	var read io.ReadCloser

--- a/cmd/fyne_settings/main.go
+++ b/cmd/fyne_settings/main.go
@@ -20,6 +20,6 @@ func main() {
 	tabs.SetTabLocation(container.TabLocationLeading)
 	w.SetContent(tabs)
 
-	w.Resize(fyne.NewSize(520, 520))
+	w.Resize(fyne.NewSize(520, 520)) //revive:disable-line:add-constant
 	w.ShowAndRun()
 }

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/container"
 	internalapp "fyne.io/fyne/v2/internal/app"
 	"fyne.io/fyne/v2/internal/goos"
+	"fyne.io/fyne/v2/internal/repository"
 	internaltheme "fyne.io/fyne/v2/internal/theme"
 	intWidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
@@ -138,12 +139,9 @@ func (s *Settings) loadFromFile(path string) error {
 	file, err := os.Open(path) // #nosec
 	if err != nil {
 		if os.IsNotExist(err) {
-			err := os.MkdirAll(filepath.Dir(path), 0o700)
-			if err != nil {
-				return err
-			}
-			return nil
+			return os.MkdirAll(filepath.Dir(path), repository.PermUserReadWriteExec)
 		}
+
 		return err
 	}
 	decode := json.NewDecoder(file)
@@ -161,8 +159,7 @@ func (s *Settings) save() error {
 }
 
 func (s *Settings) saveToFile(path string) error {
-	err := os.MkdirAll(filepath.Dir(path), 0o700)
-	if err != nil { // this is not an exists error according to docs
+	if err := os.MkdirAll(filepath.Dir(path), repository.PermUserReadWriteExec); err != nil { // this is not an exists error according to docs
 		return err
 	}
 
@@ -171,7 +168,7 @@ func (s *Settings) saveToFile(path string) error {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, repository.PermGroupRead|repository.PermOtherRead|repository.PermUserRead|repository.PermUserWrite)
 }
 
 type primaryColorButton struct {
@@ -219,7 +216,7 @@ func (c *primaryColorButtonRenderer) Layout(s fyne.Size) {
 }
 
 func (c *primaryColorButtonRenderer) MinSize() fyne.Size {
-	return fyne.NewSize(20, 32)
+	return fyne.NewSize(20, 32) //revive:disable-line:add-constant
 }
 
 func (c *primaryColorButtonRenderer) Refresh() {

--- a/cmd/fyne_settings/settings/appearance.go
+++ b/cmd/fyne_settings/settings/appearance.go
@@ -12,6 +12,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	internalapp "fyne.io/fyne/v2/internal/app"
+	"fyne.io/fyne/v2/internal/goos"
 	internaltheme "fyne.io/fyne/v2/internal/theme"
 	intWidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
@@ -62,7 +63,7 @@ func (s *Settings) LoadAppearanceScreen(w fyne.Window) fyne.CanvasObject {
 
 	def := s.fyneSettings.ThemeName
 	themeNames := []string{themeNameDark, themeNameLight}
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+	if runtime.GOOS == goos.Darwin || runtime.GOOS == goos.Windows {
 		themeNames = append(themeNames, themeNameSystemLabel)
 		if s.fyneSettings.ThemeName == themeNameSystem {
 			def = themeNameSystemLabel

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -20,6 +20,8 @@ const (
 	modeMinimize
 	modeMaximize
 	modeIcon
+
+	sizeDraggableCorner = 16
 )
 
 var _ fyne.Widget = (*InnerWindow)(nil)
@@ -349,7 +351,7 @@ func newDraggableCorner(w *InnerWindow) *draggableCorner {
 
 func (c *draggableCorner) CreateRenderer() fyne.WidgetRenderer {
 	prop := canvas.NewImageFromResource(fyne.CurrentApp().Settings().Theme().Icon(theme.IconNameDragCornerIndicator))
-	prop.SetMinSize(fyne.NewSquareSize(16))
+	prop.SetMinSize(fyne.NewSquareSize(sizeDraggableCorner))
 	return widget.NewSimpleRenderer(prop)
 }
 

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -3,10 +3,10 @@ package container
 import (
 	"image/color"
 	"runtime"
-	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/goos"
 	intWidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
@@ -184,7 +184,7 @@ func (w *InnerWindow) buttonPosition() widget.ButtonAlign {
 		return w.Alignment
 	}
 
-	if runtime.GOOS == "windows" || runtime.GOOS == "linux" || strings.Contains(runtime.GOOS, "bsd") {
+	if runtime.GOOS == goos.Windows || runtime.GOOS == goos.Linux || goos.IsBSD(runtime.GOOS) {
 		return widget.ButtonAlignTrailing
 	}
 	// macOS

--- a/container/split.go
+++ b/container/split.go
@@ -307,12 +307,12 @@ func (d *divider) Dragged(e *fyne.DragEvent) {
 	if d.split.Horizontal {
 		widthFree := float64(d.split.Size().Width - dividerThickness(d))
 		leadingRatio = float64(d.split.Leading.MinSize().Width) / widthFree
-		trailingRatio = 1. - (float64(d.split.Trailing.MinSize().Width) / widthFree)
+		trailingRatio = 1.0 - (float64(d.split.Trailing.MinSize().Width) / widthFree)
 		offset = float64(x-d.startDragOff.X) / widthFree
 	} else {
 		heightFree := float64(d.split.Size().Height - dividerThickness(d))
 		leadingRatio = float64(d.split.Leading.MinSize().Height) / heightFree
-		trailingRatio = 1. - (float64(d.split.Trailing.MinSize().Height) / heightFree)
+		trailingRatio = 1.0 - (float64(d.split.Trailing.MinSize().Height) / heightFree)
 		offset = float64(y-d.startDragOff.Y) / heightFree
 	}
 
@@ -412,7 +412,7 @@ func dividerThickness(d *divider) float32 {
 
 func dividerLength(d *divider) float32 {
 	th := dividerTheme(d)
-	return th.Size(theme.SizeNamePadding) * 6
+	return th.Size(theme.SizeNamePadding) * 6 //revive:disable-line:add-constant
 }
 
 func handleThickness(d *divider) float32 {

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -761,7 +761,7 @@ func (r *tabButtonRenderer) Refresh() {
 func (r *tabButtonRenderer) iconSize() float32 {
 	iconSize := r.button.Theme().Size(theme.SizeNameInlineIcon)
 	if r.button.iconPosition == buttonIconTop {
-		return 1.5 * iconSize
+		return 1.5 * iconSize //revive:disable-line:add-constant
 	}
 
 	return iconSize

--- a/container/theme_test.go
+++ b/container/theme_test.go
@@ -5,8 +5,9 @@ import (
 	"image/color"
 	"testing"
 
-	"fyne.io/fyne/v2/canvas"
 	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2/canvas"
 
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/test"
@@ -65,5 +66,5 @@ func TestThemeOverride_CurrentTheme(t *testing.T) {
 	o.Refresh()
 
 	text = test.WidgetRenderer(l).Objects()[0].(*widget.RichText).Segments[0].Visual()
-	assert.Equal(t, &color.NRGBA{R: 0, G: 0, B: 0, A: 0xff}, text.(*canvas.Text).Color)
+	assert.Equal(t, color.NRGBA{R: 0, G: 0, B: 0, A: 0xff}, text.(*canvas.Text).Color)
 }

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -215,7 +215,7 @@ func (renderer *themedBackgroundRenderer) Objects() []fyne.CanvasObject {
 
 func (renderer *themedBackgroundRenderer) Refresh() {
 	r, g, b, _ := col.ToNRGBA(theme.Color(theme.ColorNameOverlayBackground))
-	bg := &color.NRGBA{R: r, G: g, B: b, A: 230}
+	bg := &color.NRGBA{R: r, G: g, B: b, A: 230} //revive:disable-line:add-constant
 	renderer.rect.FillColor = bg
 }
 

--- a/dialog/color.go
+++ b/dialog/color.go
@@ -234,24 +234,12 @@ func colorToString(c color.Color) string {
 	return fmt.Sprintf("#%02x%02x%02x%02x", red, green, blue, alpha)
 }
 
-func stringToColor(s string) (color.Color, error) {
-	var c color.NRGBA
-	var err error
-	if len(s) == 7 {
-		c.A = 0xFF
-		_, err = fmt.Sscanf(s, "#%02x%02x%02x", &c.R, &c.G, &c.B)
-	} else {
-		_, err = fmt.Sscanf(s, "#%02x%02x%02x%02x", &c.R, &c.G, &c.B, &c.A)
-	}
-	return c, err
-}
-
 func stringsToColors(ss ...string) (colors []color.Color) {
 	for _, s := range ss {
 		if s == "" {
 			continue
 		}
-		c, err := stringToColor(s)
+		c, err := col.Parse(s)
 		if err != nil {
 			fyne.LogError("Couldn't parse color:", err)
 		} else {

--- a/dialog/color.go
+++ b/dialog/color.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	col "fyne.io/fyne/v2/internal/color"
+	"fyne.io/fyne/v2/internal/painter/geom"
 	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -156,10 +157,10 @@ func clamp(value, min, max int) int {
 
 func wrapHue(hue int) int {
 	for hue < 0 {
-		hue += 360
+		hue += geom.AngleFull
 	}
-	for hue > 360 {
-		hue -= 360
+	for hue > geom.AngleFull {
+		hue -= geom.AngleFull
 	}
 	return hue
 }
@@ -172,23 +173,23 @@ func newColorButtonBox(colors []color.Color, icon fyne.Resource, callback func(c
 	for _, c := range colors {
 		objects = append(objects, newColorButton(c, callback))
 	}
-	return container.NewGridWithColumns(8, objects...)
+	return container.NewGridWithColumns(8, objects...) //revive:disable-line:add-constant
 }
 
 func newCheckeredBackground(radial bool) *canvas.Raster {
 	f := func(x, y, _, _ int) color.Color {
 		if (x/checkeredBoxSize)%2 == (y/checkeredBoxSize)%2 {
-			return color.Gray{Y: 58}
+			return color.Gray{Y: 58} //revive:disable-line:add-constant
 		}
 
-		return color.Gray{Y: 84}
+		return color.Gray{Y: 84} //revive:disable-line:add-constant
 	}
 
 	if radial {
 		rect := f
 		f = func(x, y, w, h int) color.Color {
 			r, t := cmplx.Polar(complex(float64(x)-float64(w)/2, float64(y)-float64(h)/2))
-			limit := math.Min(float64(w), float64(h)) / 2.0
+			limit := math.Min(float64(w), float64(h)) / 2
 			if r > limit {
 				// Out of bounds
 				return &color.NRGBA{A: 0}
@@ -252,20 +253,20 @@ func stringsToColors(ss ...string) (colors []color.Color) {
 // https://www.niwa.nu/2013/05/math-behind-colorspace-conversions-rgb-hsl/
 
 func rgbToHsl(r, g, b uint8) (int, int, int) {
-	red := float64(r) / 255.0
-	green := float64(g) / 255.0
-	blue := float64(b) / 255.0
+	red := float64(r) / math.MaxUint8
+	green := float64(g) / math.MaxUint8
+	blue := float64(b) / math.MaxUint8
 
 	min := math.Min(red, math.Min(green, blue))
 	max := math.Max(red, math.Max(green, blue))
 
-	lightness := (max + min) / 2.0
+	lightness := (max + min) / 2
 
 	delta := max - min
 
 	if delta == 0.0 {
 		// Achromatic
-		return 0, 0, int(lightness * 100.0)
+		return 0, 0, int(lightness * 100)
 	}
 
 	// Chromatic
@@ -275,7 +276,7 @@ func rgbToHsl(r, g, b uint8) (int, int, int) {
 	if lightness < 0.5 {
 		saturation = (max - min) / (max + min)
 	} else {
-		saturation = (max - min) / (2.0 - max - min)
+		saturation = (max - min) / (2 - max - min)
 	}
 
 	var hue float64
@@ -283,49 +284,50 @@ func rgbToHsl(r, g, b uint8) (int, int, int) {
 	if red == max {
 		hue = (green - blue) / delta
 	} else if green == max {
-		hue = 2.0 + (blue-red)/delta
+		hue = 2 + (blue-red)/delta
 	} else if blue == max {
-		hue = 4.0 + (red-green)/delta
+		hue = 4 + (red-green)/delta
 	}
 
-	h := wrapHue(int(hue * 60.0))
+	h := wrapHue(int(hue * 60.0)) //revive:disable-line:add-constant
 	s := int(saturation * 100.0)
 	l := int(lightness * 100.0)
 	return h, s, l
 }
 
 func hslToRgb(h, s, l int) (uint8, uint8, uint8) {
-	hue := float64(h) / 360.0
-	saturation := float64(s) / 100.0
-	lightness := float64(l) / 100.0
+	hue := float64(h) / geom.AngleFull
+	saturation := float64(s) / 100
+	lightness := float64(l) / 100
 
 	if saturation == 0.0 {
 		// Greyscale
-		g := uint8(lightness * 255.0)
+		g := uint8(lightness * math.MaxUint8)
 		return g, g, g
 	}
 
 	var v1 float64
 	if lightness < 0.5 {
-		v1 = lightness * (1.0 + saturation)
+		v1 = lightness * (1 + saturation)
 	} else {
 		v1 = (lightness + saturation) - (lightness * saturation)
 	}
 
-	v2 := 2.0*lightness - v1
+	v2 := 2*lightness - v1
 
-	red := hueToChannel(hue+(1.0/3.0), v1, v2)
+	red := hueToChannel(hue+(1.0/3), v1, v2)
 	green := hueToChannel(hue, v1, v2)
-	blue := hueToChannel(hue-(1.0/3.0), v1, v2)
+	blue := hueToChannel(hue-(1.0/3), v1, v2)
 
-	r := uint8(math.Round(255.0 * red))
-	g := uint8(math.Round(255.0 * green))
-	b := uint8(math.Round(255.0 * blue))
+	r := uint8(math.Round(math.MaxUint8 * red))
+	g := uint8(math.Round(math.MaxUint8 * green))
+	b := uint8(math.Round(math.MaxUint8 * blue))
 
 	return r, g, b
 }
 
 func hueToChannel(h, v1, v2 float64) float64 {
+	//revive:disable:add-constant
 	for h < 0.0 {
 		h += 1.0
 	}
@@ -342,4 +344,5 @@ func hueToChannel(h, v1, v2 float64) float64 {
 		return v2 + (v1-v2)*6*((2.0/3.0)-h)
 	}
 	return v2
+	//revive:enable-line:add-constant
 }

--- a/dialog/color_button.go
+++ b/dialog/color_button.go
@@ -100,7 +100,7 @@ func (r *colorButtonRenderer) Layout(size fyne.Size) {
 }
 
 func (r *colorButtonRenderer) MinSize() fyne.Size {
-	return r.rectangle.MinSize().Max(fyne.NewSize(32, 32))
+	return r.rectangle.MinSize().Max(fyne.NewSize(32, 32)) //revive:disable-line:add-constant
 }
 
 func (r *colorButtonRenderer) Refresh() {

--- a/dialog/color_picker.go
+++ b/dialog/color_picker.go
@@ -2,10 +2,12 @@ package dialog
 
 import (
 	"image/color"
+	"math"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	col "fyne.io/fyne/v2/internal/color"
+	"fyne.io/fyne/v2/internal/painter/geom"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 )
@@ -109,7 +111,7 @@ func (p *colorAdvancedPicker) CreateRenderer() fyne.WidgetRenderer {
 	preview := newColorPreview(p.previousColor)
 
 	// HSL
-	hueChannel := newColorChannel("H", 0, 360, p.Hue, func(h int) {
+	hueChannel := newColorChannel("H", 0, geom.AngleFull, p.Hue, func(h int) {
 		p.setHSLA(h, p.Saturation, p.Lightness, p.Alpha)
 	})
 	saturationChannel := newColorChannel("S", 0, 100, p.Saturation, func(s int) {
@@ -125,13 +127,13 @@ func (p *colorAdvancedPicker) CreateRenderer() fyne.WidgetRenderer {
 	)
 
 	// RGB
-	redChannel := newColorChannel("R", 0, 255, int(p.Red), func(r int) {
+	redChannel := newColorChannel("R", 0, math.MaxUint8, int(p.Red), func(r int) {
 		p.setRGBA(uint8(r), p.Green, p.Blue, p.Alpha) //gosec:disable G115 -- r’s value is limited by newColorChannel
 	})
-	greenChannel := newColorChannel("G", 0, 255, int(p.Green), func(g int) {
+	greenChannel := newColorChannel("G", 0, math.MaxUint8, int(p.Green), func(g int) {
 		p.setRGBA(p.Red, uint8(g), p.Blue, p.Alpha) //gosec:disable G115 -- g’s value is limited by newColorChannel
 	})
-	blueChannel := newColorChannel("B", 0, 255, int(p.Blue), func(b int) {
+	blueChannel := newColorChannel("B", 0, math.MaxUint8, int(p.Blue), func(b int) {
 		p.setRGBA(p.Red, p.Green, uint8(b), p.Alpha) //gosec:disable G115 -- b’s value is limited by newColorChannel
 	})
 	rgbBox := container.NewVBox(
@@ -146,7 +148,7 @@ func (p *colorAdvancedPicker) CreateRenderer() fyne.WidgetRenderer {
 	})
 
 	// Alpha
-	alphaChannel := newColorChannel("A", 0, 255, int(p.Alpha), func(a int) {
+	alphaChannel := newColorChannel("A", 0, math.MaxUint8, int(p.Alpha), func(a int) {
 		p.setRGBA(p.Red, p.Green, p.Blue, uint8(a)) //gosec:disable G115 -- a’s value is limited by newColorChannel
 	})
 

--- a/dialog/color_picker.go
+++ b/dialog/color_picker.go
@@ -153,7 +153,7 @@ func (p *colorAdvancedPicker) CreateRenderer() fyne.WidgetRenderer {
 	// Hex
 	hex := newUserChangeEntry("")
 	hex.setOnChanged(func(text string) {
-		c, err := stringToColor(text)
+		c, err := col.Parse(text)
 		if err != nil {
 			fyne.LogError("Error parsing color: "+text, err)
 			// TODO trigger entry invalid state

--- a/dialog/color_preview.go
+++ b/dialog/color_preview.go
@@ -65,7 +65,7 @@ func (r *colorPreviewRenderer) Layout(size fyne.Size) {
 func (r *colorPreviewRenderer) MinSize() fyne.Size {
 	s := r.old.MinSize()
 	s.Width *= 2
-	return s.Max(fyne.NewSize(16, 8))
+	return s.Max(fyne.NewSize(16, 8)) //revive:disable-line:add-constant
 }
 
 func (r *colorPreviewRenderer) Refresh() {

--- a/dialog/color_test.go
+++ b/dialog/color_test.go
@@ -307,20 +307,6 @@ func Test_colorToString(t *testing.T) {
 	}
 }
 
-func Test_stringToColor(t *testing.T) {
-	for name, tt := range rgbhslMap {
-		t.Run(name, func(t *testing.T) {
-			c, err := stringToColor(tt.hex)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.hex, colorToString(c))
-		})
-	}
-	t.Run("Invalid", func(t *testing.T) {
-		_, err := stringToColor("potato")
-		assert.Error(t, err)
-	})
-}
-
 func Test_colorToHSLA(t *testing.T) {
 	for name, tt := range rgbhslMap {
 		t.Run(name, func(t *testing.T) {

--- a/dialog/color_wheel.go
+++ b/dialog/color_wheel.go
@@ -129,7 +129,7 @@ func (a *colorWheel) colorAt(x, y, w, h int) color.Color {
 		R: red,
 		G: green,
 		B: blue,
-		A: uint8(a.Alpha),
+		A: a.Alpha,
 	}
 }
 

--- a/dialog/color_wheel.go
+++ b/dialog/color_wheel.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal/painter/geom"
 	internalwidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -113,17 +114,17 @@ func (a *colorWheel) DragEnd() {
 
 func (a *colorWheel) colorAt(x, y, w, h int) color.Color {
 	width, height := float64(w), float64(h)
-	dx := float64(x) - (width / 2.0)
-	dy := float64(y) - (height / 2.0)
+	dx := float64(x) - (width / 2)
+	dy := float64(y) - (height / 2)
 	radius, radians := cmplx.Polar(complex(dx, dy))
-	limit := math.Min(width, height) / 2.0
+	limit := math.Min(width, height) / 2
 	if radius > limit {
 		// Out of bounds
 		return color.Transparent
 	}
-	degrees := radians * (180.0 / math.Pi)
+	degrees := radians * (geom.AngleHalf / math.Pi)
 	hue := wrapHue(int(degrees))
-	saturation := int(radius / limit * 100.0)
+	saturation := int(radius / limit * 100)
 	red, green, blue := hslToRgb(hue, saturation, a.Lightness)
 	return &color.NRGBA{
 		R: red,
@@ -144,11 +145,11 @@ func (a *colorWheel) locationForPosition(pos fyne.Position) (x, y int) {
 
 func (a *colorWheel) selection(width, height float32) (float32, float32) {
 	w, h := float64(width), float64(height)
-	radius := float64(a.Saturation) / 100.0 * math.Min(w, h) / 2.0
+	radius := float64(a.Saturation) / 100 * math.Min(w, h) / 2
 	degrees := float64(a.Hue)
-	radians := degrees * math.Pi / 180.0
+	radians := degrees * math.Pi / geom.AngleHalf
 	c := cmplx.Rect(radius, radians)
-	return float32(real(c) + w/2.0), float32(imag(c) + h/2.0)
+	return float32(real(c) + w/2), float32(imag(c) + h/2)
 }
 
 func (a *colorWheel) trigger(pos fyne.Position) {
@@ -159,14 +160,14 @@ func (a *colorWheel) trigger(pos fyne.Position) {
 		dx := float64(x) - (width / 2)
 		dy := float64(y) - (height / 2)
 		radius, radians := cmplx.Polar(complex(dx, dy))
-		limit := math.Min(width, height) / 2.0
+		limit := math.Min(width, height) / 2
 		if radius > limit {
 			// Out of bounds
 			return
 		}
-		degrees := radians * (180.0 / math.Pi)
+		degrees := radians * (geom.AngleHalf / math.Pi)
 		a.Hue = wrapHue(int(degrees))
-		a.Saturation = int(radius / limit * 100.0)
+		a.Saturation = int(radius / limit * 100)
 		f(a.Hue, a.Saturation, a.Lightness, a.Alpha)
 	}
 	a.Refresh()
@@ -192,7 +193,7 @@ func (r *colorWheelRenderer) Layout(size fyne.Size) {
 }
 
 func (r *colorWheelRenderer) MinSize() fyne.Size {
-	return r.raster.MinSize().Max(fyne.NewSize(128, 128))
+	return r.raster.MinSize().Max(fyne.NewSize(128, 128)) //revive:disable-line:add-constant
 }
 
 func (r *colorWheelRenderer) Refresh() {

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -32,8 +32,15 @@ const (
 )
 
 const (
-	viewLayoutKey = "fyne:fileDialogViewLayout"
+	folderDesktop   = "Desktop"
+	folderDocuments = "Documents"
+	folderDownloads = "Downloads"
+	folderHome      = "Home"
+	folderMusic     = "Music"
+	folderPictures  = "Pictures"
+
 	lastFolderKey = "fyne:fileDialogLastFolder"
+	viewLayoutKey = "fyne:fileDialogViewLayout"
 )
 
 type textWidget interface {
@@ -145,7 +152,7 @@ func (f *fileDialog) makeUI() fyne.CanvasObject {
 	buttons := container.NewGridWithRows(1, f.dismiss, f.open)
 
 	f.filesScroll = container.NewScroll(nil) // filesScroll's content will be set by setView function.
-	verticalExtra := float32(float64(fileIconSize) * 0.25)
+	verticalExtra := float32(float64(iconSize) * 0.25)
 	itemMin := f.newFileItem(storage.NewFileURI("filename.txt"), false, false).MinSize()
 	f.filesScroll.SetMinSize(itemMin.AddWidthHeight(itemMin.Width+theme.Padding()*3, verticalExtra))
 
@@ -401,7 +408,7 @@ func (f *fileDialog) loadFavorites() {
 	}
 
 	f.favorites = []favoriteItem{
-		{locName: "Home", locIcon: theme.HomeIcon(), loc: favoriteLocations["Home"]},
+		{locName: folderHome, locIcon: theme.HomeIcon(), loc: favoriteLocations[folderHome]},
 	}
 	app := fyne.CurrentApp()
 	if hasAppFiles(app) {
@@ -925,43 +932,31 @@ func ShowFileSave(callback func(writer fyne.URIWriteCloser, err error), parent f
 
 func getFavoritesIcon(location string) fyne.Resource {
 	switch location {
-	case "Documents":
+	case folderDocuments:
 		return theme.DocumentIcon()
-	case "Desktop":
+	case folderDesktop:
 		return theme.DesktopIcon()
-	case "Downloads":
+	case folderDownloads:
 		return theme.DownloadIcon()
-	case "Music":
+	case folderMusic:
 		return theme.MediaMusicIcon()
-	case "Pictures":
+	case folderPictures:
 		return theme.MediaPhotoIcon()
-	case "Videos":
+	case folderVideos:
 		return theme.MediaVideoIcon()
 	}
-
-	if (runtime.GOOS == goos.Darwin && location == "Movies") ||
-		(runtime.GOOS != goos.Darwin && location == "Videos") {
-		return theme.MediaVideoIcon()
-	}
-
 	return nil
 }
 
-func getFavoritesOrder() [6]string {
-	order := [6]string{
-		"Desktop",
-		"Documents",
-		"Downloads",
-		"Music",
-		"Pictures",
-		"Videos",
+func getFavoritesOrder() []string {
+	return []string{
+		folderDesktop,
+		folderDocuments,
+		folderDownloads,
+		folderMusic,
+		folderPictures,
+		folderVideos,
 	}
-
-	if runtime.GOOS == goos.Darwin {
-		order[5] = "Movies"
-	}
-
-	return order
 }
 
 func hasAppFiles(a fyne.App) bool {
@@ -973,7 +968,7 @@ func hasAppFiles(a fyne.App) bool {
 }
 
 func storageURI(a fyne.App) fyne.URI {
-	dir, _ := storage.Child(a.Storage().RootURI(), "Documents")
+	dir, _ := storage.Child(a.Storage().RootURI(), folderDocuments)
 	return dir
 }
 

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -11,6 +11,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/storage/repository"
@@ -363,7 +364,7 @@ func (f *fileDialog) optionsMenu(position fyne.Position, buttonSize fyne.Size) {
 }
 
 func getFavoriteLocations() (map[string]fyne.ListableURI, error) {
-	if runtime.GOOS == "js" {
+	if runtime.GOOS == goos.JavaScript {
 		return make(map[string]fyne.ListableURI), nil
 	}
 
@@ -938,8 +939,8 @@ func getFavoritesIcon(location string) fyne.Resource {
 		return theme.MediaVideoIcon()
 	}
 
-	if (runtime.GOOS == "darwin" && location == "Movies") ||
-		(runtime.GOOS != "darwin" && location == "Videos") {
+	if (runtime.GOOS == goos.Darwin && location == "Movies") ||
+		(runtime.GOOS != goos.Darwin && location == "Videos") {
 		return theme.MediaVideoIcon()
 	}
 
@@ -956,7 +957,7 @@ func getFavoritesOrder() [6]string {
 		"Videos",
 	}
 
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == goos.Darwin {
 		order[5] = "Movies"
 	}
 

--- a/dialog/file_darwin.go
+++ b/dialog/file_darwin.go
@@ -1,11 +1,11 @@
-//go:build !ios && !android && !wasm && !js
-
 package dialog
 
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/storage"
 )
+
+const folderVideos = "Movies"
 
 func getFavoriteLocation(homeURI fyne.URI, name string) (fyne.URI, error) {
 	return storage.Child(homeURI, name)

--- a/dialog/file_notdarwin.go
+++ b/dialog/file_notdarwin.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package dialog
+
+const folderVideos = "Videos"

--- a/dialog/fileitem.go
+++ b/dialog/fileitem.go
@@ -15,9 +15,17 @@ import (
 )
 
 const (
-	fileIconSize       = 64
-	fileInlineIconSize = 24
-	fileIconCellWidth  = fileIconSize * 1.25
+	cellWidthIcon = iconSize * 1.25
+
+	folderInsetBottom       = 25
+	folderInsetBottomInline = 6
+	folderInsetTop          = 20
+	folderInsetTopInline    = 6
+	folderInsetX            = 10
+	folderInsetXInline      = 4
+
+	iconSize       = 64
+	iconSizeInline = 24
 )
 
 type fileDialogItem struct {
@@ -113,42 +121,36 @@ type fileItemRenderer struct {
 
 func (s *fileItemRenderer) Layout(size fyne.Size) {
 	if s.item.picker.view == GridView {
-		s.icon.Resize(fyne.NewSquareSize(fileIconSize))
-		s.icon.Move(fyne.NewPos((size.Width-fileIconSize)/2, 0))
+		s.icon.Resize(fyne.NewSquareSize(iconSize))
+		s.icon.Move(fyne.NewPos((size.Width-iconSize)/2, 0))
 
-		folderInsetX := float32(10)
-		folderInsetBottom := float32(25)
-		folderInsetTop := float32(20)
-		s.over.Resize(fyne.NewSize(fileIconSize-folderInsetX*2, fileIconSize-folderInsetX-folderInsetBottom))
+		s.over.Resize(fyne.NewSize(iconSize-folderInsetX*2, iconSize-folderInsetX-folderInsetBottom))
 		s.over.Move(s.icon.Position().AddXY(folderInsetX, folderInsetTop))
 
 		s.text.Alignment = fyne.TextAlignCenter
 		s.text.Resize(fyne.NewSize(size.Width, s.fileTextSize))
 		s.text.Move(fyne.NewPos(0, size.Height-s.fileTextSize))
 	} else {
-		s.icon.Resize(fyne.NewSquareSize(fileInlineIconSize))
-		s.icon.Move(fyne.NewPos(theme.Padding(), (size.Height-fileInlineIconSize)/2))
+		s.icon.Resize(fyne.NewSquareSize(iconSizeInline))
+		s.icon.Move(fyne.NewPos(theme.Padding(), (size.Height-iconSizeInline)/2))
 
-		folderInsetX := float32(4)
-		folderInsetBottom := float32(6)
-		folderInsetTop := float32(6)
-		s.over.Resize(fyne.NewSize(fileInlineIconSize-folderInsetX*2, fileInlineIconSize-folderInsetX-folderInsetBottom))
-		s.over.Move(s.icon.Position().AddXY(folderInsetX, folderInsetTop))
+		s.over.Resize(fyne.NewSize(iconSizeInline-folderInsetXInline*2, iconSizeInline-folderInsetXInline-folderInsetBottomInline))
+		s.over.Move(s.icon.Position().AddXY(folderInsetXInline, folderInsetTopInline))
 
 		s.text.Alignment = fyne.TextAlignLeading
 		textMin := s.text.MinSize()
 		s.text.Resize(fyne.NewSize(size.Width, textMin.Height))
-		s.text.Move(fyne.NewPos(fileInlineIconSize, (size.Height-textMin.Height)/2))
+		s.text.Move(fyne.NewPos(iconSizeInline, (size.Height-textMin.Height)/2))
 	}
 }
 
 func (s *fileItemRenderer) MinSize() fyne.Size {
 	if s.item.picker.view == GridView {
-		return fyne.NewSize(fileIconCellWidth, fileIconSize+s.fileTextSize)
+		return fyne.NewSize(cellWidthIcon, iconSize+s.fileTextSize)
 	}
 
 	textMin := s.text.MinSize()
-	return fyne.NewSize(fileInlineIconSize+textMin.Width+theme.Padding(), textMin.Height)
+	return fyne.NewSize(iconSizeInline+textMin.Width+theme.Padding(), textMin.Height)
 }
 
 func (s *fileItemRenderer) Refresh() {

--- a/dialog/progress.go
+++ b/dialog/progress.go
@@ -32,7 +32,7 @@ func NewProgress(title, message string, parent fyne.Window) *ProgressDialog {
 	d := newTextDialog(title, message, theme.InfoIcon(), parent)
 	bar := widget.NewProgressBar()
 	rect := canvas.NewRectangle(color.Transparent)
-	rect.SetMinSize(fyne.NewSize(200, 0))
+	rect.SetMinSize(fyne.NewSize(200, 0)) //revive:disable-line:add-constant
 
 	d.create(container.NewStack(rect, bar))
 	return &ProgressDialog{d, bar}

--- a/dialog/progressinfinite.go
+++ b/dialog/progressinfinite.go
@@ -27,7 +27,7 @@ func NewProgressInfinite(title, message string, parent fyne.Window) *ProgressInf
 	d := newTextDialog(title, message, theme.InfoIcon(), parent)
 	bar := widget.NewProgressBarInfinite()
 	rect := canvas.NewRectangle(color.Transparent)
-	rect.SetMinSize(fyne.NewSize(200, 0))
+	rect.SetMinSize(fyne.NewSize(200, 0)) //revive:disable-line:add-constant
 
 	d.create(container.NewStack(rect, bar))
 	return &ProgressInfiniteDialog{d, bar}

--- a/driver/desktop/shortcut.go
+++ b/driver/desktop/shortcut.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 )
 
 // Declare conformity with Shortcut interface
@@ -49,7 +50,7 @@ func writeModifiers(w *strings.Builder, mods fyne.KeyModifier) {
 		w.WriteString("Alt+")
 	}
 	if (mods & fyne.KeyModifierSuper) != 0 {
-		if runtime.GOOS == "darwin" {
+		if runtime.GOOS == goos.Darwin {
 			w.WriteString("Command+")
 		} else {
 			w.WriteString("Super+")

--- a/driver/software/canvas.go
+++ b/driver/software/canvas.go
@@ -15,6 +15,8 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
+const canvasDefaultSize = 100
+
 // WindowlessCanvas provides functionality for a canvas to operate without a window
 //
 // Since: 2.9
@@ -61,7 +63,7 @@ func newCanvas(painter driver.Painter, transparent bool) WindowlessCanvas {
 		padded:      true,
 		painter:     painter,
 		scale:       1.0,
-		size:        fyne.NewSize(100, 100),
+		size:        fyne.NewSize(canvasDefaultSize, canvasDefaultSize),
 		transparent: transparent,
 	}
 	c.overlays.Canvas = c

--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -7,6 +7,8 @@ import (
 	"fyne.io/fyne/v2"
 )
 
+const initialAnimationsCapacity = 16
+
 // Runner is the main driver for animations package
 type Runner struct {
 	// animationMutex synchronizes access to `animations` and `pendingAnimations`
@@ -40,14 +42,14 @@ func (r *Runner) Start(a *fyne.Animation) {
 		if r.animations == nil {
 			// initialize with excess capacity to avoid re-allocations
 			// on subsequent Starts
-			r.animations = make([]*anim, 0, 16)
+			r.animations = make([]*anim, 0, initialAnimationsCapacity)
 		}
 		r.animations = append(r.animations, newAnim(a))
 	} else {
 		if r.pendingAnimations == nil {
 			// initialize with excess capacity to avoid re-allocations
 			// on subsequent Starts
-			r.pendingAnimations = make([]*anim, 0, 16)
+			r.pendingAnimations = make([]*anim, 0, initialAnimationsCapacity)
 		}
 		r.pendingAnimations = append(r.pendingAnimations, newAnim(a))
 	}

--- a/internal/async/chan.go
+++ b/internal/async/chan.go
@@ -1,5 +1,9 @@
 package async
 
+// The size of Func, Interface, and CanvasObject are all less than 16 bytes.
+// A CPU cache line (L2) is 256 bytes, thus it can hold 16 entity references.
+const maxEntitiesPerCPUCacheLine = 16
+
 // UnboundedChan is a channel with an unbounded buffer for caching
 // Func objects. A channel must be closed via Close method.
 type UnboundedChan[T any] struct {
@@ -11,10 +15,9 @@ type UnboundedChan[T any] struct {
 // NewUnboundedChan returns a unbounded channel with unlimited capacity.
 func NewUnboundedChan[T any]() *UnboundedChan[T] {
 	ch := &UnboundedChan[T]{
-		// The size of Func, Interface, and CanvasObject are all less than 16 bytes, we use 16 to fit
-		// a CPU cache line (L2, 256 Bytes), which may reduce cache misses.
-		in:    make(chan T, 16),
-		out:   make(chan T, 16),
+		// We make the channels fit into CPU cache lines, which may reduce cache misses.
+		in:    make(chan T, maxEntitiesPerCPUCacheLine),
+		out:   make(chan T, maxEntitiesPerCPUCacheLine),
 		close: make(chan struct{}),
 	}
 	go ch.processing()

--- a/internal/async/chan_struct.go
+++ b/internal/async/chan_struct.go
@@ -1,5 +1,9 @@
 package async
 
+// The size of Struct is less than 16 bytes.
+// A CPU cache line (L2) is 256 bytes, thus it can hold 16 struct references.
+const maxStructsPerCPUCacheLine = 16
+
 // UnboundedStructChan is a channel with an unbounded buffer for caching
 // struct{} objects. This implementation is a specialized version that
 // optimizes for struct{} objects than other types. A channel must be
@@ -12,10 +16,9 @@ type UnboundedStructChan struct {
 // NewUnboundedStructChan returns a unbounded channel with unlimited capacity.
 func NewUnboundedStructChan() *UnboundedStructChan {
 	ch := &UnboundedStructChan{
-		// The size of Struct is less than 16 bytes, we use 16 to fit
-		// a CPU cache line (L2, 256 Bytes), which may reduce cache misses.
-		in:    make(chan struct{}, 16),
-		out:   make(chan struct{}, 16),
+		// We make the channels fit into CPU cache lines, which may reduce cache misses.
+		in:    make(chan struct{}, maxStructsPerCPUCacheLine),
+		out:   make(chan struct{}, maxStructsPerCPUCacheLine),
 		close: make(chan struct{}),
 	}
 	go ch.processing()

--- a/internal/async/goroutine.go
+++ b/internal/async/goroutine.go
@@ -58,7 +58,7 @@ func EnsureMain(fn func()) {
 }
 
 func logStackTop(skip int) {
-	pc := make([]uintptr, 16)
+	pc := make([]uintptr, 16) //revive:disable-line:add-constant -- TODO: What is this 16 about?
 	_ = runtime.Callers(skip, pc)
 	frames := runtime.CallersFrames(pc)
 	frame, more := frames.Next()
@@ -79,11 +79,13 @@ func logStackTop(skip int) {
 }
 
 func goroutineID() (id uint64) {
+	//revive:disable:add-constant
 	var buf [30]byte
 	runtime.Stack(buf[:], false)
 	for i := 10; buf[i] != ' '; i++ {
 		id = id*10 + uint64(buf[i]&15)
 	}
+	//revive:enable:add-constant
 
 	return id
 }

--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -7,6 +7,8 @@ import (
 	"fyne.io/fyne/v2"
 )
 
+const cacheCleanCooldown = 10 * time.Second
+
 var (
 	ValidDuration     = 1 * time.Minute
 	cleanTaskInterval = ValidDuration / 2
@@ -29,7 +31,7 @@ func init() {
 func Clean(canvasRefreshed bool) {
 	now := timeNow()
 	// do not run clean task too fast
-	if now.Sub(lastClean) < 10*time.Second {
+	if now.Sub(lastClean) < cacheCleanCooldown {
 		if canvasRefreshed {
 			skippedCleanWithCanvasRefresh = true
 		}

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,8 +1,43 @@
 package color
 
 import (
+	"encoding/hex"
+	"errors"
 	"image/color"
+	"strings"
 )
+
+const (
+	lenColorStringRGB       = lenColorStringRGBShort * 2
+	lenColorStringRGBShort  = 3
+	lenColorStringRGBA      = lenColorStringRGBAShort * 2
+	lenColorStringRGBAShort = 4
+)
+
+// Parse parses a color string representation into a color.Color.
+// It supports (#)rgb(a) and (#)rrggbb(aa)
+func Parse(str string) (color.Color, error) {
+	data := []byte(strings.TrimPrefix(str, "#"))
+	switch len(data) {
+	case lenColorStringRGB, lenColorStringRGBA:
+	case lenColorStringRGBAShort:
+		data = []byte{data[0], data[0], data[1], data[1], data[2], data[2], data[3], data[3]}
+	case lenColorStringRGBShort:
+		data = []byte{data[0], data[0], data[1], data[1], data[2], data[2]}
+	default:
+		return nil, errors.New("invalid color format: " + str)
+	}
+
+	digits, err := hex.DecodeString(string(data))
+	if err != nil {
+		return nil, err
+	}
+	a := uint8(0xff)
+	if len(digits) == 4 {
+		a = digits[3]
+	}
+	return color.NRGBA{R: digits[0], G: digits[1], B: digits[2], A: a}, nil
+}
 
 // ToNRGBA converts a color to RGBA values which are not premultiplied, unlike color.RGBA().
 func ToNRGBA(c color.Color) (r, g, b, a uint8) {

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -9,6 +9,80 @@ import (
 	"fyne.io/fyne/v2/internal/color"
 )
 
+func Test_Parse(t *testing.T) {
+	for name, tt := range map[string]struct {
+		input   string
+		want    imagecolor.NRGBA
+		wantErr string
+	}{
+		"ok: #rrggbbaa": {
+			input: "#1a2b3c4d",
+			want:  imagecolor.NRGBA{R: 0x1a, G: 0x2b, B: 0x3c, A: 0x4d},
+		},
+		"ok: rrggbbaa": {
+			input: "1a2b3c4d",
+			want:  imagecolor.NRGBA{R: 0x1a, G: 0x2b, B: 0x3c, A: 0x4d},
+		},
+		"ok: #rrggbb": {
+			input: "#1a2b3c",
+			want:  imagecolor.NRGBA{R: 0x1a, G: 0x2b, B: 0x3c, A: 0xff},
+		},
+		"ok: rrggbb": {
+			input: "1a2b3c",
+			want:  imagecolor.NRGBA{R: 0x1a, G: 0x2b, B: 0x3c, A: 0xff},
+		},
+		"ok: #rgba": {
+			input: "#1a2b",
+			want:  imagecolor.NRGBA{R: 0x11, G: 0xaa, B: 0x22, A: 0xbb},
+		},
+		"ok: rgba": {
+			input: "1a2b",
+			want:  imagecolor.NRGBA{R: 0x11, G: 0xaa, B: 0x22, A: 0xbb},
+		},
+		"ok: #rgb": {
+			input: "#1a2",
+			want:  imagecolor.NRGBA{R: 0x11, G: 0xaa, B: 0x22, A: 0xff},
+		},
+		"ok: rgb": {
+			input: "1a2",
+			want:  imagecolor.NRGBA{R: 0x11, G: 0xaa, B: 0x22, A: 0xff},
+		},
+		"err: #rg": {
+			input:   "#12",
+			wantErr: "invalid color format: #12",
+		},
+		"err: #rrggb": {
+			input:   "#12345",
+			wantErr: "invalid color format: #12345",
+		},
+		"err: #rrggbba": {
+			input:   "#1234567",
+			wantErr: "invalid color format: #1234567",
+		},
+		"err: #rrggbbaax": {
+			input:   "#123456789",
+			wantErr: "invalid color format: #123456789",
+		},
+		"err: xrrggbbaa": {
+			input:   "x1a2b3c4d",
+			wantErr: "invalid color format: x1a2b3c4d",
+		},
+		"err: #rrggbbax": {
+			input:   "#1a2b3c4x",
+			wantErr: "encoding/hex: invalid byte: U+0078 'x'",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := color.Parse(tt.input)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else if assert.NoError(t, err) {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func Test_ToNRGBA_unmultiplyAlpha(t *testing.T) {
 	for name, tt := range map[string]struct {
 		color imagecolor.Color

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -58,6 +58,7 @@ func (c *Canvas) AddShortcut(shortcut fyne.Shortcut, handler func(shortcut fyne.
 }
 
 func (c *Canvas) DrawDebugOverlay(obj fyne.CanvasObject, pos fyne.Position, size fyne.Size, clip *internal.ClipItem) {
+	//revive:disable:add-constant
 	switch obj.(type) {
 	case fyne.Widget:
 		r := canvas.NewRectangle(color.Transparent)
@@ -76,6 +77,7 @@ func (c *Canvas) DrawDebugOverlay(obj fyne.CanvasObject, pos fyne.Position, size
 		r.Resize(obj.Size())
 		c.Painter().Paint(r, pos, size, clip)
 	}
+	//revive:enable:add-constant
 }
 
 // EnsureMinSize ensure canvas min size.

--- a/internal/driver/glfw/clipboard.go
+++ b/internal/driver/glfw/clipboard.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 
 	"github.com/go-gl/glfw/v3.4/glfw"
 )
@@ -24,7 +25,7 @@ type clipboard struct{}
 // Content returns the clipboard content
 func (c clipboard) Content() string {
 	// This retry logic is to work around the "Access Denied" error often thrown in windows PR#1679
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != goos.Windows {
 		return c.content()
 	}
 	for i := 3; i > 0; i-- {
@@ -45,7 +46,7 @@ func (c clipboard) content() string {
 // SetContent sets the clipboard content
 func (c clipboard) SetContent(content string) {
 	// This retry logic is to work around the "Access Denied" error often thrown in windows PR#1679
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != goos.Windows {
 		c.setContent(content)
 		return
 	}

--- a/internal/driver/glfw/device.go
+++ b/internal/driver/glfw/device.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/lang"
 )
 
@@ -25,5 +26,5 @@ func (*glDevice) HasKeyboard() bool {
 }
 
 func (*glDevice) IsBrowser() bool {
-	return runtime.GOARCH == "js" || runtime.GOOS == "js"
+	return runtime.GOARCH == "js" || runtime.GOOS == goos.JavaScript
 }

--- a/internal/driver/glfw/device_desktop.go
+++ b/internal/driver/glfw/device_desktop.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 )
 
 func (*glDevice) IsMobile() bool {
@@ -13,10 +14,10 @@ func (*glDevice) IsMobile() bool {
 }
 
 func (*glDevice) SystemScaleForWindow(w fyne.Window) float32 {
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == goos.Darwin {
 		return 1.0 // macOS scaling is done at the texture level
 	}
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goos.Windows {
 		xScale, _ := w.(*window).viewport.GetContentScale()
 		return xScale
 	}
@@ -29,5 +30,5 @@ func connectKeyboard(*glCanvas) {
 }
 
 func isMacOSRuntime() bool {
-	return runtime.GOOS == "darwin"
+	return runtime.GOOS == goos.Darwin
 }

--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -19,6 +19,7 @@ import (
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/driver"
 	"fyne.io/fyne/v2/internal/driver/common"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/painter"
 	intRepo "fyne.io/fyne/v2/internal/repository"
 	"fyne.io/fyne/v2/storage/repository"
@@ -55,8 +56,8 @@ func toOSIcon(icon []byte) ([]byte, error) {
 
 // toOSIconForRuntime takes the input image bytes and converts it to an image type
 // that is suitable for the specified GOOS runtime. Which makes platform-specific icon handling testable.
-func toOSIconForRuntime(icon []byte, goos string) ([]byte, error) {
-	if goos != "windows" && !usesUnixSystrayIcon(goos) {
+func toOSIconForRuntime(icon []byte, os string) ([]byte, error) {
+	if os != goos.Windows && !usesUnixSystrayIcon(os) {
 		return icon, nil
 	}
 
@@ -66,7 +67,7 @@ func toOSIconForRuntime(icon []byte, goos string) ([]byte, error) {
 	}
 
 	// keep windows behavior: convert to ico
-	if goos == "windows" {
+	if os == goos.Windows {
 		buf := &bytes.Buffer{}
 		if err = ico.Encode(buf, img); err != nil {
 			return nil, err
@@ -93,8 +94,8 @@ func convertToPNG(img image.Image) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func usesUnixSystrayIcon(goos string) bool {
-	return goos == "linux" || goos == "freebsd" || goos == "openbsd" || goos == "netbsd"
+func usesUnixSystrayIcon(os string) bool {
+	return os == goos.Linux || goos.IsBSD(os)
 }
 
 func (d *gLDriver) DoFromGoroutine(f func(), wait bool) {

--- a/internal/driver/glfw/driver_desktop.go
+++ b/internal/driver/glfw/driver_desktop.go
@@ -10,16 +10,17 @@ import (
 	"runtime"
 	"syscall"
 
+	"fyne.io/systray"
+	"github.com/go-gl/glfw/v3.4/glfw"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/software"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/svg"
 	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/theme"
-	"fyne.io/systray"
-
-	"github.com/go-gl/glfw/v3.4/glfw"
 )
 
 const systrayIconSize = 64
@@ -66,7 +67,7 @@ func (d *gLDriver) runSystray(m *fyne.Menu) {
 		}
 
 		// Some XDG systray crash without a title (See #3678)
-		if runtime.GOOS == "linux" || runtime.GOOS == "openbsd" || runtime.GOOS == "freebsd" || runtime.GOOS == "netbsd" {
+		if runtime.GOOS == goos.Linux || goos.IsBSD(runtime.GOOS) {
 			app := fyne.CurrentApp()
 			title := app.Metadata().Name
 			if title == "" {
@@ -124,7 +125,7 @@ func itemForMenuItem(i *fyne.MenuItem, parent *systray.MenuItem) *systray.MenuIt
 		if svg.IsResourceSVG(i.Icon) {
 			b := &bytes.Buffer{}
 			res := i.Icon
-			if runtime.GOOS == "windows" && isDark() { // windows menus don't match dark mode so invert icons
+			if runtime.GOOS == goos.Windows && isDark() { // windows menus don't match dark mode so invert icons
 				res = theme.NewInvertedThemedResource(i.Icon)
 			}
 			img := painter.PaintImage(canvas.NewImageFromResource(res), nil, systrayIconSize, systrayIconSize)
@@ -188,7 +189,7 @@ func (d *gLDriver) SetSystemTrayIcon(resource fyne.Resource) {
 	systrayIcon = resource // in case we need it later
 
 	// only macOS supports SVG system tray
-	if runtime.GOOS != "darwin" && svg.IsResourceSVG(resource) {
+	if runtime.GOOS != goos.Darwin && svg.IsResourceSVG(resource) {
 		img := canvas.NewImageFromResource(resource)
 		c := software.NewTransparentCanvas()
 		c.SetContent(img)

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/driver/common"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/scale"
 )
@@ -186,7 +187,7 @@ func (d *gLDriver) runGL() {
 					w.shouldExpand = false
 					view := w.viewport
 
-					if shouldExpand && runtime.GOOS != "js" {
+					if shouldExpand && runtime.GOOS != goos.JavaScript {
 						view.SetSize(w.shouldWidth, w.shouldHeight)
 					}
 				}

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -342,7 +342,7 @@ func testNSMenuItemKeyEquivalent(i unsafe.Pointer) string {
 }
 
 func testNSMenuItemKeyEquivalentModifierMask(i unsafe.Pointer) uint64 {
-	return uint64(C.ulong(C.test_NSMenuItem_keyEquivalentModifierMask(i)))
+	return uint64(C.test_NSMenuItem_keyEquivalentModifierMask(i))
 }
 
 func testNSMenuItemSubmenu(i unsafe.Pointer) unsafe.Pointer {

--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -48,6 +48,13 @@ const char*   test_NSMenuItem_title(const void*);
 */
 import "C"
 
+const (
+	NSEventModifierFlagCommand = 20
+	NSEventModifierFlagControl = 18
+	NSEventModifierFlagOption  = 19
+	NSEventModifierFlagShift   = 17
+)
+
 type menuCallbacks struct {
 	action  func()
 	enabled func() bool
@@ -232,16 +239,16 @@ func keyEquivalent(item *fyne.MenuItem) (key string) {
 func keyEquivalentModifierMask(item *fyne.MenuItem) (mask uint) {
 	if s, ok := item.Shortcut.(fyne.KeyboardShortcut); ok {
 		if (s.Mod() & fyne.KeyModifierShift) != 0 {
-			mask |= 1 << 17 // NSEventModifierFlagShift
+			mask |= 1 << NSEventModifierFlagShift
 		}
 		if (s.Mod() & fyne.KeyModifierAlt) != 0 {
-			mask |= 1 << 19 // NSEventModifierFlagOption
+			mask |= 1 << NSEventModifierFlagOption
 		}
 		if (s.Mod() & fyne.KeyModifierControl) != 0 {
-			mask |= 1 << 18 // NSEventModifierFlagControl
+			mask |= 1 << NSEventModifierFlagControl
 		}
 		if (s.Mod() & fyne.KeyModifierSuper) != 0 {
-			mask |= 1 << 20 // NSEventModifierFlagCommand
+			mask |= 1 << NSEventModifierFlagCommand
 		}
 	}
 	return mask

--- a/internal/driver/glfw/scale.go
+++ b/internal/driver/glfw/scale.go
@@ -10,13 +10,16 @@ import (
 
 const (
 	baselineDPI = 120.0
+	maxDPI      = 1000
+	minDPI      = 10
+	mmPerInch   = 25.4
 	scaleEnvKey = "FYNE_SCALE"
 	scaleAuto   = float32(-1.0) // some platforms allow setting auto-scale (linux/BSD)
 )
 
 func calculateDetectedScale(widthMm, widthPx int) float32 {
-	dpi := float32(widthPx) / (float32(widthMm) / 25.4)
-	if dpi > 1000 || dpi < 10 {
+	dpi := float32(widthPx) / (float32(widthMm) / mmPerInch)
+	if dpi > maxDPI || dpi < minDPI {
 		dpi = baselineDPI
 	}
 
@@ -37,7 +40,7 @@ func calculateScale(user, system, detected float32) float32 {
 	}
 
 	raw := system * user
-	return float32(math.Round(float64(raw*10.0))) / 10.0
+	return float32(math.Round(float64(raw*10.0))) / 10.0 //revive:disable-line:add-constant
 }
 
 func userScale() float32 {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -18,6 +18,7 @@ import (
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/driver"
 	"fyne.io/fyne/v2/internal/driver/common"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/scale"
 )
 
@@ -65,7 +66,7 @@ func (w *window) Resize(size fyne.Size) {
 		}
 
 		w.requestedWidth, w.requestedHeight = width, height
-		if runtime.GOOS != "js" {
+		if runtime.GOOS != goos.JavaScript {
 			w.view().SetSize(width, height)
 			w.processResized(width, height)
 		}
@@ -264,7 +265,7 @@ func (w *window) destroy(d *gLDriver) {
 
 	if w.master {
 		d.Quit()
-	} else if runtime.GOOS == "darwin" {
+	} else if runtime.GOOS == goos.Darwin {
 		d.focusPreviousWindow()
 	}
 }
@@ -314,7 +315,7 @@ func (w *window) processResized(width, height int) {
 }
 
 func (w *window) processFrameSized(width, height int) {
-	if width == 0 || height == 0 || runtime.GOOS != "darwin" {
+	if width == 0 || height == 0 || runtime.GOOS != goos.Darwin {
 		return
 	}
 
@@ -711,7 +712,7 @@ func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, 
 		switch keyName {
 		case desktop.KeyAltLeft, desktop.KeyAltRight:
 			// compensate for GLFW modifiers bug https://github.com/glfw/glfw/issues/1630
-			if (runtime.GOOS == "linux" && keyDesktopModifier == 0) || (runtime.GOOS != "linux" && keyDesktopModifier == fyne.KeyModifierAlt) {
+			if (runtime.GOOS == goos.Linux && keyDesktopModifier == 0) || (runtime.GOOS != goos.Linux && keyDesktopModifier == fyne.KeyModifierAlt) {
 				w.menuTogglePending = keyName
 			}
 		case fyne.KeyEscape:
@@ -933,7 +934,7 @@ func (w *window) runOnMainWhenCreated(fn func()) {
 }
 
 func (d *gLDriver) CreateWindow(title string) (win fyne.Window) {
-	if runtime.GOOS != "js" {
+	if runtime.GOOS != goos.JavaScript {
 		async.EnsureMain(func() {
 			win = d.createWindow(title, true)
 		})

--- a/internal/driver/glfw/window_darwin.go
+++ b/internal/driver/glfw/window_darwin.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 
 	"fyne.io/fyne/v2/driver"
+	"fyne.io/fyne/v2/internal/goos"
 )
 
 // assert we are implementing driver.NativeWindow
@@ -32,7 +33,7 @@ func (w *window) RunNative(f func(any)) {
 }
 
 func (w *window) doSetFullScreen(full bool) {
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != goos.Darwin {
 		return
 	}
 
@@ -41,7 +42,7 @@ func (w *window) doSetFullScreen(full bool) {
 }
 
 func (w *window) doSetFullScreen2(full bool) {
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != goos.Darwin {
 		return
 	}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -19,6 +19,7 @@ import (
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/build"
 	"fyne.io/fyne/v2/internal/cache"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/painter"
 	"fyne.io/fyne/v2/internal/painter/gl"
 	"fyne.io/fyne/v2/internal/scale"
@@ -288,7 +289,7 @@ func (w *window) fitContent() {
 // getMonitorScale returns the scale factor for a given monitor, handling platform-specific cases
 func getMonitorScale(monitor *glfw.Monitor) float32 {
 	widthMm, heightMm := monitor.GetPhysicalSize()
-	if runtime.GOOS == "linux" && widthMm == 60 && heightMm == 60 { // Steam Deck incorrectly reports 6cm square!
+	if runtime.GOOS == goos.Linux && widthMm == 60 && heightMm == 60 { // Steam Deck incorrectly reports 6cm square!
 		return 1.0
 	}
 	widthPx := monitor.GetVideoMode().Width
@@ -450,7 +451,7 @@ func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.
 }
 
 func (w *window) mouseScrolled(viewport *glfw.Window, xoff float64, yoff float64) {
-	if runtime.GOOS != "darwin" && xoff == 0 &&
+	if runtime.GOOS != goos.Darwin && xoff == 0 &&
 		(viewport.GetKey(glfw.KeyLeftShift) == glfw.Press ||
 			viewport.GetKey(glfw.KeyRightShift) == glfw.Press) {
 		xoff, yoff = yoff, xoff
@@ -462,7 +463,7 @@ func (w *window) mouseScrolled(viewport *glfw.Window, xoff float64, yoff float64
 func convertMouseButton(btn glfw.MouseButton, mods glfw.ModifierKey) (desktop.MouseButton, fyne.KeyModifier) {
 	modifier := desktopModifier(mods)
 	rightClick := false
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == goos.Darwin {
 		if modifier&fyne.KeyModifierControl != 0 {
 			rightClick = true
 			modifier &^= fyne.KeyModifierControl
@@ -816,7 +817,7 @@ func (w *window) create() {
 
 	// macOS 26 places new windows on a different screen than existing app windows;
 	// default new windows onto the same monitor as a visible sibling when no position was set.
-	if runtime.GOOS == "darwin" && !build.IsWayland && w.xpos == 0 && w.ypos == 0 {
+	if runtime.GOOS == goos.Darwin && !build.IsWayland && w.xpos == 0 && w.ypos == 0 {
 		if monitor := w.findSiblingMonitor(); monitor != nil {
 			monX, monY := monitor.GetPos()
 			monMode := monitor.GetVideoMode()

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -288,10 +288,12 @@ func (w *window) fitContent() {
 
 // getMonitorScale returns the scale factor for a given monitor, handling platform-specific cases
 func getMonitorScale(monitor *glfw.Monitor) float32 {
+	const steamDeckIncorrectlyReportedDisplaySize = 60
 	widthMm, heightMm := monitor.GetPhysicalSize()
-	if runtime.GOOS == goos.Linux && widthMm == 60 && heightMm == 60 { // Steam Deck incorrectly reports 6cm square!
+	if runtime.GOOS == goos.Linux && widthMm == steamDeckIncorrectlyReportedDisplaySize && heightMm == steamDeckIncorrectlyReportedDisplaySize { // Steam Deck incorrectly reports 6cm square!
 		return 1.0
 	}
+
 	widthPx := monitor.GetVideoMode().Width
 	return calculateDetectedScale(widthMm, widthPx)
 }
@@ -772,6 +774,8 @@ func (w *window) RescaleContext() {
 }
 
 func (w *window) create() {
+	const fallbackScreenSize = 10
+
 	if !build.IsWayland {
 		// make the window hidden, we will set it up and then show it later
 		glfw.WindowHint(glfw.Visible, glfw.False)
@@ -797,11 +801,11 @@ func (w *window) create() {
 	pixWidth, pixHeight := w.screenSize(w.canvas.size)
 	pixWidth = int(fyne.Max(float32(pixWidth), float32(w.width)))
 	if pixWidth == 0 {
-		pixWidth = 10
+		pixWidth = fallbackScreenSize
 	}
 	pixHeight = int(fyne.Max(float32(pixHeight), float32(w.height)))
 	if pixHeight == 0 {
-		pixHeight = 10
+		pixHeight = fallbackScreenSize
 	}
 
 	win, err := glfw.CreateWindow(pixWidth, pixHeight, w.title, nil, nil)

--- a/internal/driver/glfw/window_windows.go
+++ b/internal/driver/glfw/window_windows.go
@@ -7,13 +7,14 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/driver"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/scale"
 
 	"golang.org/x/sys/windows/registry"
 )
 
 func (w *window) setDarkMode() {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goos.Windows {
 		hwnd := w.view().GetWin32Window()
 		dark := isDark()
 		// cannot use a go bool.
@@ -26,7 +27,7 @@ func (w *window) setDarkMode() {
 		ret, _, err := setAtt.Call(uintptr(unsafe.Pointer(hwnd)), // window handle
 			20,                                // DWMWA_USE_IMMERSIVE_DARK_MODE
 			uintptr(unsafe.Pointer(&winBool)), // on or off
-			4)                                 // sizeof(bool for windows)
+			4) // sizeof(bool for windows)
 
 		if ret != 0 && ret != 0x80070057 { // err is always non-nil, we check return value (except erroneous code)
 			fyne.LogError("Failed to set dark mode", err)

--- a/internal/driver/mobile/app/darwin_desktop.go
+++ b/internal/driver/mobile/app/darwin_desktop.go
@@ -184,7 +184,7 @@ func eventKey(runeVal int32, direction uint8, code uint16, flags uint32) {
 	}
 
 	theApp.events.In() <- key.Event{
-		Rune:      convRune(rune(runeVal)),
+		Rune:      convRune(runeVal),
 		Code:      convVirtualKeyCode(code),
 		Modifiers: modifiers,
 		Direction: key.Direction(direction),

--- a/internal/driver/mobile/device_desktop.go
+++ b/internal/driver/mobile/device_desktop.go
@@ -7,7 +7,7 @@ import "fyne.io/fyne/v2"
 const tapYOffset = 0 // no finger compensation on desktop (simulation)
 
 func (*device) SystemScaleForWindow(_ fyne.Window) float32 {
-	return 1.4 // this is simply due to the high number of pixels on a mobile device - just an approximation
+	return 1.4 //revive:disable-line:add-constant -- this is simply due to the high number of pixels on a mobile device - just an approximation
 }
 
 func setDisableScreenBlank(_ bool) {

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -24,6 +24,7 @@ import (
 	"fyne.io/fyne/v2/internal/driver/mobile/event/size"
 	"fyne.io/fyne/v2/internal/driver/mobile/event/touch"
 	"fyne.io/fyne/v2/internal/driver/mobile/gl"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/painter"
 	pgl "fyne.io/fyne/v2/internal/painter/gl"
 	"fyne.io/fyne/v2/internal/scale"
@@ -266,7 +267,7 @@ func (d *driver) Run() {
 						d.tapUpCanvas(current, e.X, e.Y, e.Sequence)
 					}
 				case key.Event:
-					if runtime.GOOS == "android" && e.Code == key.CodeDeleteBackspace && e.Rune < 0 && d.device.keyboardShown {
+					if runtime.GOOS == goos.Android && e.Code == key.CodeDeleteBackspace && e.Rune < 0 && d.device.keyboardShown {
 						break // we are getting release/press on backspace during soft backspace
 					}
 
@@ -310,7 +311,7 @@ func (d *driver) handleLifecycle(e lifecycle.Event, w *window) {
 			f()
 		}
 	case lifecycle.CrossOff: // will enter background
-		if runtime.GOOS == "darwin" || runtime.GOOS == "ios" {
+		if runtime.GOOS == goos.Darwin || runtime.GOOS == goos.IOS {
 			if d.glctx == nil {
 				return
 			}

--- a/internal/goos/goos.go
+++ b/internal/goos/goos.go
@@ -1,0 +1,19 @@
+package goos
+
+// OS constants (to compare to runtime.GOOS)
+const (
+	Android    = "android"
+	Darwin     = "darwin"
+	FreeBSD    = "freebsd"
+	IOS        = "ios"
+	JavaScript = "js"
+	Linux      = "linux"
+	NetBSD     = "netbsd"
+	OpenBSD    = "openbsd"
+	Windows    = "windows"
+)
+
+// IsBSD returns whether the specified OS is a supported BSD variant.
+func IsBSD(os string) bool {
+	return os == FreeBSD || os == NetBSD || os == OpenBSD
+}

--- a/internal/painter/draw.go
+++ b/internal/painter/draw.go
@@ -7,6 +7,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/painter/geom"
 
 	"github.com/srwiley/rasterx"
 	"golang.org/x/image/math/fixed"
@@ -131,7 +132,7 @@ func DrawLine(line *canvas.Line, vectorPad float32, scale func(float32) float32)
 	p1x, p1y := scale(line.Position1.X-position.X+vectorPad), scale(line.Position1.Y-position.Y+vectorPad)
 	p2x, p2y := scale(line.Position2.X-position.X+vectorPad), scale(line.Position2.Y-position.Y+vectorPad)
 
-	if stroke <= 1.5 { // adjust to support 1px
+	if stroke <= 1.5 { //revive:disable-line:add-constant -- adjust to support 1px
 		if p1x == p2x {
 			p1x -= 0.5
 			p2x -= 0.5
@@ -440,7 +441,7 @@ func drawRegularPolygon(cx, cy, radius, cornerRadius, rot float64, sides int, p 
 	}
 	gf := rasterx.RoundGap
 	angleStep := 2 * math.Pi / float64(sides)
-	rotRads := rot*math.Pi/180 - math.Pi/2
+	rotRads := rot*math.Pi/geom.AngleHalf - math.Pi/2
 
 	// fully rounded, draw circle
 	if math.Min(cornerRadius, radius) == radius {
@@ -663,7 +664,7 @@ func drawRoundArc(adder rasterx.Adder, cx, cy, outer, inner, start, sweep, cr fl
 			x1, y1 := cosSinPoint(cx, cy, r, a1)
 			x2, y2 := cosSinPoint(cx, cy, r, a2)
 
-			k := 4.0 / 3.0 * math.Tan((a2-a1)/4.0)
+			k := 4.0 / 3.0 * math.Tan((a2-a1)/4.0) //revive:disable-line:add-constant
 			// tangent unit vectors on our param (x = cx+rcos, y = cy-rsin)
 			c1x := x1 + k*r*(-math.Sin(a1))
 			c1y := y1 + k*r*(-math.Cos(a1))
@@ -888,8 +889,9 @@ func GetMaximumRadiusArc(outerRadius, innerRadius, sweepAngle float32) float32 {
 	// height (thickness), width (length)
 	thickness := outerRadius - innerRadius
 	// TODO: length formula can be improved to get a fully rounded (pill shape) outer edge for thin (small sweep) arc segments
-	span := math.Sin(0.5 * math.Min(math.Abs(float64(sweepAngle))*math.Pi/180.0, math.Pi)) // span in (0,1)
-	length := 1.5 * float64(outerRadius) * span / (1 + span)                               // no division-by-zero risk
+	span := math.Sin(0.5 * math.Min(math.Abs(float64(sweepAngle))*math.Pi/geom.AngleHalf, math.Pi)) // span in (0,1)
+	//revive:disable-next-line:add-constant
+	length := 1.5 * float64(outerRadius) * span / (1 + span) // no division-by-zero risk
 
 	return GetMaximumRadius(fyne.NewSize(
 		thickness, float32(length),
@@ -901,7 +903,7 @@ func GetMaximumRadiusArc(outerRadius, innerRadius, sweepAngle float32) float32 {
 // to the coordinate system used by the painter, where 0 degrees is at the top (12 o'clock position).
 // The function also reverses the direction: positive is clockwise, negative is counter-clockwise
 func NormalizeArcAngles(startAngle, endAngle float32) (float32, float32) {
-	return -(startAngle - 90), -(endAngle - 90)
+	return -(startAngle - geom.AngleQuarter), -(endAngle - geom.AngleQuarter)
 }
 
 // NormalizeBezierCurvePoints clamps the start, end, and control points of a Bezier curve

--- a/internal/painter/draw.go
+++ b/internal/painter/draw.go
@@ -169,7 +169,7 @@ func DrawPolygon(polygon *canvas.RegularPolygon, vectorPad float32, scale func(f
 	if polygon.FillColor != nil {
 		filler := rasterx.NewFiller(width, height, scanner)
 		filler.SetColor(polygon.FillColor)
-		drawRegularPolygon(float64(width/2), float64(height/2), float64(outerRadius), float64(cornerRadius), float64(angle), int(sides), filler)
+		drawRegularPolygon(float64(width/2), float64(height/2), float64(outerRadius), float64(cornerRadius), float64(angle), sides, filler)
 		filler.Draw()
 	}
 
@@ -177,7 +177,7 @@ func DrawPolygon(polygon *canvas.RegularPolygon, vectorPad float32, scale func(f
 		dasher := rasterx.NewDasher(width, height, scanner)
 		dasher.SetColor(polygon.StrokeColor)
 		dasher.SetStroke(fixed.Int26_6(float64(scale(polygon.StrokeWidth))*64), 0, nil, nil, nil, 0, nil, 0)
-		drawRegularPolygon(float64(width/2), float64(height/2), float64(outerRadius), float64(cornerRadius), float64(angle), int(sides), dasher)
+		drawRegularPolygon(float64(width/2), float64(height/2), float64(outerRadius), float64(cornerRadius), float64(angle), sides, dasher)
 		dasher.Draw()
 	}
 

--- a/internal/painter/font_prod.go
+++ b/internal/painter/font_prod.go
@@ -8,11 +8,13 @@ import (
 	"runtime"
 
 	"github.com/go-text/typesetting/fontscan"
+
+	"fyne.io/fyne/v2/internal/goos"
 )
 
 func loadSystemFonts(fm *fontscan.FontMap) error {
 	cacheDir := ""
-	if runtime.GOOS == "android" {
+	if runtime.GOOS == goos.Android {
 		parent := os.Getenv("FILESDIR")
 		cacheDir = filepath.Join(parent, "fontcache")
 	}

--- a/internal/painter/geom/geom.go
+++ b/internal/painter/geom/geom.go
@@ -2,8 +2,12 @@ package geom
 
 // Angle constants
 const (
+	AngleEighth       = 45
+	AngleFiveEighth   = 225
 	AngleHalf         = 180
 	AngleNone         = 0
 	AngleQuarter      = 90
+	AngleSevenEighth  = 315
+	AngleThreeEighth  = 135
 	AngleThreeQuarter = 270
 )

--- a/internal/painter/geom/geom.go
+++ b/internal/painter/geom/geom.go
@@ -1,0 +1,9 @@
+package geom
+
+// Angle constants
+const (
+	AngleHalf         = 180
+	AngleNone         = 0
+	AngleQuarter      = 90
+	AngleThreeQuarter = 270
+)

--- a/internal/painter/geom/geom.go
+++ b/internal/painter/geom/geom.go
@@ -4,6 +4,7 @@ package geom
 const (
 	AngleEighth       = 45
 	AngleFiveEighth   = 225
+	AngleFull         = 360
 	AngleHalf         = 180
 	AngleNone         = 0
 	AngleQuarter      = 90

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -12,7 +12,55 @@ import (
 	paint "fyne.io/fyne/v2/internal/painter"
 )
 
-const edgeSoftness = 0.5
+const (
+	attrAddShadow                = "addShadow"
+	attrAlpha                    = "alpha"
+	attrAngle                    = "angle"
+	attrAngleEnd                 = "endAngle"
+	attrAngleStart               = "startAngle"
+	attrRectangleCoordinates     = "bounds"
+	attrColor                    = "color"
+	attrDirection                = "direction"
+	attrEdgeSoftness             = "edgeSoftness"
+	attrFeather                  = "feather"
+	attrFillColor                = "fillColor"
+	attrFrameSize                = "frame"
+	attrInset                    = "inset"
+	attrLineWidth                = "lineWidth"
+	attrNormal                   = "normal"
+	attrPointControlCount        = "numControlPoints"
+	attrPointControl1            = "controlPoint1"
+	attrPointControl2            = "controlPoint2"
+	attrPointEnd                 = "endPoint"
+	attrPointStart               = "startPoint"
+	attrRadiiCorner              = "cornerRadii"
+	attrRadius                   = "radius"
+	attrRadiusCorner             = "cornerRadius"
+	attrRadiusInner              = "innerRadius"
+	attrRadiusOuter              = "outerRadius"
+	attrRectangleSizeHalf        = "rectSizeHalf"
+	attrSampleScale              = "sampleScale"
+	attrShadowBlurRadius         = "shadowBlurRadius"
+	attrShadowColor              = "shadowColor"
+	attrShadowOffset             = "shadowOffset"
+	attrShadowSpread             = "shadowSpread"
+	attrShadowType               = "shadowType"
+	attrSides                    = "sides"
+	attrSize                     = "size"
+	attrStrokeColor              = "strokeColor"
+	attrStrokeWidth              = "strokeWidth"
+	attrStrokeWidthHalf          = "strokeWidthHalf"
+	attrTexture                  = "tex"
+	attrTextureKernel            = "kernelTex"
+	attrVertex                   = "vert"
+	attrVertexCount              = "vertexCount"
+	attrVertexTextureCoordinates = "vertTexCoord"
+	attrVertices                 = "vertices"
+
+	edgeSoftness = 0.5
+
+	rectangleCoordinateSize = 5
+)
 
 func (p *painter) createBuffer(size int) Buffer {
 	vbo := p.ctx.CreateBuffer()
@@ -97,23 +145,23 @@ func (p *painter) drawBlur(b *canvas.Blur, pos fyne.Position, frame fyne.Size) {
 	// Build quad vertices. CopyTexSubImage2D places the framebuffer bottom at texture v=0,
 	// but rectCoords maps v=0 to the canvas top. Swap the v coordinates to correct orientation.
 	points, _ := p.rectCoords(b.Size(), pos, frame, canvas.ImageFillStretch, 1.0, 0)
-	points[4], points[9] = points[9], points[4]
-	points[14], points[19] = points[19], points[14]
+	points[rectangleCoordinateSize-1], points[2*rectangleCoordinateSize-1] = points[2*rectangleCoordinateSize-1], points[rectangleCoordinateSize-1]
+	points[3*rectangleCoordinateSize-1], points[4*rectangleCoordinateSize-1] = points[4*rectangleCoordinateSize-1], points[3*rectangleCoordinateSize-1]
 
 	p.ctx.UseProgram(p.blurProgram.ref)
 	p.updateBuffer(p.blurProgram.buff, points)
-	p.UpdateVertexArray(p.blurProgram, "vert", 3, 5, 0)
-	p.UpdateVertexArray(p.blurProgram, "vertTexCoord", 2, 5, 3)
+	p.UpdateVertexArray(p.blurProgram, attrVertex, 3, 5, 0)
+	p.UpdateVertexArray(p.blurProgram, attrVertexTextureCoordinates, 2, 5, 3)
 
 	p.ctx.BlendFunc(one, oneMinusSrcAlpha)
 	p.logError()
 
 	cornerRadius := fyne.Min(paint.GetMaximumRadius(b.Size()), b.CornerRadius)
-	p.SetUniform1f(p.blurProgram, "cornerRadius", roundToPixel(cornerRadius*p.pixScale, 1.0))
-	p.SetUniform2f(p.blurProgram, "size", float32(bw), float32(bh))
+	p.SetUniform1f(p.blurProgram, attrRadiusCorner, roundToPixel(cornerRadius*p.pixScale, 1.0))
+	p.SetUniform2f(p.blurProgram, attrSize, float32(bw), float32(bh))
 
-	p.SetUniform1f(p.blurProgram, "radius", kernelRadius)
-	p.SetUniform1f(p.blurProgram, "sampleScale", sampleScale)
+	p.SetUniform1f(p.blurProgram, attrRadius, kernelRadius)
+	p.SetUniform1f(p.blurProgram, attrSampleScale, sampleScale)
 
 	// Bind kernel texture to unit 1.
 	p.ctx.ActiveTexture(texture1)
@@ -124,13 +172,13 @@ func (p *painter) drawBlur(b *canvas.Blur, pos fyne.Position, frame fyne.Size) {
 	p.ctx.BindTexture(texture2D, p.blurSnapTex)
 
 	// Set sampler uniforms.
-	p.SetUniform1i(p.blurProgram, "tex", 0)
-	p.SetUniform1i(p.blurProgram, "kernelTex", 1)
+	p.SetUniform1i(p.blurProgram, attrTexture, 0)
+	p.SetUniform1i(p.blurProgram, attrTextureKernel, 1)
 
 	// Horizontal Blur
 	// Draw horizontal blur over the background. Use gl: one, gl: zero to replace the screen content.
 	p.ctx.BlendFunc(one, zero)
-	p.SetUniform2f(p.blurProgram, "direction", 1.0/float32(bw), 0.0)
+	p.SetUniform2f(p.blurProgram, attrDirection, 1.0/float32(bw), 0.0)
 
 	p.ctx.DrawArrays(triangleStrip, 0, 4)
 
@@ -141,7 +189,7 @@ func (p *painter) drawBlur(b *canvas.Blur, pos fyne.Position, frame fyne.Size) {
 	// Draw vertical blur using the horizontally-blurred texture.
 	// Use one, zero since it replaces the exact same rect we just copied from.
 	p.ctx.BlendFunc(one, zero)
-	p.SetUniform2f(p.blurProgram, "direction", 0.0, 1.0/float32(bh))
+	p.SetUniform2f(p.blurProgram, attrDirection, 0.0, 1.0/float32(bh))
 
 	p.ctx.DrawArrays(triangleStrip, 0, 4)
 	p.logError()
@@ -155,8 +203,8 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 	bounds, points := p.vecSquareCoords(pos, circle, frame, circle.Shadow)
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -164,45 +212,45 @@ func (p *painter) drawCircle(circle *canvas.Circle, pos fyne.Position, frame fyn
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(circle.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "strokeWidthHalf", strokeWidthScaled*0.5)
+	p.SetUniform1f(program, attrStrokeWidthHalf, strokeWidthScaled*0.5)
 
 	rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 	rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled
-	p.SetUniform2f(program, "rectSizeHalf", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
+	p.SetUniform2f(program, attrRectangleSizeHalf, rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
 
 	radiusScaled := roundToPixel(radius*p.pixScale, 1.0)
-	p.SetUniform4f(program, "radius", radiusScaled, radiusScaled, radiusScaled, radiusScaled)
+	p.SetUniform4f(program, attrRadius, radiusScaled, radiusScaled, radiusScaled, radiusScaled)
 
 	r, g, b, a := getFragmentColor(circle.FillColor)
-	p.SetUniform4f(program, "fillColor", r, g, b, a)
+	p.SetUniform4f(program, attrFillColor, r, g, b, a)
 
 	strokeColor := circle.StrokeColor
 	if strokeColor == nil {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "strokeColor", r, g, b, a)
+	p.SetUniform4f(program, attrStrokeColor, r, g, b, a)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
+	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
 	var addShadow float32
 	if paint.IsShadowVisible(circle.Shadow) {
 		r, g, b, a = getFragmentColor(circle.Shadow.Color)
-		p.SetUniform4f(program, "shadowColor", r, g, b, a)
-		p.SetUniform2f(program, "shadowOffset", roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowSpread", roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowType", float32(circle.Shadow.Variant))
+		p.SetUniform4f(program, attrShadowColor, r, g, b, a)
+		p.SetUniform2f(program, attrShadowOffset, roundToPixel(circle.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(circle.Shadow.Offset.Y*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowBlurRadius, roundToPixel(circle.Shadow.BlurRadius*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowSpread, roundToPixel(circle.Shadow.Spread*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowType, float32(circle.Shadow.Variant))
 		addShadow = 1.0
 	}
-	p.SetUniform1f(program, "addShadow", addShadow)
+	p.SetUniform1f(program, attrAddShadow, addShadow)
 
 	p.logError()
 	// Fragment: END
@@ -226,20 +274,20 @@ func (p *painter) drawLine(line *canvas.Line, pos fyne.Position, frame fyne.Size
 	points, halfWidth, feather := p.lineCoords(pos, line.Position1, line.Position2, line.StrokeWidth, 0.5, frame)
 	p.ctx.UseProgram(p.lineProgram.ref)
 	p.updateBuffer(p.lineProgram.buff, points)
-	p.UpdateVertexArray(p.lineProgram, "vert", 2, 4, 0)
-	p.UpdateVertexArray(p.lineProgram, "normal", 2, 4, 2)
+	p.UpdateVertexArray(p.lineProgram, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(p.lineProgram, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
 
 	r, g, b, a := getFragmentColor(line.StrokeColor)
-	p.SetUniform4f(p.lineProgram, "color", r, g, b, a)
+	p.SetUniform4f(p.lineProgram, attrColor, r, g, b, a)
 
-	p.SetUniform1f(p.lineProgram, "lineWidth", halfWidth)
+	p.SetUniform1f(p.lineProgram, attrLineWidth, halfWidth)
 
-	p.SetUniform1f(p.lineProgram, "feather", feather)
+	p.SetUniform1f(p.lineProgram, attrFeather, feather)
 
-	p.ctx.DrawArrays(triangles, 0, 6)
+	p.ctx.DrawArrays(triangles, 0, 2*vertexCountTriangle)
 	p.logError()
 }
 
@@ -253,8 +301,8 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	program := p.bezierCurveProgram
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -262,13 +310,13 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
+	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
 	// ensure stroke width is not larger than the size of the object
 	strokeWidth := fyne.Min(bezierCurve.StrokeWidth, fyne.Min(bezierCurve.Size().Width, bezierCurve.Size().Height))
@@ -278,28 +326,28 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p1, p2, cp := paint.NormalizeBezierCurvePoints(bezierCurve.StartPoint, bezierCurve.EndPoint, bezierCurve.ControlPoints, bezierCurve.Size(), strokeWidth/2.0)
 
 	p1XScaled, p1YScaled := roundToPixel(p1.X*p.pixScale, 1.0), roundToPixel(p1.Y*p.pixScale, 1.0)
-	p.SetUniform2f(program, "startPoint", p1XScaled, p1YScaled)
+	p.SetUniform2f(program, attrPointStart, p1XScaled, p1YScaled)
 
 	p2XScaled, p2YScaled := roundToPixel(p2.X*p.pixScale, 1.0), roundToPixel(p2.Y*p.pixScale, 1.0)
-	p.SetUniform2f(program, "endPoint", p2XScaled, p2YScaled)
+	p.SetUniform2f(program, attrPointEnd, p2XScaled, p2YScaled)
 
 	if len(cp) == 1 {
 		cpXScaled, cpYScaled := roundToPixel(cp[0].X*p.pixScale, 1.0), roundToPixel(cp[0].Y*p.pixScale, 1.0)
-		p.SetUniform2f(program, "controlPoint1", cpXScaled, cpYScaled)
+		p.SetUniform2f(program, attrPointControl1, cpXScaled, cpYScaled)
 	} else if len(cp) == 2 {
 		cp1XScaled, cp1YScaled := roundToPixel(cp[0].X*p.pixScale, 1.0), roundToPixel(cp[0].Y*p.pixScale, 1.0)
-		p.SetUniform2f(program, "controlPoint1", cp1XScaled, cp1YScaled)
+		p.SetUniform2f(program, attrPointControl1, cp1XScaled, cp1YScaled)
 
 		cp2XScaled, cp2YScaled := roundToPixel(cp[1].X*p.pixScale, 1.0), roundToPixel(cp[1].Y*p.pixScale, 1.0)
-		p.SetUniform2f(program, "controlPoint2", cp2XScaled, cp2YScaled)
+		p.SetUniform2f(program, attrPointControl2, cp2XScaled, cp2YScaled)
 	}
-	p.SetUniform1f(program, "numControlPoints", fyne.Min(float32(len(cp)), 2))
+	p.SetUniform1f(program, attrPointControlCount, fyne.Min(float32(len(cp)), 2))
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "strokeWidthHalf", strokeWidthScaled*0.5)
+	p.SetUniform1f(program, attrStrokeWidthHalf, strokeWidthScaled*0.5)
 
 	r, g, b, a := getFragmentColor(bezierCurve.StrokeColor)
-	p.SetUniform4f(program, "strokeColor", r, g, b, a)
+	p.SetUniform4f(program, attrStrokeColor, r, g, b, a)
 
 	p.logError()
 	// Fragment: END
@@ -318,8 +366,8 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	program := p.arbitraryPolygonProgram
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -327,16 +375,16 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
+	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
 	numPoints := int(fyne.Min(paint.ArbitraryPolygonVerticesMaximum, float32(len(polygon.Points))))
-	p.SetUniform1f(program, "vertexCount", float32(numPoints))
+	p.SetUniform1f(program, attrVertexCount, float32(numPoints))
 
 	size := polygon.Size()
 	clampPoint := func(p fyne.Position) (float32, float32) {
@@ -371,18 +419,18 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 		cornerRadiiScaled[i] = roundToPixel(cornerRadii[i]*p.pixScale, 1.0)
 	}
 
-	p.SetUniform2fv(program, "vertices", verticesScaled)
-	p.SetUniform1fv(program, "cornerRadii", cornerRadiiScaled)
+	p.SetUniform2fv(program, attrVertices, verticesScaled)
+	p.SetUniform1fv(program, attrRadiiCorner, cornerRadiiScaled)
 
 	// Colors and Stroke
 	r, g, b, a := getFragmentColor(polygon.FillColor)
-	p.SetUniform4f(program, "fillColor", r, g, b, a)
+	p.SetUniform4f(program, attrFillColor, r, g, b, a)
 
 	r, g, b, a = getFragmentColor(polygon.StrokeColor)
-	p.SetUniform4f(program, "strokeColor", r, g, b, a)
+	p.SetUniform4f(program, attrStrokeColor, r, g, b, a)
 
 	strokeWidthScaled := roundToPixel(polygon.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
+	p.SetUniform1f(program, attrStrokeWidth, strokeWidthScaled)
 
 	p.logError()
 	// Fragment: END
@@ -450,7 +498,7 @@ func (p *painter) shaderProgram(shader *canvas.Shader) (*shaderState, bool) {
 	state := &shaderState{
 		program: programState{
 			ref:        ref,
-			buff:       p.createBuffer(16),
+			buff:       p.createBuffer(programBufSizeDefault),
 			uniforms:   make(map[string]*uniformState),
 			attributes: make(map[string]Attribute),
 		},
@@ -471,8 +519,8 @@ func (p *painter) drawShader(shader *canvas.Shader, pos fyne.Position, frame fyn
 	bounds, points := p.vecRectCoords(pos, shader, frame, 0.0, canvas.Shadow{})
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -480,10 +528,10 @@ func (p *painter) drawShader(shader *canvas.Shader, pos fyne.Position, frame fyn
 
 	// Fragment: BEG - the standard uniform contract shared with the built in vector shaders
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	for name, v := range shader.Uniforms {
 		p.SetUniform1f(program, name, v)
@@ -559,8 +607,8 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 	bounds, points := p.vecRectCoords(pos, obj, frame, aspect, shadow)
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -568,18 +616,18 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
 	if roundedCorners {
-		p.SetUniform1f(program, "strokeWidthHalf", strokeWidthScaled*0.5)
+		p.SetUniform1f(program, attrStrokeWidthHalf, strokeWidthScaled*0.5)
 
 		rectSizeWidthScaled := x2Scaled - x1Scaled - strokeWidthScaled
 		rectSizeHeightScaled := y2Scaled - y1Scaled - strokeWidthScaled
-		p.SetUniform2f(program, "rectSizeHalf", rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
+		p.SetUniform2f(program, attrRectangleSizeHalf, rectSizeWidthScaled*0.5, rectSizeHeightScaled*0.5)
 
 		// the maximum possible corner radii for a circular shape, calculated taking into account the rect coords with aspect ratio
 		size := fyne.NewSize(bounds[2]-bounds[0], bounds[3]-bounds[1])
@@ -599,35 +647,35 @@ func (p *painter) drawOblong(obj fyne.CanvasObject, fill, stroke color.Color, st
 			paint.GetMaximumCornerRadius(bottomLeftRadius, bottomRightRadius, topLeftRadius, size)*p.pixScale,
 			1.0,
 		)
-		p.SetUniform4f(program, "radius", topRightRadiusScaled, bottomRightRadiusScaled, topLeftRadiusScaled, bottomLeftRadiusScaled)
+		p.SetUniform4f(program, attrRadius, topRightRadiusScaled, bottomRightRadiusScaled, topLeftRadiusScaled, bottomLeftRadiusScaled)
 
 		edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-		p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
+		p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 	} else {
-		p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
+		p.SetUniform1f(program, attrStrokeWidth, strokeWidthScaled)
 	}
 
 	r, g, b, a := getFragmentColor(fill)
-	p.SetUniform4f(program, "fillColor", r, g, b, a)
+	p.SetUniform4f(program, attrFillColor, r, g, b, a)
 
 	strokeColor := stroke
 	if strokeColor == nil {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "strokeColor", r, g, b, a)
+	p.SetUniform4f(program, attrStrokeColor, r, g, b, a)
 
 	var addShadow float32
 	if paint.IsShadowVisible(shadow) {
 		r, g, b, a = getFragmentColor(shadow.Color)
-		p.SetUniform4f(program, "shadowColor", r, g, b, a)
-		p.SetUniform2f(program, "shadowOffset", roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowSpread", roundToPixel(shadow.Spread*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowType", float32(shadow.Variant))
+		p.SetUniform4f(program, attrShadowColor, r, g, b, a)
+		p.SetUniform2f(program, attrShadowOffset, roundToPixel(shadow.Offset.X*p.pixScale, 1.0), roundToPixel(shadow.Offset.Y*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowBlurRadius, roundToPixel(shadow.BlurRadius*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowSpread, roundToPixel(shadow.Spread*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowType, float32(shadow.Variant))
 		addShadow = 1.0
 	}
-	p.SetUniform1f(program, "addShadow", addShadow)
+	p.SetUniform1f(program, attrAddShadow, addShadow)
 
 	p.logError()
 	// Fragment: END
@@ -647,8 +695,8 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 	program := p.polygonProgram
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -656,37 +704,37 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
+	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
 	outerRadius := fyne.Min(size.Width, size.Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "outerRadius", outerRadiusScaled)
+	p.SetUniform1f(program, attrRadiusOuter, outerRadiusScaled)
 
-	p.SetUniform1f(program, "angle", polygon.Angle)
-	p.SetUniform1f(program, "sides", float32(polygon.Sides))
+	p.SetUniform1f(program, attrAngle, polygon.Angle)
+	p.SetUniform1f(program, attrSides, float32(polygon.Sides))
 
 	cornerRadius := fyne.Min(paint.GetMaximumRadius(size), polygon.CornerRadius)
 	cornerRadiusScaled := roundToPixel(cornerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "cornerRadius", cornerRadiusScaled)
+	p.SetUniform1f(program, attrRadiusCorner, cornerRadiusScaled)
 
 	strokeWidthScaled := roundToPixel(polygon.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
+	p.SetUniform1f(program, attrStrokeWidth, strokeWidthScaled)
 
 	r, g, b, a := getFragmentColor(polygon.FillColor)
-	p.SetUniform4f(program, "fillColor", r, g, b, a)
+	p.SetUniform4f(program, attrFillColor, r, g, b, a)
 
 	strokeColor := polygon.StrokeColor
 	if strokeColor == nil {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "strokeColor", r, g, b, a)
+	p.SetUniform4f(program, attrStrokeColor, r, g, b, a)
 
 	p.logError()
 	// Fragment: END
@@ -705,8 +753,8 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	program := p.arcProgram
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -714,42 +762,42 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
+	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
 	outerRadius := fyne.Min(arc.Size().Width, arc.Size().Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "outerRadius", outerRadiusScaled)
+	p.SetUniform1f(program, attrRadiusOuter, outerRadiusScaled)
 
 	innerRadius := outerRadius * float32(math.Min(1.0, math.Max(0.0, float64(arc.CutoutRatio))))
 	innerRadiusScaled := roundToPixel(innerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "innerRadius", innerRadiusScaled)
+	p.SetUniform1f(program, attrRadiusInner, innerRadiusScaled)
 
 	startAngle, endAngle := paint.NormalizeArcAngles(arc.StartAngle, arc.EndAngle)
-	p.SetUniform1f(program, "startAngle", startAngle)
-	p.SetUniform1f(program, "endAngle", endAngle)
+	p.SetUniform1f(program, attrAngleStart, startAngle)
+	p.SetUniform1f(program, attrAngleEnd, endAngle)
 
 	cornerRadius := fyne.Min(paint.GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)
 	cornerRadiusScaled := roundToPixel(cornerRadius*p.pixScale, 1.0)
-	p.SetUniform1f(program, "cornerRadius", cornerRadiusScaled)
+	p.SetUniform1f(program, attrRadiusCorner, cornerRadiusScaled)
 
 	strokeWidthScaled := roundToPixel(arc.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
+	p.SetUniform1f(program, attrStrokeWidth, strokeWidthScaled)
 
 	r, g, b, a := getFragmentColor(arc.FillColor)
-	p.SetUniform4f(program, "fillColor", r, g, b, a)
+	p.SetUniform4f(program, attrFillColor, r, g, b, a)
 
 	strokeColor := arc.StrokeColor
 	if strokeColor == nil {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "strokeColor", r, g, b, a)
+	p.SetUniform4f(program, attrStrokeColor, r, g, b, a)
 
 	p.logError()
 	// Fragment: END
@@ -780,8 +828,8 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 	bounds, points := p.vecRectCoordsWithPad(pos, ellipse, frame, -xPad, -yPad, ellipse.Shadow)
 	p.ctx.UseProgram(program.ref)
 	p.updateBuffer(program.buff, points)
-	p.UpdateVertexArray(program, "vert", 2, 4, 0)
-	p.UpdateVertexArray(program, "normal", 2, 4, 2)
+	p.UpdateVertexArray(program, attrVertex, 2, 4, 0)
+	p.UpdateVertexArray(program, attrNormal, 2, 4, 2)
 
 	p.ctx.BlendFunc(srcAlpha, oneMinusSrcAlpha)
 	p.logError()
@@ -789,44 +837,44 @@ func (p *painter) drawEllipse(ellipse *canvas.Ellipse, pos fyne.Position, frame 
 
 	// Fragment: BEG
 	frameWidthScaled, frameHeightScaled := p.scaleFrameSize(frame)
-	p.SetUniform2f(program, "frame", frameWidthScaled, frameHeightScaled)
+	p.SetUniform2f(program, attrFrameSize, frameWidthScaled, frameHeightScaled)
 
 	x1Scaled, x2Scaled, y1Scaled, y2Scaled := p.scaleRectCoords(bounds[0], bounds[2], bounds[1], bounds[3])
-	p.SetUniform4f(program, "bounds", x1Scaled, y1Scaled, x2Scaled, y2Scaled)
+	p.SetUniform4f(program, attrRectangleCoordinates, x1Scaled, y1Scaled, x2Scaled, y2Scaled)
 
 	strokeWidthScaled := roundToPixel(ellipse.StrokeWidth*p.pixScale, 1.0)
-	p.SetUniform1f(program, "strokeWidth", strokeWidthScaled)
+	p.SetUniform1f(program, attrStrokeWidth, strokeWidthScaled)
 
 	radiusXScaled := roundToPixel(radiusX*p.pixScale, 1.0)
 	radiusYScaled := roundToPixel(radiusY*p.pixScale, 1.0)
-	p.SetUniform2f(program, "radius", radiusXScaled, radiusYScaled)
+	p.SetUniform2f(program, attrRadius, radiusXScaled, radiusYScaled)
 
-	p.SetUniform1f(program, "angle", 0) // angle of ellipse, in degrees (positive means clockwise, negative means counter-clockwise direction), not yet supported in public API but reserved for future use
+	p.SetUniform1f(program, attrAngle, 0) // angle of ellipse, in degrees (positive means clockwise, negative means counter-clockwise direction), not yet supported in public API but reserved for future use
 
 	r, g, b, a := getFragmentColor(ellipse.FillColor)
-	p.SetUniform4f(program, "fillColor", r, g, b, a)
+	p.SetUniform4f(program, attrFillColor, r, g, b, a)
 
 	strokeColor := ellipse.StrokeColor
 	if strokeColor == nil {
 		strokeColor = color.Transparent
 	}
 	r, g, b, a = getFragmentColor(strokeColor)
-	p.SetUniform4f(program, "strokeColor", r, g, b, a)
+	p.SetUniform4f(program, attrStrokeColor, r, g, b, a)
 
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
-	p.SetUniform1f(program, "edgeSoftness", edgeSoftnessScaled)
+	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
 	var addShadow float32
 	if paint.IsShadowVisible(ellipse.Shadow) {
 		r, g, b, a = getFragmentColor(ellipse.Shadow.Color)
-		p.SetUniform4f(program, "shadowColor", r, g, b, a)
-		p.SetUniform2f(program, "shadowOffset", roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowBlurRadius", roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowSpread", roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))
-		p.SetUniform1f(program, "shadowType", float32(ellipse.Shadow.Variant))
+		p.SetUniform4f(program, attrShadowColor, r, g, b, a)
+		p.SetUniform2f(program, attrShadowOffset, roundToPixel(ellipse.Shadow.Offset.X*p.pixScale, 1.0), roundToPixel(ellipse.Shadow.Offset.Y*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowBlurRadius, roundToPixel(ellipse.Shadow.BlurRadius*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowSpread, roundToPixel(ellipse.Shadow.Spread*p.pixScale, 1.0))
+		p.SetUniform1f(program, attrShadowType, float32(ellipse.Shadow.Variant))
 		addShadow = 1.0
 	}
-	p.SetUniform1f(program, "addShadow", addShadow)
+	p.SetUniform1f(program, attrAddShadow, addShadow)
 
 	p.logError()
 	// Fragment: END
@@ -916,13 +964,13 @@ func (p *painter) drawTextureRegion(texture Texture, pos fyne.Position, size, fr
 
 	p.ctx.UseProgram(p.program.ref)
 	p.updateBuffer(p.program.buff, points)
-	p.UpdateVertexArray(p.program, "vert", 3, 5, 0)
-	p.UpdateVertexArray(p.program, "vertTexCoord", 2, 5, 3)
+	p.UpdateVertexArray(p.program, attrVertex, 3, 5, 0)
+	p.UpdateVertexArray(p.program, attrVertexTextureCoordinates, 2, 5, 3)
 
-	p.SetUniform1f(p.program, "cornerRadius", 0)
-	p.SetUniform2f(p.program, "size", inner.Width*p.pixScale, inner.Height*p.pixScale)
-	p.SetUniform4f(p.program, "inset", insets[0], insets[1], insets[2], insets[3])
-	p.SetUniform1f(p.program, "alpha", 1.0)
+	p.SetUniform1f(p.program, attrRadiusCorner, 0)
+	p.SetUniform2f(p.program, attrSize, inner.Width*p.pixScale, inner.Height*p.pixScale)
+	p.SetUniform4f(p.program, attrInset, insets[0], insets[1], insets[2], insets[3])
+	p.SetUniform1f(p.program, attrAlpha, 1.0)
 
 	p.ctx.BlendFunc(one, oneMinusSrcAlpha)
 	p.logError()
@@ -959,16 +1007,16 @@ func (p *painter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canva
 
 	p.ctx.UseProgram(p.program.ref)
 	p.updateBuffer(p.program.buff, points)
-	p.UpdateVertexArray(p.program, "vert", 3, 5, 0)
-	p.UpdateVertexArray(p.program, "vertTexCoord", 2, 5, 3)
+	p.UpdateVertexArray(p.program, attrVertex, 3, 5, 0)
+	p.UpdateVertexArray(p.program, attrVertexTextureCoordinates, 2, 5, 3)
 
 	// Set corner radius and texture size in pixels
 	cornerRadius = fyne.Min(paint.GetMaximumRadius(size), cornerRadius)
-	p.SetUniform1f(p.program, "cornerRadius", cornerRadius*p.pixScale)
-	p.SetUniform2f(p.program, "size", inner.Width*p.pixScale, inner.Height*p.pixScale)
-	p.SetUniform4f(p.program, "inset", insets[0], insets[1], insets[2], insets[3]) // texture coordinate insets (minX, minY, maxX, maxY)
+	p.SetUniform1f(p.program, attrRadiusCorner, cornerRadius*p.pixScale)
+	p.SetUniform2f(p.program, attrSize, inner.Width*p.pixScale, inner.Height*p.pixScale)
+	p.SetUniform4f(p.program, attrInset, insets[0], insets[1], insets[2], insets[3]) // texture coordinate insets (minX, minY, maxX, maxY)
 
-	p.SetUniform1f(p.program, "alpha", alpha)
+	p.SetUniform1f(p.program, attrAlpha, alpha)
 
 	p.ctx.BlendFunc(one, oneMinusSrcAlpha)
 	p.logError()
@@ -1230,19 +1278,19 @@ func createKernel(radius float32) []float32 {
 	return values
 }
 
-// kernelToRGBA packs normalised float32 kernel weights into RGBA uint8 pixel
-// data suitable for upload via TexImage2D. Each weight is quantised to [0,255]
+// kernelToRGBA packs normalized float32 kernel weights into RGBA uint8 pixel
+// data suitable for upload via TexImage2D. Each weight is quantized to [0,255]
 // and written to all four channels (we read .r in the shader; the remaining
 // channels are padding for universal RGBA compatibility across GL backends).
 func kernelToRGBA(values []float32) []uint8 {
 	data := make([]uint8, len(values)*4)
 	for i, v := range values {
-		b := uint8(v*255.0 + 0.5)
+		b := uint8(v*math.MaxUint8 + 0.5)
 		off := i * 4
-		data[off+0] = b   // R
-		data[off+1] = b   // G
-		data[off+2] = b   // B
-		data[off+3] = 255 // A
+		data[off+0] = b             // R
+		data[off+1] = b             // G
+		data[off+2] = b             // B
+		data[off+3] = math.MaxUint8 // A
 	}
 	return data
 }

--- a/internal/painter/gl/gl_core.go
+++ b/internal/painter/gl/gl_core.go
@@ -51,6 +51,11 @@ const (
 	noBuffer  = Buffer(0)
 	noProgram = Program(0)
 	noShader  = Shader(0)
+
+	programBufSizeBlend   = 20
+	programBufSizeDefault = 16
+
+	vertexCountTriangle = 3
 )
 
 type (
@@ -82,70 +87,70 @@ func (p *painter) Init() {
 	p.logError()
 	p.program = programState{
 		ref:        p.createProgram("simple"),
-		buff:       p.createBuffer(20),
+		buff:       p.createBuffer(programBufSizeBlend),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.blurProgram = programState{
 		ref:        p.createProgram("blur"),
-		buff:       p.createBuffer(20),
+		buff:       p.createBuffer(programBufSizeBlend),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.lineProgram = programState{
 		ref:        p.createProgram("line"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.rectangleProgram = programState{
 		ref:        p.createProgram("rectangle"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.roundRectangleProgram = programState{
 		ref:        p.createProgram("round_rectangle"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.polygonProgram = programState{
 		ref:        p.createProgram("polygon"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arcProgram = programState{
 		ref:        p.createProgram("arc"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.bezierCurveProgram = programState{
 		ref:        p.createProgram("bezier_curve"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.arbitraryPolygonProgram = programState{
 		ref:        p.createProgram("arbitrary_polygon"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}
 
 	p.ellipseProgram = programState{
 		ref:        p.createProgram("ellipse"),
-		buff:       p.createBuffer(16),
+		buff:       p.createBuffer(programBufSizeDefault),
 		uniforms:   make(map[string]*uniformState),
 		attributes: make(map[string]Attribute),
 	}

--- a/internal/painter/gl/shaders/blur.frag
+++ b/internal/painter/gl/shaders/blur.frag
@@ -7,7 +7,7 @@ varying vec2 fragTexCoord;
 uniform float radius;
 uniform vec2 direction;
 uniform float sampleScale;
-uniform float cornerRadius;
+uniform float corner_radius;
 uniform vec2 size;
 
 float getKernel(int i, int kernelLen) {
@@ -17,11 +17,11 @@ float getKernel(int i, int kernelLen) {
 
 void main() {
     float alpha = 1.0;
-    if (cornerRadius > 0.5) {
+    if (corner_radius > 0.5) {
         vec2 pos = fragTexCoord * size;
         vec2 halfSize = size * 0.5;
-        vec2 q = abs(pos - halfSize) - halfSize + cornerRadius;
-        float dist = min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - cornerRadius;
+        vec2 q = abs(pos - halfSize) - halfSize + corner_radius;
+        float dist = min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - corner_radius;
         alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
     }
 

--- a/internal/painter/gl/shaders/blur_es.frag
+++ b/internal/painter/gl/shaders/blur_es.frag
@@ -17,7 +17,7 @@ varying vec2 fragTexCoord;
 uniform float radius;
 uniform vec2 direction;
 uniform float sampleScale;
-uniform float cornerRadius;
+uniform float corner_radius;
 uniform vec2 size;
 
 float getKernel(int i, int kernelLen) {
@@ -27,11 +27,11 @@ float getKernel(int i, int kernelLen) {
 
 void main() {
     float alpha = 1.0;
-    if (cornerRadius > 0.5) {
+    if (corner_radius > 0.5) {
         vec2 pos = fragTexCoord * size;
         vec2 halfSize = size * 0.5;
-        vec2 q = abs(pos - halfSize) - halfSize + cornerRadius;
-        float dist = min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - cornerRadius;
+        vec2 q = abs(pos - halfSize) - halfSize + corner_radius;
+        float dist = min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - corner_radius;
         alpha = 1.0 - smoothstep(-0.5, 0.5, dist);
     }
 

--- a/internal/painter/gl/shaders/simple.frag
+++ b/internal/painter/gl/shaders/simple.frag
@@ -1,7 +1,7 @@
 #version 110
 
 uniform sampler2D tex;
-uniform float cornerRadius;  // in pixels
+uniform float corner_radius; // in pixels
 uniform vec2 size;           // in pixels: size of the rendered image quad
 uniform vec4 inset;          // texture coordinate insets (minX, minY, maxX, maxY)
 
@@ -10,14 +10,14 @@ varying float fragAlpha;
 
 void main() {
     float alpha = 1.0;
-    if (cornerRadius > 0.5) {
+    if (corner_radius > 0.5) {
         // normalize texture coords from [insetMin, insetMax] to [0, 1]
         // this makes the rounding calculation work correctly for cropped/covered images
         vec2 normalizedCoord = (fragTexCoord - inset.xy) / (inset.zw - inset.xy);
 
         vec2 pos = normalizedCoord * size;
         vec2 halfSize = size * 0.5;
-        float dist = length(max(abs(pos - halfSize) - halfSize + cornerRadius, 0.0)) - cornerRadius;
+        float dist = length(max(abs(pos - halfSize) - halfSize + corner_radius, 0.0)) - corner_radius;
         alpha = 1.0 - smoothstep(-1.0, 1.0, dist);
     }
 

--- a/internal/painter/gl/shaders/simple_es.frag
+++ b/internal/painter/gl/shaders/simple_es.frag
@@ -11,7 +11,7 @@ precision lowp sampler2D;
 #endif
 
 uniform sampler2D tex;
-uniform float cornerRadius;  // in pixels
+uniform float corner_radius; // in pixels
 uniform vec2 size;           // in pixels: size of the rendered image quad
 uniform vec4 inset;          // texture coordinate insets (minX, minY, maxX, maxY)
 
@@ -20,14 +20,14 @@ varying float fragAlpha;
 
 void main() {
     float alpha = 1.0;
-    if (cornerRadius > 0.5) {
+    if (corner_radius > 0.5) {
         // normalize texture coords from [insetMin, insetMax] to [0, 1]
         // this makes the rounding calculation work correctly for cropped/covered images
         vec2 normalizedCoord = (fragTexCoord - inset.xy) / (inset.zw - inset.xy);
 
         vec2 pos = normalizedCoord * size;
         vec2 halfSize = size * 0.5;
-        float dist = length(max(abs(pos - halfSize) - halfSize + cornerRadius, 0.0)) - cornerRadius;
+        float dist = length(max(abs(pos - halfSize) - halfSize + corner_radius, 0.0)) - corner_radius;
         alpha = 1.0 - smoothstep(-1.0, 1.0, dist);
     }
 

--- a/internal/painter/gl/texture.go
+++ b/internal/painter/gl/texture.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/internal/cache"
 	paint "fyne.io/fyne/v2/internal/painter"
+	"fyne.io/fyne/v2/internal/painter/geom"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -164,9 +165,9 @@ func (p *painter) newGlLinearGradientTexture(obj fyne.CanvasObject) Texture {
 	w := gradient.Size().Width
 	h := gradient.Size().Height
 	switch a := gradient.Angle; {
-	case almostEqual(a, 90), almostEqual(a, 270):
+	case almostEqual(a, geom.AngleQuarter), almostEqual(a, geom.AngleThreeQuarter):
 		h = 1
-	case almostEqual(a, 0), almostEqual(a, 180):
+	case almostEqual(a, geom.AngleNone), almostEqual(a, geom.AngleHalf):
 		w = 1
 	}
 	width := p.textureScale(w)

--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -553,11 +553,11 @@ func drawShadow(c fyne.Canvas, obj fyne.CanvasObject, objSize fyne.Size, shadow 
 		var objAlpha float32
 		if fill != nil {
 			_, _, _, a := fill.RGBA()
-			objAlpha = float32(a) / 65535.0
+			objAlpha = float32(a) / math.MaxUint16
 		}
 		if strokeCol != nil && strokeWidth > 0 {
 			_, _, _, a := strokeCol.RGBA()
-			sa := float32(a) / 65535.0
+			sa := float32(a) / math.MaxUint16
 			if sa > objAlpha {
 				objAlpha = sa
 			}
@@ -571,7 +571,7 @@ func drawShadow(c fyne.Canvas, obj fyne.CanvasObject, objSize fyne.Size, shadow 
 				_, _, _, maskA := maskRaw.At(mx, my).RGBA()
 				if maskA > 0 {
 					pixel := blurred.RGBAAt(x, y)
-					cVal := float32(maskA) / 65535.0
+					cVal := float32(maskA) / math.MaxUint16
 					den := 1.0 - cVal*objAlpha
 					var invMA float32
 					if den <= 0 {

--- a/internal/painter/vector.go
+++ b/internal/painter/vector.go
@@ -13,6 +13,7 @@ const TextVectorPad = 1
 // This is to accommodate overflow caused by stroke and line endings etc.
 // THe result is in fyne.Size type coordinates and should be scaled for output.
 func VectorPad(obj fyne.CanvasObject) float32 {
+	//revive:disable:add-constant
 	switch co := obj.(type) {
 	case *canvas.Circle:
 		if co.StrokeWidth > 0 && co.StrokeColor != nil {
@@ -53,6 +54,7 @@ func VectorPad(obj fyne.CanvasObject) float32 {
 		}
 		return 1 // anti-alias on ellipse fill
 	}
+	//revive:enable:add-constant
 
 	return 0
 }

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/storage/repository"
 )
@@ -174,7 +175,7 @@ func (r *FileRepository) Parent(u fyne.URI) (fyne.URI, error) {
 	child := path.Clean(u.Path())
 	if child == "." || // Clean ending up empty returns ".".
 		strings.HasSuffix(child, filePathSeparator) || // Only root has trailing slash.
-		runtime.GOOS == "windows" && len(child) == 2 && child[1] == ':' {
+		runtime.GOOS == goos.Windows && len(child) == 2 && child[1] == ':' {
 		return nil, repository.ErrURIRoot
 	}
 
@@ -233,7 +234,7 @@ func (r *FileRepository) CanList(u fyne.URI) (bool, error) {
 		return false, nil
 	}
 
-	if runtime.GOOS == "windows" && len(p) <= 3 {
+	if runtime.GOOS == goos.Windows && len(p) <= 3 {
 		return true, nil // assume drives can be read, avoids hang if the drive is temporarily unresponsive
 	}
 

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -14,6 +14,22 @@ import (
 	"fyne.io/fyne/v2/storage/repository"
 )
 
+const (
+	dirPermDefault    = permGroupExec | permGroupRead | permOtherExec | permOtherRead | permUserExec | permUserRead | permUserWrite
+	filePathSeparator = "/"
+	filePermDefault   = permGroupRead | permGroupWrite | permOtherRead | permOtherWrite | permUserRead | permUserWrite
+
+	permGroupExec  = 0o10
+	permGroupRead  = 0o40
+	permGroupWrite = 0o20
+	permOtherExec  = 0o1
+	permOtherRead  = 0o4
+	permOtherWrite = 0o2
+	permUserExec   = 0o100
+	permUserRead   = 0o400
+	permUserWrite  = 0o200
+)
+
 // declare conformance with repository types
 var (
 	_ repository.Repository             = (*FileRepository)(nil)
@@ -83,7 +99,7 @@ func (r *FileRepository) Reader(u fyne.URI) (fyne.URIReadCloser, error) {
 //
 // Since: 2.0
 func (r *FileRepository) CanRead(u fyne.URI) (bool, error) {
-	f, err := os.OpenFile(u.Path(), os.O_RDONLY, 0o666)
+	f, err := os.OpenFile(u.Path(), os.O_RDONLY, filePermDefault)
 	if err != nil {
 		if os.IsPermission(err) || os.IsNotExist(err) {
 			return false, nil
@@ -118,7 +134,7 @@ func (r *FileRepository) Appender(u fyne.URI) (fyne.URIWriteCloser, error) {
 //
 // Since: 2.0
 func (r *FileRepository) CanWrite(u fyne.URI) (bool, error) {
-	f, err := os.OpenFile(u.Path(), os.O_WRONLY, 0o666)
+	f, err := os.OpenFile(u.Path(), os.O_WRONLY, filePermDefault)
 	if err != nil {
 		if os.IsPermission(err) {
 			return false, nil
@@ -157,17 +173,17 @@ func (r *FileRepository) DeleteAll(u fyne.URI) error {
 func (r *FileRepository) Parent(u fyne.URI) (fyne.URI, error) {
 	child := path.Clean(u.Path())
 	if child == "." || // Clean ending up empty returns ".".
-		strings.HasSuffix(child, "/") || // Only root has trailing slash.
+		strings.HasSuffix(child, filePathSeparator) || // Only root has trailing slash.
 		runtime.GOOS == "windows" && len(child) == 2 && child[1] == ':' {
 		return nil, repository.ErrURIRoot
 	}
 
 	parent := path.Dir(child)
-	if parent == "/" {
-		return storage.NewFileURI("/"), nil
+	if parent == filePathSeparator {
+		return storage.NewFileURI(filePathSeparator), nil
 	}
 
-	return storage.NewFileURI(parent + "/"), nil
+	return storage.NewFileURI(parent + filePathSeparator), nil
 }
 
 // Child creates a child URI from the given URI and component.
@@ -197,8 +213,7 @@ func (r *FileRepository) List(u fyne.URI) ([]fyne.URI, error) {
 
 // CreateListable creates a new directory at the given URI.
 func (r *FileRepository) CreateListable(u fyne.URI) error {
-	path := u.Path()
-	return os.Mkdir(path, 0o755)
+	return os.Mkdir(u.Path(), dirPermDefault)
 }
 
 // CanList checks if the given URI can be listed.
@@ -329,7 +344,7 @@ func openFile(uri fyne.URI, write bool, truncate bool) (*file, error) {
 		if truncate {
 			f, err = os.Create(path) // If it exists this will truncate which is what we wanted
 		} else {
-			f, err = os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666)
+			f, err = os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, filePermDefault)
 		}
 	} else {
 		f, err = os.Open(path)

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -15,20 +15,24 @@ import (
 	"fyne.io/fyne/v2/storage/repository"
 )
 
+// Constants for file permissions to be combined using `|`.
 const (
-	dirPermDefault    = permGroupExec | permGroupRead | permOtherExec | permOtherRead | permUserExec | permUserRead | permUserWrite
-	filePathSeparator = "/"
-	filePermDefault   = permGroupRead | permGroupWrite | permOtherRead | permOtherWrite | permUserRead | permUserWrite
+	PermGroupExec         = 0o10
+	PermGroupRead         = 0o40
+	PermGroupWrite        = 0o20
+	PermOtherExec         = 0o1
+	PermOtherRead         = 0o4
+	PermOtherWrite        = 0o2
+	PermUserExec          = 0o100
+	PermUserRead          = 0o400
+	PermUserReadWriteExec = PermUserExec | PermUserRead | PermUserWrite
+	PermUserWrite         = 0o200
+)
 
-	permGroupExec  = 0o10
-	permGroupRead  = 0o40
-	permGroupWrite = 0o20
-	permOtherExec  = 0o1
-	permOtherRead  = 0o4
-	permOtherWrite = 0o2
-	permUserExec   = 0o100
-	permUserRead   = 0o400
-	permUserWrite  = 0o200
+const (
+	dirPermDefault    = PermGroupExec | PermGroupRead | PermOtherExec | PermOtherRead | PermUserReadWriteExec
+	filePathSeparator = "/"
+	filePermDefault   = PermGroupRead | PermGroupWrite | PermOtherRead | PermOtherWrite | PermUserRead | PermUserWrite
 )
 
 // declare conformance with repository types

--- a/internal/repository/memory.go
+++ b/internal/repository/memory.go
@@ -145,44 +145,32 @@ func NewInMemoryRepository(scheme string) *InMemoryRepository {
 //
 // Since: 2.0
 func (m *InMemoryRepository) Exists(u fyne.URI) (bool, error) {
-	path := u.Path()
-	if path == "" {
-		return false, fmt.Errorf("invalid path '%s'", path)
-	}
-
-	_, ok := m.Data[path]
-	return ok, nil
+	return withValidPath(u.Path(), func(path string) bool {
+		_, ok := m.Data[path]
+		return ok
+	})
 }
 
 // Reader reads the contents of the given URI.
 //
 // Since: 2.0
 func (m *InMemoryRepository) Reader(u fyne.URI) (fyne.URIReadCloser, error) {
-	path := u.Path()
-
-	if path == "" {
-		return nil, fmt.Errorf("invalid path '%s'", path)
+	readable, err := m.CanRead(u)
+	if err != nil {
+		return nil, err
+	}
+	if !readable {
+		return nil, fmt.Errorf("no such path '%s' in InMemoryRepository", u.Path())
 	}
 
-	_, ok := m.Data[path]
-	if !ok {
-		return nil, fmt.Errorf("no such path '%s' in InMemoryRepository", path)
-	}
-
-	return &nodeReaderWriter{path: path, repo: m}, nil
+	return &nodeReaderWriter{path: u.Path(), repo: m}, nil
 }
 
 // CanRead checks if the given URI can be read.
 //
 // Since: 2.0
 func (m *InMemoryRepository) CanRead(u fyne.URI) (bool, error) {
-	path := u.Path()
-	if path == "" {
-		return false, fmt.Errorf("invalid path '%s'", path)
-	}
-
-	_, ok := m.Data[path]
-	return ok, nil
+	return m.Exists(u)
 }
 
 // Destroy tears down the InMemoryRepository.
@@ -194,12 +182,9 @@ func (m *InMemoryRepository) Destroy(scheme string) {
 //
 // Since: 2.0
 func (m *InMemoryRepository) Writer(u fyne.URI) (fyne.URIWriteCloser, error) {
-	path := u.Path()
-	if path == "" {
-		return nil, fmt.Errorf("invalid path '%s'", path)
-	}
-
-	return &nodeReaderWriter{path: path, repo: m}, nil
+	return withValidPath(u.Path(), func(path string) fyne.URIWriteCloser {
+		return &nodeReaderWriter{path: path, repo: m}
+	})
 }
 
 // Appender returns a writer that appends to the given URI.
@@ -218,11 +203,9 @@ func (m *InMemoryRepository) Appender(u fyne.URI) (fyne.URIWriteCloser, error) {
 //
 // Since: 2.0
 func (m *InMemoryRepository) CanWrite(u fyne.URI) (bool, error) {
-	if p := u.Path(); p == "" {
-		return false, fmt.Errorf("invalid path '%s'", p)
-	}
-
-	return true, nil
+	return withValidPath(u.Path(), func(path string) bool {
+		return true
+	})
 }
 
 // Delete deletes the given URI.
@@ -343,4 +326,13 @@ func (m *InMemoryRepository) CreateListable(u fyne.URI) error {
 	}
 	m.Data[path] = []byte{}
 	return nil
+}
+
+func withValidPath[R any](path string, fn func(string) R) (R, error) {
+	var noneResult R
+	if path == "" {
+		return noneResult, fmt.Errorf("invalid path '%s'", path)
+	}
+
+	return fn(path), nil
 }

--- a/internal/repository/memory.go
+++ b/internal/repository/memory.go
@@ -125,7 +125,7 @@ func (n *nodeReaderWriter) Write(p []byte) (int, error) {
 // URI returns the URI of the node.
 func (n *nodeReaderWriter) URI() fyne.URI {
 	// discarding the error because this should never fail
-	u, _ := storage.ParseURI(n.repo.scheme + "://" + n.path)
+	u, _ := storage.ParseURI(n.repo.scheme + fyne.URLSchemeSeparator + n.path)
 	return u
 }
 
@@ -277,11 +277,11 @@ func (m *InMemoryRepository) List(u fyne.URI) ([]fyne.URI, error) {
 	// '/foo/barbaz'.
 	prefix := u.Path()
 
-	if len(prefix) > 0 && prefix[len(prefix)-1] != '/' {
-		prefix = prefix + "/"
+	if !strings.HasSuffix(prefix, fyne.URLPathSeparator) {
+		prefix = prefix + fyne.URLPathSeparator
 	}
 
-	prefixSplit := strings.Split(prefix, "/")
+	prefixSplit := strings.Split(prefix, fyne.URLPathSeparator)
 	prefixSplitLen := len(prefixSplit)
 
 	// Now we can simply loop over all the paths and find the ones with an
@@ -293,14 +293,15 @@ func (m *InMemoryRepository) List(u fyne.URI) ([]fyne.URI, error) {
 		// prefixSplit, which is guaranteed to have a trailing slash,
 		// so we want to also make pSplit be counted in ncomp like it
 		// does not have one.
-		pSplit := strings.Split(p, "/")
+		pSplit := strings.Split(p, fyne.URLPathSeparator)
 		ncomp := len(pSplit)
-		if len(p) > 0 && p[len(p)-1] == '/' {
+
+		if strings.HasSuffix(p, fyne.URLPathSeparator) {
 			ncomp--
 		}
 
 		if strings.HasPrefix(p, prefix) && ncomp == prefixSplitLen {
-			uri, err := storage.ParseURI(m.scheme + "://" + p)
+			uri, err := storage.ParseURI(m.scheme + fyne.URLSchemeSeparator + p)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/svg/svg.go
+++ b/internal/svg/svg.go
@@ -21,6 +21,11 @@ import (
 	col "fyne.io/fyne/v2/internal/color"
 )
 
+const (
+	fillNone             = "none"
+	lengthValidSVGPrefix = 5
+)
+
 // Colorize creates a new SVG from a given one by replacing all fill colors by the given color.
 func Colorize(src []byte, clr color.Color) ([]byte, error) {
 	rdr := bytes.NewReader(src)
@@ -110,11 +115,11 @@ func IsResourceSVG(res fyne.Resource) bool {
 		return true
 	}
 
-	if len(res.Content()) < 5 {
+	if len(res.Content()) < lengthValidSVGPrefix {
 		return false
 	}
 
-	switch strings.ToLower(string(res.Content()[:5])) {
+	switch strings.ToLower(string(res.Content()[:lengthValidSVGPrefix])) {
 	case "<!doc", "<?xml", "<svg ":
 		return true
 	}
@@ -237,7 +242,7 @@ type objGroup struct {
 
 func replacePathsFill(paths []*pathObj, hexColor string, opacity string) {
 	for _, path := range paths {
-		if path.Fill != "none" {
+		if path.Fill != fillNone {
 			path.Fill = hexColor
 			path.FillOpacity = opacity
 		}
@@ -246,7 +251,7 @@ func replacePathsFill(paths []*pathObj, hexColor string, opacity string) {
 
 func replaceRectsFill(rects []*rectObj, hexColor string, opacity string) {
 	for _, rect := range rects {
-		if rect.Fill != "none" {
+		if rect.Fill != fillNone {
 			rect.Fill = hexColor
 			rect.FillOpacity = opacity
 		}
@@ -255,7 +260,7 @@ func replaceRectsFill(rects []*rectObj, hexColor string, opacity string) {
 
 func replaceCirclesFill(circles []*circleObj, hexColor string, opacity string) {
 	for _, circle := range circles {
-		if circle.Fill != "none" {
+		if circle.Fill != fillNone {
 			circle.Fill = hexColor
 			circle.FillOpacity = opacity
 		}
@@ -264,7 +269,7 @@ func replaceCirclesFill(circles []*circleObj, hexColor string, opacity string) {
 
 func replaceEllipsesFill(ellipses []*ellipseObj, hexColor string, opacity string) {
 	for _, ellipse := range ellipses {
-		if ellipse.Fill != "none" {
+		if ellipse.Fill != fillNone {
 			ellipse.Fill = hexColor
 			ellipse.FillOpacity = opacity
 		}
@@ -273,7 +278,7 @@ func replaceEllipsesFill(ellipses []*ellipseObj, hexColor string, opacity string
 
 func replacePolygonsFill(polys []*polygonObj, hexColor string, opacity string) {
 	for _, poly := range polys {
-		if poly.Fill != "none" {
+		if poly.Fill != fillNone {
 			poly.Fill = hexColor
 			poly.FillOpacity = opacity
 		}

--- a/internal/widget/shadow.go
+++ b/internal/widget/shadow.go
@@ -29,6 +29,24 @@ const (
 	ShadowTop
 )
 
+const (
+	shadowBlurRadiusLevelCard    = 8
+	shadowBlurRadiusLevelDialog  = 18
+	shadowBlurRadiusLevelMenu    = 6
+	shadowBlurRadiusLevelMenuBar = 2
+	shadowBlurRadiusLevelPopUp   = 14
+
+	shadowVerticalOffsetLevelCard    = 2
+	shadowVerticalOffsetLevelDialog  = 6
+	shadowVerticalOffsetLevelMenu    = 2
+	shadowVerticalOffsetLevelMenuBar = 1
+	shadowVerticalOffsetLevelPopUp   = 4
+
+	shadowOffsetRatioHorizontal = 0.2
+	shadowOffsetRatioVertical   = shadowOffsetRatioHorizontal * 2
+	shadowRadialCenterOffset    = 0.5
+)
+
 // ElevationLevel is the level of elevation of the shadow casting object.
 type ElevationLevel int
 
@@ -54,20 +72,20 @@ func ApplyShadowForLevel(s *canvas.Shadow, level ElevationLevel, shadowColor col
 	case level <= BaseLevel:
 		// no shadow
 	case level <= MenuBarLevel:
-		blurRadius = 2
-		offset = fyne.NewPos(0, 1)
+		blurRadius = shadowBlurRadiusLevelMenuBar
+		offset = fyne.NewPos(0, shadowVerticalOffsetLevelMenuBar)
 	case level <= MenuLevel:
-		blurRadius = 6
-		offset = fyne.NewPos(0, 2)
+		blurRadius = shadowBlurRadiusLevelMenu
+		offset = fyne.NewPos(0, shadowVerticalOffsetLevelMenu)
 	case level <= CardLevel: // equal to ButtonLevel
-		blurRadius = 8
-		offset = fyne.NewPos(0, 2)
+		blurRadius = shadowBlurRadiusLevelCard
+		offset = fyne.NewPos(0, shadowVerticalOffsetLevelCard)
 	case level <= PopUpLevel:
-		blurRadius = 14
-		offset = fyne.NewPos(0, 4)
+		blurRadius = shadowBlurRadiusLevelPopUp
+		offset = fyne.NewPos(0, shadowVerticalOffsetLevelPopUp)
 	default: // DialogLevel or more
-		blurRadius = 18
-		offset = fyne.NewPos(0, 6)
+		blurRadius = shadowBlurRadiusLevelDialog
+		offset = fyne.NewPos(0, shadowVerticalOffsetLevelDialog)
 	}
 
 	s.Color = shadowColor
@@ -101,43 +119,43 @@ type shadowRenderer struct {
 
 func (r *shadowRenderer) Layout(size fyne.Size) {
 	depth := float32(r.s.level)
-	sideOff, topOff := float32(0.0), float32(0.0)
+	horizontalOffset, verticalOffset := float32(0.0), float32(0.0)
 	if r.s.typ == ShadowAround {
-		sideOff = depth * 0.2
-		topOff = sideOff * 2
+		horizontalOffset = depth * shadowOffsetRatioHorizontal
+		verticalOffset = depth * shadowOffsetRatioVertical
 	}
 
 	if r.tl != nil {
 		r.tl.Resize(fyne.NewSize(depth, depth))
-		r.tl.Move(fyne.NewPos(-depth+sideOff, -depth+topOff))
+		r.tl.Move(fyne.NewPos(-depth+horizontalOffset, -depth+verticalOffset))
 	}
 	if r.t != nil {
-		r.t.Resize(fyne.NewSize(size.Width-sideOff*2, depth))
-		r.t.Move(fyne.NewPos(sideOff, -depth+topOff))
+		r.t.Resize(fyne.NewSize(size.Width-horizontalOffset*2, depth))
+		r.t.Move(fyne.NewPos(horizontalOffset, -depth+verticalOffset))
 	}
 	if r.tr != nil {
 		r.tr.Resize(fyne.NewSize(depth, depth))
-		r.tr.Move(fyne.NewPos(size.Width-sideOff, -depth+topOff))
+		r.tr.Move(fyne.NewPos(size.Width-horizontalOffset, -depth+verticalOffset))
 	}
 	if r.r != nil {
-		r.r.Resize(fyne.NewSize(depth, size.Height-topOff))
-		r.r.Move(fyne.NewPos(size.Width-sideOff, topOff))
+		r.r.Resize(fyne.NewSize(depth, size.Height-verticalOffset))
+		r.r.Move(fyne.NewPos(size.Width-horizontalOffset, verticalOffset))
 	}
 	if r.br != nil {
 		r.br.Resize(fyne.NewSize(depth, depth))
-		r.br.Move(fyne.NewPos(size.Width-sideOff, size.Height))
+		r.br.Move(fyne.NewPos(size.Width-horizontalOffset, size.Height))
 	}
 	if r.b != nil {
-		r.b.Resize(fyne.NewSize(size.Width-sideOff*2, depth))
-		r.b.Move(fyne.NewPos(sideOff, size.Height))
+		r.b.Resize(fyne.NewSize(size.Width-horizontalOffset*2, depth))
+		r.b.Move(fyne.NewPos(horizontalOffset, size.Height))
 	}
 	if r.bl != nil {
 		r.bl.Resize(fyne.NewSize(depth, depth))
-		r.bl.Move(fyne.NewPos(-depth+sideOff, size.Height))
+		r.bl.Move(fyne.NewPos(-depth+horizontalOffset, size.Height))
 	}
 	if r.l != nil {
-		r.l.Resize(fyne.NewSize(depth, size.Height-topOff))
-		r.l.Move(fyne.NewPos(-depth+sideOff, topOff))
+		r.l.Resize(fyne.NewSize(depth, size.Height-verticalOffset))
+		r.l.Move(fyne.NewPos(-depth+horizontalOffset, verticalOffset))
 	}
 }
 
@@ -171,20 +189,20 @@ func (r *shadowRenderer) createShadows() {
 		r.SetObjects([]fyne.CanvasObject{r.t})
 	case ShadowAround:
 		r.tl = canvas.NewRadialGradient(fg, color.Transparent)
-		r.tl.CenterOffsetX = 0.5
-		r.tl.CenterOffsetY = 0.5
+		r.tl.CenterOffsetX = shadowRadialCenterOffset
+		r.tl.CenterOffsetY = shadowRadialCenterOffset
 		r.t = canvas.NewVerticalGradient(color.Transparent, fg)
 		r.tr = canvas.NewRadialGradient(fg, color.Transparent)
-		r.tr.CenterOffsetX = -0.5
-		r.tr.CenterOffsetY = 0.5
+		r.tr.CenterOffsetX = -shadowRadialCenterOffset
+		r.tr.CenterOffsetY = shadowRadialCenterOffset
 		r.r = canvas.NewHorizontalGradient(fg, color.Transparent)
 		r.br = canvas.NewRadialGradient(fg, color.Transparent)
-		r.br.CenterOffsetX = -0.5
-		r.br.CenterOffsetY = -0.5
+		r.br.CenterOffsetX = -shadowRadialCenterOffset
+		r.br.CenterOffsetY = -shadowRadialCenterOffset
 		r.b = canvas.NewVerticalGradient(fg, color.Transparent)
 		r.bl = canvas.NewRadialGradient(fg, color.Transparent)
-		r.bl.CenterOffsetX = 0.5
-		r.bl.CenterOffsetY = -0.5
+		r.bl.CenterOffsetX = shadowRadialCenterOffset
+		r.bl.CenterOffsetY = -shadowRadialCenterOffset
 		r.l = canvas.NewHorizontalGradient(color.Transparent, fg)
 		r.SetObjects([]fyne.CanvasObject{r.tl, r.t, r.tr, r.r, r.br, r.b, r.bl, r.l})
 	}

--- a/internal/widget/shadow.go
+++ b/internal/widget/shadow.go
@@ -8,18 +8,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-var _ fyne.Widget = (*Shadow)(nil)
-
-// Shadow is a widget that renders a shadow.
-type Shadow struct {
-	Base
-	level ElevationLevel
-	typ   ShadowType
-}
-
-// ElevationLevel is the level of elevation of the shadow casting object.
-type ElevationLevel int
-
+// All known values for ElevationLevel.
 const (
 	BaseLevel             ElevationLevel = 0
 	MenuBarLevel          ElevationLevel = 1
@@ -31,9 +20,6 @@ const (
 	DialogLevel           ElevationLevel = 24
 )
 
-// ShadowType specifies the type of the shadow.
-type ShadowType int
-
 // ShadowType constants
 const (
 	ShadowAround ShadowType = iota
@@ -42,6 +28,21 @@ const (
 	ShadowBottom
 	ShadowTop
 )
+
+// ElevationLevel is the level of elevation of the shadow casting object.
+type ElevationLevel int
+
+// Shadow is a widget that renders a shadow.
+type Shadow struct {
+	Base
+	level ElevationLevel
+	typ   ShadowType
+}
+
+var _ fyne.Widget = (*Shadow)(nil)
+
+// ShadowType specifies the type of the shadow.
+type ShadowType int
 
 // ApplyShadowForLevel applies Material Design inspired shadow parameters (only downward Y-axis offset + blur) to the given shadow.
 // The Variant is always [canvas.DropShadow].

--- a/storage/repository/parse.go
+++ b/storage/repository/parse.go
@@ -9,6 +9,7 @@ import (
 	uriParser "github.com/fredbi/uri"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 )
 
 // NewFileURI implements the back-end logic to storage.NewFileURI, which you
@@ -21,7 +22,7 @@ func NewFileURI(path string) fyne.URI {
 	// should be OK to use the platform native filepath with UNIX
 	// or NT style paths, with / or \, but when we reconstruct
 	// the URI, we want to have / only.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goos.Windows {
 		// seems that sometimes we end up with
 		// double-backslashes
 		path = filepath.ToSlash(path)

--- a/storage/repository/uri.go
+++ b/storage/repository/uri.go
@@ -82,7 +82,7 @@ func (u *uri) String() string {
 	s.Grow(len(u.scheme) + len(u.authority) + len(u.path) + len(u.query) + len(u.fragment) + len("://?#"))
 
 	s.WriteString(u.scheme)
-	s.WriteString("://")
+	s.WriteString(fyne.URLSchemeSeparator)
 	s.WriteString(u.authority)
 	s.WriteString(u.path)
 

--- a/storage/uri.go
+++ b/storage/uri.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/storage/repository"
 )
 
@@ -19,7 +20,7 @@ func EqualURI(t1, t2 fyne.URI) bool {
 // NewFileURI creates a new URI from the given file path.
 // Relative paths will be converted to absolute using filepath.Abs if required.
 func NewFileURI(fpath string) fyne.URI {
-	if isAbsolutePath := path.IsAbs(fpath) || runtime.GOOS == "windows" && filepath.IsAbs(fpath); !isAbsolutePath {
+	if isAbsolutePath := path.IsAbs(fpath) || runtime.GOOS == goos.Windows && filepath.IsAbs(fpath); !isAbsolutePath {
 		absolute, err := filepath.Abs(fpath)
 		if err == nil {
 			fpath = absolute

--- a/theme/json.go
+++ b/theme/json.go
@@ -12,6 +12,13 @@ import (
 	"fyne.io/fyne/v2/storage"
 )
 
+const (
+	lenColorStringRGB       = lenColorStringRGBShort * 2
+	lenColorStringRGBShort  = 3
+	lenColorStringRGBA      = lenColorStringRGBAShort * 2
+	lenColorStringRGBAShort = 4
+)
+
 // FromJSON returns a Theme created from the given JSON metadata.
 // Any values not present in the data will fall back to the default theme.
 // If a parse error occurs it will be returned along with a default theme.
@@ -70,32 +77,19 @@ func (h *jsonColor) UnmarshalJSON(b []byte) error {
 }
 
 func (h *jsonColor) parseColor(str string) error {
-	data := str
-	switch len([]rune(str)) {
-	case 8, 6:
-	case 9, 7: // remove # prefix
-		data = str[1:]
-	case 5: // remove # prefix, then double up
-		data = str[1:]
-		fallthrough
-	case 4: // could be rgba or #rgb
-		if data[0] == '#' {
-			v := []rune(data[1:])
-			data = string([]rune{v[0], v[0], v[1], v[1], v[2], v[2]})
-			break
-		}
-
-		v := []rune(data)
-		data = string([]rune{v[0], v[0], v[1], v[1], v[2], v[2], v[3], v[3]})
-	case 3:
-		v := []rune(str)
-		data = string([]rune{v[0], v[0], v[1], v[1], v[2], v[2]})
+	data := []byte(strings.TrimPrefix(str, "#"))
+	switch len(data) {
+	case lenColorStringRGB, lenColorStringRGBA:
+	case lenColorStringRGBAShort:
+		data = []byte{data[0], data[0], data[1], data[1], data[2], data[2], data[3], data[3]}
+	case lenColorStringRGBShort:
+		data = []byte{data[0], data[0], data[1], data[1], data[2], data[2]}
 	default:
 		h.color = color.Transparent
 		return errors.New("invalid color format: " + str)
 	}
 
-	digits, err := hex.DecodeString(data)
+	digits, err := hex.DecodeString(string(data))
 	if err != nil {
 		return err
 	}

--- a/theme/json.go
+++ b/theme/json.go
@@ -1,22 +1,14 @@
 package theme
 
 import (
-	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"image/color"
 	"io"
 	"strings"
 
 	"fyne.io/fyne/v2"
+	fynecolor "fyne.io/fyne/v2/internal/color"
 	"fyne.io/fyne/v2/storage"
-)
-
-const (
-	lenColorStringRGB       = lenColorStringRGBShort * 2
-	lenColorStringRGBShort  = 3
-	lenColorStringRGBA      = lenColorStringRGBAShort * 2
-	lenColorStringRGBAShort = 4
 )
 
 // FromJSON returns a Theme created from the given JSON metadata.
@@ -77,30 +69,12 @@ func (h *jsonColor) UnmarshalJSON(b []byte) error {
 }
 
 func (h *jsonColor) parseColor(str string) error {
-	data := []byte(strings.TrimPrefix(str, "#"))
-	switch len(data) {
-	case lenColorStringRGB, lenColorStringRGBA:
-	case lenColorStringRGBAShort:
-		data = []byte{data[0], data[0], data[1], data[1], data[2], data[2], data[3], data[3]}
-	case lenColorStringRGBShort:
-		data = []byte{data[0], data[0], data[1], data[1], data[2], data[2]}
-	default:
-		h.color = color.Transparent
-		return errors.New("invalid color format: " + str)
-	}
-
-	digits, err := hex.DecodeString(string(data))
+	c, err := fynecolor.Parse(str)
 	if err != nil {
 		return err
 	}
-	ret := &color.NRGBA{R: digits[0], G: digits[1], B: digits[2]}
-	if len(digits) == 4 {
-		ret.A = digits[3]
-	} else {
-		ret.A = 0xff
-	}
 
-	h.color = ret
+	h.color = c
 	return nil
 }
 

--- a/theme/json_test.go
+++ b/theme/json_test.go
@@ -31,9 +31,9 @@ func TestFromJSON(t *testing.T) {
 }`)
 
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xc0, G: 0xc0, B: 0xc0, A: 0xff}, th.Color(ColorNameBackground, VariantDark))
-	assert.Equal(t, &color.NRGBA{R: 0xc0, G: 0xc0, B: 0xc0, A: 0xff}, th.Color(ColorNameBackground, VariantLight))
-	assert.Equal(t, &color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, th.Color(ColorNameForeground, VariantLight))
+	assert.Equal(t, color.NRGBA{R: 0xc0, G: 0xc0, B: 0xc0, A: 0xff}, th.Color(ColorNameBackground, VariantDark))
+	assert.Equal(t, color.NRGBA{R: 0xc0, G: 0xc0, B: 0xc0, A: 0xff}, th.Color(ColorNameBackground, VariantLight))
+	assert.Equal(t, color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, th.Color(ColorNameForeground, VariantLight))
 	assert.Equal(t, float32(5), th.Size(SizeNameInlineIcon))
 	assert.Equal(t, "NotoMono-Regular.ttf", th.Font(fyne.TextStyle{Monospace: true}).Name())
 	assert.Equal(t, "cancel_Paths.svg", th.Icon(IconNameCancel).Name())
@@ -49,9 +49,9 @@ func TestFromTOML_Resource(t *testing.T) {
 	th, err := FromJSON(string(r.Content()))
 
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0x30, G: 0x30, B: 0x30, A: 0xff}, th.Color(ColorNameBackground, VariantLight))
-	assert.Equal(t, &color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, th.Color(ColorNameForeground, VariantDark))
-	assert.Equal(t, &color.NRGBA{R: 0xc0, G: 0xc0, B: 0xc0, A: 0xff}, th.Color(ColorNameForeground, VariantLight))
+	assert.Equal(t, color.NRGBA{R: 0x30, G: 0x30, B: 0x30, A: 0xff}, th.Color(ColorNameBackground, VariantLight))
+	assert.Equal(t, color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}, th.Color(ColorNameForeground, VariantDark))
+	assert.Equal(t, color.NRGBA{R: 0xc0, G: 0xc0, B: 0xc0, A: 0xff}, th.Color(ColorNameForeground, VariantLight))
 	assert.Equal(t, float32(10), th.Size(SizeNameInlineIcon))
 }
 
@@ -59,26 +59,26 @@ func TestHexColor(t *testing.T) {
 	c := jsonColor{}
 	err := c.parseColor("#abc")
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c.color)
+	assert.Equal(t, color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c.color)
 	err = c.parseColor("abc")
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c.color)
+	assert.Equal(t, color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xff}, c.color)
 	err = c.parseColor("#abcd")
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xdd}, c.color)
+	assert.Equal(t, color.NRGBA{R: 0xaa, G: 0xbb, B: 0xcc, A: 0xdd}, c.color)
 
 	err = c.parseColor("#a1b2c3")
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c.color)
+	assert.Equal(t, color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c.color)
 	err = c.parseColor("a1b2c3")
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c.color)
+	assert.Equal(t, color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xff}, c.color)
 	err = c.parseColor("#a1b2c3f4")
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c.color)
+	assert.Equal(t, color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c.color)
 	err = c.parseColor("a1b2c3f4")
 	assert.NoError(t, err)
-	assert.Equal(t, &color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c.color)
+	assert.Equal(t, color.NRGBA{R: 0xa1, G: 0xb2, B: 0xc3, A: 0xf4}, c.color)
 }
 
 var result color.Color

--- a/theme/size.go
+++ b/theme/size.go
@@ -245,6 +245,7 @@ func TextSubHeadingSize() float32 {
 }
 
 func (t *builtinTheme) Size(s fyne.ThemeSizeName) float32 {
+	//revive:disable:add-constant
 	switch s {
 	case SizeNameSeparatorThickness:
 		return 1
@@ -302,4 +303,5 @@ func (t *builtinTheme) Size(s fyne.ThemeSizeName) float32 {
 	default:
 		return 0
 	}
+	//revive:enable:add-constant
 }

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -24,6 +24,10 @@ const (
 	VariantLight = internaltheme.VariantLight
 )
 
+const (
+	fontVariantRegular = "Regular"
+)
+
 var defaultTheme, systemTheme fyne.Theme
 
 // DarkTheme defines the built-in dark theme colors and sizes.
@@ -80,7 +84,7 @@ func (t *builtinTheme) initFonts() {
 
 	font := os.Getenv("FYNE_FONT")
 	if font != "" {
-		t.regular = loadCustomFont(font, "Regular", regular)
+		t.regular = loadCustomFont(font, fontVariantRegular, regular)
 		if t.regular == regular { // failed to load
 			t.bold = loadCustomFont(font, "Bold", bold)
 			t.italic = loadCustomFont(font, "Italic", italic)
@@ -93,11 +97,11 @@ func (t *builtinTheme) initFonts() {
 	}
 	font = os.Getenv("FYNE_FONT_MONOSPACE")
 	if font != "" {
-		t.monospace = loadCustomFont(font, "Regular", monospace)
+		t.monospace = loadCustomFont(font, fontVariantRegular, monospace)
 	}
 	font = os.Getenv("FYNE_FONT_SYMBOL")
 	if font != "" {
-		t.symbol = loadCustomFont(font, "Regular", symbol)
+		t.symbol = loadCustomFont(font, fontVariantRegular, symbol)
 	}
 }
 

--- a/uri.go
+++ b/uri.go
@@ -5,6 +5,12 @@ import (
 	"io"
 )
 
+// URL component constants
+const (
+	URLPathSeparator   = "/"
+	URLSchemeSeparator = "://"
+)
+
 // URIReadCloser represents a cross platform data stream from a file or provider of data.
 // It may refer to an item on a filesystem or data in another application that we have access to.
 type URIReadCloser interface {

--- a/uri.go
+++ b/uri.go
@@ -8,6 +8,7 @@ import (
 // URL component constants
 const (
 	URLPathSeparator   = "/"
+	URLSchemeFile      = "file"
 	URLSchemeSeparator = "://"
 )
 

--- a/widget/activity.go
+++ b/widget/activity.go
@@ -154,7 +154,7 @@ func (a *activityRenderer) animate(done float32) {
 }
 
 func (a *activityRenderer) scaleDot(dot *canvas.Circle, off float32) {
-	rad := a.maxRad - a.maxRad*off/1.2
+	rad := a.maxRad - a.maxRad*off/1.2 //revive:disable-line:add-constant
 	mid := fyne.NewPos(a.bound.Width/2, a.bound.Height/2)
 
 	dot.Move(mid.Subtract(fyne.NewSquareOffsetPos(rad)))
@@ -203,7 +203,7 @@ func (a *activityRenderer) drawStaticEllipsis() {
 	fill := color.NRGBA{R: a.maxCol.R, G: a.maxCol.G, B: a.maxCol.B, A: a.maxCol.A}
 	for i, obj := range a.dots {
 		dot := obj.(*canvas.Circle)
-		cx := startX + radius + float32(i)*1.5*d
+		cx := startX + radius + float32(i)*3*radius
 		dot.Move(fyne.NewPos(cx-radius, cy-radius))
 		dot.Resize(fyne.NewSquareSize(d))
 		dot.FillColor = fill

--- a/widget/calendar.go
+++ b/widget/calendar.go
@@ -93,9 +93,9 @@ func (c *Calendar) CreateRenderer() fyne.WidgetRenderer {
 func (c *Calendar) calendarObjects() []fyne.CanvasObject {
 	offset := 0
 	switch getLocaleWeekStart() {
-	case "Saturday":
-		offset = 6
-	case "Sunday":
+	case saturday:
+		offset = daysPerWeek - 1
+	case sunday:
 	default:
 		offset = 1
 	}
@@ -121,13 +121,13 @@ func (c *Calendar) daysOfMonth() []fyne.CanvasObject {
 	dayIndex := int(start.Weekday())
 	// account for Go time pkg starting on sunday at index 0
 	switch getLocaleWeekStart() {
-	case "Saturday":
+	case saturday:
 		if dayIndex == daysPerWeek-1 {
 			dayIndex = 0
 		} else {
 			dayIndex++
 		}
-	case "Sunday": // nothing to do
+	case sunday: // nothing to do
 	default:
 		if dayIndex == 0 {
 			dayIndex += daysPerWeek - 1

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/driver/mobile"
 	"fyne.io/fyne/v2/internal/cache"
+	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/theme"
@@ -1118,7 +1119,7 @@ func (e *Entry) registerShortcut() {
 	}
 
 	moveWordModifier := fyne.KeyModifierShortcutDefault
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == goos.Darwin {
 		moveWordModifier = fyne.KeyModifierAlt
 
 		// Cmd+left, Cmd+right shortcuts behave like Home and End keys on Mac OS

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -568,7 +568,8 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	})
 	selectAllItem := fyne.NewMenuItem(lang.L("Select all"), e.selectAll)
 
-	menuItems := make([]*fyne.MenuItem, 0, 6)
+	const maxMenuItems = 6
+	menuItems := make([]*fyne.MenuItem, 0, maxMenuItems)
 	if e.Disabled() {
 		menuItems = append(menuItems, copyItem, selectAllItem)
 	} else if e.Password {

--- a/widget/locale.go
+++ b/widget/locale.go
@@ -15,17 +15,6 @@ const (
 	saturday
 )
 
-func (w weekday) String() string {
-	switch w {
-	case sunday:
-		return "Sunday"
-	case saturday:
-		return "Saturday"
-	default:
-		return "Monday"
-	}
-}
-
 type localeSetting struct {
 	dateFormat   string
 	weekStartDay weekday
@@ -100,9 +89,8 @@ func getLocaleDateFormat() string {
 	return defaultDateFormat
 }
 
-func getLocaleWeekStart() string {
-	s := lookupLocaleSetting(lang.SystemLocale())
-	return s.weekStartDay.String()
+func getLocaleWeekStart() weekday {
+	return lookupLocaleSetting(lang.SystemLocale()).weekStartDay
 }
 
 func lookupLocaleSetting(l fyne.Locale) localeSetting {

--- a/widget/locale_test.go
+++ b/widget/locale_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestGetLocaleWeekStart(t *testing.T) {
-	assert.Equal(t, "Monday", lookupLocaleSetting("").weekStartDay.String())
-	assert.Equal(t, "Monday", lookupLocaleSetting("en").weekStartDay.String())
-	assert.Equal(t, "Monday", lookupLocaleSetting("en-GB").weekStartDay.String())
-	assert.Equal(t, "Sunday", lookupLocaleSetting("en-US").weekStartDay.String())
-	assert.Equal(t, "Sunday", lookupLocaleSetting("es-US").weekStartDay.String())
-	assert.Equal(t, "Monday", lookupLocaleSetting("de-DE").weekStartDay.String())
+	assert.Equal(t, monday, lookupLocaleSetting("").weekStartDay)
+	assert.Equal(t, monday, lookupLocaleSetting("en").weekStartDay)
+	assert.Equal(t, monday, lookupLocaleSetting("en-GB").weekStartDay)
+	assert.Equal(t, sunday, lookupLocaleSetting("en-US").weekStartDay)
+	assert.Equal(t, sunday, lookupLocaleSetting("es-US").weekStartDay)
+	assert.Equal(t, monday, lookupLocaleSetting("de-DE").weekStartDay)
 }
 
 func TestGetLocaleDateFormat(t *testing.T) {

--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -308,7 +308,7 @@ func forceIntoText(source []byte, n ast.Node) string {
 		}
 		return ast.WalkContinue, nil
 	})
-	return strings.TrimSuffix(text.String(), " ")
+	return strings.TrimSuffix(text.String(), " ") //revive:disable-line:add-constant
 }
 
 func parseMarkdown(content string) []RichTextSegment {

--- a/widget/popup_menu.go
+++ b/widget/popup_menu.go
@@ -31,7 +31,7 @@ func NewPopUpMenu(menu *fyne.Menu, c fyne.Canvas) *PopUpMenu {
 	p.Resize(p.MinSize())
 	p.customSized = true
 
-	p.Move(fyne.NewPos(10, 10)) // non-zero pos to get manual overlay, fixed on show
+	p.Move(fyne.NewPos(10, 10)) //revive:disable-line:add-constant // non-zero pos to get manual overlay, fixed on show
 	o := widget.NewOverlayContainer(p, c, p.Dismiss)
 	o.Resize(o.MinSize())
 	p.overlay = o

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -176,7 +176,7 @@ func NewProgressBarWithData(data binding.Float) *ProgressBar {
 
 func progressBlendColor(clr color.Color) color.Color {
 	r, g, b, a := col.ToNRGBA(clr)
-	faded := uint8(a) / 2
+	faded := a / 2
 	return &color.NRGBA{R: r, G: g, B: b, A: faded}
 }
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -664,13 +664,14 @@ func (r *textRenderer) MinSize() fyne.Size {
 		}
 	}
 
+	const minScrolledSize = 32
 	switch scroll {
 	case widget.ScrollBoth:
-		return fyne.NewSize(32, 32)
+		return fyne.NewSize(minScrolledSize, minScrolledSize)
 	case widget.ScrollHorizontalOnly:
-		return fyne.NewSize(32, min.Height)
+		return fyne.NewSize(minScrolledSize, min.Height)
 	case widget.ScrollVerticalOnly:
-		return fyne.NewSize(min.Width, 32)
+		return fyne.NewSize(min.Width, minScrolledSize)
 	default:
 		return min
 	}
@@ -993,7 +994,7 @@ func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width f
 
 	prior := bounds[len(bounds)-1]
 	seg := prior.segments[0].(*TextSegment)
-	ellipsisSize := fyne.MeasureText("…", seg.size(), seg.Style.TextStyle)
+	ellipsisSize := fyne.MeasureText("…", seg.size(), seg.Style.TextStyle) //revive:disable-line:add-constant
 
 	fitCount := howManyRunesFit([]rune(seg.Text)[prior.begin:prior.end], width-ellipsisSize.Width, charWidth, measurer)
 	prior.end = prior.begin + fitCount
@@ -1183,7 +1184,7 @@ func truncateLines(t *RichText, seg RichTextSegment, trunc fyne.TextTruncation, 
 	text := []rune(seg.Textual())
 	yPos := float32(0)
 	var bounds []rowBoundary
-	charSize := measurer([]rune("z"))
+	charSize := measurer([]rune("z")) //revive:disable-line:add-constant -- TODO: clarify whether we want to define a common letter constant for approximate character sizes
 	charWidth := charSize.Width
 	reuse := 0
 	for _, l := range lines {

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -223,6 +223,7 @@ func (s *Slider) buttonDiameter(inlineIconSize float32) float32 {
 }
 
 func (s *Slider) endOffset(inlineIconSize, innerPadding float32) float32 {
+	//revive:disable-next-line:add-constant -- TODO: clarify what this 1.5 is about
 	return s.buttonDiameter(inlineIconSize)/2 + innerPadding - 1.5 // align with radio icons
 }
 

--- a/widget/table.go
+++ b/widget/table.go
@@ -13,7 +13,10 @@ import (
 	"fyne.io/fyne/v2/theme"
 )
 
-const noCellMatch = math.MaxInt
+const (
+	columnLetterCount = 26
+	noCellMatch       = math.MaxInt
+)
 
 var (
 	// allTableCellsID represents all table cells when refreshing requested cells
@@ -865,11 +868,11 @@ func (t *Table) updateHeader(id TableCellID, o fyne.CanvasObject) {
 
 	l := o.(*Label)
 	if id.Row < 0 {
-		ids := []rune{'A' + rune(id.Col%26)}
-		pre := (id.Col - id.Col%26) / 26
+		ids := []rune{'A' + rune(id.Col%columnLetterCount)}
+		pre := (id.Col - id.Col%columnLetterCount) / columnLetterCount
 		for pre > 0 {
-			ids = append([]rune{'A' - 1 + rune(pre%26)}, ids...)
-			pre = (pre - pre%26) / 26
+			ids = append([]rune{'A' - 1 + rune(pre%columnLetterCount)}, ids...)
+			pre = (pre - pre%columnLetterCount) / columnLetterCount
 		}
 		l.SetText(string(ids))
 	} else if id.Col < 0 {


### PR DESCRIPTION
### Description:

This PR enables the `unconvert` and `revive` linters via `golangci-lint`.
The former checks for unnecessary type conversions while the latter is a multi-purpose linter by its own.
The most complaining rules for `revive` are disabled for now. This PR only addresses the complaints of the `add-constant` rule.
The other rules will be addressed in follow-up PRs.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
