### PR TITLE
Prevent application crashes from unknown GLFW scancodes (e.g. Fn key on Wayland)

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -5,6 +5,7 @@ package glfw
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"image"
 	_ "image/png" // for the icon
 	"os"
@@ -653,8 +654,17 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 		return ret
 	}
 
-	keyName := glfw.GetKeyName(code, scancode)
+	keyName := safeGetKeyName(code, scancode)
 	return keyCodeToKeyName(keyName)
+}
+
+func safeGetKeyName(key glfw.Key, scancode int) string {
+	defer func() {
+		if r := recover(); r != nil {
+			fyne.LogError(fmt.Sprintf("Unknown GLFW key scancode: %v", scancode), nil)
+		}
+	}()
+	return glfw.GetKeyName(key, scancode)
 }
 
 func convertAction(action glfw.Action) action {

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -5,7 +5,6 @@ package glfw
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"image"
 	_ "image/png" // for the icon
 	"os"
@@ -661,7 +660,8 @@ func keyToName(code glfw.Key, scancode int) fyne.KeyName {
 func safeGetKeyName(key glfw.Key, scancode int) string {
 	defer func() {
 		if r := recover(); r != nil {
-			fyne.LogError(fmt.Sprintf("Unknown GLFW key scancode: %v", scancode), nil)
+			err, _ := r.(error)
+			fyne.LogError("Failed to get GLFW key name", err)
 		}
 	}()
 	return glfw.GetKeyName(key, scancode)


### PR DESCRIPTION
### Description:
The go-glfw call `glfw.KeyToName` panics for unknown scancodes (the panic originates from Go, not C, so it can be recovered). On Wayland, the Fn key causes this, and has been reported to Supersonic in https://github.com/dweymouth/supersonic/issues/992 and https://github.com/dweymouth/supersonic/issues/730

This PR creates a safe wrapper around that call which catches the panic and will safely default to fyne.KeyUnknown when communicating the keypress to the rest of the driver / Fyne app.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

