### PR TITLE
Add fyne.TextTruncateMiddle truncation mode

### DIFF
--- a/cmd/fyne_demo/tutorials/widget.go
+++ b/cmd/fyne_demo/tutorials/widget.go
@@ -306,7 +306,7 @@ This styled row should also wrap as expected, but only *when required*.
 	radioWrap.Horizontal = true
 	radioWrap.SetSelected("Word")
 
-	radioTrunc := widget.NewRadioGroup([]string{"Off", "Clip", "Ellipsis"}, func(s string) {
+	radioTrunc := widget.NewRadioGroup([]string{"Off", "Clip", "Ellipsis", "Middle"}, func(s string) {
 		var trunc fyne.TextTruncation
 		switch s {
 		case "Off":
@@ -315,6 +315,8 @@ This styled row should also wrap as expected, but only *when required*.
 			trunc = fyne.TextTruncateClip
 		case "Ellipsis":
 			trunc = fyne.TextTruncateEllipsis
+		case "Middle":
+			trunc = fyne.TextTruncateMiddle
 		}
 
 		label.Truncation = trunc

--- a/text.go
+++ b/text.go
@@ -30,6 +30,11 @@ const (
 	//
 	// Since: 2.4
 	TextTruncateEllipsis
+	// TextTruncateMiddle shortens text that does not fit by inserting an ellipsis (…) in the middle,
+	// preserving the beginning and end of the string.
+	//
+	// Since: 2.9
+	TextTruncateMiddle
 )
 
 // TextWrap represents how text longer than the widget's width will be wrapped.

--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -199,6 +199,31 @@ func TestLabel_ChangeTruncate(t *testing.T) {
 	test.AssertRendersToMarkup(t, "label/truncate.xml", c)
 }
 
+func TestLabel_TruncateMiddle(t *testing.T) {
+	test.NewTempApp(t)
+
+	c := test.NewCanvasWithPainter(software.NewPainter())
+	c.SetPadded(false)
+	original := "/home/user/projects/fyne/widget/label.go"
+	label := NewLabel(original)
+	c.SetContent(label)
+	natural := label.MinSize()
+	c.Resize(natural)
+
+	truncSize := fyne.NewSize(natural.Width/2, natural.Height)
+	label.Resize(truncSize)
+	label.Truncation = fyne.TextTruncateMiddle
+	label.Refresh()
+
+	rendered := richTextRenderTexts(label.provider)
+	assert.Equal(t, 1, len(rendered))
+	display := rendered[0].Text
+	assert.Contains(t, display, "…", "expected ellipsis in truncated text")
+	assert.NotEqual(t, original, display)
+	assert.Equal(t, byte('/'), display[0], "should keep original prefix")
+	assert.Equal(t, byte('o'), display[len(display)-1], "should keep original suffix")
+}
+
 func TestLabel_Select(t *testing.T) {
 	l := NewLabel("Hello")
 	l.Selectable = true

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -658,7 +658,7 @@ func (r *textRenderer) MinSize() fyne.Size {
 		if trunc == fyne.TextTruncateClip {
 			return minBounds
 		}
-		if trunc == fyne.TextTruncateEllipsis {
+		if trunc == fyne.TextTruncateEllipsis || trunc == fyne.TextTruncateMiddle {
 			ellipsisSize := fyne.MeasureText("…", th.Size(theme.SizeNameText), fyne.TextStyle{})
 			return minBounds.AddWidthHeight(ellipsisSize.Width, 0)
 		}
@@ -759,7 +759,9 @@ func (r *textRenderer) Refresh() {
 			var txt string
 			runes := []rune(seg.Textual())
 
-			if i == 0 {
+			if i == 0 && len(bound.segments) == 1 && bound.displayText != "" {
+				txt = bound.displayText
+			} else if i == 0 {
 				if len(bound.segments) == 1 {
 					txt = string(runes[bound.begin:bound.end])
 				} else {
@@ -987,7 +989,7 @@ func concealed(seg RichTextSegment) bool {
 }
 
 func ellipsisPriorBound(bounds []rowBoundary, trunc fyne.TextTruncation, width float32, charWidth float32, measurer func([]rune) fyne.Size) []rowBoundary {
-	if trunc != fyne.TextTruncateEllipsis || len(bounds) == 0 {
+	if trunc != fyne.TextTruncateEllipsis && trunc != fyne.TextTruncateMiddle || len(bounds) == 0 {
 		return bounds
 	}
 
@@ -1075,14 +1077,14 @@ func wrapBreakLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth
 			fitCount := howManyRunesFit(text[low:high], measureWidth, charWidth, measurer)
 			switch fitCount {
 			case high - low: // all characters fit on this line
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0, ""})
 				reuse++
 				low = high
 				high = l.end
 				measureWidth = max.Width
 				yPos += lineHeight
 			case 0: // even a character won't fit
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false, 0})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + 1, false, 0, ""})
 				reuse++
 				low++
 				yPos += lineHeight
@@ -1119,7 +1121,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			sub := text[low:high]
 			fitCount := howManyRunesFit(sub, measureWidth, charWidth, measurer)
 			if fitCount == high-low { // all characters fit on this line
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0, ""})
 				reuse++
 				low = high
 				high = l.end
@@ -1133,7 +1135,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			}
 			if fitCount == 0 { // even a character won't fit
 				if measureWidth < max.Width {
-					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false, 0})
+					bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false, 0, ""})
 					reuse++
 					measureWidth = max.Width
 					yPos += lineHeight
@@ -1141,11 +1143,11 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 				}
 				include := 1
 				ellipsis := false
-				if trunc == fyne.TextTruncateEllipsis {
+				if trunc == fyne.TextTruncateEllipsis || trunc == fyne.TextTruncateMiddle {
 					include = 0
 					ellipsis = true
 				}
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis, 0})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low + include, ellipsis, 0, ""})
 				low++
 				high = low + 1
 				reuse++
@@ -1167,7 +1169,7 @@ func wrapWordLines(seg RichTextSegment, trunc fyne.TextTruncation, measureWidth 
 			oldHigh := high
 			high = low + fitCount
 			if low == 0 && measureWidth < max.Width { // add a newline as there is more space on next
-				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false, 0})
+				bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, low, false, 0, ""})
 				reuse++
 				high = oldHigh
 				measureWidth = max.Width
@@ -1213,12 +1215,21 @@ func truncateLines(t *RichText, seg RichTextSegment, trunc fyne.TextTruncation, 
 			}
 			end, full := truncateLimit(string(txt), textObj, int(measureWidth), []rune{'…'})
 			high = low + end
-			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full, 0})
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, !full, 0, ""})
 			reuse++
 		case fyne.TextTruncateClip:
 			fitCount := howManyRunesFit(text[low:high], measureWidth, charWidth, measurer)
 			high = low + fitCount
-			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0})
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0, ""})
+			reuse++
+		case fyne.TextTruncateMiddle:
+			txt := text[low:high]
+			prefix, suffix, full := middleTruncate(txt, measureWidth, measurer)
+			display := ""
+			if !full {
+				display = string(txt[:prefix]) + "…" + string(txt[len(txt)-suffix:])
+			}
+			bounds = append(bounds, rowBoundary{[]RichTextSegment{seg}, reuse, low, high, false, 0, display})
 			reuse++
 		case fyne.TextTruncateOff:
 			// don’t do anything
@@ -1276,11 +1287,51 @@ func splitLines(seg RichTextSegment) []rowBoundary {
 	for i := 0; i < length; i++ {
 		if text[i] == '\n' {
 			high = i
-			lines = append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, high, false, 0})
+			lines = append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, high, false, 0, ""})
 			low = i + 1
 		}
 	}
-	return append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, length, false, 0})
+	return append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, length, false, 0, ""})
+}
+
+// middleTruncate finds the largest prefix and suffix rune counts such that
+// runes[:prefix] + "…" + runes[len(runes)-suffix:] fits within maxWidth when
+// measured. The third return value is true when the entire input fits without
+// truncation. The prefix is the larger half when the total is odd, so a single
+// character input is always kept as-is.
+func middleTruncate(runes []rune, maxWidth float32, measurer func([]rune) fyne.Size) (int, int, bool) {
+	n := len(runes)
+	if n == 0 || measurer(runes).Width <= maxWidth {
+		return n, 0, true
+	}
+
+	ellipsis := []rune{'…'}
+	if measurer(ellipsis).Width > maxWidth {
+		return 0, 0, false
+	}
+
+	fits := func(k int) bool {
+		prefix := (k + 1) / 2
+		suffix := k / 2
+		candidate := make([]rune, 0, prefix+1+suffix)
+		candidate = append(candidate, runes[:prefix]...)
+		candidate = append(candidate, ellipsis...)
+		candidate = append(candidate, runes[n-suffix:]...)
+		return measurer(candidate).Width <= maxWidth
+	}
+
+	low, high := 0, n-1
+	best := 0
+	for low <= high {
+		mid := (low + high) / 2
+		if fits(mid) {
+			best = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return (best + 1) / 2, best / 2, false
 }
 
 func truncateLimit(s string, text *canvas.Text, limit int, ellipsis []rune) (int, bool) {
@@ -1334,4 +1385,8 @@ type rowBoundary struct {
 	begin, end        int
 	ellipsis          bool
 	indent            float32
+	// displayText overrides the [begin:end] slice when rendering. It is used
+	// to substitute a pre-computed truncated string such as the prefix+…+suffix
+	// produced by [fyne.TextTruncateMiddle].
+	displayText string
 }

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -1224,7 +1224,7 @@ func truncateLines(t *RichText, seg RichTextSegment, trunc fyne.TextTruncation, 
 			reuse++
 		case fyne.TextTruncateMiddle:
 			txt := text[low:high]
-			prefix, suffix, full := middleTruncate(txt, measureWidth, measurer)
+			prefix, suffix, full := truncateMiddle(txt, measureWidth, measurer)
 			display := ""
 			if !full {
 				display = string(txt[:prefix]) + "…" + string(txt[len(txt)-suffix:])
@@ -1294,12 +1294,11 @@ func splitLines(seg RichTextSegment) []rowBoundary {
 	return append(lines, rowBoundary{[]RichTextSegment{seg}, len(lines), low, length, false, 0, ""})
 }
 
-// middleTruncate finds the largest prefix and suffix rune counts such that
+// truncateMiddle finds the largest prefix and suffix rune counts such that
 // runes[:prefix] + "…" + runes[len(runes)-suffix:] fits within maxWidth when
 // measured. The third return value is true when the entire input fits without
-// truncation. The prefix is the larger half when the total is odd, so a single
-// character input is always kept as-is.
-func middleTruncate(runes []rune, maxWidth float32, measurer func([]rune) fyne.Size) (int, int, bool) {
+// truncation.
+func truncateMiddle(runes []rune, maxWidth float32, measurer func([]rune) fyne.Size) (int, int, bool) {
 	n := len(runes)
 	if n == 0 || measurer(runes).Width <= maxWidth {
 		return n, 0, true
@@ -1385,8 +1384,6 @@ type rowBoundary struct {
 	begin, end        int
 	ellipsis          bool
 	indent            float32
-	// displayText overrides the [begin:end] slice when rendering. It is used
-	// to substitute a pre-computed truncated string such as the prefix+…+suffix
-	// produced by [fyne.TextTruncateMiddle].
+	// displayText overrides the [begin:end] slice when rendering.
 	displayText string
 }

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1314,6 +1314,80 @@ func TestText_howManyRunesFit(t *testing.T) {
 	})
 }
 
+func TestText_lineBounds_truncateMiddle(t *testing.T) {
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), 14, fyne.TextStyle{})
+	}
+
+	t.Run("short_no_truncation", func(t *testing.T) {
+		richText := NewRichTextWithText("foobar")
+		richText.Truncation = fyne.TextTruncateMiddle
+		got, _ := lineBounds(richText, richText.Segments[0], 200, fyne.NewSize(200, 64), measurer)
+		assert.Equal(t, 1, len(got))
+		assert.Empty(t, got[0].displayText)
+		assert.False(t, got[0].ellipsis)
+	})
+
+	t.Run("long_truncates_in_middle", func(t *testing.T) {
+		richText := NewRichTextWithText("/home/user/projects/fyne/file.txt")
+		richText.Truncation = fyne.TextTruncateMiddle
+		got, _ := lineBounds(richText, richText.Segments[0], 76, fyne.NewSize(76, 64), measurer)
+		assert.Equal(t, 1, len(got))
+		assert.Contains(t, got[0].displayText, "…")
+		// displayText starts with original prefix and ends with original suffix
+		assert.Equal(t, byte('/'), got[0].displayText[0])
+		assert.Equal(t, byte('t'), got[0].displayText[len(got[0].displayText)-1])
+	})
+}
+
+func TestText_middleTruncate(t *testing.T) {
+	textSize := float32(10)
+	textStyle := fyne.TextStyle{}
+	measurer := func(text []rune) fyne.Size {
+		return fyne.MeasureText(string(text), textSize, textStyle)
+	}
+	ellipsisWidth := measurer([]rune("…")).Width
+
+	t.Run("empty", func(t *testing.T) {
+		prefix, suffix, full := middleTruncate(nil, 100, measurer)
+		assert.Equal(t, 0, prefix)
+		assert.Equal(t, 0, suffix)
+		assert.True(t, full)
+	})
+
+	t.Run("fits_whole", func(t *testing.T) {
+		runes := []rune("hello")
+		full := measurer(runes).Width
+		prefix, suffix, fullOK := middleTruncate(runes, full+10, measurer)
+		assert.True(t, fullOK)
+		assert.Equal(t, len(runes), prefix)
+		assert.Equal(t, 0, suffix)
+	})
+
+	t.Run("does_not_fit_ellipsis", func(t *testing.T) {
+		runes := []rune("hello world")
+		prefix, suffix, fullOK := middleTruncate(runes, ellipsisWidth-1, measurer)
+		assert.False(t, fullOK)
+		assert.Equal(t, 0, prefix)
+		assert.Equal(t, 0, suffix)
+	})
+
+	t.Run("balanced_split", func(t *testing.T) {
+		runes := []rune("aaaaaaaaaa") // 10 a's
+		full := measurer(runes).Width
+		// allow enough room for roughly half the characters plus ellipsis
+		prefix, suffix, fullOK := middleTruncate(runes, full/2+ellipsisWidth, measurer)
+		assert.False(t, fullOK)
+		// prefix should be the larger or equal half
+		assert.GreaterOrEqual(t, prefix, suffix)
+		// resulting candidate must actually fit
+		out := append([]rune{}, runes[:prefix]...)
+		out = append(out, '…')
+		out = append(out, runes[len(runes)-suffix:]...)
+		assert.LessOrEqual(t, measurer(out).Width, full/2+ellipsisWidth)
+	})
+}
+
 func TestText_findSpaceIndex(t *testing.T) {
 	for name, tt := range map[string]struct {
 		text string

--- a/widget/richtext_test.go
+++ b/widget/richtext_test.go
@@ -1340,7 +1340,7 @@ func TestText_lineBounds_truncateMiddle(t *testing.T) {
 	})
 }
 
-func TestText_middleTruncate(t *testing.T) {
+func TestText_truncateMiddle(t *testing.T) {
 	textSize := float32(10)
 	textStyle := fyne.TextStyle{}
 	measurer := func(text []rune) fyne.Size {
@@ -1349,7 +1349,7 @@ func TestText_middleTruncate(t *testing.T) {
 	ellipsisWidth := measurer([]rune("…")).Width
 
 	t.Run("empty", func(t *testing.T) {
-		prefix, suffix, full := middleTruncate(nil, 100, measurer)
+		prefix, suffix, full := truncateMiddle(nil, 100, measurer)
 		assert.Equal(t, 0, prefix)
 		assert.Equal(t, 0, suffix)
 		assert.True(t, full)
@@ -1358,7 +1358,7 @@ func TestText_middleTruncate(t *testing.T) {
 	t.Run("fits_whole", func(t *testing.T) {
 		runes := []rune("hello")
 		full := measurer(runes).Width
-		prefix, suffix, fullOK := middleTruncate(runes, full+10, measurer)
+		prefix, suffix, fullOK := truncateMiddle(runes, full+10, measurer)
 		assert.True(t, fullOK)
 		assert.Equal(t, len(runes), prefix)
 		assert.Equal(t, 0, suffix)
@@ -1366,7 +1366,7 @@ func TestText_middleTruncate(t *testing.T) {
 
 	t.Run("does_not_fit_ellipsis", func(t *testing.T) {
 		runes := []rune("hello world")
-		prefix, suffix, fullOK := middleTruncate(runes, ellipsisWidth-1, measurer)
+		prefix, suffix, fullOK := truncateMiddle(runes, ellipsisWidth-1, measurer)
 		assert.False(t, fullOK)
 		assert.Equal(t, 0, prefix)
 		assert.Equal(t, 0, suffix)
@@ -1376,7 +1376,7 @@ func TestText_middleTruncate(t *testing.T) {
 		runes := []rune("aaaaaaaaaa") // 10 a's
 		full := measurer(runes).Width
 		// allow enough room for roughly half the characters plus ellipsis
-		prefix, suffix, fullOK := middleTruncate(runes, full/2+ellipsisWidth, measurer)
+		prefix, suffix, fullOK := truncateMiddle(runes, full/2+ellipsisWidth, measurer)
 		assert.False(t, fullOK)
 		// prefix should be the larger or equal half
 		assert.GreaterOrEqual(t, prefix, suffix)


### PR DESCRIPTION
## Description

Adds `fyne.TextTruncateMiddle` alongside the existing `Off`/`Clip`/`Ellipsis` modes. When the text overflows, it shortens with an ellipsis in the middle while preserving the beginning and end — handy for file paths, URLs, etc. where both ends carry information.

```go
label.Truncation = fyne.TextTruncateMiddle
// "/home/user/projects/fyne/widget/label.go"  →  "/home/user/…/widget/label.go"
```

Closes #6353

## How

- New `TextTruncateMiddle` constant in `text.go`.
- `middleTruncate` helper in `widget/richtext.go` — binary search for the largest balanced prefix+ellipsis+suffix that fits the available width.
- New `displayText` field on `rowBoundary` so the renderer can substitute a pre-computed string when the slice-based path doesn't fit the use case. MinSize matches the ellipsis mode.
- Added a fourth option in the fyne_demo truncation radio so it's easy to try live.

## Tests

- `TestText_middleTruncate` — helper edge cases (empty, fits whole, only ellipsis fits, balanced split).
- `TestText_lineBounds_truncateMiddle` — short text untouched, long text gets the ellipsis with original head/tail preserved.
- `TestLabel_TruncateMiddle` — end-to-end on a real Label, asserts the rendered canvas text.