### PR TITLE
Fix: allow clicking in empty area of collection widgets to unfocus another widget

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -497,19 +497,17 @@ func (w *window) processMouseClicked(button desktop.MouseButton, action action, 
 		w.mouseClickedHandleMouseable(mev, action, wid)
 	}
 
-	if wid, ok := co.(fyne.Focusable); !ok || wid != w.canvas.Focused() {
+	focused := w.canvas.Focused()
+	if wid, ok := co.(fyne.Focusable); !ok || wid != focused {
 		ignore := false
-		_, _, _ = w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) bool {
-			switch object.(type) {
-			case fyne.Focusable:
-				ignore = true
-				return true
-			}
+		if focusedObj, ok := focused.(fyne.CanvasObject); ok {
+			found, _, _ := w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) bool {
+				return object == focusedObj
+			})
+			ignore = found != nil
+		}
 
-			return false
-		})
-
-		if !ignore { // if a parent item under the mouse has focus then ignore this tap unfocus
+		if !ignore { // if the currently focused widget is under the mouse then ignore this tap unfocus
 			w.canvas.Unfocus()
 		}
 	}

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1595,6 +1595,56 @@ func TestWindow_Focus(t *testing.T) {
 	assert.Equal(t, "ef", e2.Text)
 }
 
+func TestWindow_CollectionEmptyAreaUnfocus(t *testing.T) {
+	// List, GridWrap, Table and Tree are all Focusable themselves (for keyboard
+	// navigation), but that should not stop a tap on an empty area (with no
+	// row/cell/node under the cursor) from unfocusing another currently
+	// focused widget - see https://github.com/fyne-io/fyne/issues/4770.
+	newWidgets := map[string]func() fyne.CanvasObject{
+		"List": func() fyne.CanvasObject {
+			return widget.NewList(func() int { return 1 },
+				func() fyne.CanvasObject { return widget.NewLabel("Item") },
+				func(widget.ListItemID, fyne.CanvasObject) {})
+		},
+		"GridWrap": func() fyne.CanvasObject {
+			return widget.NewGridWrap(func() int { return 1 },
+				func() fyne.CanvasObject { return widget.NewLabel("Item") },
+				func(widget.GridWrapItemID, fyne.CanvasObject) {})
+		},
+		"Table": func() fyne.CanvasObject {
+			return widget.NewTable(func() (int, int) { return 1, 1 },
+				func() fyne.CanvasObject { return widget.NewLabel("Item") },
+				func(widget.TableCellID, fyne.CanvasObject) {})
+		},
+		"Tree": func() fyne.CanvasObject {
+			return widget.NewTreeWithStrings(map[string][]string{"": {"leaf1"}})
+		},
+	}
+
+	for name, newWidget := range newWidgets {
+		t.Run(name, func(t *testing.T) {
+			w := createWindow("Test")
+			entry := widget.NewEntry()
+			coll := newWidget()
+
+			w.SetContent(container.NewBorder(entry, nil, nil, nil, coll))
+			w.Resize(fyne.NewSize(200, 200))
+			repaintWindow(w)
+
+			w.Canvas().Focus(entry)
+			require.Equal(t, entry, w.Canvas().Focused())
+
+			runOnMain(func() {
+				w.moveMouse(20, 150) // well below the single row/cell/node, but still within the widget
+				w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+				w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Release, 0)
+			})
+
+			assert.Nil(t, w.Canvas().Focused())
+		})
+	}
+}
+
 func TestWindow_CaptureTypedShortcut(t *testing.T) {
 	w := createWindow("Test")
 	content := &typedShortcutable{}


### PR DESCRIPTION
### Description:
Skip unfocus on mouseClicked only if click is over currently focused widget rather than any focusable widget.
Since the collection widget itself is Focusable, it previously skipped unfocusing another widget if a click landed anywhere in a collection widget's bounds including in the empty area.

Fixes #4770 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
