### PR TITLE
Add environment to override x11/wayland auto detection

### DIFF
--- a/internal/driver/glfw/loop_desktop.go
+++ b/internal/driver/glfw/loop_desktop.go
@@ -9,11 +9,19 @@ import (
 	"github.com/go-gl/glfw/v3.4/glfw"
 )
 
+// platform values returned by forcePlatform to override GLFW's auto-detection.
+const (
+	platformAuto    = ""
+	platformX11     = "x11"
+	platformWayland = "wayland"
+)
+
 func (d *gLDriver) initGLFW() {
-	if shouldForceX11() {
-		// A Wayland compositor that forces client-side decorations would push
-		// GLFW onto libdecor, which is unstable. Prefer X11 through XWayland.
+	switch forcePlatform() {
+	case platformX11:
 		glfw.InitHint(glfw.PlatformHint, int(glfw.PlatformX11))
+	case platformWayland:
+		glfw.InitHint(glfw.PlatformHint, int(glfw.PlatformWayland))
 	}
 
 	err := glfw.Init()

--- a/internal/driver/glfw/wayland_csd_linux.go
+++ b/internal/driver/glfw/wayland_csd_linux.go
@@ -48,17 +48,29 @@ import "C"
 
 import "os"
 
-// shouldForceX11 reports whether GLFW's auto-detected backend is built with X11
-// and Wayland, and is running a Wayland session with Client Side Decorations (CSD).
-// If so we should force X11 (XWayland) platform before glfw.Init() is called.
-func shouldForceX11() bool {
+// forcePlatform reports which GLFW platform should be forced before glfw.Init()
+// is called, or platformAuto to leave the choice to GLFW's own detection.
+//
+// A FYNE_PLATFORM value of "x11" or "wayland" overrides both the auto-detection and our CSD
+// workaround; any other value is ignored.
+func forcePlatform() string {
+	switch os.Getenv("FYNE_PLATFORM") {
+	case platformX11:
+		return platformX11
+	case platformWayland:
+		return platformWayland
+	}
+
 	if os.Getenv("WAYLAND_DISPLAY") == "" {
-		return false // not a Wayland session, leave the choice to GLFW
+		return platformAuto // not a Wayland session, leave the choice to GLFW
 	}
 	if os.Getenv("DISPLAY") == "" {
-		return false // no XWayland available to fall back to, stay on Wayland
+		return platformAuto // no XWayland available to fall back to, stay on Wayland
 	}
 
 	// Zero means the detected compositor forces client-side decorations (libdecor).
-	return C.fyne_wayland_has_ssd() == 0
+	if C.fyne_wayland_has_ssd() == 0 {
+		return platformX11
+	}
+	return platformAuto
 }

--- a/internal/driver/glfw/wayland_csd_other.go
+++ b/internal/driver/glfw/wayland_csd_other.go
@@ -2,8 +2,8 @@
 
 package glfw
 
-// shouldForceX11 returns false when either x11 or wayland was specified
+// forcePlatform returns platformAuto when either x11 or wayland was specified
 // or if we're not on a suitable OS.
-func shouldForceX11() bool {
-	return false
+func forcePlatform() string {
+	return platformAuto
 }


### PR DESCRIPTION
Also allows overriding our workaround for CSD.

Follow up to #6392 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
