### PR TITLE
Fix popup menu immediately dismissing when opened over an existing overlay

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -549,8 +549,9 @@ func (w *window) processMouseClicked(button desktop.MouseButton, action action, 
 				prevOverlay := w.canvas.Overlays().Top()
 				secondary.TappedSecondary(ev)
 
-				// if the secondary tap dismissed an overlay, forward the event to the widget underneath
-				if prevOverlay != nil && w.canvas.Overlays().Top() != prevOverlay {
+				// if the secondary tap dismissed an overlay (rather than opening a new
+				// one on top), forward the event to the widget underneath
+				if prevOverlay != nil && !overlayStillPresent(w.canvas.Overlays().List(), prevOverlay) {
 					co2, pos2, _ := w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) bool {
 						_, ok := object.(fyne.SecondaryTappable)
 						return ok
@@ -568,6 +569,15 @@ func (w *window) processMouseClicked(button desktop.MouseButton, action action, 
 	if action == release && button == desktop.MouseButtonPrimary && !mouseDragStarted {
 		w.mouseClickedHandleTapDoubleTap(co, ev)
 	}
+}
+
+func overlayStillPresent(overlays []fyne.CanvasObject, overlay fyne.CanvasObject) bool {
+	for _, o := range overlays {
+		if o == overlay {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *window) mouseClickedHandleMouseable(mev *desktop.MouseEvent, action action, wid desktop.Mouseable) {

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1240,6 +1240,35 @@ func TestWindow_TappedSecondary_RedispatchAfterOverlayDismiss(t *testing.T) {
 	})
 }
 
+func TestWindow_TappedSecondary_OpenMenuInsideExistingOverlay(t *testing.T) {
+	w := createWindow("Test")
+	inner := &tappableObject{Rectangle: canvas.NewRectangle(color.White)}
+	inner.SetMinSize(fyne.NewSize(100, 100))
+
+	pop := widget.NewModalPopUp(inner, w.canvas)
+	ensureCanvasSize(t, w, fyne.NewSize(200, 200))
+
+	runOnMain(func() {
+		pop.Show()
+
+		menu := fyne.NewMenu("", fyne.NewMenuItem("A", nil))
+		inner.secondaryTapAction = func(e *fyne.PointEvent) {
+			widget.ShowPopUpMenuAtPosition(menu, w.canvas, e.AbsolutePosition)
+		}
+
+		before := len(w.canvas.Overlays().List())
+
+		// right-click inside the widget under the modal popup, which opens a
+		// new pop-up menu overlay on top of the existing modal overlay
+		w.mousePos = fyne.NewPos(50, 50)
+		w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Press, 0)
+		w.mouseClicked(w.viewport, glfw.MouseButton2, glfw.Release, 0)
+
+		after := len(w.canvas.Overlays().List())
+		assert.Equal(t, before+1, after, "the newly opened menu overlay should not be immediately dismissed")
+	})
+}
+
 func TestWindow_TappedSecondary_OnPrimaryOnlyTarget(t *testing.T) {
 	w := createWindow("Test")
 	tapped := false
@@ -2092,6 +2121,7 @@ var _ fyne.Tappable = (*tappable)(nil)
 type tappable struct {
 	tapEvents          []any
 	secondaryTapEvents []any
+	secondaryTapAction func(*fyne.PointEvent)
 }
 
 func (t *tappable) Tapped(e *fyne.PointEvent) {
@@ -2100,6 +2130,9 @@ func (t *tappable) Tapped(e *fyne.PointEvent) {
 
 func (t *tappable) TappedSecondary(e *fyne.PointEvent) {
 	t.secondaryTapEvents = append(t.secondaryTapEvents, e)
+	if t.secondaryTapAction != nil {
+		t.secondaryTapAction(e)
+	}
 }
 
 func (t *tappable) popTapEvent() (e any) {

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -419,8 +419,9 @@ func (c *canvas) tapUp(pos fyne.Position, tapID int,
 			prevOverlay := c.Overlays().Top()
 			tapAltCallback(wid, ev)
 
-			// if the secondary tap dismissed an overlay, forward the event to the widget underneath
-			if prevOverlay != nil && c.Overlays().Top() != prevOverlay {
+			// if the secondary tap dismissed an overlay (rather than opening a new
+			// one on top), forward the event to the widget underneath
+			if prevOverlay != nil && !overlayStillPresent(c.Overlays().List(), prevOverlay) {
 				co2, objPos2, _ := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
 					_, ok := object.(fyne.SecondaryTappable)
 					return ok
@@ -464,6 +465,15 @@ func (c *canvas) waitForDoubleTap(co fyne.CanvasObject, ev *fyne.PointEvent, tap
 		c.touchLastTapped = nil
 		c.touchCancelLock.Unlock()
 	}, true)
+}
+
+func overlayStillPresent(overlays []fyne.CanvasObject, overlay fyne.CanvasObject) bool {
+	for _, o := range overlays {
+		if o == overlay {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *canvas) windowHeadIsDisplacing() bool {


### PR DESCRIPTION
### Description:

Fixes #6425 

The right-click "did this dismiss an overlay?" check added in 79ab2f6c8 detects a dismiss by comparing `canvas.Overlays().Top()` before and after TappedSecondary. That comparison is ambiguous: Top() also changes when TappedSecondary opens a new overlay on top of an existing one (e.g. right-clicking a widget inside a modal PopUp to show a context menu), not just when one is removed. In that case the code assumes the just-opened menu is "whatever's left after a dismiss" and immediately calls TappedSecondary on the menu's own OverlayContainer, which dismisses it before it's ever rendered, so the context menu appears to not show at all.

The fix replaces the `Top() != prevOverlay` comparison with an explicit check that the previous top overlay was actually removed from the stack, in both the glfw and mobile drivers, so re-dispatch only happens on a genuine dismiss.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
