### PR TITLE
widget: sync menu item label text on Refresh

### DIFF
--- a/widget/menu_item.go
+++ b/widget/menu_item.go
@@ -291,6 +291,7 @@ func (r *menuItemRenderer) updateVisuals() {
 		r.background.Show()
 	}
 	r.background.Refresh()
+	r.text.Text = r.i.Item.Label
 	r.text.Alignment = r.i.alignment
 	r.refreshText(r.text, false)
 	for _, text := range r.shortcutTexts {

--- a/widget/menu_item_test.go
+++ b/widget/menu_item_test.go
@@ -106,3 +106,17 @@ func TestMenuItem_Disabled(t *testing.T) {
 		assert.Equal(t, "", buf.String()) // should not log an error
 	})
 }
+
+func TestMenuItem_Refresh(t *testing.T) {
+	i := fyne.NewMenuItem("before", func() {})
+	m := fyne.NewMenu("top", i)
+	w := newMenuItem(i, NewMenu(m))
+	r := cache.Renderer(w).(*menuItemRenderer)
+
+	assert.Equal(t, "before", r.text.Text)
+
+	i.Label = "after"
+	w.Refresh()
+
+	assert.Equal(t, "after", r.text.Text)
+}


### PR DESCRIPTION
### Description:

`menuItemRenderer.updateVisuals()` (called from `Refresh()`) re-applies the
item's colour, alignment and size every time, but the `canvas.Text` holding
the label was only ever set once in `CreateRenderer()`. As a result, changing
`MenuItem.Label` after the menu item widget was created and calling
`Refresh()` never updated what was rendered on screen.

Fix: read `Item.Label` into the `canvas.Text` in `updateVisuals()` as well,
so it stays in sync on every refresh, consistent with how `Disabled`,
`Checked` and `Icon` are already handled.

Fixes #6404

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.