### PR TITLE
feat(cursors): add glfw 3.4 cursors for corners

### DIFF
--- a/driver/desktop/cursor.go
+++ b/driver/desktop/cursor.go
@@ -38,8 +38,12 @@ const (
 	// VResizeCursor is the cursor often used to indicate vertical resize
 	VResizeCursor
 	// NESWResizeCursor is the cursor often used to indicate diagonal resize (top-right to bottom-left)
+	//
+	// Since: 2.8
 	NESWResizeCursor
 	// NWSEResizeCursor is the cursor often used to indicate diagonal resize (top-left to bottom-right)
+	//
+	// Since: 2.8
 	NWSEResizeCursor
 	// HiddenCursor will cause the cursor to not be shown
 	HiddenCursor

--- a/driver/desktop/cursor.go
+++ b/driver/desktop/cursor.go
@@ -37,6 +37,10 @@ const (
 	HResizeCursor
 	// VResizeCursor is the cursor often used to indicate vertical resize
 	VResizeCursor
+	// NESWResizeCursor is the cursor often used to indicate diagonal resize (top-right to bottom-left)
+	NESWResizeCursor
+	// NWSEResizeCursor is the cursor often used to indicate diagonal resize (top-left to bottom-right)
+	NWSEResizeCursor
 	// HiddenCursor will cause the cursor to not be shown
 	HiddenCursor
 )

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -53,13 +53,15 @@ var cursors [desktop.HiddenCursor + 1]*glfw.Cursor
 
 func initCursors() {
 	cursors = [desktop.HiddenCursor + 1]*glfw.Cursor{
-		desktop.DefaultCursor:   glfw.CreateStandardCursor(glfw.ArrowCursor),
-		desktop.TextCursor:      glfw.CreateStandardCursor(glfw.IBeamCursor),
-		desktop.CrosshairCursor: glfw.CreateStandardCursor(glfw.CrosshairCursor),
-		desktop.PointerCursor:   glfw.CreateStandardCursor(glfw.HandCursor),
-		desktop.HResizeCursor:   glfw.CreateStandardCursor(glfw.HResizeCursor),
-		desktop.VResizeCursor:   glfw.CreateStandardCursor(glfw.VResizeCursor),
-		desktop.HiddenCursor:    nil,
+		desktop.DefaultCursor:    glfw.CreateStandardCursor(glfw.ArrowCursor),
+		desktop.TextCursor:       glfw.CreateStandardCursor(glfw.IBeamCursor),
+		desktop.CrosshairCursor:  glfw.CreateStandardCursor(glfw.CrosshairCursor),
+		desktop.PointerCursor:    glfw.CreateStandardCursor(glfw.HandCursor),
+		desktop.HResizeCursor:    glfw.CreateStandardCursor(glfw.HResizeCursor),
+		desktop.VResizeCursor:    glfw.CreateStandardCursor(glfw.VResizeCursor),
+		desktop.NESWResizeCursor: glfw.CreateStandardCursor(glfw.ResizeNESWCursor),
+		desktop.NWSEResizeCursor: glfw.CreateStandardCursor(glfw.ResizeNWSECursor),
+		desktop.HiddenCursor:     nil,
 	}
 }
 

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -205,6 +205,10 @@ func fyneToNativeCursor(cursor desktop.Cursor) (*Cursor, bool) {
 		name = "ew-resize"
 	case desktop.VResizeCursor:
 		name = "ns-resize"
+	case desktop.NESWResizeCursor:
+		name = "nesw-resize"
+	case desktop.NWSEResizeCursor:
+		name = "nwse-resize"
 	case desktop.HiddenCursor:
 		name = "none"
 	}


### PR DESCRIPTION
### Description:
Add 2 new mouse cursors from GLFW 3.4

* NESWResizeCursor is the cursor often used to indicate diagonal resize (top-right to bottom-left)
* NWSEResizeCursor is the cursor often used to indicate diagonal resize (top-left to bottom-right)

Fixes #(issue)
-

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
