### PR TITLE
Handle edge case when parsing as float fails

### DIFF
--- a/data/binding/convert_helper.go
+++ b/data/binding/convert_helper.go
@@ -41,6 +41,10 @@ func stripFormatPrecision(in string) string {
 	}
 
 	sizeRunes := runes[start+1 : end]
+	if len(sizeRunes) == 1 && sizeRunes[0] == '.' { // %.f fails to parse as float "."
+		return string(runes[:start+1]) + string(runes[end:])
+	}
+
 	width, err := parseFloat(string(sizeRunes))
 	if err != nil {
 		return string(runes[:start+1]) + string(runes[:end])

--- a/data/binding/convert_helper_test.go
+++ b/data/binding/convert_helper_test.go
@@ -22,6 +22,12 @@ func TestStripPrecision(t *testing.T) {
 
 	format = "%v"
 	assert.Equal(t, "%v", stripFormatPrecision(format))
+
+	format = "%.f"
+	assert.Equal(t, "%f", stripFormatPrecision(format))
+
+	format = "foo=%.f"
+	assert.Equal(t, "foo=%f", stripFormatPrecision(format))
 }
 
 func TestURIFromStringHelper(t *testing.T) {

--- a/data/binding/convert_test.go
+++ b/data/binding/convert_test.go
@@ -255,6 +255,19 @@ func TestFloatToStringWithFormat(t *testing.T) {
 	v2, err := f.Get()
 	assert.Nil(t, err)
 	assert.Equal(t, 5.0, v2)
+
+	f = NewFloat()
+	s = FloatToStringWithFormat(f, "%.f")
+	v, err = s.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "0", v)
+
+	err = s.Set("1.2")
+	assert.NoError(t, err)
+
+	v, err = s.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, "1", v)
 }
 
 func TestIntToString(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:
<!-- A summary of the change included and which issue it addresses.
Please include any relevant motivation and background. -->

Fixes `binding.FloatToStringWithFormat(f, "%.f")` edge case, which wasn't handled correctly in `stripFormatPrecision`.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
