### PR TITLE
do not re-invent standard lib functionality

### DIFF
--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -6,6 +6,7 @@ import (
 	_ "image/png" // for the icon
 	"math"
 	"runtime"
+	"slices"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -550,7 +551,7 @@ func (w *window) processMouseClicked(button desktop.MouseButton, action action, 
 
 				// if the secondary tap dismissed an overlay (rather than opening a new
 				// one on top), forward the event to the widget underneath
-				if prevOverlay != nil && !overlayStillPresent(w.canvas.Overlays().List(), prevOverlay) {
+				if prevOverlay != nil && !slices.Contains(w.canvas.Overlays().List(), prevOverlay) {
 					co2, pos2, _ := w.findObjectAtPositionMatching(w.canvas, mousePos, func(object fyne.CanvasObject) bool {
 						_, ok := object.(fyne.SecondaryTappable)
 						return ok
@@ -568,15 +569,6 @@ func (w *window) processMouseClicked(button desktop.MouseButton, action action, 
 	if action == release && button == desktop.MouseButtonPrimary && !mouseDragStarted {
 		w.mouseClickedHandleTapDoubleTap(co, ev)
 	}
-}
-
-func overlayStillPresent(overlays []fyne.CanvasObject, overlay fyne.CanvasObject) bool {
-	for _, o := range overlays {
-		if o == overlay {
-			return true
-		}
-	}
-	return false
 }
 
 func (w *window) mouseClickedHandleMouseable(mev *desktop.MouseEvent, action action, wid desktop.Mouseable) {

--- a/internal/driver/mobile/canvas.go
+++ b/internal/driver/mobile/canvas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"image"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -421,7 +422,7 @@ func (c *canvas) tapUp(pos fyne.Position, tapID int,
 
 			// if the secondary tap dismissed an overlay (rather than opening a new
 			// one on top), forward the event to the widget underneath
-			if prevOverlay != nil && !overlayStillPresent(c.Overlays().List(), prevOverlay) {
+			if prevOverlay != nil && !slices.Contains(c.Overlays().List(), prevOverlay) {
 				co2, objPos2, _ := c.findObjectAtPositionMatching(pos, func(object fyne.CanvasObject) bool {
 					_, ok := object.(fyne.SecondaryTappable)
 					return ok
@@ -465,15 +466,6 @@ func (c *canvas) waitForDoubleTap(co fyne.CanvasObject, ev *fyne.PointEvent, tap
 		c.touchLastTapped = nil
 		c.touchCancelLock.Unlock()
 	}, true)
-}
-
-func overlayStillPresent(overlays []fyne.CanvasObject, overlay fyne.CanvasObject) bool {
-	for _, o := range overlays {
-		if o == overlay {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *canvas) windowHeadIsDisplacing() bool {


### PR DESCRIPTION
### Description:

Removes newly introduced helpers in favor of standard library functionality (`slices` is available since 1.21).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
