### PR TITLE
Don't report entering the foreground before the app runs

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -25,7 +25,13 @@ import (
 	"fyne.io/fyne/v2/storage/repository"
 )
 
-var curWindow *window
+var (
+	curWindow *window
+
+	// set when a window gained focus before the run loop started, so that the
+	// entered foreground hook can be called once the app is really running
+	foregroundPending bool
+)
 
 // Declare conformity with Driver
 var _ fyne.Driver = (*gLDriver)(nil)
@@ -132,14 +138,18 @@ func (*gLDriver) Device() fyne.Device {
 
 func (d *gLDriver) Quit() {
 	if curWindow != nil {
-		if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
-			f()
+		// if the foreground event is still pending then it never ran, so there is nothing to exit
+		if !foregroundPending {
+			if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
+				f()
+			}
 		}
 		curWindow = nil
 		if d.trayStop != nil {
 			d.trayStop()
 		}
 	}
+	foregroundPending = false
 
 	// Only call close once to avoid panic.
 	if running.CompareAndSwap(true, false) {

--- a/internal/driver/glfw/loop.go
+++ b/internal/driver/glfw/loop.go
@@ -130,6 +130,13 @@ func (d *gLDriver) runGL() {
 		f()
 	}
 
+	if foregroundPending {
+		foregroundPending = false
+		if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnEnteredForeground(); f != nil {
+			f()
+		}
+	}
+
 	eventTick := time.NewTicker(time.Second / 60)
 	for {
 		select {

--- a/internal/driver/glfw/window.go
+++ b/internal/driver/glfw/window.go
@@ -777,8 +777,14 @@ func (w *window) processCharInput(char rune) {
 func (w *window) processFocused(focus bool) {
 	if focus {
 		if curWindow == nil {
-			if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnEnteredForeground(); f != nil {
-				f()
+			if running.Load() {
+				if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnEnteredForeground(); f != nil {
+					f()
+				}
+			} else {
+				// Windows reports the first focus during Show(), which is before the run loop
+				// has begun - defer to runGL so the hook cannot precede the started hook
+				foregroundPending = true
 			}
 		}
 		curWindow = w
@@ -806,8 +812,13 @@ func (w *window) processFocused(focus bool) {
 		}
 
 		curWindow = nil
-		if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnExitedForeground(); f != nil {
-			f()
+		if running.Load() {
+			if f := fyne.CurrentApp().Lifecycle().(*app.Lifecycle).OnExitedForeground(); f != nil {
+				f()
+			}
+		} else {
+			// an app that lost the focus again before it started running was never in the foreground
+			foregroundPending = false
 		}
 	}
 }


### PR DESCRIPTION
On Windows glfw delivers the first focus event synchronously inside `view.Show()`, so `SetOnEnteredForeground` fired before `Run()`, and before the started hook. On macOS it arrives through the platform queue and isn't seen until the loop is polling, so the bug is Windows-only.

`processFocused` now calls the foreground hooks only while the driver is running; a focus gained earlier is held in a pending flag and replayed by `runGL` after the started hook. `Quit` clears a pending event instead of reporting a foreground exit that never had an entry. On Windows 11 the issue's reproducer now prints "started!" before "foreground!", and alt-tabbing still works.

No test for the pre-run branch, `TestMain` calls `d.Run()`, so reaching it means flipping a package global under a live run loop, which looked more flaky than useful. Happy to add one if you'd rather.

Fixes #5848
