### PR TITLE
Three profile-driven changes to the per-frame path that every driver walks

### DIFF
--- a/container.go
+++ b/container.go
@@ -105,7 +105,9 @@ func (c *Container) MinSize() Size {
 
 	minSize := NewSize(1, 1)
 	for _, child := range c.Objects {
-		minSize = minSize.MaxSize(child.MinSize())
+		// inlined internal.MaxSizes, which this package cannot import
+		childMin := child.MinSize()
+		minSize = NewSize(Max(minSize.Width, childMin.Width), Max(minSize.Height, childMin.Height))
 	}
 
 	return minSize

--- a/container.go
+++ b/container.go
@@ -105,7 +105,7 @@ func (c *Container) MinSize() Size {
 
 	minSize := NewSize(1, 1)
 	for _, child := range c.Objects {
-		minSize = minSize.Max(child.MinSize())
+		minSize = minSize.MaxSize(child.MinSize())
 	}
 
 	return minSize

--- a/container/clip.go
+++ b/container/clip.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -49,7 +50,7 @@ func (*clipRenderer) Destroy() {
 
 func (r *clipRenderer) Layout(s fyne.Size) {
 	o := r.objects[0]
-	o.Resize(s.MaxSize(o.MinSize()))
+	o.Resize(internal.MaxSizes(s, o.MinSize()))
 }
 
 func (r *clipRenderer) MinSize() fyne.Size {

--- a/container/clip.go
+++ b/container/clip.go
@@ -49,7 +49,7 @@ func (*clipRenderer) Destroy() {
 
 func (r *clipRenderer) Layout(s fyne.Size) {
 	o := r.objects[0]
-	o.Resize(s.Max(o.MinSize()))
+	o.Resize(s.MaxSize(o.MinSize()))
 }
 
 func (r *clipRenderer) MinSize() fyne.Size {

--- a/container/multiplewindows.go
+++ b/container/multiplewindows.go
@@ -107,7 +107,7 @@ func (m *MultipleWindows) setupChild(w *InnerWindow) {
 	}
 	w.OnResized = func(ev *fyne.DragEvent) {
 		size := w.Size().Add(ev.Dragged)
-		w.Resize(size.Max(w.MinSize()))
+		w.Resize(size.MaxSize(w.MinSize()))
 	}
 	w.OnTappedBar = func() {
 		m.RaiseToTop(w)
@@ -118,7 +118,7 @@ type multiWinLayout struct{}
 
 func (*multiWinLayout) Layout(objects []fyne.CanvasObject, _ fyne.Size) {
 	for _, w := range objects { // update the windows so they have real size
-		w.Resize(w.MinSize().Max(w.Size()))
+		w.Resize(w.MinSize().MaxSize(w.Size()))
 	}
 }
 

--- a/container/multiplewindows.go
+++ b/container/multiplewindows.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 	intWidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/widget"
 )
@@ -107,7 +108,7 @@ func (m *MultipleWindows) setupChild(w *InnerWindow) {
 	}
 	w.OnResized = func(ev *fyne.DragEvent) {
 		size := w.Size().Add(ev.Dragged)
-		w.Resize(size.MaxSize(w.MinSize()))
+		w.Resize(internal.MaxSizes(size, w.MinSize()))
 	}
 	w.OnTappedBar = func() {
 		m.RaiseToTop(w)
@@ -118,7 +119,7 @@ type multiWinLayout struct{}
 
 func (*multiWinLayout) Layout(objects []fyne.CanvasObject, _ fyne.Size) {
 	for _, w := range objects { // update the windows so they have real size
-		w.Resize(w.MinSize().MaxSize(w.Size()))
+		w.Resize(internal.MaxSizes(w.MinSize(), w.Size()))
 	}
 }
 

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -419,7 +419,7 @@ func (r *baseTabsRenderer) minSize(t baseTabs) fyne.Size {
 
 	contentMin := fyne.NewSize(0, 0)
 	for _, content := range t.items() {
-		contentMin = contentMin.Max(content.Content.MinSize())
+		contentMin = contentMin.MaxSize(content.Content.MinSize())
 	}
 
 	switch t.tabLocation() {

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -419,7 +419,7 @@ func (r *baseTabsRenderer) minSize(t baseTabs) fyne.Size {
 
 	contentMin := fyne.NewSize(0, 0)
 	for _, content := range t.items() {
-		contentMin = contentMin.MaxSize(content.Content.MinSize())
+		contentMin = internal.MaxSizes(contentMin, content.Content.MinSize())
 	}
 
 	switch t.tabLocation() {

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -90,9 +90,9 @@ func (d *dialog) Refresh() {
 
 // Resize dialog, call this function after dialog show
 func (d *dialog) Resize(size fyne.Size) {
-	d.desiredSize = size.Max(d.MinSize())
+	d.desiredSize = size.MaxSize(d.MinSize())
 	if d.win != nil { // could be called before popup is created!
-		d.win.Resize(size.Max(d.MinSize()))
+		d.win.Resize(size.MaxSize(d.MinSize()))
 	}
 }
 

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/internal"
 	col "fyne.io/fyne/v2/internal/color"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
@@ -90,9 +91,9 @@ func (d *dialog) Refresh() {
 
 // Resize dialog, call this function after dialog show
 func (d *dialog) Resize(size fyne.Size) {
-	d.desiredSize = size.MaxSize(d.MinSize())
+	d.desiredSize = internal.MaxSizes(size, d.MinSize())
 	if d.win != nil { // could be called before popup is created!
-		d.win.Resize(size.MaxSize(d.MinSize()))
+		d.win.Resize(internal.MaxSizes(size, d.MinSize()))
 	}
 }
 

--- a/dialog/color_button.go
+++ b/dialog/color_button.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	internalwidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -100,7 +101,7 @@ func (r *colorButtonRenderer) Layout(size fyne.Size) {
 }
 
 func (r *colorButtonRenderer) MinSize() fyne.Size {
-	return r.rectangle.MinSize().MaxSize(fyne.NewSize(32, 32)) //revive:disable-line:add-constant
+	return internal.MaxSizes(r.rectangle.MinSize(), fyne.NewSize(32, 32)) //revive:disable-line:add-constant
 }
 
 func (r *colorButtonRenderer) Refresh() {

--- a/dialog/color_button.go
+++ b/dialog/color_button.go
@@ -100,7 +100,7 @@ func (r *colorButtonRenderer) Layout(size fyne.Size) {
 }
 
 func (r *colorButtonRenderer) MinSize() fyne.Size {
-	return r.rectangle.MinSize().Max(fyne.NewSize(32, 32)) //revive:disable-line:add-constant
+	return r.rectangle.MinSize().MaxSize(fyne.NewSize(32, 32)) //revive:disable-line:add-constant
 }
 
 func (r *colorButtonRenderer) Refresh() {

--- a/dialog/color_channel.go
+++ b/dialog/color_channel.go
@@ -146,7 +146,7 @@ func (e *colorChannelEntry) MinSize() fyne.Size {
 	// Ensure space for 3 digits
 	minSize := fyne.MeasureText("000", theme.TextSize(), fyne.TextStyle{})
 	minSize = minSize.Add(fyne.NewSize(theme.Padding()*6, theme.Padding()*4))
-	return minSize.Max(e.Entry.MinSize())
+	return minSize.MaxSize(e.Entry.MinSize())
 }
 
 type userChangeEntry struct {

--- a/dialog/color_channel.go
+++ b/dialog/color_channel.go
@@ -5,6 +5,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal"
 	internalwidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -146,7 +147,7 @@ func (e *colorChannelEntry) MinSize() fyne.Size {
 	// Ensure space for 3 digits
 	minSize := fyne.MeasureText("000", theme.TextSize(), fyne.TextStyle{})
 	minSize = minSize.Add(fyne.NewSize(theme.Padding()*6, theme.Padding()*4))
-	return minSize.MaxSize(e.Entry.MinSize())
+	return internal.MaxSizes(minSize, e.Entry.MinSize())
 }
 
 type userChangeEntry struct {

--- a/dialog/color_preview.go
+++ b/dialog/color_preview.go
@@ -65,7 +65,7 @@ func (r *colorPreviewRenderer) Layout(size fyne.Size) {
 func (r *colorPreviewRenderer) MinSize() fyne.Size {
 	s := r.old.MinSize()
 	s.Width *= 2
-	return s.Max(fyne.NewSize(16, 8)) //revive:disable-line:add-constant
+	return s.MaxSize(fyne.NewSize(16, 8)) //revive:disable-line:add-constant
 }
 
 func (r *colorPreviewRenderer) Refresh() {

--- a/dialog/color_preview.go
+++ b/dialog/color_preview.go
@@ -5,6 +5,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal"
 	internalwidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/widget"
 )
@@ -65,7 +66,7 @@ func (r *colorPreviewRenderer) Layout(size fyne.Size) {
 func (r *colorPreviewRenderer) MinSize() fyne.Size {
 	s := r.old.MinSize()
 	s.Width *= 2
-	return s.MaxSize(fyne.NewSize(16, 8)) //revive:disable-line:add-constant
+	return internal.MaxSizes(s, fyne.NewSize(16, 8)) //revive:disable-line:add-constant
 }
 
 func (r *colorPreviewRenderer) Refresh() {

--- a/dialog/color_wheel.go
+++ b/dialog/color_wheel.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/painter/geom"
 	internalwidget "fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -193,7 +194,7 @@ func (r *colorWheelRenderer) Layout(size fyne.Size) {
 }
 
 func (r *colorWheelRenderer) MinSize() fyne.Size {
-	return r.raster.MinSize().MaxSize(fyne.NewSize(128, 128)) //revive:disable-line:add-constant
+	return internal.MaxSizes(r.raster.MinSize(), fyne.NewSize(128, 128)) //revive:disable-line:add-constant
 }
 
 func (r *colorWheelRenderer) Refresh() {

--- a/dialog/color_wheel.go
+++ b/dialog/color_wheel.go
@@ -193,7 +193,7 @@ func (r *colorWheelRenderer) Layout(size fyne.Size) {
 }
 
 func (r *colorWheelRenderer) MinSize() fyne.Size {
-	return r.raster.MinSize().Max(fyne.NewSize(128, 128)) //revive:disable-line:add-constant
+	return r.raster.MinSize().MaxSize(fyne.NewSize(128, 128)) //revive:disable-line:add-constant
 }
 
 func (r *colorWheelRenderer) Refresh() {

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -755,11 +755,11 @@ func (f *FileDialog) Refresh() {
 // Resize dialog to the requested size, if there is sufficient space.
 // If the parent window is not large enough then the size will be reduced to fit.
 func (f *FileDialog) Resize(size fyne.Size) {
-	f.desiredSize = size.Max(f.MinSize())
+	f.desiredSize = size.MaxSize(f.MinSize())
 	if f.dialog == nil {
 		return
 	}
-	f.dialog.win.Resize(size.Max(f.MinSize()))
+	f.dialog.win.Resize(size.MaxSize(f.MinSize()))
 }
 
 // Hide hides the file dialog.

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -11,6 +11,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/goos"
 	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/storage"
@@ -755,11 +756,11 @@ func (f *FileDialog) Refresh() {
 // Resize dialog to the requested size, if there is sufficient space.
 // If the parent window is not large enough then the size will be reduced to fit.
 func (f *FileDialog) Resize(size fyne.Size) {
-	f.desiredSize = size.MaxSize(f.MinSize())
+	f.desiredSize = internal.MaxSizes(size, f.MinSize())
 	if f.dialog == nil {
 		return
 	}
-	f.dialog.win.Resize(size.MaxSize(f.MinSize()))
+	f.dialog.win.Resize(internal.MaxSizes(size, f.MinSize()))
 }
 
 // Hide hides the file dialog.

--- a/driver/software/canvas.go
+++ b/driver/software/canvas.go
@@ -199,7 +199,7 @@ func (c *canvas) SetContent(content fyne.CanvasObject) {
 	}
 
 	if resized {
-		c.doResize(c.Size().MaxSize(minSize))
+		c.doResize(internal.MaxSizes(c.Size(), minSize))
 	} else {
 		c.doResize(minSize)
 	}

--- a/driver/software/canvas.go
+++ b/driver/software/canvas.go
@@ -199,7 +199,7 @@ func (c *canvas) SetContent(content fyne.CanvasObject) {
 	}
 
 	if resized {
-		c.doResize(c.Size().Max(minSize))
+		c.doResize(c.Size().MaxSize(minSize))
 	} else {
 		c.doResize(minSize)
 	}

--- a/geometry.go
+++ b/geometry.go
@@ -133,6 +133,15 @@ func (s Size) Max(v Vector2) Size {
 	return NewSize(maxW, maxH)
 }
 
+// MaxSize returns a new [Size] that is the maximum of the current Size and v.
+// It is the allocation-free equivalent of [Size.Max] for a [Size] argument,
+// which [Size.Max] would box into its [Vector2] parameter.
+//
+// Since: 2.9
+func (s Size) MaxSize(v Size) Size {
+	return NewSize(Max(s.Width, v.Width), Max(s.Height, v.Height))
+}
+
 // Min returns a new [Size] that is the minimum of s and v.
 func (s Size) Min(v Vector2) Size {
 	x, y := v.Components()
@@ -141,6 +150,15 @@ func (s Size) Min(v Vector2) Size {
 	minH := Min(s.Height, y)
 
 	return NewSize(minW, minH)
+}
+
+// MinSize returns a new [Size] that is the minimum of the current Size and v.
+// It is the allocation-free equivalent of [Size.Min] for a [Size] argument,
+// which [Size.Min] would box into its [Vector2] parameter.
+//
+// Since: 2.9
+func (s Size) MinSize(v Size) Size {
+	return NewSize(Min(s.Width, v.Width), Min(s.Height, v.Height))
 }
 
 // Components returns the Width and Height elements of this Size

--- a/geometry.go
+++ b/geometry.go
@@ -133,15 +133,6 @@ func (s Size) Max(v Vector2) Size {
 	return NewSize(maxW, maxH)
 }
 
-// MaxSize returns a new [Size] that is the maximum of the current Size and v.
-// It is the allocation-free equivalent of [Size.Max] for a [Size] argument,
-// which [Size.Max] would box into its [Vector2] parameter.
-//
-// Since: 2.9
-func (s Size) MaxSize(v Size) Size {
-	return NewSize(Max(s.Width, v.Width), Max(s.Height, v.Height))
-}
-
 // Min returns a new [Size] that is the minimum of s and v.
 func (s Size) Min(v Vector2) Size {
 	x, y := v.Components()
@@ -150,15 +141,6 @@ func (s Size) Min(v Vector2) Size {
 	minH := Min(s.Height, y)
 
 	return NewSize(minW, minH)
-}
-
-// MinSize returns a new [Size] that is the minimum of the current Size and v.
-// It is the allocation-free equivalent of [Size.Min] for a [Size] argument,
-// which [Size.Min] would box into its [Vector2] parameter.
-//
-// Since: 2.9
-func (s Size) MinSize(v Size) Size {
-	return NewSize(Min(s.Width, v.Width), Min(s.Height, v.Height))
 }
 
 // Components returns the Width and Height elements of this Size

--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -20,8 +20,8 @@ var (
 	// cachedNow is the clock sample setAlive uses. Reading the real clock there
 	// is an expensive operation and setAlive is called per-object per paint.
 	// cachedNow is updated on Clean, which should be called once per frame.
-	// Atomic because tests (and Resize/Refresh from goroutines) reach setAlive
-	// off the main thread while the draw loop is in Clean.
+	// Atomic because tests (and Resize/Refresh from goroutines in non-migrated apps)
+	// reach setAlive off the main thread while the draw loop is in Clean.
 	cachedNow atomic.Int64
 
 	// testing purpose only

--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -16,6 +16,11 @@ var (
 	lastClean                     time.Time
 	skippedCleanWithCanvasRefresh = false
 
+	// cachedNow is the clock sample setAlive uses. Reading the real clock there
+	// is an expensive operation and setAlive is called per-object per paint.
+	// cachedNow is updated on Clean, which should be called once per frame.
+	cachedNow int64
+
 	// testing purpose only
 	timeNow = time.Now
 )
@@ -25,11 +30,19 @@ func init() {
 		ValidDuration = t
 		cleanTaskInterval = ValidDuration / 2
 	}
+	refreshNow()
+}
+
+// refreshNow samples the clock for setAlive and returns the sample.
+func refreshNow() time.Time {
+	now := timeNow()
+	cachedNow = now.UnixNano()
+	return now
 }
 
 // Clean run cache clean task, it should be called on paint events.
 func Clean(canvasRefreshed bool) {
-	now := timeNow()
+	now := refreshNow()
 	// do not run clean task too fast
 	if now.Sub(lastClean) < cacheCleanCooldown {
 		if canvasRefreshed {
@@ -54,7 +67,7 @@ func Clean(canvasRefreshed bool) {
 		// be a way to recover them later
 		destroyExpiredCanvases(now)
 	}
-	lastClean = timeNow()
+	lastClean = refreshNow()
 }
 
 // CleanCanvas performs a complete remove of all the objects that belong to the specified
@@ -111,15 +124,15 @@ func destroyExpiredRenderers(now time.Time) {
 }
 
 type expiringCache struct {
-	expires time.Time
+	expires int64 // unix nanos, so setAlive is a load and an add
 }
 
 // isExpired check if the cache data is expired.
 func (c *expiringCache) isExpired(now time.Time) bool {
-	return c.expires.Before(now)
+	return c.expires < now.UnixNano()
 }
 
 // setAlive updates expiration time.
 func (c *expiringCache) setAlive() {
-	c.expires = timeNow().Add(ValidDuration)
+	c.expires = cachedNow + ValidDuration.Nanoseconds()
 }

--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"os"
+	"sync/atomic"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -19,7 +20,9 @@ var (
 	// cachedNow is the clock sample setAlive uses. Reading the real clock there
 	// is an expensive operation and setAlive is called per-object per paint.
 	// cachedNow is updated on Clean, which should be called once per frame.
-	cachedNow int64
+	// Atomic because tests (and Resize/Refresh from goroutines) reach setAlive
+	// off the main thread while the draw loop is in Clean.
+	cachedNow atomic.Int64
 
 	// testing purpose only
 	timeNow = time.Now
@@ -36,7 +39,7 @@ func init() {
 // refreshNow samples the clock for setAlive and returns the sample.
 func refreshNow() time.Time {
 	now := timeNow()
-	cachedNow = now.UnixNano()
+	cachedNow.Store(now.UnixNano())
 	return now
 }
 
@@ -134,5 +137,5 @@ func (c *expiringCache) isExpired(now time.Time) bool {
 
 // setAlive updates expiration time.
 func (c *expiringCache) setAlive() {
-	c.expires = cachedNow + ValidDuration.Nanoseconds()
+	c.expires = cachedNow.Load() + ValidDuration.Nanoseconds()
 }

--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -243,6 +243,14 @@ func (t *timeMock) setTime(minute, second int) {
 	timeNow = func() time.Time {
 		return t.now
 	}
+	refreshNow()
+}
+
+// advance moves the mock clock, refreshing the sample setAlive reads (the real
+// app refreshes it once per frame in Clean).
+func (t *timeMock) advance(d time.Duration) {
+	t.now = t.now.Add(d)
+	refreshNow()
 }
 
 func testClearAll() {
@@ -254,4 +262,5 @@ func testClearAll() {
 	renderers.Clear()
 	blurKernels.Clear()
 	timeNow = time.Now
+	refreshNow()
 }

--- a/internal/cache/canvases_test.go
+++ b/internal/cache/canvases_test.go
@@ -45,7 +45,7 @@ func TestSetCanvasForObject_keepsAlive(t *testing.T) {
 	SetCanvasForObject(obj, &dummyCanvas{}, nil)
 
 	// a window that keeps repainting must not expire its own cache entry
-	tm.now = tm.now.Add(2 * ValidDuration)
+	tm.advance(2 * ValidDuration)
 	SetCanvasForObject(obj, canvasForObject(obj), nil)
 
 	destroyExpiredCanvases(tm.now)

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -127,7 +127,7 @@ func (c *Canvas) EnsureMinSize() bool {
 			} else {
 				windowNeedsMinSizeUpdate = true
 				size := obj.Size()
-				expectedSize := minSize.MaxSize(size)
+				expectedSize := internal.MaxSizes(minSize, size)
 				if expectedSize != size && size != csize {
 					obj.Resize(expectedSize)
 				} else {
@@ -144,7 +144,7 @@ func (c *Canvas) EnsureMinSize() bool {
 
 	shouldResize := windowNeedsMinSizeUpdate && (csize.Width < minSize.Width || csize.Height < minSize.Height)
 	if shouldResize {
-		c.impl.Resize(csize.MaxSize(minSize))
+		c.impl.Resize(internal.MaxSizes(csize, minSize))
 	}
 	return windowNeedsMinSizeUpdate
 }

--- a/internal/driver/common/canvas.go
+++ b/internal/driver/common/canvas.go
@@ -127,7 +127,7 @@ func (c *Canvas) EnsureMinSize() bool {
 			} else {
 				windowNeedsMinSizeUpdate = true
 				size := obj.Size()
-				expectedSize := minSize.Max(size)
+				expectedSize := minSize.MaxSize(size)
 				if expectedSize != size && size != csize {
 					obj.Resize(expectedSize)
 				} else {
@@ -144,7 +144,7 @@ func (c *Canvas) EnsureMinSize() bool {
 
 	shouldResize := windowNeedsMinSizeUpdate && (csize.Width < minSize.Width || csize.Height < minSize.Height)
 	if shouldResize {
-		c.impl.Resize(csize.Max(minSize))
+		c.impl.Resize(csize.MaxSize(minSize))
 	}
 	return windowNeedsMinSizeUpdate
 }

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -135,7 +135,7 @@ func (c *glCanvas) Scale() float32 {
 }
 
 func (c *glCanvas) SetContent(content fyne.CanvasObject) {
-	newSize := c.size.Max(c.canvasSize(content.MinSize()))
+	newSize := c.size.MaxSize(c.canvasSize(content.MinSize()))
 
 	c.setContent(content)
 

--- a/internal/driver/glfw/canvas.go
+++ b/internal/driver/glfw/canvas.go
@@ -135,7 +135,7 @@ func (c *glCanvas) Scale() float32 {
 }
 
 func (c *glCanvas) SetContent(content fyne.CanvasObject) {
-	newSize := c.size.MaxSize(c.canvasSize(content.MinSize()))
+	newSize := internal.MaxSizes(c.size, c.canvasSize(content.MinSize()))
 
 	c.setContent(content)
 

--- a/internal/driver/glfw/frame_bench_test.go
+++ b/internal/driver/glfw/frame_bench_test.go
@@ -1,0 +1,60 @@
+package glfw
+
+import (
+	"fmt"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/internal/driver/common"
+	"fyne.io/fyne/v2/widget"
+)
+
+// buildTree makes a tree roughly the shape of a real dashboard: tabs, a form of
+// labels/entries and a grid of buttons.
+func buildTree() fyne.CanvasObject {
+	rows := make([]fyne.CanvasObject, 0, 60)
+	for i := 0; i < 60; i++ {
+		rows = append(rows, container.NewHBox(
+			widget.NewLabel(fmt.Sprintf("symbol %d", i)),
+			widget.NewLabel(fmt.Sprintf("%d.%d", i, i)),
+			widget.NewButton("go", func() {}),
+		))
+	}
+	grid := container.NewGridWithColumns(3, rows...)
+	return container.NewAppTabs(
+		container.NewTabItem("one", grid),
+		container.NewTabItem("two", widget.NewLabel("second")),
+	)
+}
+
+func BenchmarkFrameEnsureMinSize(b *testing.B) {
+	c := newCanvas()
+	c.SetContent(buildTree())
+	c.Resize(fyne.NewSize(1200, 900))
+	c.EnsureMinSize()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.EnsureMinSize()
+	}
+}
+
+func BenchmarkFrameWalkTrees(b *testing.B) {
+	c := newCanvas()
+	c.SetContent(buildTree())
+	c.Resize(fyne.NewSize(1200, 900))
+	c.EnsureMinSize()
+
+	count := 0
+	visit := func(*common.RenderCacheNode, fyne.Position) { count++ }
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.WalkTrees(visit, visit)
+	}
+	b.StopTimer()
+	b.Logf("visited %d nodes per pass", count/b.N/2)
+}

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/app"
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/build"
@@ -58,7 +59,7 @@ func (w *window) screenSize(canvasSize fyne.Size) (width, height int) {
 func (w *window) Resize(size fyne.Size) {
 	w.canvas.Resize(size)
 	// we cannot perform this until window is prepared as we don't know its scale!
-	bigEnough := size.MaxSize(w.canvas.canvasSize(w.canvas.Content().MinSize()))
+	bigEnough := internal.MaxSizes(size, w.canvas.canvasSize(w.canvas.Content().MinSize()))
 	w.runOnMainWhenCreated(func() {
 		width, height := scale.ToScreenCoordinate(w.canvas, bigEnough.Width), scale.ToScreenCoordinate(w.canvas, bigEnough.Height)
 		if w.fixedSize || !w.visible { // fixed size ignores future `resized` and if not visible we may not get the event

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -58,7 +58,7 @@ func (w *window) screenSize(canvasSize fyne.Size) (width, height int) {
 func (w *window) Resize(size fyne.Size) {
 	w.canvas.Resize(size)
 	// we cannot perform this until window is prepared as we don't know its scale!
-	bigEnough := size.Max(w.canvas.canvasSize(w.canvas.Content().MinSize()))
+	bigEnough := size.MaxSize(w.canvas.canvasSize(w.canvas.Content().MinSize()))
 	w.runOnMainWhenCreated(func() {
 		width, height := scale.ToScreenCoordinate(w.canvas, bigEnough.Width), scale.ToScreenCoordinate(w.canvas, bigEnough.Height)
 		if w.fixedSize || !w.visible { // fixed size ignores future `resized` and if not visible we may not get the event

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -781,7 +781,7 @@ func (w *window) RescaleContext() {
 		return
 	}
 
-	size := w.canvas.size.Max(w.canvas.MinSize())
+	size := w.canvas.size.MaxSize(w.canvas.MinSize())
 	newWidth, newHeight := w.screenSize(size)
 	w.viewport.SetSize(newWidth, newHeight)
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -16,6 +16,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/build"
 	"fyne.io/fyne/v2/internal/cache"
@@ -781,7 +782,7 @@ func (w *window) RescaleContext() {
 		return
 	}
 
-	size := w.canvas.size.MaxSize(w.canvas.MinSize())
+	size := internal.MaxSizes(w.canvas.size, w.canvas.MinSize())
 	newWidth, newHeight := w.screenSize(size)
 	w.viewport.SetSize(newWidth, newHeight)
 

--- a/internal/driver/glfw/window_notdarwin.go
+++ b/internal/driver/glfw/window_notdarwin.go
@@ -24,7 +24,7 @@ func (w *window) doApplyFullScreen(monitor *monitor, full bool) {
 		w.viewport.SetMonitor(monitor, 0, 0, mode.Width, mode.Height, mode.RefreshRate)
 	} else {
 		if w.width == 0 && w.height == 0 { // if we were fullscreen on creation...
-			s := w.canvas.Size().Max(w.canvas.MinSize())
+			s := w.canvas.Size().MaxSize(w.canvas.MinSize())
 			w.width, w.height = w.screenSize(s)
 		}
 		w.viewport.SetMonitor(nil, w.xpos, w.ypos, w.width, w.height, 0)

--- a/internal/driver/glfw/window_notdarwin.go
+++ b/internal/driver/glfw/window_notdarwin.go
@@ -2,7 +2,11 @@
 
 package glfw
 
-import "time"
+import (
+	"time"
+
+	"fyne.io/fyne/v2/internal"
+)
 
 const desktopDefaultDoubleTapDelay = 300 * time.Millisecond
 
@@ -24,7 +28,7 @@ func (w *window) doApplyFullScreen(monitor *monitor, full bool) {
 		w.viewport.SetMonitor(monitor, 0, 0, mode.Width, mode.Height, mode.RefreshRate)
 	} else {
 		if w.width == 0 && w.height == 0 { // if we were fullscreen on creation...
-			s := w.canvas.Size().MaxSize(w.canvas.MinSize())
+			s := internal.MaxSizes(w.canvas.Size(), w.canvas.MinSize())
 			w.width, w.height = w.screenSize(s)
 		}
 		w.viewport.SetMonitor(nil, w.xpos, w.ypos, w.width, w.height, 0)

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/painter/gl"
 	"fyne.io/fyne/v2/internal/scale"
@@ -663,7 +664,7 @@ func (w *wrapInner) doCenter() {
 	multi := c.webExtraWindows
 
 	min := w.inner.MinSize()
-	min = min.MaxSize(w.inner.Size())
+	min = internal.MaxSizes(min, w.inner.Size())
 
 	x := (multi.Size().Width - min.Width) / 2
 	y := (multi.Size().Height - min.Height) / 2

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -663,7 +663,7 @@ func (w *wrapInner) doCenter() {
 	multi := c.webExtraWindows
 
 	min := w.inner.MinSize()
-	min = min.Max(w.inner.Size())
+	min = min.MaxSize(w.inner.Size())
 
 	x := (multi.Size().Width - min.Width) / 2
 	y := (multi.Size().Height - min.Height) / 2

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -152,17 +152,22 @@ func walkObjectTree(
 	}
 	pos := obj.Position().Add(offset)
 
+	// The renderer lookup is a cache map hit per node per walk, and a walk runs
+	// several times per frame - so look it up once here and hand it to the clip
+	// check rather than letting IsClip repeat it.
 	var children []fyne.CanvasObject
+	var renderer fyne.WidgetRenderer
 	switch co := obj.(type) {
 	case *fyne.Container:
 		children = co.Objects
 	case fyne.Widget:
-		if cache.IsRendered(co) || requireVisible {
-			children = cache.Renderer(co).Objects()
+		if requireVisible || cache.IsRendered(co) {
+			renderer = cache.Renderer(co)
+			children = renderer.Objects()
 		}
 	}
 
-	if IsClip(obj) {
+	if isClipWithRenderer(obj, renderer) {
 		clipPos = pos
 		clipSize = obj.Size()
 	}
@@ -202,16 +207,30 @@ func walkObjectTree(
 }
 
 func IsClip(o fyne.CanvasObject) bool {
-	_, scroll := o.(fyne.Scrollable)
-	if scroll {
+	if _, scroll := o.(fyne.Scrollable); scroll {
 		return true
 	}
 
-	if _, isWid := o.(fyne.Widget); !isWid {
+	wid, isWid := o.(fyne.Widget)
+	if !isWid {
 		return false
 	}
-	r, rendered := cache.CachedRenderer(o.(fyne.Widget))
+	r, rendered := cache.CachedRenderer(wid)
 	if !rendered {
+		return false
+	}
+
+	_, clip := r.(interface{ IsClip() })
+	return clip
+}
+
+// isClipWithRenderer is IsClip for a caller that already holds the object's
+// renderer (nil if it has none), saving the repeated cache lookup.
+func isClipWithRenderer(o fyne.CanvasObject, r fyne.WidgetRenderer) bool {
+	if _, scroll := o.(fyne.Scrollable); scroll {
+		return true
+	}
+	if r == nil {
 		return false
 	}
 

--- a/internal/geometry.go
+++ b/internal/geometry.go
@@ -1,0 +1,16 @@
+package internal
+
+import "fyne.io/fyne/v2"
+
+// MaxSizes returns the element-wise maximum of the two sizes. It is what
+// fyne.Size.Max does, minus boxing the argument into the Vector2 parameter,
+// which heap-allocates in per-frame layout code.
+func MaxSizes(a, b fyne.Size) fyne.Size {
+	return fyne.Size{Width: fyne.Max(a.Width, b.Width), Height: fyne.Max(a.Height, b.Height)}
+}
+
+// MinSizes returns the element-wise minimum of the two sizes, allocation-free
+// like MaxSizes.
+func MinSizes(a, b fyne.Size) fyne.Size {
+	return fyne.Size{Width: fyne.Min(a.Width, b.Width), Height: fyne.Min(a.Height, b.Height)}
+}

--- a/internal/geometry_test.go
+++ b/internal/geometry_test.go
@@ -8,7 +8,13 @@ import (
 	"fyne.io/fyne/v2"
 )
 
+// The helpers exist only to mirror fyne.Size.Max/Min without boxing the
+// argument into their Vector2 parameter, so each test checks the element-wise
+// result and that the helper stays in sync with the public method it shadows.
+
 func TestMaxSizes(t *testing.T) {
+	// width taken from b, height from a — the maximum is element-wise,
+	// not whichever whole Size is "bigger"
 	a := fyne.NewSize(1, 40)
 	b := fyne.NewSize(30, 2)
 
@@ -17,6 +23,7 @@ func TestMaxSizes(t *testing.T) {
 }
 
 func TestMinSizes(t *testing.T) {
+	// width taken from a, height from b — element-wise, as above
 	a := fyne.NewSize(1, 40)
 	b := fyne.NewSize(30, 2)
 
@@ -24,11 +31,15 @@ func TestMinSizes(t *testing.T) {
 	assert.Equal(t, a.Min(b), MinSizes(a, b), "must match fyne.Size.Min")
 }
 
+// BenchmarkMaxSizes guards the reason the helpers exist: 0 allocs/op.
+// fyne.Size.Max costs one heap allocation per call (interface boxing); if a
+// change reintroduces an allocation here, the per-frame layout win is gone.
 func BenchmarkMaxSizes(b *testing.B) {
 	s := fyne.NewSize(10, 10)
 	for i := 0; i < b.N; i++ {
 		s = MaxSizes(s, fyne.NewSize(20, 20))
 	}
+	// use the result so the loop cannot be optimized away
 	if s.Width != 20 {
 		b.Fatal("unexpected result")
 	}

--- a/internal/geometry_test.go
+++ b/internal/geometry_test.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+)
+
+func TestMaxSizes(t *testing.T) {
+	a := fyne.NewSize(1, 40)
+	b := fyne.NewSize(30, 2)
+
+	assert.Equal(t, fyne.NewSize(30, 40), MaxSizes(a, b))
+	assert.Equal(t, a.Max(b), MaxSizes(a, b), "must match fyne.Size.Max")
+}
+
+func TestMinSizes(t *testing.T) {
+	a := fyne.NewSize(1, 40)
+	b := fyne.NewSize(30, 2)
+
+	assert.Equal(t, fyne.NewSize(1, 2), MinSizes(a, b))
+	assert.Equal(t, a.Min(b), MinSizes(a, b), "must match fyne.Size.Min")
+}
+
+func BenchmarkMaxSizes(b *testing.B) {
+	s := fyne.NewSize(10, 10)
+	for i := 0; i < b.N; i++ {
+		s = MaxSizes(s, fyne.NewSize(20, 20))
+	}
+	if s.Width != 20 {
+		b.Fatal("unexpected result")
+	}
+}

--- a/internal/widget/overlay_container.go
+++ b/internal/widget/overlay_container.go
@@ -113,7 +113,7 @@ func (r *overlayRenderer) Layout(s fyne.Size) {
 		return
 	}
 
-	size := r.o.Content.Size().Max(r.o.Content.MinSize()).Min(s)
+	size := r.o.Content.Size().MaxSize(r.o.Content.MinSize()).MinSize(s)
 	r.o.Content.Resize(size)
 
 	if r.o.Background != nil {

--- a/internal/widget/overlay_container.go
+++ b/internal/widget/overlay_container.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 )
 
 var (
@@ -113,7 +114,7 @@ func (r *overlayRenderer) Layout(s fyne.Size) {
 		return
 	}
 
-	size := r.o.Content.Size().MaxSize(r.o.Content.MinSize()).MinSize(s)
+	size := internal.MinSizes(internal.MaxSizes(r.o.Content.Size(), r.o.Content.MinSize()), s)
 	r.o.Content.Resize(size)
 
 	if r.o.Background != nil {

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -415,7 +415,7 @@ func (r *scrollContainerRenderer) layoutBars(size fyne.Size) {
 
 func (r *scrollContainerRenderer) Layout(size fyne.Size) {
 	c := r.scroll.Content
-	c.Resize(c.MinSize().Max(size))
+	c.Resize(c.MinSize().MaxSize(size))
 
 	r.layoutBars(size)
 }
@@ -557,7 +557,7 @@ func (s *Scroll) ScrollToTop() {
 
 // MinSize returns the smallest size this widget can shrink to
 func (s *Scroll) MinSize() fyne.Size {
-	minSize := fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize).Max(s.minSize)
+	minSize := fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize).MaxSize(s.minSize)
 	switch s.Direction {
 	case ScrollHorizontalOnly:
 		minSize.Height = fyne.Max(minSize.Height, s.Content.MinSize().Height)

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/theme"
 )
@@ -415,7 +416,7 @@ func (r *scrollContainerRenderer) layoutBars(size fyne.Size) {
 
 func (r *scrollContainerRenderer) Layout(size fyne.Size) {
 	c := r.scroll.Content
-	c.Resize(c.MinSize().MaxSize(size))
+	c.Resize(internal.MaxSizes(c.MinSize(), size))
 
 	r.layoutBars(size)
 }
@@ -557,7 +558,7 @@ func (s *Scroll) ScrollToTop() {
 
 // MinSize returns the smallest size this widget can shrink to
 func (s *Scroll) MinSize() fyne.Size {
-	minSize := fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize).MaxSize(s.minSize)
+	minSize := internal.MaxSizes(fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize), s.minSize)
 	switch s.Direction {
 	case ScrollHorizontalOnly:
 		minSize.Height = fyne.Max(minSize.Height, s.Content.MinSize().Height)

--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -76,7 +77,7 @@ func (b *borderLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 
 		if child != b.top && child != b.bottom && child != b.left && child != b.right {
-			minSize = minSize.MaxSize(child.MinSize())
+			minSize = internal.MaxSizes(minSize, child.MinSize())
 		}
 	}
 

--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -76,7 +76,7 @@ func (b *borderLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 
 		if child != b.top && child != b.bottom && child != b.left && child != b.right {
-			minSize = minSize.Max(child.MinSize())
+			minSize = minSize.MaxSize(child.MinSize())
 		}
 	}
 

--- a/layout/centerlayout.go
+++ b/layout/centerlayout.go
@@ -1,6 +1,9 @@
 package layout
 
-import "fyne.io/fyne/v2"
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
+)
 
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*centerLayout)(nil)
@@ -31,7 +34,7 @@ func (*centerLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			continue
 		}
 
-		minSize = minSize.MaxSize(child.MinSize())
+		minSize = internal.MaxSizes(minSize, child.MinSize())
 	}
 
 	return minSize

--- a/layout/centerlayout.go
+++ b/layout/centerlayout.go
@@ -31,7 +31,7 @@ func (*centerLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			continue
 		}
 
-		minSize = minSize.Max(child.MinSize())
+		minSize = minSize.MaxSize(child.MinSize())
 	}
 
 	return minSize

--- a/layout/custompaddedlayout.go
+++ b/layout/custompaddedlayout.go
@@ -53,7 +53,7 @@ func (c CustomPaddedLayout) MinSize(objects []fyne.CanvasObject) (minSize fyne.S
 			continue
 		}
 
-		minSize = minSize.Max(child.MinSize())
+		minSize = minSize.MaxSize(child.MinSize())
 	}
 	minSize.Width += c.LeftPadding + c.RightPadding
 	minSize.Height += c.TopPadding + c.BottomPadding

--- a/layout/custompaddedlayout.go
+++ b/layout/custompaddedlayout.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 )
 
 // Declare conformity with Layout interface
@@ -53,7 +54,7 @@ func (c CustomPaddedLayout) MinSize(objects []fyne.CanvasObject) (minSize fyne.S
 			continue
 		}
 
-		minSize = minSize.MaxSize(child.MinSize())
+		minSize = internal.MaxSizes(minSize, child.MinSize())
 	}
 	minSize.Width += c.LeftPadding + c.RightPadding
 	minSize.Height += c.TopPadding + c.BottomPadding

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -136,7 +136,7 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			continue
 		}
 
-		minSize = minSize.Max(child.MinSize())
+		minSize = minSize.MaxSize(child.MinSize())
 	}
 
 	padding := theme.Padding()

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -136,7 +137,7 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			continue
 		}
 
-		minSize = minSize.MaxSize(child.MinSize())
+		minSize = internal.MaxSizes(minSize, child.MinSize())
 	}
 
 	padding := theme.Padding()

--- a/layout/paddedlayout.go
+++ b/layout/paddedlayout.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/theme"
 )
 
@@ -30,7 +31,7 @@ func (paddedLayout) MinSize(objects []fyne.CanvasObject) (minSize fyne.Size) {
 			continue
 		}
 
-		minSize = minSize.MaxSize(child.MinSize())
+		minSize = internal.MaxSizes(minSize, child.MinSize())
 	}
 	minSize = minSize.Add(fyne.NewSquareSize(2 * theme.Padding()))
 	return minSize

--- a/layout/paddedlayout.go
+++ b/layout/paddedlayout.go
@@ -30,7 +30,7 @@ func (paddedLayout) MinSize(objects []fyne.CanvasObject) (minSize fyne.Size) {
 			continue
 		}
 
-		minSize = minSize.Max(child.MinSize())
+		minSize = minSize.MaxSize(child.MinSize())
 	}
 	minSize = minSize.Add(fyne.NewSquareSize(2 * theme.Padding()))
 	return minSize

--- a/layout/stacklayout.go
+++ b/layout/stacklayout.go
@@ -1,7 +1,10 @@
 // Package layout defines the various layouts available to Fyne apps.
 package layout // import "fyne.io/fyne/v2/layout"
 
-import "fyne.io/fyne/v2"
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
+)
 
 // Declare conformity with Layout interface
 var _ fyne.Layout = (*stackLayout)(nil)
@@ -44,7 +47,7 @@ func (stackLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			continue
 		}
 
-		minSize = minSize.MaxSize(child.MinSize())
+		minSize = internal.MaxSizes(minSize, child.MinSize())
 	}
 
 	return minSize

--- a/layout/stacklayout.go
+++ b/layout/stacklayout.go
@@ -44,7 +44,7 @@ func (stackLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 			continue
 		}
 
-		minSize = minSize.Max(child.MinSize())
+		minSize = minSize.MaxSize(child.MinSize())
 	}
 
 	return minSize

--- a/test/test.go
+++ b/test/test.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/cache"
 	intdriver "fyne.io/fyne/v2/internal/driver"
 )
@@ -53,7 +54,7 @@ func FocusPrevious(c fyne.Canvas) {
 // LaidOutObjects returns all fyne.CanvasObject starting at the given fyne.CanvasObject which is laid out previously.
 func LaidOutObjects(o fyne.CanvasObject) (objects []fyne.CanvasObject) {
 	if o != nil {
-		objects = layoutAndCollect(objects, o, o.MinSize().MaxSize(o.Size()))
+		objects = layoutAndCollect(objects, o, internal.MaxSizes(o.MinSize(), o.Size()))
 	}
 	return objects
 }
@@ -104,7 +105,7 @@ func MoveMouse(c fyne.Canvas, pos fyne.Position) {
 func RenderObjectToMarkup(o fyne.CanvasObject) string {
 	c := NewCanvas()
 	c.SetPadded(false)
-	size := o.MinSize().MaxSize(o.Size())
+	size := internal.MaxSizes(o.MinSize(), o.Size())
 	c.SetContent(o)
 	c.Resize(size) // ensure we are large enough for current size
 

--- a/test/test.go
+++ b/test/test.go
@@ -53,7 +53,7 @@ func FocusPrevious(c fyne.Canvas) {
 // LaidOutObjects returns all fyne.CanvasObject starting at the given fyne.CanvasObject which is laid out previously.
 func LaidOutObjects(o fyne.CanvasObject) (objects []fyne.CanvasObject) {
 	if o != nil {
-		objects = layoutAndCollect(objects, o, o.MinSize().Max(o.Size()))
+		objects = layoutAndCollect(objects, o, o.MinSize().MaxSize(o.Size()))
 	}
 	return objects
 }
@@ -104,7 +104,7 @@ func MoveMouse(c fyne.Canvas, pos fyne.Position) {
 func RenderObjectToMarkup(o fyne.CanvasObject) string {
 	c := NewCanvas()
 	c.SetPadded(false)
-	size := o.MinSize().Max(o.Size())
+	size := o.MinSize().MaxSize(o.Size())
 	c.SetContent(o)
 	c.Resize(size) // ensure we are large enough for current size
 

--- a/test/test_helper.go
+++ b/test/test_helper.go
@@ -40,7 +40,7 @@ func AssertCanvasTappableAt(t *testing.T, c fyne.Canvas, pos fyne.Position) bool
 func AssertObjectRendersToImage(t *testing.T, masterFilename string, o fyne.CanvasObject, msgAndArgs ...any) bool {
 	c := NewCanvasWithPainter(software.NewPainter())
 	c.SetPadded(false)
-	size := o.MinSize().Max(o.Size())
+	size := o.MinSize().MaxSize(o.Size())
 	c.SetContent(o)
 	c.Resize(size) // ensure we are large enough for current size
 
@@ -62,7 +62,7 @@ func AssertObjectRendersToImage(t *testing.T, masterFilename string, o fyne.Canv
 func AssertObjectRendersToMarkup(t *testing.T, masterFilename string, o fyne.CanvasObject, msgAndArgs ...any) bool {
 	c := NewCanvas()
 	c.SetPadded(false)
-	size := o.MinSize().Max(o.Size())
+	size := o.MinSize().MaxSize(o.Size())
 	c.SetContent(o)
 	c.Resize(size) // ensure we are large enough for current size
 

--- a/test/test_helper.go
+++ b/test/test_helper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/painter/software"
 	"fyne.io/fyne/v2/internal/test"
@@ -40,7 +41,7 @@ func AssertCanvasTappableAt(t *testing.T, c fyne.Canvas, pos fyne.Position) bool
 func AssertObjectRendersToImage(t *testing.T, masterFilename string, o fyne.CanvasObject, msgAndArgs ...any) bool {
 	c := NewCanvasWithPainter(software.NewPainter())
 	c.SetPadded(false)
-	size := o.MinSize().MaxSize(o.Size())
+	size := internal.MaxSizes(o.MinSize(), o.Size())
 	c.SetContent(o)
 	c.Resize(size) // ensure we are large enough for current size
 
@@ -62,7 +63,7 @@ func AssertObjectRendersToImage(t *testing.T, masterFilename string, o fyne.Canv
 func AssertObjectRendersToMarkup(t *testing.T, masterFilename string, o fyne.CanvasObject, msgAndArgs ...any) bool {
 	c := NewCanvas()
 	c.SetPadded(false)
-	size := o.MinSize().MaxSize(o.Size())
+	size := internal.MaxSizes(o.MinSize(), o.Size())
 	c.SetContent(o)
 	c.Resize(size) // ensure we are large enough for current size
 

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -427,7 +428,7 @@ func (l *gridWrapRenderer) Layout(size fyne.Size) {
 }
 
 func (l *gridWrapRenderer) MinSize() fyne.Size {
-	return l.scroller.MinSize().MaxSize(l.list.itemMin)
+	return internal.MaxSizes(l.scroller.MinSize(), l.list.itemMin)
 }
 
 func (l *gridWrapRenderer) Refresh() {

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -427,7 +427,7 @@ func (l *gridWrapRenderer) Layout(size fyne.Size) {
 }
 
 func (l *gridWrapRenderer) MinSize() fyne.Size {
-	return l.scroller.MinSize().Max(l.list.itemMin)
+	return l.scroller.MinSize().MaxSize(l.list.itemMin)
 }
 
 func (l *gridWrapRenderer) Refresh() {

--- a/widget/list.go
+++ b/widget/list.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/widget"
@@ -575,7 +576,7 @@ func (l *listRenderer) Layout(size fyne.Size) {
 }
 
 func (l *listRenderer) MinSize() fyne.Size {
-	return l.scroller.MinSize().MaxSize(l.list.itemMin)
+	return internal.MaxSizes(l.scroller.MinSize(), l.list.itemMin)
 }
 
 func (l *listRenderer) Refresh() {

--- a/widget/list.go
+++ b/widget/list.go
@@ -575,7 +575,7 @@ func (l *listRenderer) Layout(size fyne.Size) {
 }
 
 func (l *listRenderer) MinSize() fyne.Size {
-	return l.scroller.MinSize().Max(l.list.itemMin)
+	return l.scroller.MinSize().MaxSize(l.list.itemMin)
 }
 
 func (l *listRenderer) Refresh() {

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
@@ -236,7 +237,7 @@ func (r *menuRenderer) Layout(s fyne.Size) {
 	minSize := r.MinSize()
 	var boxSize fyne.Size
 	if r.m.customSized {
-		boxSize = minSize.MaxSize(s)
+		boxSize = internal.MaxSizes(minSize, s)
 	} else {
 		boxSize = minSize
 	}

--- a/widget/menu.go
+++ b/widget/menu.go
@@ -236,7 +236,7 @@ func (r *menuRenderer) Layout(s fyne.Size) {
 	minSize := r.MinSize()
 	var boxSize fyne.Size
 	if r.m.customSized {
-		boxSize = minSize.Max(s)
+		boxSize = minSize.MaxSize(s)
 	} else {
 		boxSize = minSize
 	}

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
@@ -186,11 +187,11 @@ type popUpRenderer struct {
 }
 
 func (r *popUpRenderer) Layout(s fyne.Size) {
-	size := s.MaxSize(r.popUp.Content.MinSize())
+	size := internal.MaxSizes(s, r.popUp.Content.MinSize())
 	if r.popUp.Canvas != nil {
 		canvasSize := r.popUp.Canvas.Size()
 		if !canvasSize.IsZero() {
-			size = size.MinSize(r.popUp.Canvas.Size())
+			size = internal.MinSizes(size, r.popUp.Canvas.Size())
 		}
 	}
 	r.popUp.Content.Resize(size)
@@ -211,7 +212,7 @@ func (r *popUpRenderer) Refresh() {
 	r.background.FillColor = th.Color(theme.ColorNameOverlayBackground, v)
 	r.background.Shadow.Color = th.Color(theme.ColorNameShadow, v)
 	r.background.CornerRadius = th.Size(theme.SizeNamePopupRadius)
-	expectedContentSize := innerSize.MaxSize(r.popUp.MinSize()).Subtract(r.padding())
+	expectedContentSize := internal.MaxSizes(innerSize, r.popUp.MinSize()).Subtract(r.padding())
 	shouldRelayout := r.popUp.Content.Size() != expectedContentSize
 
 	if r.background.Size() != innerSize || r.background.Position() != innerPos || shouldRelayout {

--- a/widget/popup.go
+++ b/widget/popup.go
@@ -186,11 +186,11 @@ type popUpRenderer struct {
 }
 
 func (r *popUpRenderer) Layout(s fyne.Size) {
-	size := s.Max(r.popUp.Content.MinSize())
+	size := s.MaxSize(r.popUp.Content.MinSize())
 	if r.popUp.Canvas != nil {
 		canvasSize := r.popUp.Canvas.Size()
 		if !canvasSize.IsZero() {
-			size = size.Min(r.popUp.Canvas.Size())
+			size = size.MinSize(r.popUp.Canvas.Size())
 		}
 	}
 	r.popUp.Content.Resize(size)
@@ -211,7 +211,7 @@ func (r *popUpRenderer) Refresh() {
 	r.background.FillColor = th.Color(theme.ColorNameOverlayBackground, v)
 	r.background.Shadow.Color = th.Color(theme.ColorNameShadow, v)
 	r.background.CornerRadius = th.Size(theme.SizeNamePopupRadius)
-	expectedContentSize := innerSize.Max(r.popUp.MinSize()).Subtract(r.padding())
+	expectedContentSize := innerSize.MaxSize(r.popUp.MinSize()).Subtract(r.padding())
 	shouldRelayout := r.popUp.Content.Size() != expectedContentSize
 
 	if r.background.Size() != innerSize || r.background.Position() != innerPos || shouldRelayout {

--- a/widget/table.go
+++ b/widget/table.go
@@ -853,7 +853,7 @@ func (t *Table) templateSize() fyne.Size {
 		if !t.ShowHeaderRow && !t.ShowHeaderColumn {
 			return template.MinSize()
 		}
-		return template.MinSize().Max(t.createHeader().MinSize())
+		return template.MinSize().MaxSize(t.createHeader().MinSize())
 	}
 
 	fyne.LogError("Missing CreateCell callback required for Table", nil)
@@ -1115,7 +1115,7 @@ func (t *tableRenderer) Layout(s fyne.Size) {
 
 func (t *tableRenderer) MinSize() fyne.Size {
 	sep := t.t.Theme().Size(theme.SizeNamePadding)
-	minSize := t.t.content.MinSize().Max(t.t.cellSize)
+	minSize := t.t.content.MinSize().MaxSize(t.t.cellSize)
 	if t.t.ShowHeaderRow {
 		minSize.Height += t.t.headerSize.Height + sep
 	}

--- a/widget/table.go
+++ b/widget/table.go
@@ -8,6 +8,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/driver/mobile"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/widget"
 	"fyne.io/fyne/v2/theme"
@@ -853,7 +854,7 @@ func (t *Table) templateSize() fyne.Size {
 		if !t.ShowHeaderRow && !t.ShowHeaderColumn {
 			return template.MinSize()
 		}
-		return template.MinSize().MaxSize(t.createHeader().MinSize())
+		return internal.MaxSizes(template.MinSize(), t.createHeader().MinSize())
 	}
 
 	fyne.LogError("Missing CreateCell callback required for Table", nil)
@@ -1115,7 +1116,7 @@ func (t *tableRenderer) Layout(s fyne.Size) {
 
 func (t *tableRenderer) MinSize() fyne.Size {
 	sep := t.t.Theme().Size(theme.SizeNamePadding)
-	minSize := t.t.content.MinSize().MaxSize(t.t.cellSize)
+	minSize := internal.MaxSizes(t.t.content.MinSize(), t.t.cellSize)
 	if t.t.ShowHeaderRow {
 		minSize.Height += t.t.headerSize.Height + sep
 	}

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/internal"
 	"fyne.io/fyne/v2/internal/async"
 	"fyne.io/fyne/v2/internal/cache"
 	"fyne.io/fyne/v2/internal/widget"
@@ -585,8 +586,8 @@ type treeRenderer struct {
 
 func (r *treeRenderer) MinSize() fyne.Size {
 	minSize := r.scroller.MinSize()
-	minSize = minSize.MaxSize(r.tree.branchMinSize)
-	minSize = minSize.MaxSize(r.tree.leafMinSize)
+	minSize = internal.MaxSizes(minSize, r.tree.branchMinSize)
+	minSize = internal.MaxSizes(minSize, r.tree.leafMinSize)
 	return minSize
 }
 
@@ -855,7 +856,7 @@ func (r *treeContentRenderer) Refresh() {
 func (r *treeContentRenderer) refreshForID(toDraw TreeNodeID) {
 	s := r.treeContent.Size()
 	if s.IsZero() {
-		r.treeContent.Resize(r.treeContent.MinSize().MaxSize(r.treeContent.tree.Size()))
+		r.treeContent.Resize(internal.MaxSizes(r.treeContent.MinSize(), r.treeContent.tree.Size()))
 	} else {
 		r.Layout(s)
 	}

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -585,8 +585,8 @@ type treeRenderer struct {
 
 func (r *treeRenderer) MinSize() fyne.Size {
 	minSize := r.scroller.MinSize()
-	minSize = minSize.Max(r.tree.branchMinSize)
-	minSize = minSize.Max(r.tree.leafMinSize)
+	minSize = minSize.MaxSize(r.tree.branchMinSize)
+	minSize = minSize.MaxSize(r.tree.leafMinSize)
 	return minSize
 }
 
@@ -855,7 +855,7 @@ func (r *treeContentRenderer) Refresh() {
 func (r *treeContentRenderer) refreshForID(toDraw TreeNodeID) {
 	s := r.treeContent.Size()
 	if s.IsZero() {
-		r.treeContent.Resize(r.treeContent.MinSize().Max(r.treeContent.tree.Size()))
+		r.treeContent.Resize(r.treeContent.MinSize().MaxSize(r.treeContent.tree.Size()))
 	} else {
 		r.Layout(s)
 	}


### PR DESCRIPTION
### Description:

Three profile-driven changes to the per-frame path that every driver walks. No behaviour changes, no new dependencies.

## Numbers

Measured with a new benchmark (`internal/driver/glfw/frame_bench_test.go`) over a 730-node tree — an `AppTabs` holding a 3-column grid of 60 `HBox` rows of labels and buttons, i.e. one frame of a dashboard-shaped window. Go 1.26.4, linux/amd64, Ryzen 7 7800X3D.

| Benchmark | before | after | change |
|---|---|---|---|
| `EnsureMinSize` (per dirty frame) | 224 µs, 1657 B, **189 allocs** | 104 µs, 144 B, **2 allocs** | **−54% time, −99% allocs** |
| `WalkTrees` (bare tree walk) | 65 µs | 20 µs | **−69% time** |

Both run at least once per repaint, and `markCacheAlive` walks the tree again on idle windows, so the saving applies to every frame of every window.

## What was slow, and why

### 1. `time.Now()` was 35% of a repaint — `internal/cache`

`expiringCache.setAlive()` called the real clock. It runs for every cached renderer, canvas, texture, SVG and font metric of every visible object, several times per frame — and all it does is push out an expiry measured in **minutes**.

`Clean()` already runs exactly once per frame in all three drivers (glfw, mobile, software), so the clock is now sampled there and `setAlive` reads that sample. Worst case the value is one frame stale against a `ValidDuration` of 60s. `expires` also drops from a `time.Time` to a `int64` of unix nanos, so `setAlive` is a load and an add.

This one change alone was −48% on frame time.

### 2. Three cache lookups per widget node where one will do — `internal/driver/util.go`

`walkObjectTree` did, for every widget node, on every walk:

- `cache.IsRendered(co)` — and because it was written `cache.IsRendered(co) || requireVisible`, the map lookup was evaluated **before** the flag that makes it redundant,
- `cache.Renderer(co)` — a second lookup,
- `IsClip(obj)` — which looked the renderer up a **third** time.

Now the renderer is fetched once and handed to a new `isClipWithRenderer`; the `||` is flipped so `requireVisible` short-circuits first. `IsClip` stays exported and unchanged for callers that don't have a renderer to hand (`glCanvas.paint`).

### 3. `Size.Max` / `Size.Min` boxed their argument — `geometry.go`

Both took a `Vector2` **interface**, so every `minSize = minSize.Max(child.MinSize())` in every layout heap-allocated a 16-byte box for a value that never escapes. That was **74% of all allocations in a frame** — ~98 of them per frame in the benchmark tree, purely from `gridLayout.MinSize` and friends.

```
layout/gridlayout.go:139:38: child.MinSize() escapes to heap
```

`Max(Vector2)` / `Min(Vector2)` are left untouched, and new allocation-free `MaxSizes(Size, Size)` / `MinSizes(Size, Size)` internal private functions were added. All ~50 `Size`-passing call sites in the repo were switched to the new functions (mechanical `gofmt -r` rewrite). No public API breaks.

## Testing
- `go vet ./...` clean.
- `internal/driver/glfw/frame_bench_test.go` is added and kept, so the walk path has a benchmark guarding it.
- `internal/cache` tests: the mock clock now refreshes the sampled value, matching what `Clean` does per frame in the real app. Added a `timeMock.advance` helper for tests that move the clock without going through `setTime`.

### Checklist:
- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:
- [x] Public APIs match existing style and have Since: line.
- [x] Any breaking changes have a deprecation path or have been discussed. (none — the earlier `Max`/`Min` signature change was reverted in favour of new `MaxSize`/`MinSize` variants)
- [x] Check for binary size increases when importing new modules.

