### PR TITLE
Fix a few bugs with CurrentKeyModifiers

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -132,9 +132,7 @@ func (*gLDriver) Device() fyne.Device {
 
 func (d *gLDriver) Quit() {
 	if curWindow != nil {
-		if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
-			f()
-		}
+		d.handleExitedForeground()
 		curWindow = nil
 		if d.trayStop != nil {
 			d.trayStop()
@@ -144,6 +142,13 @@ func (d *gLDriver) Quit() {
 	// Only call close once to avoid panic.
 	if running.CompareAndSwap(true, false) {
 		close(d.done)
+	}
+}
+
+func (d *gLDriver) handleExitedForeground() {
+	d.currentKeyModifiers = 0
+	if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
+		f()
 	}
 }
 

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -793,9 +793,7 @@ func (w *window) processFocused(focus bool) {
 		}
 
 		curWindow = nil
-		if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnExitedForeground(); f != nil {
-			f()
-		}
+		w.driver.handleExitedForeground()
 	}
 }
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -458,6 +458,7 @@ func (w *window) mouseMoved(_ *glfw.Window, xpos, ypos float64) {
 func (w *window) mouseClicked(_ *glfw.Window, btn glfw.MouseButton, action glfw.Action, mods glfw.ModifierKey) {
 	button, modifiers := convertMouseButton(btn, mods)
 	mouseAction := convertAction(action)
+	w.driver.currentKeyModifiers = modifiers
 
 	w.processMouseClicked(button, mouseAction, modifiers)
 }
@@ -727,10 +728,11 @@ func desktopModifier(mods glfw.ModifierKey) fyne.KeyModifier {
 func desktopModifierCorrected(mods glfw.ModifierKey, key glfw.Key, action glfw.Action) fyne.KeyModifier {
 	// On X11, pressing/releasing modifier keys does not include newly pressed/released keys in 'mod' mask.
 	// https://github.com/glfw/glfw/issues/1630
-	if action == glfw.Press {
-		mods |= glfwKeyToModifier(key)
-	} else {
+	if action == glfw.Release {
 		mods &= ^glfwKeyToModifier(key)
+	} else {
+		// both Press and Repeat actions mean the key is currently held down
+		mods |= glfwKeyToModifier(key)
 	}
 	return desktopModifier(mods)
 }

--- a/internal/driver/glfw/window_test.go
+++ b/internal/driver/glfw/window_test.go
@@ -1889,6 +1889,53 @@ func TestWindow_KeyDownOnRepeat(t *testing.T) {
 	require.Len(t, content.keyDownEvents, 3) // release does not trigger KeyDown
 }
 
+func TestDesktopModifierCorrected_Repeat(t *testing.T) {
+	// A held modifier key auto-repeats; Repeat must be treated the same as Press,
+	// not as a release, or CurrentKeyModifiers() reports the key as released while
+	// it is still physically held (fyne-io/fyne#6486).
+	mods := desktopModifierCorrected(glfw.ModControl, glfw.KeyLeftControl, glfw.Press)
+	assert.Equal(t, fyne.KeyModifierControl, mods)
+
+	mods = desktopModifierCorrected(glfw.ModControl, glfw.KeyLeftControl, glfw.Repeat)
+	assert.Equal(t, fyne.KeyModifierControl, mods, "repeat of a held modifier must still report it as held")
+
+	mods = desktopModifierCorrected(0, glfw.KeyLeftControl, glfw.Release)
+	assert.Equal(t, fyne.KeyModifier(0), mods)
+}
+
+func TestWindow_CurrentKeyModifiers_ResyncOnMouseClick(t *testing.T) {
+	w := createWindow("Test")
+	t.Cleanup(func() { w.driver.currentKeyModifiers = 0 })
+
+	// Simulate a modifier key-up event having been missed, e.g. because it was
+	// released while the window was unfocused, leaving the tracked state stuck "on".
+	w.driver.currentKeyModifiers = fyne.KeyModifierControl
+
+	// GLFW queries the OS for the live modifier state on every mouse click, so a
+	// click should resync our tracked state even without a matching key event.
+	w.mouseClicked(w.viewport, glfw.MouseButton1, glfw.Press, 0)
+
+	assert.Equal(t, fyne.KeyModifier(0), w.driver.currentKeyModifiers)
+}
+
+func TestWindow_CurrentKeyModifiers_ResetOnFocusLost(t *testing.T) {
+	w := createWindow("Test")
+	t.Cleanup(func() {
+		w.driver.currentKeyModifiers = 0
+		curWindow = nil
+	})
+
+	w.processFocused(true)
+	w.driver.currentKeyModifiers = fyne.KeyModifierControl
+
+	// GLFW only delivers key events to a focused window, so a modifier released while
+	// the app is in the background would otherwise never be observed, leaving it
+	// reported as held forever.
+	w.processFocused(false)
+
+	assert.Equal(t, fyne.KeyModifier(0), w.driver.currentKeyModifiers)
+}
+
 func TestWindow_KeyDownOnRepeat_NoFocused(t *testing.T) {
 	w := createWindow("Test")
 	w.SetContent(canvas.NewRectangle(color.Black))


### PR DESCRIPTION
Fixes #6486 

Also synchronizes currentKeyModifiers on mouse click events from GLFW (which carry the freshest key modifier state from the OS), and clear it on app backgrounding, to prevent a held, then unfocus, then released modifier key from being reported as if it were stuck on.

One note is that since we can only sync this info on mouse clicks and key press/release events, the CurrentKeyModifiers API will unavoidably be potentially stale if called after an application is re-focused but before any mouse clicks (an existing unsolvable issue).

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
