### PR TITLE
Pass wayland app ID to window properties

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -795,6 +795,9 @@ func (w *window) create() {
 	}
 	glfw.WindowHint(glfw.AutoIconify, glfw.False)
 	initWindowHints()
+	if build.IsWayland {
+		glfw.WindowHintString(glfw.WaylandAppID, fyne.CurrentApp().UniqueID())
+	}
 
 	pixWidth, pixHeight := w.screenSize(w.canvas.size)
 	pixWidth = int(fyne.Max(float32(pixWidth), float32(w.width)))


### PR DESCRIPTION
### Description:

Adding the app ID as window hint property, so that compositors can do things based on the ID, like move to specific workspaces, set icons on bars, etc.

I believe this should also help with these two issues:
- https://github.com/fyne-io/fyne/issues/5983
- https://github.com/fyne-io/fyne/issues/6004

### Checklist:
- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [X] Tests all pass.
