### PR TITLE
allocate less when walking labels

### DIFF
--- a/widget/label.go
+++ b/widget/label.go
@@ -107,7 +107,7 @@ func (l *Label) CreateRenderer() fyne.WidgetRenderer {
 	l.selection.theme = l.Theme()
 	l.selection.provider = l.provider
 
-	return &labelRenderer{l}
+	return &labelRenderer{l: l, objects: []fyne.CanvasObject{l.selection, l.provider}}
 }
 
 // MinSize returns the size that this label should not shrink below.
@@ -221,7 +221,8 @@ func (l *Label) updateFromData(data binding.DataItem) {
 }
 
 type labelRenderer struct {
-	l *Label
+	l       *Label
+	objects []fyne.CanvasObject
 }
 
 func (*labelRenderer) Destroy() {
@@ -238,10 +239,10 @@ func (r *labelRenderer) MinSize() fyne.Size {
 
 func (r *labelRenderer) Objects() []fyne.CanvasObject {
 	if !r.l.Selectable {
-		return []fyne.CanvasObject{r.l.provider}
+		return r.objects[1:]
 	}
 
-	return []fyne.CanvasObject{r.l.selection, r.l.provider}
+	return r.objects
 }
 
 func (r *labelRenderer) Refresh() {

--- a/widget/label.go
+++ b/widget/label.go
@@ -239,7 +239,7 @@ func (r *labelRenderer) MinSize() fyne.Size {
 
 func (r *labelRenderer) Objects() []fyne.CanvasObject {
 	if !r.l.Selectable {
-		return r.objects[1:]
+		return r.objects[1:] // only the RichText provider; exclude selection
 	}
 
 	return r.objects


### PR DESCRIPTION
### Description:
`labelRenderer.Objects()` built a new slice on every call. `Objects()` is not an occasional call — `driver.WalkVisibleObjectTree` invokes it for every widget it descends into, and the driver walks the tree two to three times per frame: once in `Canvas.EnsureMinSize`, once in `glCanvas.paint`, and again in `FindObjectAtPositionMatching` for every mouse move. Every `Label` on screen therefore allocated a slice several times per frame purely to be walked over.

Both children already exist when the renderer is built, so a single slice held on the renderer covers both cases — the selectable view is the whole slice, the plain view is its tail. No allocation on either path, and nothing to keep in sync, since `Selectable` is still read per call.

Returning a subslice is safe against a caller appending to the result: `objects[1:]` has length 1 and capacity 1, so an `append` copies rather than writing over `selection`.

## Benchmark

A tree of 100 rows, each `container.NewHBox(widget.NewLabel, widget.NewButton, canvas.NewRectangle)` — 1001 objects — walked once per op with `driver.WalkVisibleObjectTree` and a no-op visitor, which is what a single repaint pass costs before any painting happens:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 61986 | 1600 | 100 |
| after | 62231 | 0 | 0 |

Time is unchanged; the win is garbage. For this tree that is 100 allocations per walk, so roughly 18k allocations per second at 60 fps once the three walks per frame are counted, all of it collectable immediately and none of it necessary.

`widget.(*labelRenderer).Objects` was the single largest allocation site in the walk profile at 42% of `alloc_objects` before this change.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.