### PR TITLE
Fix stopped lifecycle callback ordering

### DIFF
--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -138,7 +138,7 @@ func (d *gLDriver) runGL() {
 			d.Terminate()
 			l := fyne.CurrentApp().Lifecycle().(*app.Lifecycle)
 			if f := l.OnStopped(); f != nil {
-				l.QueueEvent(f)
+				f()
 			}
 
 			// as we are shutting down make sure we drain the pending funcQueue and close it out.

--- a/internal/driver/glfw/loop_test.go
+++ b/internal/driver/glfw/loop_test.go
@@ -2,7 +2,126 @@
 
 package glfw
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"fyne.io/fyne/v2"
+	intapp "fyne.io/fyne/v2/internal/app"
+	"fyne.io/fyne/v2/internal/async"
+	"fyne.io/fyne/v2/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const runLifecycleShutdownHelperEnv = "FYNE_TEST_RUN_LIFECYCLE_SHUTDOWN_HELPER"
+
+var (
+	runLifecycleShutdownReady    = make(chan struct{})
+	runLifecycleShutdownReturned = make(chan struct{})
+)
+
+type driverOverrideApp struct {
+	fyne.App
+	driver fyne.Driver
+}
+
+func (a *driverOverrideApp) Driver() fyne.Driver {
+	return a.driver
+}
+
+func TestRunLifecycleShutdown(t *testing.T) {
+	cmd := exec.Command(os.Args[0], //nolint:gosec // os.Args[0] is the current test binary.
+		"-test.run=^TestRunLifecycleShutdownHelper$",
+		"-test.timeout=10s")
+	cmd.Env = append(os.Environ(), runLifecycleShutdownHelperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+}
+
+func TestRunLifecycleShutdownHelper(t *testing.T) {
+	if os.Getenv(runLifecycleShutdownHelperEnv) != "1" {
+		t.Skip("only run as a subprocess with fresh package state")
+	}
+
+	baseApp := test.NewApp()
+	fyne.SetCurrentApp(&driverOverrideApp{App: baseApp, driver: d})
+
+	lifecycle := baseApp.Lifecycle().(*intapp.Lifecycle)
+	lifecycle.InitEventQueue()
+	go lifecycle.RunEventQueue(d.DoFromGoroutine)
+
+	var (
+		orderMu sync.Mutex
+		order   []string
+
+		userCalls     atomic.Int32
+		internalCalls atomic.Int32
+		cancelledRan  atomic.Bool
+	)
+	doAndWaitReturned := make(chan struct{})
+
+	record := func(name string, calls *atomic.Int32) {
+		assert.False(t, drained.Load(), "%s callback ran after the main queue was drained", name)
+		assert.True(t, async.IsMainGoroutine(), "%s callback did not run on the main goroutine", name)
+		calls.Add(1)
+
+		orderMu.Lock()
+		order = append(order, name)
+		orderMu.Unlock()
+	}
+
+	lifecycle.SetOnStopped(func() {
+		record("user", &userCalls)
+
+		go func() {
+			fyne.DoAndWait(func() {
+				cancelledRan.Store(true)
+			})
+			close(doAndWaitReturned)
+		}()
+
+		deadline := time.Now().Add(time.Second)
+		for len(funcQueue.Out()) == 0 && time.Now().Before(deadline) {
+			time.Sleep(time.Millisecond)
+		}
+		assert.NotZero(t, len(funcQueue.Out()), "DoAndWait was not queued during shutdown")
+	})
+	lifecycle.SetOnStoppedHookExecuted(func() {
+		record("internal", &internalCalls)
+	})
+
+	go func() {
+		for !running.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		d.Quit()
+	}()
+
+	close(runLifecycleShutdownReady)
+	<-runLifecycleShutdownReturned
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-doAndWaitReturned:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond, "shutdown-pending DoAndWait did not return")
+	assert.False(t, cancelledRan.Load(), "shutdown-pending DoAndWait callback was executed")
+	assert.EqualValues(t, 1, userCalls.Load())
+	assert.EqualValues(t, 1, internalCalls.Load())
+
+	orderMu.Lock()
+	assert.Equal(t, []string{"user", "internal"}, order)
+	orderMu.Unlock()
+}
 
 // BenchmarkRunOnMain measures the cost of calling a function
 // on the main thread.

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -36,6 +36,18 @@ func init() {
 // TestMain makes sure that our driver is running on the main thread.
 // This must be done for some of our tests to function correctly.
 func TestMain(m *testing.M) {
+	if os.Getenv(runLifecycleShutdownHelperEnv) == "1" {
+		exitCode := make(chan int)
+		go func() {
+			exitCode <- m.Run()
+		}()
+
+		<-runLifecycleShutdownReady
+		d.Run()
+		close(runLifecycleShutdownReturned)
+		os.Exit(<-exitCode)
+	}
+
 	d.init()
 
 	waitForStart := make(chan struct{})


### PR DESCRIPTION
### Description:

Run the GLFW stopped lifecycle callback synchronously on the app/main goroutine before the function queue is drained.

The shutdown loop currently queues the composite stopped callback after Terminate and immediately drains the function queue. Depending on timing, the callback can be drained without execution and then run through the post-drain direct path from another goroutine. That breaks lifecycle ordering, moves the callback off the app goroutine, and can race cleanup.

This keeps the existing Terminate-before-OnStopped ordering, but invokes the already-composed callback directly from runGL before queue drain. The user hook still runs before the internal preferences hook. Mobile behavior is unchanged.

A fresh-subprocess regression proves both stopped hooks run exactly once, on the main goroutine, before drained is set; Driver.Run returns; and a background DoAndWait queued during shutdown is released without its canceled callback executing.

Related to #5748, but deliberately does not claim to fix the broader post-shutdown Do/DoAndWait queue race.

Local focused, race, ci/migrated_fynedo, no_glfw, WebAssembly build, lint, vet, and formatting checks pass. The full platform/GLFW matrix is left to upstream CI because the local macOS suite has an unrelated nil-monitor failure and local Linux/ARM64 golden images differ.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass across the full platform matrix; upstream CI pending.