### PR TITLE
glfw: fall back to EGL when the native context API cannot supply GLES

### DIFF
--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -840,6 +840,26 @@ func (w *window) create() {
 
 	win, err := glfw.CreateWindow(pixWidth, pixHeight, w.title, nil, nil)
 	if err != nil {
+		// Some platforms cannot supply the requested client API through their
+		// native context API: Windows on ARM exposes no
+		// WGL_EXT_create_context_es2_profile, and Mesa's software renderer
+		// exposes no GLX_EXT_create_context_es2_profile. Both can still reach
+		// it through EGL, so try once more that way before giving up.
+		//
+		// This only runs once the native attempt has already failed, so it
+		// cannot change the outcome for a driver that works today. If EGL
+		// succeeds the hint is left in place, because any later window would
+		// otherwise fail the same way the first one just did.
+		glfw.WindowHint(glfw.ContextCreationAPI, glfw.EGLContextAPI)
+		if eglWin, eglErr := glfw.CreateWindow(pixWidth, pixHeight, w.title, nil, nil); eglErr == nil {
+			win, err = eglWin, nil
+		} else {
+			// Keep reporting the native failure: it names the extension the
+			// platform is missing, which is the actionable half.
+			glfw.WindowHint(glfw.ContextCreationAPI, glfw.NativeContextAPI)
+		}
+	}
+	if err != nil {
 		w.driver.initFailed("window creation error", err)
 		return
 	}


### PR DESCRIPTION
### Description:

On `windows/arm64` the GLES painter is selected by architecture, not by platform, so a desktop Windows-on-ARM binary asks GLFW for an OpenGL ES 2.0 context through **WGL**. That needs `WGL_EXT_create_context_es2_profile` from the display driver, which is an uncommon path on Windows, and where it is missing no window can be created at all. The same shape appears under X11 with Mesa's software renderer, which exposes no `GLX_EXT_create_context_es2_profile` (#4782).

Both platforms can still reach GLES through EGL. This change retries once that way when the native attempt fails.

```go
win, err := glfw.CreateWindow(pixWidth, pixHeight, w.title, nil, nil)
if err != nil {
	glfw.WindowHint(glfw.ContextCreationAPI, glfw.EGLContextAPI)
	if eglWin, eglErr := glfw.CreateWindow(pixWidth, pixHeight, w.title, nil, nil); eglErr == nil {
		win, err = eglWin, nil
	} else {
		glfw.WindowHint(glfw.ContextCreationAPI, glfw.NativeContextAPI)
	}
}
```

Three properties worth calling out, since they are what make this safe:

- **It cannot regress a working driver.** The retry runs only after the platform has already refused to create a window. There is no configuration in which it replaces a context that would otherwise have been created.
- **Diagnostics do not get worse.** If EGL also fails, the reported error stays the original one, because that is the error naming the extension the platform is missing. The hint is reset so a later attempt reports the same way.
- **If EGL succeeds the hint is left set,** since any later window would otherwise fail exactly as the first one did.

`glfw.ContextCreationAPI` and `glfw.EGLContextAPI` already exist in the GLFW binding this repo depends on, and `egl_context.c` is compiled into its Windows build and looks for `libEGL.dll` by name. No new dependency, and no change to the painter selection or to the build tags.

I deliberately did **not** request EGL unconditionally on Windows, which was the shape suggested on #4782. A physical Snapdragon device may well expose the WGL extension, and forcing EGL there would break a working configuration and oblige every application to ship ANGLE. A fallback avoids making that bet in either direction.

Fixes #6483

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.

**On tests, honestly.** I could not find a way to cover this that is worth the code. The branch is reached only when `glfw.CreateWindow` fails, which needs a driver that refuses a GLES context; CI has none, and faking it would mean turning the cgo call into an injectable function variable purely for the test. I am happy to add that seam if you would prefer it, but I did not want to reshape the call site uninvited. Say the word and I will push it.

**On "tests all pass".** `go test ./...` on `darwin/arm64` is green except for `TestDocTabs_ApplyTheme`, which fails identically on unmodified `develop` on this machine. I confirmed that by stashing the change and re-running. It is a golden-image mismatch and unrelated to this PR.

**On verification, and its limits.** `gofmt` clean, `go vet` clean, and `./internal/driver/glfw/...` passes. I have not been able to build for `windows/arm64` here, as I have no cross toolchain on this machine, nor to test on a physical Windows-on-ARM device. The code touches only `window_desktop.go`, whose build tag is `!wasm && !test_web_driver`, and uses only platform-independent symbols from the binding, so I would expect no platform-specific build risk. But I would rather say that than imply I have run it where it matters.

The background evidence, including a second independent report of this failure in a shipping application, is in #6483.
