### PR TITLE
Apply always-on-top after window creation (fixes #6436)

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -134,6 +134,12 @@ func (w *window) SetFullScreen(full bool) {
 
 func (w *window) RequestAlwaysOnTop() {
 	w.onTop = true
+
+	if w.view() != nil {
+		async.EnsureMain(func() {
+			w.view().SetAttrib(glfw.Floating, glfw.True)
+		})
+	}
 }
 
 func (w *window) RequestFullScreenSecondary() {


### PR DESCRIPTION
## Summary

`RequestAlwaysOnTop()` only set an internal `onTop` flag, which is only consumed as a `WindowHint(Floating)` inside `createWindow`. Calling it after the window was already created — or from a goroutine that races with `ShowAndRun` (as in the reproducer in #6436) — silently did nothing, because GLFW window hints are only read at creation time.

This change keeps the pre-creation behavior and additionally updates the live window via `SetAttrib(glfw.Floating, glfw.True)` on the main thread when a viewport already exists, matching the pattern used by `SetFullScreen`.

Fixes #6436.

## Test plan

- [x] `go build ./...`
- [x] `gofumpt -d -e .` clean
- [x] `goimports -e -d .` clean
- [x] `golangci-lint run ./internal/driver/glfw/...` — 0 issues
- [x] `go test -race -tags "no_glfw,ci,migrated_fynedo" ./...` — all pass on macOS
- [x] Manual: run the reproducer from #6436 and confirm the window stays above others after foregrounding another app