### PR TITLE
Use Go 1.21 builtin clear() to nil slices when we can

### DIFF
--- a/internal/animation/runner.go
+++ b/internal/animation/runner.go
@@ -115,15 +115,10 @@ func (r *Runner) runOneFrame() (done bool) {
 	r.animationMutex.Lock()
 	// nil out old r.animations for re-use as next r.nextFrameAnimations
 	tmp := r.animations
-	for i := range tmp {
-		tmp[i] = nil
-	}
+	clear(tmp)
 	r.animations = append(r.nextFrameAnimations, r.pendingAnimations...)
 	r.nextFrameAnimations = tmp[:0]
-	// nil out r.pendingAnimations
-	for i := range r.pendingAnimations {
-		r.pendingAnimations[i] = nil
-	}
+	clear(r.pendingAnimations)
 	r.pendingAnimations = r.pendingAnimations[:0]
 	done = len(r.animations) == 0
 	r.animationMutex.Unlock()

--- a/internal/driver/common/structures.go
+++ b/internal/driver/common/structures.go
@@ -87,9 +87,6 @@ func (o *overlayStack) Remove(overlay fyne.CanvasObject) {
 	o.OverlayStack.Remove(overlay)
 	overlayCount := len(o.List())
 
-	for i := overlayCount; i < len(o.renderCaches); i++ {
-		o.renderCaches[i] = nil // release memory reference to removed element
-	}
-
+	clear(o.renderCaches[overlayCount:])
 	o.renderCaches = o.renderCaches[:overlayCount]
 }

--- a/internal/overlay_stack.go
+++ b/internal/overlay_stack.go
@@ -63,10 +63,8 @@ func (s *OverlayStack) Remove(overlay fyne.CanvasObject) {
 		return
 	}
 	// set removed elements in backing array to nil to release memory references
-	for i := overlayIdx; i < len(s.overlays); i++ {
-		s.overlays[i] = nil
-		s.focusManagers[i] = nil
-	}
+	clear(s.overlays[overlayIdx:])
+	clear(s.focusManagers[overlayIdx:])
 	s.overlays = s.overlays[:overlayIdx]
 	s.focusManagers = s.focusManagers[:overlayIdx]
 }

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -745,9 +745,7 @@ func (l *gridWrapLayout) updateGrid(newOnly bool) {
 
 	// we don't need wasVisible now until next call to update
 	// nil out all references before truncating slice
-	for i := 0; i < len(l.wasVisible); i++ {
-		l.wasVisible[i].item = nil
-	}
+	clear(l.wasVisible)
 	l.wasVisible = l.wasVisible[:0]
 }
 
@@ -764,8 +762,6 @@ func (*gridWrapLayout) searchVisible(visible []gridItemAndID, id GridWrapItemID)
 func (*gridWrapLayout) nilOldSliceData(objs []fyne.CanvasObject, length, oldLength int) {
 	if oldLength > length {
 		objs = objs[:oldLength] // gain view into old data
-		for i := length; i < oldLength; i++ {
-			objs[i] = nil
-		}
+		clear(objs[length:])
 	}
 }

--- a/widget/list.go
+++ b/widget/list.go
@@ -880,11 +880,8 @@ func (l *listLayout) updateList(newOnly bool) {
 		}
 	}
 
-	// we don't need wasVisible now until next call to update
-	// nil out all references before truncating slice
-	for i := 0; i < len(l.wasVisible); i++ {
-		l.wasVisible[i].item = nil
-	}
+	// we don't need wasVisible now until next call to update; clear and reset its length
+	clear(l.wasVisible)
 	l.wasVisible = l.wasVisible[:0]
 }
 
@@ -935,9 +932,7 @@ func (*listLayout) searchVisible(visible []listItemAndID, id ListItemID) (*listI
 func (*listLayout) nilOldSliceData(objs []fyne.CanvasObject, length, oldLength int) {
 	if oldLength > length {
 		objs = objs[:oldLength] // gain view into old data
-		for i := length; i < oldLength; i++ {
-			objs[i] = nil
-		}
+		clear(objs[length:])
 	}
 }
 


### PR DESCRIPTION
### Description:

For #3242 

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
