### PR TITLE
Optimize a few more renderers to not allocate fresh objects slices

### DIFF
--- a/container/navigation.go
+++ b/container/navigation.go
@@ -149,7 +149,7 @@ type navigatorRenderer struct {
 	back    widget.Button
 	forward widget.Button
 	title   widget.Label
-	object  fyne.CanvasObject
+	objects []fyne.CanvasObject
 }
 
 func (nav *Navigation) CreateRenderer() fyne.WidgetRenderer {
@@ -175,14 +175,14 @@ func (nav *Navigation) CreateRenderer() fyne.WidgetRenderer {
 	nav.setup()
 
 	pad := r.back.MinSize().Width
-	r.object = NewBorder(
+	r.objects = []fyne.CanvasObject{NewBorder(
 		NewStack(NewHBox(&r.back, layout.NewSpacer(), &r.forward),
 			&fyne.Container{Layout: layout.NewCustomPaddedLayout(0, 0, pad, pad), Objects: []fyne.CanvasObject{&r.title}}),
 		nil,
 		nil,
 		nil,
 		&nav.stack,
-	)
+	)}
 
 	return r
 }
@@ -191,15 +191,15 @@ func (*navigatorRenderer) Destroy() {
 }
 
 func (r *navigatorRenderer) Layout(s fyne.Size) {
-	r.object.Resize(s)
+	r.objects[0].Resize(s)
 }
 
 func (r *navigatorRenderer) MinSize() fyne.Size {
-	return r.object.MinSize()
+	return r.objects[0].MinSize()
 }
 
 func (r *navigatorRenderer) Objects() []fyne.CanvasObject {
-	return []fyne.CanvasObject{r.object}
+	return r.objects
 }
 
 func (r *navigatorRenderer) Refresh() {
@@ -221,5 +221,5 @@ func (r *navigatorRenderer) Refresh() {
 		r.title.Text = r.nav.Title
 	}
 
-	r.object.Refresh()
+	r.objects[0].Refresh()
 }

--- a/internal/driver/mobile/menu.go
+++ b/internal/driver/mobile/menu.go
@@ -36,7 +36,7 @@ func (m *menuLabel) CreateRenderer() fyne.WidgetRenderer {
 	label := widget.NewLabel(m.menu.Label)
 	box := container.NewHBox(layout.NewSpacer(), label, layout.NewSpacer(), widget.NewIcon(theme.MenuExpandIcon()))
 
-	return &menuLabelRenderer{menu: m, content: box}
+	return &menuLabelRenderer{menu: m, content: box, objects: []fyne.CanvasObject{box}}
 }
 
 func newMenuLabel(item *fyne.Menu, parent *fyne.Container, c *canvas) *menuLabel {
@@ -99,6 +99,7 @@ func (d *driver) findMenu(win *window) *fyne.MainMenu {
 type menuLabelRenderer struct {
 	menu    *menuLabel
 	content *fyne.Container
+	objects []fyne.CanvasObject
 }
 
 func (*menuLabelRenderer) BackgroundColor() color.Color {
@@ -117,7 +118,7 @@ func (m *menuLabelRenderer) MinSize() fyne.Size {
 }
 
 func (m *menuLabelRenderer) Objects() []fyne.CanvasObject {
-	return []fyne.CanvasObject{m.content}
+	return m.objects
 }
 
 func (m *menuLabelRenderer) Refresh() {

--- a/internal/driver/mobile/menubutton.go
+++ b/internal/driver/mobile/menubutton.go
@@ -20,14 +20,17 @@ func (w *window) newMenuButton(menu *fyne.MainMenu) *menuButton {
 }
 
 func (m *menuButton) CreateRenderer() fyne.WidgetRenderer {
-	return &menuButtonRenderer{btn: widget.NewButtonWithIcon("", theme.MenuIcon(), func() {
+	btn := widget.NewButtonWithIcon("", theme.MenuIcon(), func() {
 		m.win.canvas.showMenu(m.menu)
-	}), bg: fynecanvas.NewRectangle(theme.Color(theme.ColorNameBackground))}
+	})
+	bg := fynecanvas.NewRectangle(theme.Color(theme.ColorNameBackground))
+	return &menuButtonRenderer{btn: btn, bg: bg, objects: []fyne.CanvasObject{bg, btn}}
 }
 
 type menuButtonRenderer struct {
-	btn *widget.Button
-	bg  *fynecanvas.Rectangle
+	btn     *widget.Button
+	bg      *fynecanvas.Rectangle
+	objects []fyne.CanvasObject
 }
 
 func (*menuButtonRenderer) Destroy() {
@@ -44,7 +47,7 @@ func (m *menuButtonRenderer) MinSize() fyne.Size {
 }
 
 func (m *menuButtonRenderer) Objects() []fyne.CanvasObject {
-	return []fyne.CanvasObject{m.bg, m.btn}
+	return m.objects
 }
 
 func (m *menuButtonRenderer) Refresh() {

--- a/widget.go
+++ b/widget.go
@@ -25,7 +25,9 @@ type WidgetRenderer interface {
 	Layout(Size)
 	// MinSize returns the minimum size of the widget that is rendered by this renderer.
 	MinSize() Size
-	// Objects returns all objects that should be drawn.
+	// Objects returns all objects that should be drawn. The slice returned will not be
+	// modified by the driver, so it is safe for renderer implementations
+	// to cache and return the same slice on subsequent calls.
 	Objects() []CanvasObject
 	// Refresh is a hook that is called if the widget has updated and needs to be redrawn.
 	// This might trigger a [Layout].


### PR DESCRIPTION
### Description:
Continuing along with the same idea in #6453. Also documenting the contract that the driver will not modify the objects slices returned by the renderer so it can be safely cached and reused.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
