### PR TITLE
Fix: rebuild native MacOS menu when switching windows

### DIFF
--- a/internal/driver/glfw/menu_darwin.go
+++ b/internal/driver/glfw/menu_darwin.go
@@ -288,6 +288,10 @@ func menuChecked(id int) bool {
 
 func setupNativeMenu(w *window, main *fyne.MainMenu) {
 	clearNativeMenu()
+	if main == nil {
+		return
+	}
+
 	nextItemID := 0
 	callbacks = []*menuCallbacks{}
 	var helpMenu *fyne.Menu

--- a/internal/driver/glfw/menu_darwin_test.go
+++ b/internal/driver/glfw/menu_darwin_test.go
@@ -273,6 +273,47 @@ func TestDarwinMenu_specialKeyShortcuts(t *testing.T) {
 	}
 }
 
+func TestDarwinMenu_focusChangeUpdatesNativeMenu(t *testing.T) {
+	setExceptionCallback(func(msg string) { t.Error("Obj-C exception:", msg) })
+	defer setExceptionCallback(nil)
+
+	runOnMain(func() {
+		resetMainMenu()
+	})
+
+	w1 := createWindow("Test1")
+	w2 := createWindow("Test2")
+
+	menu1 := fyne.NewMainMenu(fyne.NewMenu("Menu1", fyne.NewMenuItem("Item1", func() {})))
+	menu2 := fyne.NewMainMenu(fyne.NewMenu("Menu2", fyne.NewMenuItem("Item2", func() {})))
+
+	runOnMain(func() {
+		w1.SetMainMenu(menu1)
+		w2.SetMainMenu(menu2)
+	})
+
+	titleOfSecondMenu := func() string {
+		mm := testDarwinMainMenu()
+		m := testNSMenuItemSubmenu(testNSMenuItemAtIndex(mm, 1))
+		return testNSMenuTitle(m)
+	}
+
+	// Focusing w2 last (as SetMainMenu does above) shows its menu.
+	assert.Equal(t, "Menu2", titleOfSecondMenu())
+
+	// Switching focus back to w1 should switch the native menu back to menu1.
+	runOnMain(func() {
+		w1.window.processFocused(true)
+	})
+	assert.Equal(t, "Menu1", titleOfSecondMenu())
+
+	// Switching focus to w2 should switch the native menu back to menu2.
+	runOnMain(func() {
+		w2.window.processFocused(true)
+	})
+	assert.Equal(t, "Menu2", titleOfSecondMenu())
+}
+
 var (
 	initialAppMenuItems []string
 	initialMenus        []string

--- a/internal/driver/glfw/menu_darwin_test.go
+++ b/internal/driver/glfw/menu_darwin_test.go
@@ -303,13 +303,13 @@ func TestDarwinMenu_focusChangeUpdatesNativeMenu(t *testing.T) {
 
 	// Switching focus back to w1 should switch the native menu back to menu1.
 	runOnMain(func() {
-		w1.window.processFocused(true)
+		w1.processFocused(true)
 	})
 	assert.Equal(t, "Menu1", titleOfSecondMenu())
 
 	// Switching focus to w2 should switch the native menu back to menu2.
 	runOnMain(func() {
-		w2.window.processFocused(true)
+		w2.processFocused(true)
 	})
 	assert.Equal(t, "Menu2", titleOfSecondMenu())
 }

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -768,6 +768,10 @@ func (w *window) processFocused(focus bool) {
 		curWindow = w
 		w.canvas.FocusGained()
 
+		if build.HasNativeMenu && w.mainmenu != nil {
+			setupNativeMenu(w, w.mainmenu)
+		}
+
 		if build.IsWayland {
 			w.frame.markReady()
 			w.canvas.SetDirty()

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -768,7 +768,7 @@ func (w *window) processFocused(focus bool) {
 		curWindow = w
 		w.canvas.FocusGained()
 
-		if build.HasNativeMenu && w.mainmenu != nil {
+		if build.HasNativeMenu {
 			setupNativeMenu(w, w.mainmenu)
 		}
 


### PR DESCRIPTION
### Description:

Fixes #4740 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
