### PR TITLE
Deprecate fyne.Min and fyne.Max in favor of Go 1.21 builtins

### DIFF
--- a/canvas/line.go
+++ b/canvas/line.go
@@ -51,7 +51,7 @@ func (l *Line) Resize(size fyne.Size) {
 
 // Position gets the current top-left position of this line object, relative to its parent / canvas
 func (l *Line) Position() fyne.Position {
-	return fyne.NewPos(fyne.Min(l.Position1.X, l.Position2.X), fyne.Min(l.Position1.Y, l.Position2.Y))
+	return fyne.NewPos(min(l.Position1.X, l.Position2.X), min(l.Position1.Y, l.Position2.Y))
 }
 
 // Move the line object to a new position, relative to its parent / canvas

--- a/container.go
+++ b/container.go
@@ -107,7 +107,7 @@ func (c *Container) MinSize() Size {
 	for _, child := range c.Objects {
 		// inlined internal.MaxSizes, which this package cannot import
 		childMin := child.MinSize()
-		minSize = NewSize(Max(minSize.Width, childMin.Width), Max(minSize.Height, childMin.Height))
+		minSize = NewSize(max(minSize.Width, childMin.Width), max(minSize.Height, childMin.Height))
 	}
 
 	return minSize

--- a/container/doctabs.go
+++ b/container/doctabs.go
@@ -427,16 +427,16 @@ func (r *docTabsRenderer) updateIndicator(animate bool) {
 	switch r.docTabs.location {
 	case TabLocationTop:
 		indicatorPos = fyne.NewPos(selectedPos.X-scrollOffset.X, r.bar.MinSize().Height)
-		indicatorSize = fyne.NewSize(fyne.Min(selectedSize.Width, scrollSize.Width-indicatorPos.X), dividerWidth)
+		indicatorSize = fyne.NewSize(min(selectedSize.Width, scrollSize.Width-indicatorPos.X), dividerWidth)
 	case TabLocationLeading:
 		indicatorPos = fyne.NewPos(r.bar.MinSize().Width, selectedPos.Y-scrollOffset.Y)
-		indicatorSize = fyne.NewSize(dividerWidth, fyne.Min(selectedSize.Height, scrollSize.Height-indicatorPos.Y))
+		indicatorSize = fyne.NewSize(dividerWidth, min(selectedSize.Height, scrollSize.Height-indicatorPos.Y))
 	case TabLocationBottom:
 		indicatorPos = fyne.NewPos(selectedPos.X-scrollOffset.X, r.bar.Position().Y-pad)
-		indicatorSize = fyne.NewSize(fyne.Min(selectedSize.Width, scrollSize.Width-indicatorPos.X), dividerWidth)
+		indicatorSize = fyne.NewSize(min(selectedSize.Width, scrollSize.Width-indicatorPos.X), dividerWidth)
 	case TabLocationTrailing:
 		indicatorPos = fyne.NewPos(r.bar.Position().X-pad, selectedPos.Y-scrollOffset.Y)
-		indicatorSize = fyne.NewSize(dividerWidth, fyne.Min(selectedSize.Height, scrollSize.Height-indicatorPos.Y))
+		indicatorSize = fyne.NewSize(dividerWidth, min(selectedSize.Height, scrollSize.Height-indicatorPos.Y))
 	}
 
 	if indicatorPos.X < 0 {

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -236,7 +236,7 @@ func (i *innerWindowRenderer) MinSize() fyne.Size {
 	contentMin := i.win.Content.MinSize()
 	barHeight := th.Size(theme.SizeNameWindowTitleBarHeight)
 
-	innerWidth := fyne.Max(i.bar.MinSize().Width, contentMin.Width)
+	innerWidth := max(i.bar.MinSize().Width, contentMin.Width)
 
 	return fyne.NewSize(innerWidth+pad*2, contentMin.Height+pad+barHeight)
 }
@@ -478,5 +478,5 @@ func (t *titleBarLayout) MinSize(_ []fyne.CanvasObject) fyne.Size {
 	titleMin := t.title.MinSize() // can truncate
 
 	return fyne.NewSize(buttonMin.Width+iconMin.Width+titleMin.Width,
-		fyne.Max(fyne.Max(buttonMin.Height, iconMin.Height), titleMin.Height))
+		max(max(buttonMin.Height, iconMin.Height), titleMin.Height))
 }

--- a/container/split.go
+++ b/container/split.go
@@ -156,9 +156,9 @@ func (r *splitContainerRenderer) MinSize() fyne.Size {
 		minSize := o.MinSize()
 		if r.split.Horizontal {
 			s.Width += minSize.Width
-			s.Height = fyne.Max(s.Height, minSize.Height)
+			s.Height = max(s.Height, minSize.Height)
 		} else {
-			s.Width = fyne.Max(s.Width, minSize.Width)
+			s.Width = max(s.Width, minSize.Width)
 			s.Height += minSize.Height
 		}
 	}

--- a/container/split_test.go
+++ b/container/split_test.go
@@ -23,11 +23,11 @@ func TestSplitContainer_MinSize(t *testing.T) {
 	t.Run("Horizontal", func(t *testing.T) {
 		minSize := NewHSplit(rectA, rectB).MinSize()
 		assert.Equal(t, rectA.MinSize().Width+rectB.MinSize().Width+dividerThickness(nil), minSize.Width)
-		assert.Equal(t, fyne.Max(rectA.MinSize().Height, fyne.Max(rectB.MinSize().Height, dividerLength(nil))), minSize.Height)
+		assert.Equal(t, max(rectA.MinSize().Height, max(rectB.MinSize().Height, dividerLength(nil))), minSize.Height)
 	})
 	t.Run("Vertical", func(t *testing.T) {
 		minSize := NewVSplit(rectA, rectB).MinSize()
-		assert.Equal(t, fyne.Max(rectA.MinSize().Width, fyne.Max(rectB.MinSize().Width, dividerLength(nil))), minSize.Width)
+		assert.Equal(t, max(rectA.MinSize().Width, max(rectB.MinSize().Width, dividerLength(nil))), minSize.Width)
 		assert.Equal(t, rectA.MinSize().Height+rectB.MinSize().Height+dividerThickness(nil), minSize.Height)
 	})
 }
@@ -263,9 +263,9 @@ func TestSplitContainer_swap_contents(t *testing.T) {
 	dl := dividerLength(nil)
 	dt := dividerThickness(nil)
 	initialWidth := 10 + 10 + dt
-	initialHeight := fyne.Max(10, dl)
+	initialHeight := max(10, dl)
 	expectedWidth := 100 + 10 + dt
-	expectedHeight := fyne.Max(100, dl)
+	expectedHeight := max(100, dl)
 
 	objA := canvas.NewRectangle(color.NRGBA{0, 0, 0, 0})
 	objA.SetMinSize(fyne.NewSize(10, 10))

--- a/container/tabs.go
+++ b/container/tabs.go
@@ -425,9 +425,9 @@ func (r *baseTabsRenderer) minSize(t baseTabs) fyne.Size {
 	switch t.tabLocation() {
 	case TabLocationLeading, TabLocationTrailing:
 		return fyne.NewSize(barMin.Width+contentMin.Width+pad,
-			fyne.Max(contentMin.Height, accessoryMin.Height+buttonPad+tabsMin.Height))
+			max(contentMin.Height, accessoryMin.Height+buttonPad+tabsMin.Height))
 	default:
-		return fyne.NewSize(fyne.Max(contentMin.Width, accessoryMin.Width+buttonPad+tabsMin.Width),
+		return fyne.NewSize(max(contentMin.Width, accessoryMin.Width+buttonPad+tabsMin.Width),
 			barMin.Height+contentMin.Height+pad)
 	}
 }
@@ -662,7 +662,7 @@ func (r *tabButtonRenderer) MinSize() fyne.Size {
 	iconSize := r.iconSize()
 	padding := th.Size(theme.SizeNamePadding)
 	if r.button.iconPosition == buttonIconTop {
-		contentWidth = fyne.Max(textSize.Width, iconSize)
+		contentWidth = max(textSize.Width, iconSize)
 		if r.icon.Visible() {
 			contentHeight += iconSize - padding*2
 		}
@@ -673,7 +673,7 @@ func (r *tabButtonRenderer) MinSize() fyne.Size {
 			contentHeight += textSize.Height
 		}
 	} else {
-		contentHeight = fyne.Max(textSize.Height, iconSize)
+		contentHeight = max(textSize.Height, iconSize)
 		if r.icon.Visible() {
 			contentWidth += iconSize
 		}
@@ -687,7 +687,7 @@ func (r *tabButtonRenderer) MinSize() fyne.Size {
 	if r.button.onClosed != nil {
 		inlineIconSize := th.Size(theme.SizeNameInlineIcon)
 		contentWidth += inlineIconSize + padding
-		contentHeight = fyne.Max(contentHeight, inlineIconSize)
+		contentHeight = max(contentHeight, inlineIconSize)
 	}
 	return fyne.NewSize(contentWidth, contentHeight).Add(r.padding())
 }

--- a/dialog/base.go
+++ b/dialog/base.go
@@ -258,7 +258,7 @@ func (*dialogLayout) MinSize(obj []fyne.CanvasObject) fyne.Size {
 	btnMin := obj[3].MinSize()
 	labelMin := obj[4].MinSize()
 
-	width := fyne.Max(fyne.Max(contentMin.Width, btnMin.Width), labelMin.Width) + padWidth
+	width := max(max(contentMin.Width, btnMin.Width), labelMin.Width) + padWidth
 	height := contentMin.Height + btnMin.Height + labelMin.Height + theme.Padding() + padHeight*2
 
 	return fyne.NewSize(width, height)

--- a/dialog/color_channel.go
+++ b/dialog/color_channel.go
@@ -108,7 +108,7 @@ func (r *colorChannelRenderer) MinSize() fyne.Size {
 	eMin := r.entry.MinSize()
 	return fyne.NewSize(
 		lMin.Width+sMin.Width+eMin.Width,
-		fyne.Max(lMin.Height, fyne.Max(sMin.Height, eMin.Height)),
+		max(lMin.Height, max(sMin.Height, eMin.Height)),
 	)
 }
 

--- a/dialog/text.go
+++ b/dialog/text.go
@@ -39,7 +39,7 @@ func createBeforeShowHook(d *dialog, message string) func() {
 	return func() {
 		if d.desiredSize.IsZero() {
 			maxWinWitth := d.parent.Canvas().Size().Width * maxTextDialogWinPcntWidth
-			w := fyne.Min(fyne.Min(noWrapWidth, maxTextDialogAbsoluteWidth), maxWinWitth)
+			w := min(min(noWrapWidth, maxTextDialogAbsoluteWidth), maxWinWitth)
 			d.desiredSize = fyne.NewSize(w, d.MinSize().Height)
 		}
 	}

--- a/geometry.go
+++ b/geometry.go
@@ -127,8 +127,8 @@ func (s Size) IsZero() bool {
 func (s Size) Max(v Vector2) Size {
 	x, y := v.Components()
 
-	maxW := Max(s.Width, x)
-	maxH := Max(s.Height, y)
+	maxW := max(s.Width, x)
+	maxH := max(s.Height, y)
 
 	return NewSize(maxW, maxH)
 }
@@ -137,8 +137,8 @@ func (s Size) Max(v Vector2) Size {
 func (s Size) Min(v Vector2) Size {
 	x, y := v.Components()
 
-	minW := Min(s.Width, x)
-	minH := Min(s.Height, y)
+	minW := min(s.Width, x)
+	minH := min(s.Height, y)
 
 	return NewSize(minW, minH)
 }

--- a/internal/driver/glfw/menu_bar.go
+++ b/internal/driver/glfw/menu_bar.go
@@ -129,7 +129,7 @@ type menuBarRenderer struct {
 func (r *menuBarRenderer) Layout(size fyne.Size) {
 	minSize := r.MinSize()
 	if size.Height != minSize.Height || size.Width < minSize.Width {
-		r.b.Resize(fyne.NewSize(fyne.Max(size.Width, minSize.Width), minSize.Height))
+		r.b.Resize(fyne.NewSize(max(size.Width, minSize.Width), minSize.Height))
 		return
 	}
 

--- a/internal/driver/glfw/window_desktop.go
+++ b/internal/driver/glfw/window_desktop.go
@@ -829,11 +829,11 @@ func (w *window) create() {
 	}
 
 	pixWidth, pixHeight := w.screenSize(w.canvas.size)
-	pixWidth = int(fyne.Max(float32(pixWidth), float32(w.width)))
+	pixWidth = int(max(float32(pixWidth), float32(w.width)))
 	if pixWidth == 0 {
 		pixWidth = fallbackScreenSize
 	}
-	pixHeight = int(fyne.Max(float32(pixHeight), float32(w.height)))
+	pixHeight = int(max(float32(pixHeight), float32(w.height)))
 	if pixHeight == 0 {
 		pixHeight = fallbackScreenSize
 	}

--- a/internal/driver/glfw/window_wasm.go
+++ b/internal/driver/glfw/window_wasm.go
@@ -535,11 +535,11 @@ func (w *window) create() {
 	initWindowHints()
 
 	pixWidth, pixHeight := w.screenSize(w.canvas.size)
-	pixWidth = int(fyne.Max(float32(pixWidth), float32(w.width)))
+	pixWidth = int(max(float32(pixWidth), float32(w.width)))
 	if pixWidth == 0 {
 		pixWidth = 10
 	}
-	pixHeight = int(fyne.Max(float32(pixHeight), float32(w.height)))
+	pixHeight = int(max(float32(pixHeight), float32(w.height)))
 	if pixHeight == 0 {
 		pixHeight = 10
 	}

--- a/internal/geometry.go
+++ b/internal/geometry.go
@@ -6,11 +6,11 @@ import "fyne.io/fyne/v2"
 // fyne.Size.Max does, minus boxing the argument into the Vector2 parameter,
 // which heap-allocates in per-frame layout code.
 func MaxSizes(a, b fyne.Size) fyne.Size {
-	return fyne.Size{Width: fyne.Max(a.Width, b.Width), Height: fyne.Max(a.Height, b.Height)}
+	return fyne.Size{Width: max(a.Width, b.Width), Height: max(a.Height, b.Height)}
 }
 
 // MinSizes returns the element-wise minimum of the two sizes, allocation-free
 // like MaxSizes.
 func MinSizes(a, b fyne.Size) fyne.Size {
-	return fyne.Size{Width: fyne.Min(a.Width, b.Width), Height: fyne.Min(a.Height, b.Height)}
+	return fyne.Size{Width: min(a.Width, b.Width), Height: min(a.Height, b.Height)}
 }

--- a/internal/painter/draw.go
+++ b/internal/painter/draw.go
@@ -35,9 +35,9 @@ func DrawArc(arc *canvas.Arc, vectorPad float32, scale func(float32) float32) *i
 	centerX := float64(width) / 2
 	centerY := float64(height) / 2
 
-	outerRadius := fyne.Min(size.Width, size.Height) / 2
+	outerRadius := min(size.Width, size.Height) / 2
 	innerRadius := float32(float64(outerRadius) * math.Min(1.0, math.Max(0.0, float64(arc.CutoutRatio))))
-	cornerRadius := fyne.Min(GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)
+	cornerRadius := min(GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)
 	startAngle, endAngle := NormalizeArcAngles(arc.StartAngle, arc.EndAngle)
 
 	// convert to radians
@@ -159,8 +159,8 @@ func DrawPolygon(polygon *canvas.RegularPolygon, vectorPad float32, scale func(f
 
 	width := int(scale(size.Width + vectorPad*2))
 	height := int(scale(size.Height + vectorPad*2))
-	outerRadius := scale(fyne.Min(size.Width, size.Height) / 2)
-	cornerRadius := scale(fyne.Min(GetMaximumRadius(size), polygon.CornerRadius))
+	outerRadius := scale(min(size.Width, size.Height) / 2)
+	cornerRadius := scale(min(GetMaximumRadius(size), polygon.CornerRadius))
 	sides := int(polygon.Sides)
 	angle := polygon.Angle
 
@@ -194,7 +194,7 @@ func DrawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, vectorPad float32, s
 	width := int(scale(size.Width + vectorPad*2))
 	height := int(scale(size.Height + vectorPad*2))
 	vertices := polygon.Points
-	numPoints := int(fyne.Min(ArbitraryPolygonVerticesMaximum, float32(len(vertices))))
+	numPoints := int(min(ArbitraryPolygonVerticesMaximum, float32(len(vertices))))
 
 	raw := image.NewRGBA(image.Rect(0, 0, width, height))
 	scanner := rasterx.NewScannerGV(int(size.Width), int(size.Height), raw, raw.Bounds())
@@ -204,7 +204,7 @@ func DrawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, vectorPad float32, s
 	}
 
 	clampPoint := func(p fyne.Position) (float32, float32) {
-		return fyne.Min(fyne.Max(p.X, 0), fyne.Max(size.Width, 0)), fyne.Min(fyne.Max(p.Y, 0), fyne.Max(size.Height, 0))
+		return min(max(p.X, 0), max(size.Width, 0)), min(max(p.Y, 0), max(size.Height, 0))
 	}
 
 	xScaled := make([]float64, numPoints)
@@ -857,7 +857,7 @@ func GetCornerRadius(perCornerRadius, baseCornerRadius float32) float32 {
 //
 // This is typically used for drawing circular corners in rectangles, circles or squares with the same radius for all corners.
 func GetMaximumRadius(size fyne.Size) float32 {
-	return fyne.Min(size.Height, size.Width) / 2
+	return min(size.Height, size.Width) / 2
 }
 
 // GetMaximumCornerRadius returns the maximum possible corner radius for an individual corner,
@@ -870,16 +870,16 @@ func GetMaximumCornerRadius(radius, adjacentWidthRadius, adjacentHeightRadius fl
 	maxWidthRadius := size.Width / 2
 	maxHeightRadius := size.Height / 2
 	// fast path: corner radius fits within both per-axis maxima
-	if radius <= fyne.Min(maxWidthRadius, maxHeightRadius) {
+	if radius <= min(maxWidthRadius, maxHeightRadius) {
 		return radius
 	}
 	// expand per-axis limits by borrowing any unused capacity from adjacent corners
-	expandedMaxWidthRadius := 2*maxWidthRadius - fyne.Min(maxWidthRadius, adjacentWidthRadius)
-	expandedMaxHeightRadius := 2*maxHeightRadius - fyne.Min(maxHeightRadius, adjacentHeightRadius)
+	expandedMaxWidthRadius := 2*maxWidthRadius - min(maxWidthRadius, adjacentWidthRadius)
+	expandedMaxHeightRadius := 2*maxHeightRadius - min(maxHeightRadius, adjacentHeightRadius)
 
 	// respect the smaller axis and never exceed the requested radius
-	expandedMaxRadius := fyne.Min(expandedMaxWidthRadius, expandedMaxHeightRadius)
-	return fyne.Min(expandedMaxRadius, radius)
+	expandedMaxRadius := min(expandedMaxWidthRadius, expandedMaxHeightRadius)
+	return min(expandedMaxRadius, radius)
 }
 
 // GetMaximumRadiusArc returns the maximum possible corner radius for an arc segment based on the outer radius,
@@ -913,7 +913,7 @@ func NormalizeArcAngles(startAngle, endAngle float32) (normalizedStartAngle, nor
 // and they are identical, only one is added if it is not coincident with the start or end.
 func NormalizeBezierCurvePoints(startPoint, endPoint fyne.Position, controlPoints []fyne.Position, size fyne.Size, offset float32) (normalizedStart, normalizedEnd fyne.Position, control []fyne.Position) {
 	clampPoint := func(p fyne.Position) (float32, float32) {
-		return fyne.Min(fyne.Max(p.X, offset), fyne.Max(size.Width-offset, 0)), fyne.Min(fyne.Max(p.Y, offset), fyne.Max(size.Height-offset, 0))
+		return min(max(p.X, offset), max(size.Width-offset, 0)), min(max(p.Y, offset), max(size.Height-offset, 0))
 	}
 	p1x, p1y := clampPoint(startPoint)
 	p2x, p2y := clampPoint(endPoint)

--- a/internal/painter/gl/draw.go
+++ b/internal/painter/gl/draw.go
@@ -165,7 +165,7 @@ func (p *painter) drawBlur(b *canvas.Blur, pos fyne.Position, frame fyne.Size) {
 	p.ctx.BlendFunc(one, oneMinusSrcAlpha)
 	p.logError()
 
-	cornerRadius := fyne.Min(paint.GetMaximumRadius(b.Size()), b.CornerRadius)
+	cornerRadius := min(paint.GetMaximumRadius(b.Size()), b.CornerRadius)
 	p.SetUniform1f(p.programs.blur, attrRadiusCorner, roundToPixel(cornerRadius*p.pixScale, 1.0))
 	p.SetUniform2f(p.programs.blur, attrSize, float32(bw), float32(bh))
 
@@ -326,7 +326,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
 	// ensure stroke width is not larger than the size of the object
-	strokeWidth := fyne.Min(bezierCurve.StrokeWidth, fyne.Min(bezierCurve.Size().Width, bezierCurve.Size().Height))
+	strokeWidth := min(bezierCurve.StrokeWidth, min(bezierCurve.Size().Width, bezierCurve.Size().Height))
 	if strokeWidth < 1 {
 		strokeWidth = 1
 	}
@@ -348,7 +348,7 @@ func (p *painter) drawBezierCurve(bezierCurve *canvas.BezierCurve, pos fyne.Posi
 		cp2XScaled, cp2YScaled := roundToPixel(cp[1].X*p.pixScale, 1.0), roundToPixel(cp[1].Y*p.pixScale, 1.0)
 		p.SetUniform2f(program, attrPointControl2, cp2XScaled, cp2YScaled)
 	}
-	p.SetUniform1f(program, attrPointControlCount, fyne.Min(float32(len(cp)), 2))
+	p.SetUniform1f(program, attrPointControlCount, min(float32(len(cp)), 2))
 
 	strokeWidthScaled := roundToPixel(strokeWidth*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrStrokeWidthHalf, strokeWidthScaled*0.5)
@@ -389,12 +389,12 @@ func (p *painter) drawArbitraryPolygon(polygon *canvas.ArbitraryPolygon, pos fyn
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
-	numPoints := int(fyne.Min(paint.ArbitraryPolygonVerticesMaximum, float32(len(polygon.Points))))
+	numPoints := int(min(paint.ArbitraryPolygonVerticesMaximum, float32(len(polygon.Points))))
 	p.SetUniform1f(program, attrVertexCount, float32(numPoints))
 
 	size := polygon.Size()
 	clampPoint := func(p fyne.Position) (float32, float32) {
-		return fyne.Min(fyne.Max(p.X, 0), fyne.Max(size.Width, 0)), fyne.Min(fyne.Max(p.Y, 0), fyne.Max(size.Height, 0))
+		return min(max(p.X, 0), max(size.Width, 0)), min(max(p.Y, 0), max(size.Height, 0))
 	}
 
 	fixedPoints := make([]fyne.Position, numPoints)
@@ -715,14 +715,14 @@ func (p *painter) drawPolygon(polygon *canvas.RegularPolygon, pos fyne.Position,
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
-	outerRadius := fyne.Min(size.Width, size.Height) / 2
+	outerRadius := min(size.Width, size.Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrRadiusOuter, outerRadiusScaled)
 
 	p.SetUniform1f(program, attrAngle, polygon.Angle)
 	p.SetUniform1f(program, attrSides, float32(polygon.Sides))
 
-	cornerRadius := fyne.Min(paint.GetMaximumRadius(size), polygon.CornerRadius)
+	cornerRadius := min(paint.GetMaximumRadius(size), polygon.CornerRadius)
 	cornerRadiusScaled := roundToPixel(cornerRadius*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrRadiusCorner, cornerRadiusScaled)
 
@@ -772,7 +772,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	edgeSoftnessScaled := roundToPixel(edgeSoftness*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrEdgeSoftness, edgeSoftnessScaled)
 
-	outerRadius := fyne.Min(arc.Size().Width, arc.Size().Height) / 2
+	outerRadius := min(arc.Size().Width, arc.Size().Height) / 2
 	outerRadiusScaled := roundToPixel(outerRadius*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrRadiusOuter, outerRadiusScaled)
 
@@ -784,7 +784,7 @@ func (p *painter) drawArc(arc *canvas.Arc, pos fyne.Position, frame fyne.Size) {
 	p.SetUniform1f(program, attrAngleStart, startAngle)
 	p.SetUniform1f(program, attrAngleEnd, endAngle)
 
-	cornerRadius := fyne.Min(paint.GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)
+	cornerRadius := min(paint.GetMaximumRadiusArc(outerRadius, innerRadius, arc.EndAngle-arc.StartAngle), arc.CornerRadius)
 	cornerRadiusScaled := roundToPixel(cornerRadius*p.pixScale, 1.0)
 	p.SetUniform1f(program, attrRadiusCorner, cornerRadiusScaled)
 
@@ -948,8 +948,8 @@ func visibleTextPixels(pos fyne.Position, size, frame fyne.Size, clip *internal.
 		clipPos, clipSize = clip.Rect()
 	}
 
-	left := fyne.Max(pos.X, clipPos.X)
-	right := fyne.Min(pos.X+size.Width, clipPos.X+clipSize.Width)
+	left := max(pos.X, clipPos.X)
+	right := min(pos.X+size.Width, clipPos.X+clipSize.Width)
 	if right <= left {
 		return 0, 0
 	}
@@ -969,7 +969,7 @@ func (p *painter) drawTextureRegion(texture Texture, pos fyne.Position, size, fr
 
 	// Set corner radius and texture size in pixels
 	if cornerRadius != 0 {
-		cornerRadius = fyne.Min(paint.GetMaximumRadius(size), cornerRadius) * p.pixScale
+		cornerRadius = min(paint.GetMaximumRadius(size), cornerRadius) * p.pixScale
 	}
 	p.SetUniform1f(p.programs.simple, attrRadiusCorner, cornerRadius)
 	p.SetUniform2f(p.programs.simple, attrSize, inner.Width*p.pixScale, inner.Height*p.pixScale)
@@ -1012,8 +1012,8 @@ func (p *painter) drawTextureWithDetails(o fyne.CanvasObject, creator func(canva
 
 func (p *painter) lineCoords(pos, pos1, pos2 fyne.Position, lineWidth, feather float32, frame fyne.Size) (points [coordinatesSizeLine]float32, halfWidth, featherWidth float32) {
 	// Shift line coordinates so that they match the target position.
-	xPosDiff := pos.X - fyne.Min(pos1.X, pos2.X)
-	yPosDiff := pos.Y - fyne.Min(pos1.Y, pos2.Y)
+	xPosDiff := pos.X - min(pos1.X, pos2.X)
+	yPosDiff := pos.Y - min(pos1.Y, pos2.Y)
 	pos1.X = roundToPixel(pos1.X+xPosDiff, p.pixScale)
 	pos1.Y = roundToPixel(pos1.Y+yPosDiff, p.pixScale)
 	pos2.X = roundToPixel(pos2.X+xPosDiff, p.pixScale)

--- a/internal/painter/image.go
+++ b/internal/painter/image.go
@@ -55,8 +55,8 @@ func scaleImage(pixels image.Image, scaledW, scaledH int, scale canvas.ImageScal
 	}
 
 	bounds := pixels.Bounds()
-	pixW := int(fyne.Min(float32(scaledW), float32(bounds.Dx()))) // don't push more pixels than we have to
-	pixH := int(fyne.Min(float32(scaledH), float32(bounds.Dy()))) // the GL calls will scale this up on GPU.
+	pixW := int(min(float32(scaledW), float32(bounds.Dx()))) // don't push more pixels than we have to
+	pixH := int(min(float32(scaledH), float32(bounds.Dy()))) // the GL calls will scale this up on GPU.
 	scaledBounds := image.Rect(0, 0, pixW, pixH)
 	tex := image.NewNRGBA(scaledBounds)
 	switch scale {

--- a/internal/painter/software/draw.go
+++ b/internal/painter/software/draw.go
@@ -36,7 +36,7 @@ func drawBlur(c fyne.Canvas, blurObj *canvas.Blur, pos fyne.Position, base *imag
 	crop := base.SubImage(bounds)
 	blurred := blur.Gaussian(crop, float64(blurObj.Radius*c.Scale()))
 
-	cornerRadius := fyne.Min(painter.GetMaximumRadius(blurObj.Size()), blurObj.CornerRadius)
+	cornerRadius := min(painter.GetMaximumRadius(blurObj.Size()), blurObj.CornerRadius)
 
 	if cornerRadius > 0.5 {
 		applyRoundedCorners(blurred, cornerRadius*c.Scale())
@@ -151,7 +151,7 @@ func drawImage(c fyne.Canvas, img *canvas.Image, pos fyne.Position, base *image.
 		}
 	}
 
-	cornerRadius := fyne.Min(painter.GetMaximumRadius(bounds), img.CornerRadius)
+	cornerRadius := min(painter.GetMaximumRadius(bounds), img.CornerRadius)
 	drawPixels(scaledX, scaledY, width, height, img.ScaleMode, base, rawImg, clip, img.Alpha(), cornerRadius*c.Scale())
 }
 
@@ -483,7 +483,7 @@ func drawShadow(c fyne.Canvas, obj fyne.CanvasObject, objSize fyne.Size, shadow 
 			TopLeftCornerRadius:     o.TopLeftCornerRadius,
 			BottomRightCornerRadius: o.BottomRightCornerRadius,
 			BottomLeftCornerRadius:  o.BottomLeftCornerRadius,
-		}, fyne.Max(objSize.Width+2*shadowSpread, 0), fyne.Max(objSize.Height+2*shadowSpread, 0), vPad, func(in float32) float32 {
+		}, max(objSize.Width+2*shadowSpread, 0), max(objSize.Height+2*shadowSpread, 0), vPad, func(in float32) float32 {
 			return float32(math.Round(float64(in) * float64(c.Scale())))
 		})
 		maskRaw = painter.DrawRectangle(&canvas.Rectangle{

--- a/internal/painter/software/painter.go
+++ b/internal/painter/software/painter.go
@@ -25,8 +25,8 @@ func (*Painter) Paint(c fyne.Canvas) image.Image {
 	base := image.NewNRGBA(bounds)
 
 	paint := func(obj fyne.CanvasObject, pos, clipPos fyne.Position, clipSize fyne.Size) bool {
-		w := fyne.Min(clipPos.X+clipSize.Width, c.Size().Width)
-		h := fyne.Min(clipPos.Y+clipSize.Height, c.Size().Height)
+		w := min(clipPos.X+clipSize.Width, c.Size().Width)
+		h := min(clipPos.Y+clipSize.Height, c.Size().Height)
 		clip := image.Rect(
 			scale.ToScreenCoordinate(c, clipPos.X),
 			scale.ToScreenCoordinate(c, clipPos.Y),

--- a/internal/widget/scroller.go
+++ b/internal/widget/scroller.go
@@ -237,7 +237,7 @@ func (r *scrollBarAreaRenderer) barSizeAndOffset(th fyne.Theme, contentOffset, c
 	if scrollLength < contentLength {
 		portion := scrollLength / contentLength
 		length = float32(int(scrollLength)) * portion
-		length = fyne.Max(length, scrollBarSize)
+		length = max(length, scrollBarSize)
 	} else {
 		length = scrollLength
 	}
@@ -293,11 +293,11 @@ func (a *scrollBarArea) Tapped(e *fyne.PointEvent) {
 	switch a.orientation {
 	case scrollBarOrientationHorizontal:
 		if e.Position.X < a.barLeadingEdge || e.Position.X > a.barTrailingEdge {
-			a.moveBar(fyne.Max(0, e.Position.X-barSize.Width/2), barSize)
+			a.moveBar(max(0, e.Position.X-barSize.Width/2), barSize)
 		}
 	case scrollBarOrientationVertical:
 		if e.Position.Y < a.barLeadingEdge || e.Position.Y > a.barTrailingEdge {
-			a.moveBar(fyne.Max(0, e.Position.Y-barSize.Height/2), a.bar.Size())
+			a.moveBar(max(0, e.Position.Y-barSize.Height/2), a.bar.Size())
 		}
 	}
 }
@@ -309,17 +309,17 @@ func (a *scrollBarArea) scrollFullPageOnTap(e *fyne.PointEvent) {
 	switch a.orientation {
 	case scrollBarOrientationHorizontal:
 		if e.Position.X < a.barLeadingEdge {
-			newOffset.X = fyne.Max(0, newOffset.X-a.scroll.Size().Width*pageScrollFraction)
+			newOffset.X = max(0, newOffset.X-a.scroll.Size().Width*pageScrollFraction)
 		} else if e.Position.X > a.barTrailingEdge {
 			viewWid := a.scroll.Size().Width
-			newOffset.X = fyne.Min(a.scroll.Content.Size().Width-viewWid, newOffset.X+viewWid*pageScrollFraction)
+			newOffset.X = min(a.scroll.Content.Size().Width-viewWid, newOffset.X+viewWid*pageScrollFraction)
 		}
 	default:
 		if e.Position.Y < a.barLeadingEdge {
-			newOffset.Y = fyne.Max(0, newOffset.Y-a.scroll.Size().Height*pageScrollFraction)
+			newOffset.Y = max(0, newOffset.Y-a.scroll.Size().Height*pageScrollFraction)
 		} else if e.Position.Y > a.barTrailingEdge {
 			viewHt := a.scroll.Size().Height
-			newOffset.Y = fyne.Min(a.scroll.Content.Size().Height-viewHt, newOffset.Y+viewHt*pageScrollFraction)
+			newOffset.Y = min(a.scroll.Content.Size().Height-viewHt, newOffset.Y+viewHt*pageScrollFraction)
 		}
 	}
 	if newOffset == a.scroll.Offset {
@@ -561,9 +561,9 @@ func (s *Scroll) MinSize() fyne.Size {
 	minSize := internal.MaxSizes(fyne.NewSize(scrollContainerMinSize, scrollContainerMinSize), s.minSize)
 	switch s.Direction {
 	case ScrollHorizontalOnly:
-		minSize.Height = fyne.Max(minSize.Height, s.Content.MinSize().Height)
+		minSize.Height = max(minSize.Height, s.Content.MinSize().Height)
 	case ScrollVerticalOnly:
-		minSize.Width = fyne.Max(minSize.Width, s.Content.MinSize().Width)
+		minSize.Width = max(minSize.Width, s.Content.MinSize().Width)
 	case ScrollNone:
 		return s.Content.MinSize()
 	}
@@ -679,7 +679,7 @@ func computeOffset(start, delta, outerWidth, innerWidth float32) float32 {
 		offset = innerWidth - outerWidth
 	}
 
-	return fyne.Max(offset, 0)
+	return max(offset, 0)
 }
 
 // NewScroll creates a scrollable parent wrapping the specified content.

--- a/layout/borderlayout.go
+++ b/layout/borderlayout.go
@@ -85,23 +85,23 @@ func (b *borderLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 
 	if b.left != nil && b.left.Visible() {
 		leftMin := b.left.MinSize()
-		minHeight := fyne.Max(minSize.Height, leftMin.Height)
+		minHeight := max(minSize.Height, leftMin.Height)
 		minSize = fyne.NewSize(minSize.Width+leftMin.Width+padding, minHeight)
 	}
 	if b.right != nil && b.right.Visible() {
 		rightMin := b.right.MinSize()
-		minHeight := fyne.Max(minSize.Height, rightMin.Height)
+		minHeight := max(minSize.Height, rightMin.Height)
 		minSize = fyne.NewSize(minSize.Width+rightMin.Width+padding, minHeight)
 	}
 
 	if b.top != nil && b.top.Visible() {
 		topMin := b.top.MinSize()
-		minWidth := fyne.Max(minSize.Width, topMin.Width)
+		minWidth := max(minSize.Width, topMin.Width)
 		minSize = fyne.NewSize(minWidth, minSize.Height+topMin.Height+padding)
 	}
 	if b.bottom != nil && b.bottom.Visible() {
 		bottomMin := b.bottom.MinSize()
-		minWidth := fyne.Max(minSize.Width, bottomMin.Width)
+		minWidth := max(minSize.Width, bottomMin.Width)
 		minSize = fyne.NewSize(minWidth, minSize.Height+bottomMin.Height+padding)
 	}
 

--- a/layout/boxlayout.go
+++ b/layout/boxlayout.go
@@ -120,7 +120,7 @@ func (v vBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 
 		childMin := child.MinSize()
-		minSize.Width = fyne.Max(childMin.Width, minSize.Width)
+		minSize.Width = max(childMin.Width, minSize.Width)
 		minSize.Height += childMin.Height
 		if addPadding {
 			minSize.Height += padding
@@ -206,7 +206,7 @@ func (g hBoxLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 
 		childMin := child.MinSize()
-		minSize.Height = fyne.Max(childMin.Height, minSize.Height)
+		minSize.Height = max(childMin.Height, minSize.Height)
 		minSize.Width += childMin.Width
 		if addPadding {
 			minSize.Width += padding

--- a/layout/formlayout.go
+++ b/layout/formlayout.go
@@ -37,7 +37,7 @@ func (*formLayout) calculateTableSizes(objects []fyne.CanvasObject, containerWid
 			labelSize.Width += innerPadding * 2
 			labelSize.Height += innerPadding * 2
 		}
-		labelWidth = fyne.Max(labelWidth, labelSize.Width)
+		labelWidth = max(labelWidth, labelSize.Width)
 
 		// Content column width is the maximum of all content items.
 		contentSize := contentCell.MinSize()
@@ -45,15 +45,15 @@ func (*formLayout) calculateTableSizes(objects []fyne.CanvasObject, containerWid
 			contentSize.Width += innerPadding * 2
 			contentSize.Height += innerPadding * 2
 		}
-		contentWidth = fyne.Max(contentWidth, contentSize.Width)
+		contentWidth = max(contentWidth, contentSize.Width)
 
-		rowHeight := fyne.Max(labelSize.Height, contentSize.Height)
+		rowHeight := max(labelSize.Height, contentSize.Height)
 		height += rowHeight
 		rows++
 	}
 
 	padding := theme.Padding()
-	contentWidth = fyne.Max(contentWidth, containerWidth-labelWidth-padding)
+	contentWidth = max(contentWidth, containerWidth-labelWidth-padding)
 	return labelWidth, contentWidth, height + float32(rows-1)*padding
 }
 
@@ -95,7 +95,7 @@ func (f *formLayout) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		if _, ok := contentCell.(*canvas.Text); ok {
 			contentHeight += innerPadding * 2
 		}
-		rowHeight := fyne.Max(labelHeight, contentHeight)
+		rowHeight := max(labelHeight, contentHeight)
 
 		pos, size := objectLayout(labelCell, 0, labelWidth, rowHeight, labelMin.Height)
 		labelCell.Move(pos)

--- a/layout/formlayout_test.go
+++ b/layout/formlayout_test.go
@@ -187,7 +187,7 @@ func TestFormLayout_MinSize_CanvasText_SingleRow(t *testing.T) {
 	min2 := text2.MinSize()
 	expectedWidth := (min1.Width + inner*2) + (min2.Width + inner*2) + theme.Padding()
 
-	expectedHeight := fyne.Max(min1.Height, min2.Height) + inner*2
+	expectedHeight := max(min1.Height, min2.Height) + inner*2
 
 	assert.Equal(t, fyne.NewSize(expectedWidth, expectedHeight), layoutMin)
 }
@@ -206,11 +206,11 @@ func TestFormLayout_MinSize_CanvasText_TwoRows(t *testing.T) {
 	l2 := label2.MinSize()
 	v1 := value1.MinSize()
 	v2 := value2.MinSize()
-	labelCol := fyne.Max(l1.Width+inner*2, l2.Width+inner*2)
-	valueCol := fyne.Max(v1.Width+inner*2, v2.Width+inner*2)
+	labelCol := max(l1.Width+inner*2, l2.Width+inner*2)
+	valueCol := max(v1.Width+inner*2, v2.Width+inner*2)
 	expectedWidth := labelCol + valueCol + theme.Padding()
-	row1 := fyne.Max(l1.Height+inner*2, v1.Height+inner*2)
-	row2 := fyne.Max(l2.Height+inner*2, v2.Height+inner*2)
+	row1 := max(l1.Height+inner*2, v1.Height+inner*2)
+	row2 := max(l2.Height+inner*2, v2.Height+inner*2)
 	expectedHeight := row1 + row2 + theme.Padding()
 
 	assert.Equal(t, fyne.NewSize(expectedWidth, expectedHeight), layoutMin)

--- a/layout/gridlayout.go
+++ b/layout/gridlayout.go
@@ -150,8 +150,8 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 
 	width := minSize.Width * float32(primaryObjects)
 	height := minSize.Height * float32(secondaryObjects)
-	xpad := padding * fyne.Max(float32(primaryObjects-1), 0)
-	ypad := padding * fyne.Max(float32(secondaryObjects-1), 0)
+	xpad := padding * max(float32(primaryObjects-1), 0)
+	ypad := padding * max(float32(secondaryObjects-1), 0)
 
 	return fyne.NewSize(width+xpad, height+ypad)
 }

--- a/layout/rowwrap.go
+++ b/layout/rowwrap.go
@@ -57,8 +57,8 @@ func (l *rowWrapLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 		objCount++
 		s := o.MinSize()
-		maxW = fyne.Max(maxW, s.Width)
-		maxH = fyne.Max(maxH, s.Height)
+		maxW = max(maxW, s.Width)
+		maxH = max(maxH, s.Height)
 	}
 	return fyne.NewSize(maxW, l.minHeight(maxH, objCount))
 }
@@ -79,7 +79,7 @@ func (l *rowWrapLayout) Layout(objects []fyne.CanvasObject, containerSize fyne.S
 		if !o.Visible() {
 			continue
 		}
-		maxH = fyne.Max(maxH, o.MinSize().Height)
+		maxH = max(maxH, o.MinSize().Height)
 	}
 	var minSize fyne.Size
 	pos := fyne.NewPos(0, 0)
@@ -97,7 +97,7 @@ func (l *rowWrapLayout) Layout(objects []fyne.CanvasObject, containerSize fyne.S
 			rows++
 		}
 		isFirst = false
-		minSize.Width = fyne.Max(minSize.Width, pos.X+size.Width)
+		minSize.Width = max(minSize.Width, pos.X+size.Width)
 		minSize.Height = l.minHeight(maxH, rows)
 		o.Move(pos)
 		pos = pos.Add(fyne.NewPos(size.Width+l.horizontalPadding, 0))

--- a/math.go
+++ b/math.go
@@ -1,17 +1,15 @@
 package fyne
 
 // Min returns the smaller of the passed values.
+//
+// Deprecated: use the Go builtin min(x, y) instead
 func Min(x, y float32) float32 {
-	if x < y {
-		return x
-	}
-	return y
+	return min(x, y)
 }
 
 // Max returns the larger of the passed values.
+//
+// Deprecated: use the Go builtin max(x, y) instead
 func Max(x, y float32) float32 {
-	if x > y {
-		return x
-	}
-	return y
+	return max(x, y)
 }

--- a/math.go
+++ b/math.go
@@ -3,6 +3,8 @@ package fyne
 // Min returns the smaller of the passed values.
 //
 // Deprecated: use the Go builtin min(x, y) instead
+//
+//go:fix inline
 func Min(x, y float32) float32 {
 	return min(x, y)
 }
@@ -10,6 +12,8 @@ func Min(x, y float32) float32 {
 // Max returns the larger of the passed values.
 //
 // Deprecated: use the Go builtin max(x, y) instead
+//
+//go:fix inline
 func Max(x, y float32) float32 {
 	return max(x, y)
 }

--- a/math_test.go
+++ b/math_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestMin(t *testing.T) {
-	assert.Equal(t, float32(1), Min(1, 3))
-	assert.Equal(t, float32(-3), Min(1, -3))
+	assert.Equal(t, float32(1), min(1, 3))
+	assert.Equal(t, float32(-3), min(1, -3))
 }
 
 func TestMax(t *testing.T) {
-	assert.Equal(t, float32(3), Max(1, 3))
-	assert.Equal(t, float32(1), Max(1, -3))
+	assert.Equal(t, float32(3), max(1, 3))
+	assert.Equal(t, float32(1), max(1, -3))
 }

--- a/math_test.go
+++ b/math_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestMin(t *testing.T) {
-	assert.Equal(t, float32(1), min(1, 3))
-	assert.Equal(t, float32(-3), min(1, -3))
+	assert.Equal(t, float32(1), min(float32(1), float32(3)))
+	assert.Equal(t, float32(-3), min(float32(1), float32(-3)))
 }
 
 func TestMax(t *testing.T) {
-	assert.Equal(t, float32(3), max(1, 3))
-	assert.Equal(t, float32(1), max(1, -3))
+	assert.Equal(t, float32(3), max(float32(1), float32(3)))
+	assert.Equal(t, float32(1), max(float32(1), float32(-3)))
 }

--- a/widget/accordion.go
+++ b/widget/accordion.go
@@ -209,10 +209,10 @@ func (r *accordionRenderer) MinSize() fyne.Size {
 			size.Height += pad
 		}
 		minSize := r.headers[i].MinSize()
-		size.Width = fyne.Max(size.Width, minSize.Width)
+		size.Width = max(size.Width, minSize.Width)
 		size.Height += minSize.Height
 		minSize = ai.Detail.MinSize()
-		size.Width = fyne.Max(size.Width, minSize.Width)
+		size.Width = max(size.Width, minSize.Width)
 		if ai.Open {
 			size.Height += minSize.Height
 			size.Height += pad

--- a/widget/accordion_internal_test.go
+++ b/widget/accordion_internal_test.go
@@ -3,7 +3,6 @@ package widget
 import (
 	"testing"
 
-	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/theme"
 
@@ -158,7 +157,7 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			minSize := ar.MinSize()
 			aih := ar.headers[0].MinSize()
 			aid := ai.Detail.MinSize()
-			assert.Equal(t, fyne.Max(aih.Width, aid.Width), minSize.Width)
+			assert.Equal(t, max(aih.Width, aid.Width), minSize.Width)
 			assert.Equal(t, aih.Height+aid.Height+theme.Padding(), minSize.Height)
 		})
 		t.Run("Closed", func(t *testing.T) {
@@ -190,9 +189,9 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			aih1 := ar.headers[1].MinSize()
 			aih2 := ar.headers[2].MinSize()
 			aid0 := ai0.Detail.MinSize()
-			width := fyne.Max(aih0.Width, aid0.Width)
-			width = fyne.Max(width, aih1.Width)
-			width = fyne.Max(width, aih2.Width)
+			width := max(aih0.Width, aid0.Width)
+			width = max(width, aih1.Width)
+			width = max(width, aih2.Width)
 			assert.Equal(t, width, minSize.Width)
 			height := aih0.Height
 			height += aid0.Height + theme.Padding()
@@ -217,9 +216,9 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			aid0 := ai0.Detail.MinSize()
 			aid1 := ai1.Detail.MinSize()
 			aid2 := ai2.Detail.MinSize()
-			width := fyne.Max(aih0.Width, aid0.Width)
-			width = fyne.Max(width, fyne.Max(aih1.Width, aid1.Width))
-			width = fyne.Max(width, fyne.Max(aih2.Width, aid2.Width))
+			width := max(aih0.Width, aid0.Width)
+			width = max(width, max(aih1.Width, aid1.Width))
+			width = max(width, max(aih2.Width, aid2.Width))
 			assert.Equal(t, width, minSize.Width)
 			height := aih0.Height
 			height += aid0.Height + theme.Padding()
@@ -249,9 +248,9 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			aih2 := ar.headers[2].MinSize()
 			aid0 := ai0.Detail.MinSize()
 			aid1 := ai1.Detail.MinSize()
-			width := fyne.Max(aih0.Width, aid0.Width)
-			width = fyne.Max(width, fyne.Max(aih1.Width, aid1.Width))
-			width = fyne.Max(width, aih2.Width)
+			width := max(aih0.Width, aid0.Width)
+			width = max(width, max(aih1.Width, aid1.Width))
+			width = max(width, aih2.Width)
 			assert.Equal(t, width, minSize.Width)
 			height := aih0.Height
 			height += aid0.Height + theme.Padding()
@@ -274,8 +273,8 @@ func TestAccordionRenderer_MinSize(t *testing.T) {
 			aih1 := ar.headers[1].MinSize()
 			aih2 := ar.headers[2].MinSize()
 			width := aih0.Width
-			width = fyne.Max(width, aih1.Width)
-			width = fyne.Max(width, aih2.Width)
+			width = max(width, aih1.Width)
+			width = max(width, aih2.Width)
 			assert.Equal(t, width, minSize.Width)
 			height := aih0.Height + theme.Padding()
 			height += aih1.Height + theme.Padding()

--- a/widget/accordion_test.go
+++ b/widget/accordion_test.go
@@ -333,10 +333,10 @@ func TestAccordion_Layout_Expanded(t *testing.T) {
 func TestAccordion_MinSize(t *testing.T) {
 	minSizeA := fyne.MeasureText("A", theme.TextSize(), fyne.TextStyle{})
 	minSizeA.Width += theme.IconInlineSize() + theme.InnerPadding()*3 + theme.Padding()
-	minSizeA.Height = fyne.Max(minSizeA.Height, theme.IconInlineSize()) + theme.InnerPadding()
+	minSizeA.Height = max(minSizeA.Height, theme.IconInlineSize()) + theme.InnerPadding()
 	minSizeB := fyne.MeasureText("B", theme.TextSize(), fyne.TextStyle{})
 	minSizeB.Width += theme.IconInlineSize() + theme.InnerPadding()*3 + theme.Padding()
-	minSizeB.Height = fyne.Max(minSizeB.Height, theme.IconInlineSize()) + theme.InnerPadding()
+	minSizeB.Height = max(minSizeB.Height, theme.IconInlineSize()) + theme.InnerPadding()
 	minSize1 := fyne.MeasureText("111111", theme.TextSize(), fyne.TextStyle{})
 	minSize1.Width += theme.Padding() * 4
 	minSize1.Height += theme.Padding() * 4
@@ -344,9 +344,9 @@ func TestAccordion_MinSize(t *testing.T) {
 	minSize2.Width += theme.Padding() * 4
 	minSize2.Height += theme.Padding() * 4
 
-	minWidthA1 := fyne.Max(minSizeA.Width, minSize1.Width)
-	minWidthB2 := fyne.Max(minSizeB.Width, minSize2.Width)
-	minWidthA1B2 := fyne.Max(minWidthA1, minWidthB2)
+	minWidthA1 := max(minSizeA.Width, minSize1.Width)
+	minWidthB2 := max(minSizeB.Width, minSize2.Width)
+	minWidthA1B2 := max(minWidthA1, minWidthB2)
 
 	minHeightA1 := minSizeA.Height + minSize1.Height + theme.Padding()
 

--- a/widget/activity.go
+++ b/widget/activity.go
@@ -98,7 +98,7 @@ func (a *activityRenderer) Destroy() {
 }
 
 func (a *activityRenderer) Layout(size fyne.Size) {
-	a.maxRad = fyne.Min(size.Width, size.Height) / 2
+	a.maxRad = min(size.Width, size.Height) / 2
 	a.bound = size
 
 	if a.parent.started && !fyne.CurrentApp().Settings().ShowAnimations() {
@@ -188,7 +188,7 @@ func (a *activityRenderer) stop() {
 func (a *activityRenderer) drawStaticEllipsis() {
 	th := a.parent.Theme()
 	innerPad := th.Size(theme.SizeNameInnerPadding)
-	d := fyne.Min(a.bound.Width/4, a.bound.Height)
+	d := min(a.bound.Width/4, a.bound.Height)
 	if d > th.Size(theme.SizeNameInlineIcon)/2 {
 		d -= innerPad
 	}

--- a/widget/button.go
+++ b/widget/button.go
@@ -315,7 +315,7 @@ func (r *buttonRenderer) MinSize() (size fyne.Size) {
 		}
 		size.Width += iconSize.Width
 	}
-	size.Height = fyne.Max(labelSize.Height, iconSize.Height)
+	size.Height = max(labelSize.Height, iconSize.Height)
 	size = size.Add(r.padding(th))
 	return size
 }

--- a/widget/button_internal_test.go
+++ b/widget/button_internal_test.go
@@ -172,7 +172,7 @@ func TestButtonRenderer_Layout_Stretch(t *testing.T) {
 	render := test.TempWidgetRenderer(t, button).(*buttonRenderer)
 
 	textHeight := render.label.MinSize().Height
-	minIconHeight := fyne.Max(theme.IconInlineSize(), textHeight)
+	minIconHeight := max(theme.IconInlineSize(), textHeight)
 	assert.Equal(t, 50+theme.InnerPadding(), render.icon.Position().X, "icon x")
 	assert.Equal(t, 50+theme.InnerPadding(), render.icon.Position().Y, "icon y")
 	assert.Equal(t, theme.IconInlineSize(), render.icon.Size().Width, "icon width")

--- a/widget/card.go
+++ b/widget/card.go
@@ -185,7 +185,7 @@ func (c *cardRenderer) MinSize() fyne.Size {
 		minSize = minSize.Add(fyne.NewSize(0, titlePad*2))
 		if hasHeader {
 			headerMin := c.header.MinSize()
-			minSize = fyne.NewSize(fyne.Max(minSize.Width, headerMin.Width+titlePad*2+padding),
+			minSize = fyne.NewSize(max(minSize.Width, headerMin.Width+titlePad*2+padding),
 				minSize.Height+headerMin.Height)
 			if hasSubHeader {
 				minSize.Height += padding
@@ -193,14 +193,14 @@ func (c *cardRenderer) MinSize() fyne.Size {
 		}
 		if hasSubHeader {
 			subHeaderMin := c.subHeader.MinSize()
-			minSize = fyne.NewSize(fyne.Max(minSize.Width, subHeaderMin.Width+titlePad*2+padding),
+			minSize = fyne.NewSize(max(minSize.Width, subHeaderMin.Width+titlePad*2+padding),
 				minSize.Height+subHeaderMin.Height)
 		}
 	}
 
 	if hasContent {
 		contentMin := c.card.Content.MinSize()
-		minSize = fyne.NewSize(fyne.Max(minSize.Width, contentMin.Width+padding*3),
+		minSize = fyne.NewSize(max(minSize.Width, contentMin.Width+padding*3),
 			minSize.Height+contentMin.Height+padding*2)
 	}
 

--- a/widget/check_group.go
+++ b/widget/check_group.go
@@ -211,8 +211,8 @@ func (r *checkGroupRenderer) MinSize() fyne.Size {
 	for _, item := range r.items {
 		itemMin := item.MinSize()
 
-		width = fyne.Max(width, itemMin.Width)
-		height = fyne.Max(height, itemMin.Height)
+		width = max(width, itemMin.Width)
+		height = max(height, itemMin.Height)
 	}
 
 	if r.checks.Horizontal {

--- a/widget/fileicon.go
+++ b/widget/fileicon.go
@@ -149,7 +149,7 @@ func (s *fileIconRenderer) MinSize() fyne.Size {
 }
 
 func (s *fileIconRenderer) Layout(size fyne.Size) {
-	isize := fyne.Min(size.Width, size.Height)
+	isize := min(size.Width, size.Height)
 
 	xoff := float32(0)
 	yoff := (size.Height - isize) / 2

--- a/widget/form.go
+++ b/widget/form.go
@@ -607,7 +607,7 @@ func (f formItemLayout) MinSize(objs []fyne.CanvasObject) fyne.Size {
 	min0 := objs[0].MinSize()
 	min1 := objs[1].MinSize()
 
-	minWidth := fyne.Max(min0.Width, min1.Width)
+	minWidth := max(min0.Width, min1.Width)
 	height := min0.Height
 
 	items := objs[1].(*fyne.Container).Objects

--- a/widget/hyperlink.go
+++ b/widget/hyperlink.go
@@ -159,7 +159,7 @@ func (hl *Hyperlink) focusWidth() float32 {
 	th := hl.Theme()
 
 	innerPad := th.Size(theme.SizeNameInnerPadding)
-	return fyne.Min(hl.Size().Width, hl.textSize.Width+innerPad+th.Size(theme.SizeNamePadding)*2) - innerPad
+	return min(hl.Size().Width, hl.textSize.Width+innerPad+th.Size(theme.SizeNamePadding)*2) - innerPad
 }
 
 func (hl *Hyperlink) focusXPos() float32 {
@@ -181,7 +181,7 @@ func (hl *Hyperlink) isPosOverText(pos fyne.Position) bool {
 	th := hl.Theme()
 	innerPad := th.Size(theme.SizeNameInnerPadding)
 	pad := th.Size(theme.SizeNamePadding)
-	lineCount := fyne.Max(1, float32(len(hl.provider.rowBounds)))
+	lineCount := max(1, float32(len(hl.provider.rowBounds)))
 
 	xpos := hl.focusXPos()
 	return pos.X >= xpos && pos.X <= xpos+hl.focusWidth() &&

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -191,8 +191,8 @@ func (r *radioGroupRenderer) MinSize() fyne.Size {
 	for _, item := range r.items {
 		itemMin := item.MinSize()
 
-		width = fyne.Max(width, itemMin.Width)
-		height = fyne.Max(height, itemMin.Height)
+		width = max(width, itemMin.Width)
+		height = max(height, itemMin.Height)
 	}
 
 	if r.radio.Horizontal {

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -334,7 +334,7 @@ func (t *RichText) lineSizeToColumn(col, row int, textSize, innerPad float32) fy
 		}
 
 		total.Width += size.Width
-		total.Height = fyne.Max(total.Height, size.Height)
+		total.Height = max(total.Height, size.Height)
 		if last {
 			break
 		}
@@ -711,12 +711,12 @@ func (r *textRenderer) calculateMin(bounds []rowBoundary, wrap fyne.TextWrap, ob
 					r.Refresh() // TODO resolve this in a similar way to #2991
 				}
 			}
-			rowHeight = fyne.Max(rowHeight, minSize.Height)
+			rowHeight = max(rowHeight, minSize.Height)
 			rowWidth += minSize.Width
 		}
 
 		if wrap == fyne.TextWrapOff && trunc == fyne.TextTruncateOff {
-			width = fyne.Max(width, rowWidth)
+			width = max(width, rowWidth)
 		}
 		height += rowHeight
 		rowHeight = 0
@@ -888,7 +888,7 @@ func (r *textRenderer) layoutRow(texts []fyne.CanvasObject, align fyne.TextAlign
 		if height == 0 {
 			height = size.Height
 		} else if height != size.Height {
-			height = fyne.Max(height, size.Height)
+			height = max(height, size.Height)
 			realign = true
 		}
 	}

--- a/widget/table.go
+++ b/widget/table.go
@@ -1638,11 +1638,11 @@ func (r *tableCellsRenderer) moveMarker(marker fyne.CanvasObject, row, col int, 
 	} else {
 		left := x1
 		if col >= stickCols { // clip X
-			left = fyne.Max(r.cells.t.stuckXOff+r.cells.t.stuckWidth, x1)
+			left = max(r.cells.t.stuckXOff+r.cells.t.stuckWidth, x1)
 		}
 		top := y1
 		if row >= stickRows { // clip Y
-			top = fyne.Max(r.cells.t.stuckYOff+r.cells.t.stuckHeight, y1)
+			top = max(r.cells.t.stuckYOff+r.cells.t.stuckHeight, y1)
 		}
 		marker.Move(fyne.NewPos(left, top))
 		marker.Resize(fyne.NewSize(x2-left, y2-top))

--- a/widget/textgrid.go
+++ b/widget/textgrid.go
@@ -567,7 +567,7 @@ func (t *textGridContentRenderer) Layout(s fyne.Size) {
 func (t *textGridContentRenderer) MinSize() fyne.Size {
 	longestRow := float32(0)
 	for _, row := range t.text.text.Rows {
-		longestRow = fyne.Max(longestRow, float32(len(row.Cells)))
+		longestRow = max(longestRow, float32(len(row.Cells)))
 	}
 
 	if t.text.text.ShowLineNumbers {

--- a/widget/tree.go
+++ b/widget/tree.go
@@ -693,7 +693,7 @@ func (r *treeContentRenderer) Layout(size fyne.Size) {
 	pad := th.Size(theme.SizeNamePadding)
 	offsetY := r.treeContent.tree.offset.Y
 	viewport := r.treeContent.viewport
-	width := fyne.Max(size.Width, viewport.Width)
+	width := max(size.Width, viewport.Width)
 	separatorCount := 0
 	separatorThickness := th.Size(theme.SizeNameSeparatorThickness)
 	separatorSize := fyne.NewSize(width, separatorThickness)
@@ -833,7 +833,7 @@ func (r *treeContentRenderer) MinSize() fyne.Size {
 			m = r.treeContent.tree.branchMinSize
 		}
 		m.Width += float32(depth) * (iconSize + pad)
-		minSize.Width = fyne.Max(minSize.Width, m.Width)
+		minSize.Width = max(minSize.Width, m.Width)
 		minSize.Height += m.Height
 	})
 
@@ -1034,7 +1034,7 @@ func (r *treeNodeRenderer) MinSize() fyne.Size {
 	iconSize := th.Size(theme.SizeNameInlineIcon)
 
 	minSize.Width += th.Size(theme.SizeNameInnerPadding) + r.treeNode.Indent() + iconSize
-	minSize.Height = fyne.Max(minSize.Height, iconSize)
+	minSize.Height = max(minSize.Height, iconSize)
 	return minSize
 }
 

--- a/widget/tree_internal_test.go
+++ b/widget/tree_internal_test.go
@@ -356,7 +356,7 @@ func TestTree_Resize(t *testing.T) {
 	separatorThickness := theme.Padding()
 
 	width := templateMinSize.Width + indentation() + theme.IconInlineSize() + theme.InnerPadding()
-	height := fyne.Max(templateMinSize.Height, theme.IconInlineSize())*3 + separatorThickness*2
+	height := max(templateMinSize.Height, theme.IconInlineSize())*3 + separatorThickness*2
 	assertTreeContentMinSize(t, tree, fyne.NewSize(width, height))
 
 	a := getLeaf(t, tree, "A")
@@ -366,17 +366,17 @@ func TestTree_Resize(t *testing.T) {
 	assert.Equal(t, float32(0), a.Position().X)
 	assert.Equal(t, float32(0), a.Position().Y)
 	assert.Equal(t, treeSize, a.Size().Width)
-	assert.Equal(t, fyne.Max(templateMinSize.Height, theme.IconInlineSize()), a.Size().Height)
+	assert.Equal(t, max(templateMinSize.Height, theme.IconInlineSize()), a.Size().Height)
 
 	assert.Equal(t, float32(0), b.Position().X)
-	assert.Equal(t, fyne.Max(templateMinSize.Height, theme.IconInlineSize())+separatorThickness, b.Position().Y)
+	assert.Equal(t, max(templateMinSize.Height, theme.IconInlineSize())+separatorThickness, b.Position().Y)
 	assert.Equal(t, treeSize, b.Size().Width)
-	assert.Equal(t, fyne.Max(templateMinSize.Height, theme.IconInlineSize()), b.Size().Height)
+	assert.Equal(t, max(templateMinSize.Height, theme.IconInlineSize()), b.Size().Height)
 
 	assert.Equal(t, float32(0), c.Position().X)
-	assert.Equal(t, 2*(fyne.Max(templateMinSize.Height, theme.IconInlineSize())+separatorThickness), c.Position().Y)
+	assert.Equal(t, 2*(max(templateMinSize.Height, theme.IconInlineSize())+separatorThickness), c.Position().Y)
 	assert.Equal(t, treeSize, c.Size().Width)
-	assert.Equal(t, fyne.Max(templateMinSize.Height, theme.IconInlineSize()), c.Size().Height)
+	assert.Equal(t, max(templateMinSize.Height, theme.IconInlineSize()), c.Size().Height)
 }
 
 func TestTree_MinSize(t *testing.T) {
@@ -396,7 +396,7 @@ func TestTree_MinSize(t *testing.T) {
 			"small": {
 				fyne.NewSize(1, 1),
 				fyne.NewSize(1, 1),
-				fyne.NewSize(fyne.Max(1+2*theme.Padding()+theme.IconInlineSize(), float32(32)), float32(32)),
+				fyne.NewSize(max(1+2*theme.Padding()+theme.IconInlineSize(), float32(32)), float32(32)),
 			},
 			"large-leaf": {
 				fyne.NewSize(100, 100),
@@ -440,7 +440,7 @@ func TestTree_MinSize(t *testing.T) {
 			},
 			want: fyne.NewSize(
 				templateMinSize.Width+2*theme.Padding()+theme.IconInlineSize(),
-				fyne.Max(templateMinSize.Height, theme.IconInlineSize()),
+				max(templateMinSize.Height, theme.IconInlineSize()),
 			),
 		},
 		"single_item_opened": {
@@ -452,7 +452,7 @@ func TestTree_MinSize(t *testing.T) {
 			opened: []string{"A"},
 			want: fyne.NewSize(
 				templateMinSize.Width+indentation()+2*theme.Padding()+theme.IconInlineSize(),
-				fyne.Max(templateMinSize.Height, theme.IconInlineSize())*2+separatorThickness,
+				max(templateMinSize.Height, theme.IconInlineSize())*2+separatorThickness,
 			),
 		},
 		"multiple_items": {
@@ -469,7 +469,7 @@ func TestTree_MinSize(t *testing.T) {
 			},
 			want: fyne.NewSize(
 				templateMinSize.Width+2*theme.Padding()+theme.IconInlineSize(),
-				fyne.Max(templateMinSize.Height, theme.IconInlineSize())*2+separatorThickness,
+				max(templateMinSize.Height, theme.IconInlineSize())*2+separatorThickness,
 			),
 		},
 		"multiple_items_opened": {
@@ -487,7 +487,7 @@ func TestTree_MinSize(t *testing.T) {
 			opened: []string{"A", "B", "C"},
 			want: fyne.NewSize(
 				templateMinSize.Width+2*indentation()+theme.IconInlineSize()+2*theme.Padding(),
-				fyne.Max(templateMinSize.Height, theme.IconInlineSize())*6+(5*separatorThickness),
+				max(templateMinSize.Height, theme.IconInlineSize())*6+(5*separatorThickness),
 			),
 		},
 	} {


### PR DESCRIPTION
### Description:

Progresses #3242   

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.