### PR TITLE
Fix issue with key caps in the emoji parser

### DIFF
--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 	"image/draw"
 	"math"
+	"slices"
 	"strings"
 	"sync"
 
@@ -393,7 +394,7 @@ func shapeCallback(in shaping.Input, x, scale float32, cb func(shaping.Output, f
 // splitEmojiSequences segments in for the shaper, keeping any emoji sequence
 // whole in a single face.
 func splitEmojiSequences(in shaping.Input, faces shaping.Fontmap, seg *shaping.Segmenter) []shaping.Input {
-	if !hasEmojiSequence(in) {
+	if !slices.Contains(in.Text[in.RunStart:in.RunEnd], emojiVariationSelector) {
 		return seg.Split(in, faces) // by far the common case, split in one pass
 	}
 
@@ -432,17 +433,6 @@ func appendSplit(out []shaping.Input, in shaping.Input, start, end int, faces sh
 ) []shaping.Input {
 	in.RunStart, in.RunEnd = start, end
 	return append(out, seg.Split(in, faces)...)
-}
-
-// hasEmojiSequence reports whether the run holds a variation selector - the
-// marker that some rune may need judging alongside its neighbours.
-func hasEmojiSequence(in shaping.Input) bool {
-	for _, r := range in.Text[in.RunStart:in.RunEnd] {
-		if r == emojiVariationSelector {
-			return true
-		}
-	}
-	return false
 }
 
 // emojiSequenceLen returns the length of the emoji sequence starting at index i,

--- a/internal/painter/font.go
+++ b/internal/painter/font.go
@@ -31,6 +31,11 @@ const (
 
 	fontTabSpaceSize = 10
 	replacementChar  = 0xfffd // that’s '�'
+
+	// emojiVariationSelector (VS16) asks for the preceding rune to be presented as emoji rather than text.
+	emojiVariationSelector = '\uFE0F'
+	// keycapMark encloses the preceding rune in a key, as in "0️⃣".
+	keycapMark = '\u20E3'
 )
 
 var (
@@ -315,7 +320,7 @@ func walkString(faces shaping.Fontmap, s string, textSize fixed.Int26_6, style f
 		runBuffer = append(runBuffer, shapedRun{out: run, x: runX})
 	}
 
-	ins := segmenter.Split(in, faces)
+	ins := splitEmojiSequences(in, faces, segmenter)
 	runBufferMut.Lock()
 	for _, in := range ins {
 		inEnd := in.RunEnd
@@ -383,6 +388,122 @@ func shapeCallback(in shaping.Input, x, scale float32, cb func(shaping.Output, f
 		adv = 0
 	}
 	return x + fixed266ToFloat32(adv)*scale
+}
+
+// splitEmojiSequences segments in for the shaper, keeping any emoji sequence
+// whole in a single face.
+func splitEmojiSequences(in shaping.Input, faces shaping.Fontmap, seg *shaping.Segmenter) []shaping.Input {
+	if !hasEmojiSequence(in) {
+		return seg.Split(in, faces) // by far the common case, split in one pass
+	}
+
+	var out []shaping.Input
+	start := in.RunStart
+	for i := start; i < in.RunEnd; {
+		var face *font.Face
+		length := emojiSequenceLen(in.Text, i, in.RunEnd)
+		if length > 0 {
+			face = resolveSequence(faces, in.Text[i:i+length])
+		}
+		if face == nil { // no sequence here, or none that one face draws better
+			i++
+			continue
+		}
+
+		if i > start {
+			out = appendSplit(out, in, start, i, faces, seg)
+		}
+		out = appendSplit(out, in, i, i+length, fixedFontMap{face: face}, seg)
+
+		i += length
+		start = i
+	}
+	if start < in.RunEnd {
+		out = appendSplit(out, in, start, in.RunEnd, faces, seg)
+	}
+	return out
+}
+
+// appendSplit segments the runes of in between start and end and adds the runs
+// to out. They have to be copied out because seg reuses its buffers between
+// calls.
+func appendSplit(out []shaping.Input, in shaping.Input, start, end int, faces shaping.Fontmap,
+	seg *shaping.Segmenter,
+) []shaping.Input {
+	in.RunStart, in.RunEnd = start, end
+	return append(out, seg.Split(in, faces)...)
+}
+
+// hasEmojiSequence reports whether the run holds a variation selector - the
+// marker that some rune may need judging alongside its neighbours.
+func hasEmojiSequence(in shaping.Input) bool {
+	for _, r := range in.Text[in.RunStart:in.RunEnd] {
+		if r == emojiVariationSelector {
+			return true
+		}
+	}
+	return false
+}
+
+// emojiSequenceLen returns the length of the emoji sequence starting at index i,
+// or 0 if none starts there. A sequence is a base rune and the variation
+// selector asking for emoji presentation, plus the enclosing mark of a keycap.
+func emojiSequenceLen(text []rune, i, end int) int {
+	if i+1 >= end || text[i+1] != emojiVariationSelector {
+		return 0
+	}
+	if i+2 < end && text[i+2] == keycapMark {
+		return 3
+	}
+	return 2
+}
+
+// resolveSequence returns the one face to shape a whole emoji sequence in, or
+// nil to leave the choice to the segmenter.
+func resolveSequence(faces shaping.Fontmap, seq []rune) *font.Face {
+	var candidates []*font.Face
+	torn := false
+	for _, r := range seq {
+		if r == emojiVariationSelector {
+			continue // ignorable, so the segmenter never asks for a face for it
+		}
+
+		face := faces.ResolveFace(r)
+		if len(candidates) > 0 && face != candidates[0] {
+			torn = true
+		}
+		candidates = append(candidates, face)
+	}
+	if !torn {
+		return nil
+	}
+
+	for _, face := range candidates {
+		if coversSequence(face, seq) {
+			return face
+		}
+	}
+	return nil
+}
+
+// coversSequence reports whether one face has a glyph for every rune of seq.
+func coversSequence(face *font.Face, seq []rune) bool {
+	for _, r := range seq {
+		if _, ok := face.NominalGlyph(r); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// fixedFontMap is a [shaping.Fontmap] that answers with a single face, used to
+// shape an emoji sequence whose face was already resolved as a whole.
+type fixedFontMap struct {
+	face *font.Face
+}
+
+func (f fixedFontMap) ResolveFace(rune) *font.Face {
+	return f.face
 }
 
 type FontCacheItem struct {

--- a/internal/painter/font_internal_test.go
+++ b/internal/painter/font_internal_test.go
@@ -81,6 +81,65 @@ func TestWalkStringSharedLineAscent(t *testing.T) {
 	}
 }
 
+// TestWalkStringKeycapSequences ensures an emoji sequence whose base rune also
+// exists in the text font is still shaped in the emoji font, as a whole.
+//
+// A keycap is three runes - "0️⃣" is 0030 FE0F 20E3 - make sure we render as 1 emoji.
+func TestWalkStringKeycapSequences(t *testing.T) {
+	text := loadMeasureFont(theme.DefaultTextFont())
+	emoji := loadMeasureFont(theme.DefaultEmojiFont())
+	if text == nil || emoji == nil {
+		t.Fatal("failed to load bundled fonts for test")
+	}
+	faces := &dynamicFontMap{family: "sans-serif", faces: []*font.Face{text, emoji}}
+
+	shape := func(s string) []shaping.Output {
+		var runs []shaping.Output
+		adv := float32(0)
+		walkString(faces, s, float32ToFixed266(24), fyne.TextStyle{}, &adv, 1,
+			func(run shaping.Output, _, _ float32) {
+				runs = append(runs, run)
+			})
+		return runs
+	}
+
+	for _, s := range []string{"#️⃣", "*️⃣", "0️⃣", "5️⃣", "9️⃣", "🔟"} {
+		runs := shape(s)
+		if !assert.Len(t, runs, 1, "%q should shape as one run", s) {
+			continue
+		}
+		assert.Same(t, emoji, runs[0].Face, "%q should be drawn by the emoji font", s)
+		if assert.Len(t, runs[0].Glyphs, 1, "%q should ligate into one glyph", s) {
+			assert.NotZero(t, runs[0].Glyphs[0].GlyphID, "%q shaped to .notdef", s)
+		}
+	}
+}
+
+// TestWalkStringKeycapInText ensures taking a keycap into the emoji font does
+// not drag its neighbors along with it.
+func TestWalkStringKeycapInText(t *testing.T) {
+	text := loadMeasureFont(theme.DefaultTextFont())
+	emoji := loadMeasureFont(theme.DefaultEmojiFont())
+	if text == nil || emoji == nil {
+		t.Fatal("failed to load bundled fonts for test")
+	}
+	faces := &dynamicFontMap{family: "sans-serif", faces: []*font.Face{text, emoji}}
+
+	var runs []shaping.Output
+	adv := float32(0)
+	walkString(faces, "1 1️⃣ 1", float32ToFixed266(24), fyne.TextStyle{}, &adv, 1,
+		func(run shaping.Output, _, _ float32) {
+			runs = append(runs, run)
+		})
+
+	if assert.Len(t, runs, 3, "the keycap should split the text either side of it") {
+		assert.Same(t, text, runs[0].Face)
+		assert.Same(t, emoji, runs[1].Face)
+		assert.Same(t, text, runs[2].Face)
+		assert.Len(t, runs[1].Glyphs, 1, "the keycap should ligate into one glyph")
+	}
+}
+
 //
 //func Test_compositeFace_Close(t *testing.T) {
 //	chosenFont := &truetype.Font{}


### PR DESCRIPTION
we may want to upstream this to go-text

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
