### PR TITLE
perf(painter/software): add direct scanline fast-path for opaque solid rectangle fills

### DIFF
--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -415,6 +415,24 @@ func drawOblong(c fyne.Canvas, obj fyne.CanvasObject, fill, stroke color.Color, 
 		drawShadow(c, obj, fyne.NewSize(width, height), shadow, 0, base, clip, pos)
 	}
 
+	if fill != nil {
+		r, g, b, a := fill.RGBA()
+		if a == 0xFFFF && bounds.Dx() > 0 && bounds.Dy() > 0 {
+			nr, ng, nb := uint8(r>>8), uint8(g>>8), uint8(b>>8)
+			for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+				off := base.PixOffset(bounds.Min.X, y)
+				endOff := base.PixOffset(bounds.Max.X, y)
+				for p := off; p < endOff; p += 4 {
+					base.Pix[p] = nr
+					base.Pix[p+1] = ng
+					base.Pix[p+2] = nb
+					base.Pix[p+3] = 0xFF
+				}
+			}
+			return
+		}
+	}
+
 	draw.Draw(base, bounds, image.NewUniform(fill), image.Point{}, draw.Over)
 }
 

--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -417,6 +417,9 @@ func drawOblong(c fyne.Canvas, obj fyne.CanvasObject, fill, stroke color.Color, 
 
 	if fill != nil {
 		r, g, b, a := fill.RGBA()
+		// Opaque axis-aligned fill (no stroke, no radius): write pixels directly.
+		// The draw.Draw(Uniform, Over) path allocates and does per-pixel Porter-Duff
+		// for a source that completely replaces the destination.
 		if a == 0xFFFF && bounds.Dx() > 0 && bounds.Dy() > 0 {
 			nr, ng, nb := uint8(r>>8), uint8(g>>8), uint8(b>>8)
 			for y := bounds.Min.Y; y < bounds.Max.Y; y++ {

--- a/internal/painter/software/draw_bench_test.go
+++ b/internal/painter/software/draw_bench_test.go
@@ -1,0 +1,47 @@
+package software
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+
+	"golang.org/x/image/draw"
+)
+
+// benchCanvas implements only Scale; drawOblong does not call other Canvas methods.
+type benchCanvas struct {
+	fyne.Canvas
+}
+
+func (benchCanvas) Scale() float32 { return 1 }
+
+func setupOblongBench(fill color.Color) (fyne.Canvas, *canvas.Rectangle, *image.NRGBA, image.Rectangle) {
+	const w, h = 1280, 800
+	rect := canvas.NewRectangle(fill)
+	rect.Resize(fyne.NewSize(float32(w), float32(h)))
+	base := image.NewNRGBA(image.Rect(0, 0, w, h))
+	clip := base.Rect
+	return benchCanvas{}, rect, base, clip
+}
+
+func BenchmarkDrawRectangle_opaqueScanline(b *testing.B) {
+	c, rect, base, clip := setupOblongBench(color.NRGBA{R: 0x33, G: 0x33, B: 0x33, A: 0xff})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drawRectangle(c, rect, fyne.NewPos(0, 0), base, clip)
+	}
+}
+
+func BenchmarkDrawRectangle_opaqueUniformOver(b *testing.B) {
+	fill := color.NRGBA{R: 0x33, G: 0x33, B: 0x33, A: 0xff}
+	_, _, base, clip := setupOblongBench(fill)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		draw.Draw(base, clip, image.NewUniform(fill), image.Point{}, draw.Over)
+	}
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/fyne-io/fyne/blob/develop/CONTRIBUTING.md) guide.
- [x] I have formatted my code using `gofumpt` and executed all relevant tests.

### Summary

This PR addresses #6501 by introducing an optimized direct scanline fast-path for opaque solid color rectangles (`canvas.Rectangle`, container backgrounds, headers) in the software renderer (`internal/painter/software`).

### Motivation

Currently, drawing solid opaque rectangles in `drawOblong()` invokes `draw.Draw(base, bounds, image.NewUniform(fill), image.Point{}, draw.Over)`.
For fully opaque solid colors (alpha = 0xFFFF), the general `draw.Draw` loop incurs unnecessary per-pixel composition overhead and allocates a `image.Uniform` wrapper.

### Changes

- Add a direct scanline slice pixel assignment loop in `drawOblong` when `fill` is fully opaque and bounds are unstroked/unrounded.
- Bypass mask and uniform allocations during solid rectangle fills.
- Validated with all existing software painter visual tests (`go test -v ./internal/painter/software`).

Fixes #6501