### PR TITLE
Don't offset table scrolling by the header size

### DIFF
--- a/widget/table.go
+++ b/widget/table.go
@@ -507,16 +507,14 @@ func (t *Table) ScrollTo(id TableCellID) {
 
 	scrollPos := t.offset
 
+	// the scroll offset is measured in cell space, where the first cell starts at zero.
+	// Any header is outside the scrolling content, so it must not be added here, but the
+	// sticky cells cover the leading edge of the viewport so they do have to be allowed for.
 	cellX, cellWidth := t.findX(id.Col)
-	stickCols := t.StickyColumnCount
-	if stickCols > 0 {
-		cellX -= t.stuckXOff + t.stuckWidth
+	if t.StickyColumnCount > 0 {
+		cellX -= t.stuckWidth
 	}
-	if t.ShowHeaderColumn {
-		cellX += t.headerSize.Width
-		stickCols--
-	}
-	if stickCols == 0 || id.Col > stickCols {
+	if id.Col >= t.StickyColumnCount {
 		if cellX < scrollPos.X {
 			scrollPos.X = cellX
 		} else if cellX+cellWidth > scrollPos.X+t.content.Size().Width {
@@ -525,15 +523,10 @@ func (t *Table) ScrollTo(id TableCellID) {
 	}
 
 	cellY, cellHeight := t.findY(id.Row)
-	stickRows := t.StickyRowCount
-	if stickRows > 0 {
-		cellY -= t.stuckYOff + t.stuckHeight
+	if t.StickyRowCount > 0 {
+		cellY -= t.stuckHeight
 	}
-	if t.ShowHeaderRow {
-		cellY += t.headerSize.Height
-		stickRows--
-	}
-	if stickRows == 0 || id.Row >= stickRows {
+	if id.Row >= t.StickyRowCount {
 		if cellY < scrollPos.Y {
 			scrollPos.Y = cellY
 		} else if cellY+cellHeight > scrollPos.Y+t.content.Size().Height {

--- a/widget/table.go
+++ b/widget/table.go
@@ -495,10 +495,14 @@ func (t *Table) ScrollTo(id TableCellID) {
 	rows, cols := t.Length()
 	if id.Row >= rows {
 		id.Row = rows - 1
+	} else if id.Row < 0 {
+		id.Row = 0
 	}
 
 	if id.Col >= cols {
 		id.Col = cols - 1
+	} else if id.Col < 0 {
+		id.Col = 0
 	}
 
 	scrollPos := t.offset

--- a/widget/table_internal_test.go
+++ b/widget/table_internal_test.go
@@ -217,7 +217,7 @@ func TestTable_Sticky(t *testing.T) {
 	table.ScrollTo(TableCellID{Row: 7, Col: 2})
 	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 6,1"))
 	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 6,2"))
-	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 9,3"))
+	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 8,3"))
 	assert.True(t, areaContainsLabel(table.top.Content.(*fyne.Container).Objects, "C"))
 	assert.True(t, areaContainsLabel(table.top.Content.(*fyne.Container).Objects, "D"))
 	assert.True(t, areaContainsLabel(table.left.Content.(*fyne.Container).Objects, "7"))
@@ -227,8 +227,8 @@ func TestTable_Sticky(t *testing.T) {
 	table.StickyColumnCount = 1
 	table.Refresh()
 	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 7,2"))
-	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 7,4"))
-	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 9,3"))
+	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 7,3"))
+	assert.True(t, areaContainsLabel(cellRenderer.Objects(), "text 8,3"))
 	// stuck cells
 	assert.True(t, areaContainsLabel(table.top.Content.(*fyne.Container).Objects, "text 0,3"))
 	assert.True(t, areaContainsLabel(table.left.Content.(*fyne.Container).Objects, "text 7,0"))
@@ -1023,4 +1023,89 @@ func areaContainsLabel(list []fyne.CanvasObject, text string) bool {
 		}
 	}
 	return false
+}
+
+func TestTable_ScrollTo_Headers(t *testing.T) {
+	test.NewTempApp(t)
+
+	// for this test the separator thickness is 0
+	test.ApplyTheme(t, &paddingZeroTheme{test.Theme()})
+
+	// we will test a 20 row x 5 column table where each cell is 50x50
+	// and any header row or column is 30x30
+	const (
+		maxRows int     = 20
+		maxCols int     = 5
+		cell    float32 = 50
+		header  float32 = 30
+	)
+
+	newTable := func(setup func(*Table)) *Table {
+		templ := canvas.NewRectangle(color.Gray16{})
+		templ.SetMinSize(fyne.Size{Width: cell, Height: cell})
+
+		table := NewTable(
+			func() (int, int) { return maxRows, maxCols },
+			func() fyne.CanvasObject { return templ },
+			func(TableCellID, fyne.CanvasObject) {},
+		)
+		table.CreateHeader = func() fyne.CanvasObject { return canvas.NewRectangle(color.Gray16{}) }
+		table.UpdateHeader = func(TableCellID, fyne.CanvasObject) {}
+		setup(table)
+		table.SetColumnWidth(-1, header)
+		table.SetRowHeight(-1, header)
+		return table
+	}
+
+	// the window ends up the size of one cell plus any header and sticky cells,
+	// so the scrolling viewport is always exactly one cell in each direction.
+	tt := []struct {
+		name  string
+		setup func(*Table)
+		steps []TableCellID
+		want  fyne.Position
+	}{
+		{
+			"header row does not shift the offset when scrolling back",
+			func(table *Table) { table.ShowHeaderRow = true },
+			[]TableCellID{{Row: 10}, {}},
+			fyne.Position{},
+		},
+		{
+			"header column does not shift the offset when scrolling back",
+			func(table *Table) { table.ShowHeaderColumn = true },
+			[]TableCellID{{Col: 4}, {}},
+			fyne.Position{},
+		},
+		{
+			"first non-sticky column is scrolled into view",
+			func(table *Table) { table.StickyColumnCount = 2 },
+			[]TableCellID{{Col: 4}, {Col: 2}},
+			fyne.Position{},
+		},
+		{
+			"sticky row is never scrolled to",
+			func(table *Table) {
+				table.ShowHeaderRow = true
+				table.StickyRowCount = 2
+			},
+			[]TableCellID{{Row: 10}, {Row: 1}},
+			fyne.Position{Y: 8 * cell},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			table := newTable(tc.setup)
+			w := test.NewWindow(table)
+			defer w.Close()
+
+			for _, id := range tc.steps {
+				table.ScrollTo(id)
+			}
+
+			assert.Equal(t, tc.want, table.offset)
+			assert.Equal(t, tc.want, table.content.Offset)
+		})
+	}
 }


### PR DESCRIPTION
### Description:

A `Table` with `ShowHeaderRow` set can never scroll back to row 0 using keyboard navigation — the row ends up hidden underneath the header. The same applies to column 0 with `ShowHeaderColumn`.

The scroll offset is measured in cell space, where the first cell starts at zero: `tableRenderer.Layout` moves the scrolling content below the header and shrinks it, so the header is not part of that space. `ScrollTo` was adding the header size to the target position anyway, so every scroll overshot by exactly that amount, and scrolling back to the first cell left an offset of one header instead of zero.

Measured with 50x50 cells, a 30x30 header and zero padding, scrolling far away and then back to cell (0, 0):

| configuration | before | after |
| --- | --- | --- |
| `ShowHeaderRow` | `{0, 30}` | `{0, 0}` |
| `ShowHeaderColumn` | `{30, 0}` | `{0, 0}` |
| both headers | `{30, 30}` | `{0, 0}` |
| `StickyRowCount = 2` (no header) | `{0, 0}` | `{0, 0}` |
| `StickyRowCount = 2` + header | `{0, 0}` | `{0, 0}` |

The subtraction of `stuckYOff`/`stuckXOff` and the decrements of the sticky counts only cancelled that addition out when a header and sticky cells were used together, so they are removed with it and the two axes end up symmetrical.

Two things fall out of that which are worth calling out separately:

**An off-by-one the decrements were hiding.** Columns tested `id.Col > stickCols` where rows tested `id.Row >= stickRows`. Without a header column, `StickyColumnCount = 2` meant `ScrollTo` refused to scroll to column 2, the first non-sticky one; with a header column the decrement accidentally corrected it. The reverse case is worse: with a header row and `StickyRowCount = 2`, `ScrollTo` on the *sticky* row 1 scrolled the table, although that row is permanently visible. Both are gone now. Happy to split this out if you would rather keep the change to #5088 alone.

**Three assertions in `TestTable_Sticky` changed.** After `ScrollTo({Row: 7, Col: 2})` the offset is now `{43.41, 223.70}`, which is the smallest offset that puts cell (7, 2) fully in view; it used to be `{75.44, 258.78}`, one header further. The assertions on `text 9,3` and `text 7,4` were naming cells that were only visible because of the overshoot, and now name `text 8,3` and `text 7,3`. The assertions on the target cell, the sticky panes and the corner are untouched and still pass.

Negative row and column IDs are clamped in a separate commit: `ScrollTo` already clamped IDs past the last row or column, and the guards after this change need the lower bound clamped too.

Fixes #5088

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
