### PR TITLE
Fix inconsistent vertical positioning of mixed-font text lines

### DIFF
--- a/internal/async/mutex.go
+++ b/internal/async/mutex.go
@@ -1,4 +1,5 @@
 //go:build !migrated_fynedo
+
 package async
 
 import "sync"

--- a/internal/async/mutex.go
+++ b/internal/async/mutex.go
@@ -1,0 +1,8 @@
+//go:build !migrated_fynedo
+package async
+
+import "sync"
+
+// Mutex is an alias for sync.Mutex on non-migrated builds
+// In migrated builds it is a no-op.
+type Mutex = sync.Mutex

--- a/internal/async/mutex_migratedfynedo.go
+++ b/internal/async/mutex_migratedfynedo.go
@@ -1,4 +1,5 @@
 //go:build migrated_fynedo
+
 package async
 
 // Mutex is a no-op sync.Locker for when we are running single-threaded

--- a/internal/async/mutex_migratedfynedo.go
+++ b/internal/async/mutex_migratedfynedo.go
@@ -1,0 +1,9 @@
+//go:build migrated_fynedo
+package async
+
+// Mutex is a no-op sync.Locker for when we are running single-threaded
+type Mutex struct{}
+
+func (Mutex) Lock() {}
+
+func (Mutex) Unlock() {}

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -266,7 +266,6 @@ func tabStop(spacew, x float32, tabWidth int) float32 {
 	return tabw * float32(tabs)
 }
 
-
 type shapedRun struct {
 	out shaping.Output
 	x   float32
@@ -308,8 +307,6 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 		spacew = scale * fixed266ToFloat32(out.Advance)
 	}
 
-	runBufferMut.Lock()
-
 	maxAscent := fixed.Int26_6(0)
 	collect := func(run shaping.Output, runX float32) {
 		if run.LineBounds.Ascent > maxAscent {
@@ -319,6 +316,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 	}
 
 	ins := segmenter.Split(in, faces)
+	runBufferMut.Lock()
 	for _, in := range ins {
 		inEnd := in.RunEnd
 

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -203,14 +203,14 @@ func DrawStringOffset(dst draw.Image, s string, color color.Color, f shaping.Fon
 	}
 
 	advance := float32(0)
-	walkString(f, s, float32ToFixed266(fontSize), style, &advance, scale, func(run shaping.Output, x float32) {
-		y := int(math.Ceil(float64(fixed266ToFloat32(run.LineBounds.Ascent) * r.PixScale)))
+	walkString(f, s, float32ToFixed266(fontSize), style, &advance, scale, func(run shaping.Output, x, y float32) {
+		yPix := int(math.Ceil(float64(y)))
 		if len(run.Glyphs) == 1 && run.Glyphs[0].GlyphID == 0 {
-			r.DrawStringAt(string([]rune{replacementChar}), dst, int(x)-offset, y, f.ResolveFace(replacementChar))
+			r.DrawStringAt(string([]rune{replacementChar}), dst, int(x)-offset, yPix, f.ResolveFace(replacementChar))
 			return
 		}
 
-		r.DrawShapedRunAt(run, dst, int(x)-offset, y)
+		r.DrawShapedRunAt(run, dst, int(x)-offset, yPix)
 	})
 }
 
@@ -227,7 +227,7 @@ func loadMeasureFont(data fyne.Resource) *font.Face {
 // MeasureString returns how far dot would advance by drawing s with f.
 // Tabs are translated into a dot location change.
 func MeasureString(f shaping.Fontmap, s string, textSize float32, style fyne.TextStyle) (size fyne.Size, advance float32) {
-	return walkString(f, s, float32ToFixed266(textSize), style, &advance, 1, func(shaping.Output, float32) {})
+	return walkString(f, s, float32ToFixed266(textSize), style, &advance, 1, func(shaping.Output, float32, float32) {})
 }
 
 // RenderedTextSize looks up how big a string would be if drawn on screen.
@@ -266,8 +266,12 @@ func tabStop(spacew, x float32, tabWidth int) float32 {
 	return tabw * float32(tabs)
 }
 
+// walkString shapes s and invokes cb once per shaped run, in left-to-right order.
+// All runs share a single ascent (the max ascent of any run in the string), so that
+// runs shaped in different fallback fonts (e.g. mixed-script or emoji + text)
+// still align on a common baseline
 func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style fyne.TextStyle, advance *float32, scale float32,
-	cb func(run shaping.Output, x float32),
+	cb func(run shaping.Output, x, y float32),
 ) (size fyne.Size, base float32) {
 	s = strings.ReplaceAll(s, "\r", "")
 
@@ -292,6 +296,16 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 	if style.Monospace {
 		spacew = scale * fixed266ToFloat32(out.Advance)
 	}
+
+	var runs []shapedRun
+	maxAscent := fixed.Int26_6(0)
+	collect := func(run shaping.Output, runX float32) {
+		if run.LineBounds.Ascent > maxAscent {
+			maxAscent = run.LineBounds.Ascent
+		}
+		runs = append(runs, shapedRun{out: run, x: runX})
+	}
+
 	ins := segmenter.Split(in, faces)
 	for _, in := range ins {
 		inEnd := in.RunEnd
@@ -301,7 +315,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 			if r == '\t' {
 				if pending {
 					in.RunEnd = i
-					x = shapeCallback(in, x, scale, cb)
+					x = shapeCallback(in, x, scale, collect)
 				}
 				x = tabStop(spacew, x, style.TabWidth)
 
@@ -313,12 +327,22 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 			}
 		}
 
-		x = shapeCallback(in, x, scale, cb)
+		x = shapeCallback(in, x, scale, collect)
+	}
+
+	y := fixed266ToFloat32(maxAscent) * scale
+	for _, run := range runs {
+		cb(run.out, run.x, y)
 	}
 
 	*advance = x
 	return fyne.NewSize(*advance, fixed266ToFloat32(out.LineBounds.LineThickness())),
 		fixed266ToFloat32(out.LineBounds.Ascent)
+}
+
+type shapedRun struct {
+	out shaping.Output
+	x   float32
 }
 
 func shapeCallback(in shaping.Input, x, scale float32, cb func(shaping.Output, float32)) float32 {

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -266,6 +266,17 @@ func tabStop(spacew, x float32, tabWidth int) float32 {
 	return tabw * float32(tabs)
 }
 
+
+type shapedRun struct {
+	out shaping.Output
+	x   float32
+}
+
+var (
+	runBuffer    []shapedRun
+	runBufferMut async.Mutex
+)
+
 // walkString shapes s and invokes cb once per shaped run, in left-to-right order.
 // All runs share a single ascent (the max ascent of any run in the string), so that
 // runs shaped in different fallback fonts (e.g. mixed-script or emoji + text)
@@ -297,13 +308,14 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 		spacew = scale * fixed266ToFloat32(out.Advance)
 	}
 
-	var runs []shapedRun
+	runBufferMut.Lock()
+
 	maxAscent := fixed.Int26_6(0)
 	collect := func(run shaping.Output, runX float32) {
 		if run.LineBounds.Ascent > maxAscent {
 			maxAscent = run.LineBounds.Ascent
 		}
-		runs = append(runs, shapedRun{out: run, x: runX})
+		runBuffer = append(runBuffer, shapedRun{out: run, x: runX})
 	}
 
 	ins := segmenter.Split(in, faces)
@@ -331,18 +343,16 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 	}
 
 	y := fixed266ToFloat32(maxAscent) * scale
-	for _, run := range runs {
+	for _, run := range runBuffer {
 		cb(run.out, run.x, y)
 	}
+	clear(runBuffer)
+	runBuffer = runBuffer[:0]
+	runBufferMut.Unlock()
 
 	*advance = x
 	return fyne.NewSize(*advance, fixed266ToFloat32(out.LineBounds.LineThickness())),
 		fixed266ToFloat32(out.LineBounds.Ascent)
-}
-
-type shapedRun struct {
-	out shaping.Output
-	x   float32
 }
 
 func shapeCallback(in shaping.Input, x, scale float32, cb func(shaping.Output, float32)) float32 {

--- a/internal/painter/font_internal_test.go
+++ b/internal/painter/font_internal_test.go
@@ -2,6 +2,85 @@
 
 package painter
 
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+	"github.com/go-text/typesetting/font"
+	"github.com/go-text/typesetting/shaping"
+	"github.com/stretchr/testify/assert"
+)
+
+// splitFaceMap resolves ASCII runes to one face and everything else to another,
+// modeling a string whose glyphs get shaped across two different fallback fonts
+// (as happens with mixed-script text, or text mixed with symbols/emoji).
+type splitFaceMap struct {
+	ascii, other *font.Face
+}
+
+func (m splitFaceMap) ResolveFace(r rune) *font.Face {
+	if r < 128 {
+		return m.ascii
+	}
+	return m.other
+}
+
+// TestWalkStringSharedLineAscent ensures that when a string is shaped across more
+// than one font (e.g. mixed CJK fallback fonts, or text mixed with symbols/emoji),
+// every run is positioned against the same, shared line ascent rather than each
+// run's own font ascent - which is what previously caused visibly inconsistent
+// vertical positioning within a single line (fyne-io/fyne#6446).
+func TestWalkStringSharedLineAscent(t *testing.T) {
+	ascii := loadMeasureFont(theme.DefaultTextFont())
+	other := loadMeasureFont(theme.DefaultSymbolFont())
+	if ascii == nil || other == nil {
+		t.Fatal("failed to load bundled fonts for test")
+	}
+	faces := splitFaceMap{ascii: ascii, other: other}
+
+	// soloAscent shapes a single-face string in isolation, so its one (and only)
+	// run necessarily gets its own font's true ascent - this gives us a reference
+	// value to compare against, without hard-coding font metrics in the test.
+	soloAscent := func(s string) float32 {
+		var y float32
+		found := false
+		adv := float32(0)
+		walkString(faces, s, float32ToFixed266(24), fyne.TextStyle{}, &adv, 1, func(_ shaping.Output, _, ry float32) {
+			y = ry
+			found = true
+		})
+		if !found {
+			t.Fatalf("no run produced for %q", s)
+		}
+		return y
+	}
+
+	asciiAscent := soloAscent("A")
+	otherAscent := soloAscent("⌘") // '⌘', present in the symbol font but not the text font
+	if asciiAscent == otherAscent {
+		t.Fatal("test fonts have identical ascent, can't verify sharing between distinct ascents")
+	}
+	expected := asciiAscent
+	if otherAscent > expected {
+		expected = otherAscent
+	}
+
+	for _, s := range []string{"A⌘", "⌘A", "A⌘A⌘"} {
+		var ys []float32
+		adv := float32(0)
+		walkString(faces, s, float32ToFixed266(24), fyne.TextStyle{}, &adv, 1, func(_ shaping.Output, _, y float32) {
+			ys = append(ys, y)
+		})
+
+		if assert.NotEmpty(t, ys, "expected at least one shaped run for %q", s) {
+			for i, y := range ys {
+				assert.Equal(t, expected, y, "run %d of %q should share the line's max ascent", i, s)
+			}
+		}
+	}
+}
+
 //
 //func Test_compositeFace_Close(t *testing.T) {
 //	chosenFont := &truetype.Font{}


### PR DESCRIPTION
### Description:
Compute a single shared ascent/descent for a line of multiple runs rather than using the metrics individually per font/run.

Fixes #6446 

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
