### PR TITLE
Implement key repeat for desktop.Keyable interface

### DIFF
--- a/event.go
+++ b/event.go
@@ -13,6 +13,10 @@ type KeyEvent struct {
 	Name KeyName
 	// Physical is a platform specific field that reports the hardware information of physical keyboard events.
 	Physical HardwareKey
+	// Repeat indicates that this event is a key repeat, i.e. the key was held down long enough to trigger repeated events.
+	//
+	// Since: 2.9
+	Repeat bool
 }
 
 // PointEvent describes a pointer input event. The position is relative to the

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -729,18 +729,18 @@ func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, 
 		case fyne.KeyEscape:
 			w.menuDeactivationPending = keyName
 		}
-		if w.canvas.Focused() != nil {
-			if focused, ok := w.canvas.Focused().(desktop.Keyable); ok {
-				focused.KeyDown(keyEvent)
+		if focused := w.canvas.Focused(); focused != nil {
+			if keyable, ok := focused.(desktop.Keyable); ok {
+				keyable.KeyDown(keyEvent)
 			}
 		} else if w.canvas.onKeyDown != nil {
 			w.canvas.onKeyDown(keyEvent)
 		}
 	default:
 		// key repeat triggers KeyDown and falls through to TypedKey and TypedShortcut
-		if w.canvas.Focused() != nil {
-			if focused, ok := w.canvas.Focused().(desktop.Keyable); ok {
-				focused.KeyDown(keyEvent)
+		if focused := w.canvas.Focused(); focused != nil {
+			if keyable, ok := focused.(desktop.Keyable); ok {
+				keyable.KeyDown(keyEvent)
 			}
 		} else if w.canvas.onKeyDown != nil {
 			w.canvas.onKeyDown(keyEvent)
@@ -756,8 +756,7 @@ func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, 
 	}
 
 	// No shortcut detected, pass down to TypedKey
-	focused := w.canvas.Focused()
-	if focused != nil {
+	if focused := w.canvas.Focused(); focused != nil {
 		focused.TypedKey(keyEvent)
 	} else if w.canvas.onTypedKey != nil {
 		w.canvas.onTypedKey(keyEvent)

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -692,7 +692,7 @@ func (w *window) capturesTab(modifier fyne.KeyModifier) bool {
 }
 
 func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, scancode int, action action, keyDesktopModifier fyne.KeyModifier) {
-	keyEvent := &fyne.KeyEvent{Name: keyName, Physical: fyne.HardwareKey{ScanCode: scancode}}
+	keyEvent := &fyne.KeyEvent{Name: keyName, Physical: fyne.HardwareKey{ScanCode: scancode}, Repeat: action == repeat}
 
 	pendingMenuToggle := w.menuTogglePending
 	w.menuTogglePending = desktop.KeyNone
@@ -737,7 +737,14 @@ func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, 
 			w.canvas.onKeyDown(keyEvent)
 		}
 	default:
-		// key repeat will fall through to TypedKey and TypedShortcut
+		// key repeat triggers KeyDown and falls through to TypedKey and TypedShortcut
+		if w.canvas.Focused() != nil {
+			if focused, ok := w.canvas.Focused().(desktop.Keyable); ok {
+				focused.KeyDown(keyEvent)
+			}
+		} else if w.canvas.onKeyDown != nil {
+			w.canvas.onKeyDown(keyEvent)
+		}
 	}
 
 	modifierOtherThanShift := (keyDesktopModifier & fyne.KeyModifierControl) |

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -711,9 +711,9 @@ func (w *window) processKeyPressed(keyName fyne.KeyName, keyASCII fyne.KeyName, 
 			}
 		}
 
-		if w.canvas.Focused() != nil {
-			if focused, ok := w.canvas.Focused().(desktop.Keyable); ok {
-				focused.KeyUp(keyEvent)
+		if focused := w.canvas.Focused(); focused != nil {
+			if keyable, ok := focused.(desktop.Keyable); ok {
+				keyable.KeyUp(keyEvent)
 			}
 		} else if w.canvas.onKeyUp != nil {
 			w.canvas.onKeyUp(keyEvent)

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1812,6 +1812,54 @@ func TestWindow_ClipboardCopy_DisabledEntry(t *testing.T) {
 	assert.Equal(t, "Testing", NewClipboard().Content())
 }
 
+func TestWindow_KeyDownOnRepeat(t *testing.T) {
+	w := createWindow("Test")
+	content := &keyableFocusable{}
+	content.SetMinSize(fyne.NewSize(10, 10))
+	w.SetContent(content)
+	repaintWindow(w)
+
+	w.Canvas().Focus(content)
+
+	w.keyPressed(nil, glfw.KeyDown, 0, glfw.Press, 0)
+	require.Len(t, content.keyDownEvents, 1)
+	assert.Equal(t, fyne.KeyDown, content.keyDownEvents[0].Name)
+	assert.False(t, content.keyDownEvents[0].Repeat)
+
+	w.keyPressed(nil, glfw.KeyDown, 0, glfw.Repeat, 0)
+	require.Len(t, content.keyDownEvents, 2)
+	assert.Equal(t, fyne.KeyDown, content.keyDownEvents[1].Name)
+	assert.True(t, content.keyDownEvents[1].Repeat)
+
+	w.keyPressed(nil, glfw.KeyDown, 0, glfw.Repeat, 0)
+	require.Len(t, content.keyDownEvents, 3)
+	assert.True(t, content.keyDownEvents[2].Repeat)
+
+	w.keyPressed(nil, glfw.KeyDown, 0, glfw.Release, 0)
+	require.Len(t, content.keyDownEvents, 3) // release does not trigger KeyDown
+}
+
+func TestWindow_KeyDownOnRepeat_NoFocused(t *testing.T) {
+	w := createWindow("Test")
+	w.SetContent(canvas.NewRectangle(color.Black))
+	repaintWindow(w)
+
+	var lastEvent *fyne.KeyEvent
+	w.canvas.onKeyDown = func(ev *fyne.KeyEvent) {
+		lastEvent = ev
+	}
+
+	w.keyPressed(nil, glfw.KeyDown, 0, glfw.Press, 0)
+	require.NotNil(t, lastEvent)
+	assert.False(t, lastEvent.Repeat)
+
+	lastEvent = nil
+	w.keyPressed(nil, glfw.KeyDown, 0, glfw.Repeat, 0)
+	require.NotNil(t, lastEvent)
+	assert.True(t, lastEvent.Repeat)
+	assert.Equal(t, fyne.KeyDown, lastEvent.Name)
+}
+
 func TestWindow_CloseInterception(t *testing.T) {
 	// Note: The #Close() is run asynchronously when the window is notified about the viewport close.
 	// Therefore, we have to wait some time before checking its state via the onClosed callback.
@@ -2155,6 +2203,22 @@ var (
 	_ fyne.Focusable   = (*focusable)(nil)
 	_ fyne.Disableable = (*focusable)(nil)
 )
+
+var _ desktop.Keyable = (*keyableFocusable)(nil)
+
+type keyableFocusable struct {
+	focusable
+	keyDownEvents []*fyne.KeyEvent
+	keyUpEvents   []*fyne.KeyEvent
+}
+
+func (k *keyableFocusable) KeyDown(ev *fyne.KeyEvent) {
+	k.keyDownEvents = append(k.keyDownEvents, ev)
+}
+
+func (k *keyableFocusable) KeyUp(ev *fyne.KeyEvent) {
+	k.keyUpEvents = append(k.keyUpEvents, ev)
+}
 
 type focusable struct {
 	canvas.Rectangle


### PR DESCRIPTION
GLFW natively provides key repeat events but Fyne only dispatched them to TypedKey/shortcuts, not to KeyDown/KeyUp. Widgets using the desktop.Keyable interface (e.g. custom list widgets) did not receive repeat events when holding down keys.

- Add Repeat bool field to fyne.KeyEvent
- Dispatch KeyDown on repeat events in processKeyPressed
- Add tests for key repeat behavior

(This PR was created using an LLM.)

### Description:

Fixes #6430.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [x] Public APIs match existing style and have Since: line.
