### PR TITLE
container: preserve user OnTappedBar when MultipleWindows wraps it

### DIFF
--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -56,6 +56,10 @@ type InnerWindow struct {
 	Content *fyne.Container
 
 	maximized, inactive bool
+
+	// tappedBarWrapped tracks whether MultipleWindows has already wrapped
+	// OnTappedBar with its own raise-to-top behaviour for this window.
+	tappedBarWrapped bool
 }
 
 // NewInnerWindow creates a new window border around the given `content`, displaying the `title` along the top.

--- a/container/multiplewindows.go
+++ b/container/multiplewindows.go
@@ -110,7 +110,16 @@ func (m *MultipleWindows) setupChild(w *InnerWindow) {
 		size := w.Size().Add(ev.Dragged)
 		w.Resize(internal.MaxSizes(size, w.MinSize()))
 	}
+	if w.tappedBarWrapped {
+		return
+	}
+	w.tappedBarWrapped = true
+
+	userTappedBar := w.OnTappedBar
 	w.OnTappedBar = func() {
+		if userTappedBar != nil {
+			userTappedBar()
+		}
 		m.RaiseToTop(w)
 	}
 }

--- a/container/multiplewindows_test.go
+++ b/container/multiplewindows_test.go
@@ -58,3 +58,35 @@ func TestMultipleWindows_Top(t *testing.T) {
 	m.Add(w1)
 	assert.Equal(t, w1, m.Top())
 }
+
+func TestMultipleWindows_OnTappedBarPreserved(t *testing.T) {
+	w1 := NewInnerWindow("1", widget.NewLabel("Content"))
+	called := 0
+	w1.OnTappedBar = func() { called++ }
+
+	w2 := NewInnerWindow("2", widget.NewLabel("Content"))
+	m := NewMultipleWindows(w1, w2)
+	_ = test.TempWidgetRenderer(t, m) // triggers the first refreshChildren/setupChild
+
+	assert.Equal(t, w2, m.Top())
+
+	w1.OnTappedBar()
+	assert.Equal(t, 1, called, "user's OnTappedBar set before adding the window should still be called")
+	assert.Equal(t, w1, m.Top(), "the built-in raise-to-top behaviour must still run")
+}
+
+func TestMultipleWindows_OnTappedBarNotDoubled(t *testing.T) {
+	w1 := NewInnerWindow("1", widget.NewLabel("Content"))
+	called := 0
+	w1.OnTappedBar = func() { called++ }
+
+	m := NewMultipleWindows(w1)
+	_ = test.TempWidgetRenderer(t, m)
+
+	m.Refresh()
+	m.Refresh()
+	m.Add(NewInnerWindow("2", widget.NewLabel("Content")))
+
+	w1.OnTappedBar()
+	assert.Equal(t, 1, called, "repeated Refresh()/Add() calls must not wrap the callback more than once")
+}


### PR DESCRIPTION
### Description:

`MultipleWindows.setupChild()` runs on every `refreshChildren()` call — i.e. on
`Add`, `RaiseToTop` and `Refresh` — and unconditionally replaced
`InnerWindow.OnTappedBar` with its own raise-to-top handler. Any callback the
caller had already set on the window (before or after it was added) was
silently discarded, so setting `OnTappedBar` before the window's first render
never survived.

Fix: capture the existing `OnTappedBar` once and wrap it (user callback first,
then the built-in raise-to-top), guarded by a private `tappedBarWrapped` flag
on `InnerWindow` so repeated `Refresh()`/`Add()` calls don't keep re-wrapping
it into an ever-growing closure chain that would call the user's callback
multiple times per tap.

Fixes #6433

#### Scope note

`InnerWindow.OnDragged`/`OnResized` are overwritten by the same `setupChild()`
in exactly the same way and have the identical latent bug — I left them out of
this PR to keep it scoped to the one reported symptom, and opened #6481 to
track fixing them separately.

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

#### Where applicable:

- [ ] Public APIs match existing style and have Since: line.
- [ ] Any breaking changes have a deprecation path or have been discussed.
- [ ] Check for binary size increases when importing new modules.