### PR TITLE
widget: rebuild form item render slot when its Widget is replaced

### DIFF
--- a/widget/form.go
+++ b/widget/form.go
@@ -220,6 +220,16 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 	return &fyne.Container{Layout: formItemLayout{form: f}, Objects: []fyne.CanvasObject{item.Widget, textContainer}}
 }
 
+// itemRendersWidget reports whether rendered already shows widget, accounting for
+// createInput sometimes wrapping it in a hint/validation container.
+func (*Form) itemRendersWidget(rendered, widget fyne.CanvasObject) bool {
+	if rendered == widget {
+		return true
+	}
+	c, ok := rendered.(*fyne.Container)
+	return ok && len(c.Objects) > 0 && c.Objects[0] == widget
+}
+
 func (*Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
 	value := reflect.ValueOf(w).Elem()
 	validatorField := value.FieldByName("Validator")
@@ -327,6 +337,16 @@ func (f *Form) checkValidation(err error) {
 
 func (f *Form) ensureRenderItems() {
 	done := len(f.itemGrid.Objects) / 2
+	for i := 0; i < done && i < len(f.Items); i++ {
+		item := f.Items[i]
+		if f.itemRendersWidget(f.itemGrid.Objects[i*2+1], item.Widget) {
+			continue
+		}
+
+		f.setUpValidation(item.Widget, i)
+		f.itemGrid.Objects[i*2+1] = f.createInput(item)
+	}
+
 	if done >= len(f.Items) {
 		f.itemGrid.Objects = f.itemGrid.Objects[0 : len(f.Items)*2]
 		return

--- a/widget/form.go
+++ b/widget/form.go
@@ -220,14 +220,29 @@ func (f *Form) createInput(item *FormItem) fyne.CanvasObject {
 	return &fyne.Container{Layout: formItemLayout{form: f}, Objects: []fyne.CanvasObject{item.Widget, textContainer}}
 }
 
-// itemRendersWidget reports whether rendered already shows widget, accounting for
-// createInput sometimes wrapping it in a hint/validation container.
-func (*Form) itemRendersWidget(rendered, widget fyne.CanvasObject) bool {
-	if rendered == widget {
-		return true
+// unwrapItemWidget returns the widget actually shown by rendered, stripping the
+// hint/validation container createInput sometimes wraps it in.
+func (*Form) unwrapItemWidget(rendered fyne.CanvasObject) fyne.CanvasObject {
+	if c, ok := rendered.(*fyne.Container); ok && len(c.Objects) > 0 {
+		return c.Objects[0]
 	}
-	c, ok := rendered.(*fyne.Container)
-	return ok && len(c.Objects) > 0 && c.Objects[0] == widget
+	return rendered
+}
+
+func (f *Form) itemRendersWidget(rendered, widget fyne.CanvasObject) bool {
+	return f.unwrapItemWidget(rendered) == widget
+}
+
+// detachValidation unhooks the callbacks setUpValidation registered on widget, so a
+// caller that keeps interacting with a widget no longer shown by the form can't have
+// it write stale state into the FormItem slot it used to occupy.
+func (*Form) detachValidation(widget fyne.CanvasObject) {
+	if v, ok := widget.(fyne.Validatable); ok {
+		v.SetOnValidationChanged(nil)
+	}
+	if r, ok := widget.(fyne.Requireable); ok {
+		r.SetOnRequiredChanged(nil)
+	}
 }
 
 func (*Form) itemWidgetHasValidator(w fyne.CanvasObject) bool {
@@ -339,9 +354,16 @@ func (f *Form) ensureRenderItems() {
 	done := len(f.itemGrid.Objects) / 2
 	for i := 0; i < done && i < len(f.Items); i++ {
 		item := f.Items[i]
-		if f.itemRendersWidget(f.itemGrid.Objects[i*2+1], item.Widget) {
+		old := f.itemGrid.Objects[i*2+1]
+		if f.itemRendersWidget(old, item.Widget) {
 			continue
 		}
+
+		f.detachValidation(f.unwrapItemWidget(old))
+		item.validationError = nil
+		item.invalid = false
+		item.wasFocused = false
+		item.helperOutput = nil
 
 		f.setUpValidation(item.Widget, i)
 		f.itemGrid.Objects[i*2+1] = f.createInput(item)

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -142,6 +142,21 @@ func TestForm_ChangeText(t *testing.T) {
 	assert.Equal(t, "Changed", c.Objects[0].(*RichText).String())
 }
 
+func TestForm_ChangeItemWidget(t *testing.T) {
+	oldEntry := NewEntry()
+	item := NewFormItem("Test", oldEntry)
+	form := NewForm(item)
+	test.TempWidgetRenderer(t, form)
+
+	assert.Equal(t, oldEntry, form.itemGrid.Objects[1])
+
+	newEntry := NewEntry()
+	item.Widget = newEntry
+	form.Refresh()
+
+	assert.Equal(t, newEntry, form.itemGrid.Objects[1])
+}
+
 func TestForm_ChangeTheme(t *testing.T) {
 	test.NewTempApp(t)
 

--- a/widget/form_test.go
+++ b/widget/form_test.go
@@ -157,6 +157,80 @@ func TestForm_ChangeItemWidget(t *testing.T) {
 	assert.Equal(t, newEntry, form.itemGrid.Objects[1])
 }
 
+func TestForm_ChangeItemWidget_ResetsValidation(t *testing.T) {
+	test.NewTempApp(t)
+
+	invalidEntry := &Entry{Validator: validation.NewRegexp(`^\d+$`, "must be numeric"), Text: "not-a-number"}
+	item := NewFormItem("Test", invalidEntry)
+	form := &Form{Items: []*FormItem{item}, OnSubmit: func() {}}
+	test.NewTempWindow(t, form)
+
+	assert.True(t, item.invalid)
+	assert.Error(t, item.validationError)
+	assert.True(t, form.submitButton.Disabled())
+
+	item.Widget = NewLabel("static") // not fyne.Validatable
+	form.Refresh()
+
+	assert.False(t, item.invalid)
+	assert.NoError(t, item.validationError)
+	assert.False(t, form.submitButton.Disabled())
+}
+
+func TestForm_ChangeItemWidget_ResetsWasFocused(t *testing.T) {
+	test.NewTempApp(t)
+
+	entry := &Entry{}
+	item := &FormItem{Text: "Test", Widget: entry, HintText: "a hint"}
+	form := &Form{Items: []*FormItem{item}}
+	test.NewTempWindow(t, form)
+
+	entry.FocusGained()
+	entry.FocusLost()
+	form.Refresh()
+	assert.True(t, item.wasFocused)
+
+	item.Widget = &Entry{}
+	form.Refresh()
+
+	assert.False(t, item.wasFocused)
+}
+
+func TestForm_ChangeItemWidget_DetachesOldWidget(t *testing.T) {
+	test.NewTempApp(t)
+
+	oldEntry := &Entry{Validator: validation.NewRegexp(`^\d+$`, "must be numeric")}
+	item := NewFormItem("Test", oldEntry)
+	form := &Form{Items: []*FormItem{item}, OnSubmit: func() {}}
+	test.NewTempWindow(t, form)
+
+	item.Widget = &Entry{}
+	form.Refresh()
+
+	// oldEntry is no longer part of the form; validating it must not write into item.
+	oldEntry.Text = "not-a-number"
+	oldEntry.Validate()
+
+	assert.False(t, item.invalid)
+	assert.NoError(t, item.validationError)
+}
+
+func TestForm_ChangeItemWidget_ClearsHelperOutput(t *testing.T) {
+	test.NewTempApp(t)
+
+	entry := &Entry{Validator: validation.NewRegexp(`^\d+$`, "must be numeric"), Text: "not-a-number"}
+	item := NewFormItem("Test", entry)
+	form := &Form{Items: []*FormItem{item}, OnSubmit: func() {}}
+	test.NewTempWindow(t, form)
+
+	assert.NotNil(t, item.helperOutput)
+
+	item.Widget = NewLabel("static")
+	form.Refresh()
+
+	assert.Nil(t, item.helperOutput)
+}
+
 func TestForm_ChangeTheme(t *testing.T) {
 	test.NewTempApp(t)
 


### PR DESCRIPTION
### Description:

`ensureRenderItems()` only ever appends render objects for newly added
`Items`. If an existing `FormItem.Widget` is swapped for a different
`fyne.CanvasObject` after the form was already rendered, `Refresh()`
silently kept showing the old widget — unlike `Text` changes, which are
already applied in place by `updateLabels()`.

The fix adds a pass over the already-rendered items that rebuilds the
render slot (via the existing `createInput`) whenever the currently
displayed object no longer matches `item.Widget`, accounting for
`createInput` sometimes wrapping the widget in a hint/validation
container.

Fixes #1966

#### Related prior attempt

There is an older open PR, #5308, attempting the same fix. It has been
inactive since December 2024 and has unresolved `CHANGES_REQUESTED`
feedback noting it broke existing form tests — its approach unconditionally
recreated both the label and the input for every item on every `Refresh()`,
which conflicts with `updateLabels()` mutating the existing `RichText` in
place. This PR only rebuilds the slot for the item whose widget actually
changed, leaving everything else untouched, and the full `TestForm_*` suite
passes.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.