### PR TITLE
mobile/android.c: Fix typo when checking for NULL

### DIFF
--- a/internal/driver/mobile/android.c
+++ b/internal/driver/mobile/android.c
@@ -447,7 +447,7 @@ char* listContentURI(uintptr_t jni_env, uintptr_t ctx, char* uriCstr) {
 
 	jclass resolverClass = (*env)->GetObjectClass(env, resolver);
 	jmethodID query = find_method(env, resolverClass, "query", "(Landroid/net/Uri;[Ljava/lang/String;Landroid/os/Bundle;Landroid/os/CancellationSignal;)Landroid/database/Cursor;");
-	if (getDoc == NULL) { // API 26
+	if (query == NULL) { // API 26
 		return "ERROR: Cannot list content for URI";
 	}
 


### PR DESCRIPTION
As proposed by GitHub user abakum in PR #6402.

### Description:

In `internal/driver/mobile/android.c`: `getDoc` → `query` (this was likely a copy-paste error)

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.