### PR TITLE
Use container.NewPadded around file dialog content

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -701,7 +701,7 @@ func showFile(file *FileDialog) *fileDialog {
 	itemMin := d.newFileItem(storage.NewFileURI("filename.txt"), false, false).MinSize()
 	size := ui.MinSize().Add(itemMin.AddWidthHeight(itemMin.Width+pad*4, pad*2))
 
-	d.win = widget.NewModalPopUp(ui, file.parent.Canvas())
+	d.win = widget.NewModalPopUp(container.NewPadded(ui), file.parent.Canvas())
 	d.win.Resize(size)
 
 	d.setLocation(file.effectiveStartingDir())

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -803,7 +803,6 @@ func TestCreateNewFolderInDir(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(inputPopup)
 	assert.NotNil(t, inputPopup)
 
-	// padded container -> content container
 	folderNameInputUI := inputPopup.Content.(*fyne.Container)
 
 	folderNameInputTitle := folderNameInputUI.Objects[4].(*widget.Label)

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -175,7 +175,8 @@ func TestShowFileOpen(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 	// header
 	title := ui.Objects[1].(*fyne.Container).Objects[0].(*widget.Label)
 	assert.Equal(t, lang.L("Open")+" "+lang.L("File"), title.Text)
@@ -265,7 +266,8 @@ func TestHiddenFiles(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 
 	createNewFolderButton := ui.Objects[1].(*fyne.Container).Objects[1].(*fyne.Container).Objects[0].(*widget.Button)
 	assert.Equal(t, "", createNewFolderButton.Text)
@@ -316,7 +318,8 @@ func TestShowFileSave(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 	title := ui.Objects[1].(*fyne.Container).Objects[0].(*widget.Label)
 	assert.Equal(t, "Save File", title.Text)
 
@@ -458,7 +461,8 @@ func TestFileSort(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 
 	files := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[0].(*container.Scroll).Content.(*fyne.Container).Objects[0].(*widget.GridWrap)
 	objects := test.TempWidgetRenderer(t, files).Objects()[0].(*container.Scroll).Content.(*fyne.Container).Objects
@@ -498,7 +502,8 @@ func TestView(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[1].(*fyne.Container).Objects[1].(*widget.Button)
 	panel := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[0].(*container.Scroll).Content.(*fyne.Container).Objects[0]
 
@@ -564,7 +569,8 @@ func TestSetView(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[1].(*fyne.Container).Objects[1].(*widget.Button)
 	panel := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[0].(*container.Scroll).Content.(*fyne.Container).Objects[0]
 
@@ -616,7 +622,8 @@ func TestSetViewPreferences(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[1].(*fyne.Container).Objects[1].(*widget.Button)
 	panel := ui.Objects[0].(*container.Split).Trailing.(*fyne.Container).Objects[0].(*container.Scroll).Content.(*fyne.Container).Objects[0]
 
@@ -647,7 +654,8 @@ func TestViewPreferences(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 	toggleViewButton := ui.Objects[1].(*fyne.Container).Objects[1].(*fyne.Container).Objects[1].(*widget.Button)
 
 	// default viewLayout preference should be 'grid'
@@ -684,7 +692,8 @@ func TestFileFavorites(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 
 	dlg.dialog.loadFavorites()
 	favoriteLocations, _ := getFavoriteLocations()
@@ -780,7 +789,8 @@ func TestCreateNewFolderInDir(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(folderDialogPopup)
 	assert.NotNil(t, folderDialogPopup)
 
-	folderDialogUI := folderDialogPopup.Content.(*fyne.Container)
+	// padded container -> content container
+	folderDialogUI := folderDialogPopup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 
 	createNewFolderButton := folderDialogUI.Objects[1].(*fyne.Container).Objects[1].(*fyne.Container).Objects[0].(*widget.Button)
 	assert.Equal(t, "", createNewFolderButton.Text)
@@ -793,6 +803,7 @@ func TestCreateNewFolderInDir(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(inputPopup)
 	assert.NotNil(t, inputPopup)
 
+	// padded container -> content container
 	folderNameInputUI := inputPopup.Content.(*fyne.Container)
 
 	folderNameInputTitle := folderNameInputUI.Objects[4].(*widget.Label)

--- a/dialog/folder_test.go
+++ b/dialog/folder_test.go
@@ -35,7 +35,8 @@ func TestShowFolderOpen(t *testing.T) {
 	defer win.Canvas().Overlays().Remove(popup)
 	assert.NotNil(t, popup)
 
-	ui := popup.Content.(*fyne.Container)
+	// padded container -> content container
+	ui := popup.Content.(*fyne.Container).Objects[0].(*fyne.Container)
 	title := ui.Objects[1].(*fyne.Container).Objects[0].(*widget.Label)
 	assert.Equal(t, lang.L("Open")+" "+lang.L("Folder"), title.Text)
 


### PR DESCRIPTION
### Description:
Since 2.8, PopUps no longer add padding automatically, so we need to manually add it for the FileDialog to retain the same look and keep buttons and UI elements from exactly touching the boundary of the modal popup.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

