### PR TITLE
Fix stale cache sample expiring active entries

### DIFF
--- a/internal/cache/base.go
+++ b/internal/cache/base.go
@@ -45,7 +45,18 @@ func refreshNow() time.Time {
 
 // Clean run cache clean task, it should be called on paint events.
 func Clean(canvasRefreshed bool) {
+	previousSample := cachedNow.Load()
 	now := refreshNow()
+	// If the driver has not painted for longer than the cache lifetime, entries
+	// used since its previous frame were stamped with an already-expired time.
+	// Defer cleanup for one pass so active entries can be stamped from this
+	// refreshed sample before they are considered for expiry.
+	if ValidDuration > 0 && now.UnixNano()-previousSample > ValidDuration.Nanoseconds() {
+		if canvasRefreshed {
+			skippedCleanWithCanvasRefresh = true
+		}
+		return
+	}
 	// do not run clean task too fast
 	if now.Sub(lastClean) < cacheCleanCooldown {
 		if canvasRefreshed {

--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -134,6 +134,45 @@ func TestCacheClean(t *testing.T) {
 	})
 }
 
+func TestCacheCleanWithStaleClockKeepsRecentlyUsedEntries(t *testing.T) {
+	testClearAll()
+	previousLastClean := lastClean
+	lastClean = time.Time{}
+	t.Cleanup(func() {
+		lastClean = previousLastClean
+		testClearAll()
+	})
+
+	tm := &timeMock{}
+	tm.setTime(10, 10)
+	canvas := &dummyCanvas{}
+	oldObject := &dummyWidget{}
+	recentObject := &dummyWidget{}
+	SetCanvasForObject(oldObject, canvas, nil)
+
+	// Simulate a driver that has not painted for longer than the cache lifetime.
+	// The recent entry is used before the next Clean refreshes the sampled clock.
+	tm.now = tm.now.Add(ValidDuration + time.Second)
+	SetCanvasForObject(recentObject, canvas, nil)
+	Clean(true)
+
+	_, oldFound := canvases.Load(oldObject)
+	_, recentFound := canvases.Load(recentObject)
+	assert.True(t, oldFound)
+	assert.True(t, recentFound)
+
+	// The refreshed sample lets the next pass distinguish an entry used in the
+	// current frame from one that really is expired.
+	SetCanvasForObject(recentObject, canvas, nil)
+	tm.now = tm.now.Add(cacheCleanCooldown + time.Second)
+	Clean(true)
+
+	_, oldFound = canvases.Load(oldObject)
+	_, recentFound = canvases.Load(recentObject)
+	assert.False(t, oldFound)
+	assert.True(t, recentFound)
+}
+
 func TestCleanCanvas(t *testing.T) {
 	destroyedRenderersCnt := 0
 	testClearAll()

--- a/internal/cache/base_test.go
+++ b/internal/cache/base_test.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"fmt"
+	"image"
+	"image/color"
 	"testing"
 	"time"
 
@@ -173,6 +175,90 @@ func TestCacheCleanWithStaleClockKeepsRecentlyUsedEntries(t *testing.T) {
 	assert.True(t, recentFound)
 }
 
+func TestCacheCleanWithStaleClockWithoutCanvasRefreshLeavesSkippedUnset(t *testing.T) {
+	testClearAll()
+	previousLastClean := lastClean
+	lastClean = time.Time{}
+	t.Cleanup(func() {
+		lastClean = previousLastClean
+		testClearAll()
+	})
+
+	tm := &timeMock{}
+	tm.setTime(10, 10)
+	obj := &dummyWidget{}
+	SetCanvasForObject(obj, &dummyCanvas{}, nil)
+
+	tm.now = tm.now.Add(ValidDuration + time.Second)
+	Clean(false)
+
+	assert.False(t, skippedCleanWithCanvasRefresh)
+	_, found := canvases.Load(obj)
+	assert.True(t, found)
+}
+
+func TestCacheCleanWithStaleClockKeepsSvgFontAndBlurEntries(t *testing.T) {
+	testClearAll()
+	previousLastClean := lastClean
+	lastClean = time.Time{}
+	t.Cleanup(func() {
+		lastClean = previousLastClean
+		testClearAll()
+	})
+
+	tm := &timeMock{}
+	tm.setTime(10, 10)
+	pix := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	SetSvg("old.svg", nil, pix, 1, 1)
+	SetFontMetrics("old", 10, fyne.TextStyle{}, nil, fyne.NewSize(1, 1), 1)
+	SetBlurKernel(1, []float32{1})
+	oldWidget := &dummyWidget{}
+	Renderer(oldWidget)
+
+	tm.now = tm.now.Add(ValidDuration + time.Second)
+	SetSvg("recent.svg", nil, pix, 1, 1)
+	SetFontMetrics("recent", 10, fyne.TextStyle{}, nil, fyne.NewSize(2, 2), 2)
+	SetBlurKernel(2, []float32{2})
+	recentWidget := &dummyWidget{}
+	Renderer(recentWidget)
+	Clean(true)
+
+	_, oldSvg := svgs.Load("old.svg")
+	_, recentSvg := svgs.Load("recent.svg")
+	assert.True(t, oldSvg)
+	assert.True(t, recentSvg)
+	_, oldFont := fontSizeCache.Load(fontSizeEntry{Text: "old", Size: 10})
+	_, recentFont := fontSizeCache.Load(fontSizeEntry{Text: "recent", Size: 10})
+	assert.True(t, oldFont)
+	assert.True(t, recentFont)
+	_, oldBlur := blurKernels.Load(float32(1))
+	_, recentBlur := blurKernels.Load(float32(2))
+	assert.True(t, oldBlur)
+	assert.True(t, recentBlur)
+	assert.True(t, IsRendered(oldWidget))
+	assert.True(t, IsRendered(recentWidget))
+
+	SetSvg("recent.svg", nil, pix, 1, 1)
+	SetFontMetrics("recent", 10, fyne.TextStyle{}, nil, fyne.NewSize(2, 2), 2)
+	SetBlurKernel(2, []float32{2})
+	Renderer(recentWidget)
+	tm.now = tm.now.Add(cacheCleanCooldown + time.Second)
+	Clean(true)
+
+	assert.Nil(t, GetSvg("old.svg", nil, 1, 1))
+	assert.NotNil(t, GetSvg("recent.svg", nil, 1, 1))
+	oldSize, _ := GetFontMetrics("old", 10, fyne.TextStyle{}, nil)
+	recentSize, _ := GetFontMetrics("recent", 10, fyne.TextStyle{}, nil)
+	assert.True(t, oldSize.IsZero())
+	assert.Equal(t, fyne.NewSize(2, 2), recentSize)
+	_, oldBlur = GetBlurKernel(1)
+	_, recentBlur = GetBlurKernel(2)
+	assert.False(t, oldBlur)
+	assert.True(t, recentBlur)
+	assert.False(t, IsRendered(oldWidget))
+	assert.True(t, IsRendered(recentWidget))
+}
+
 func TestCleanCanvas(t *testing.T) {
 	destroyedRenderersCnt := 0
 	testClearAll()
@@ -214,6 +300,21 @@ func TestCleanCanvas(t *testing.T) {
 	assert.Equal(t, 42, destroyedRenderersCnt)
 }
 
+func TestCleanCanvas_NonWidgetAndMissingRenderer(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	c := &dummyCanvas{}
+	obj := &dummyCanvasObject{}
+	wid := &dummyWidget{}
+	SetCanvasForObject(obj, c, nil)
+	SetCanvasForObject(wid, c, nil)
+
+	CleanCanvas(c)
+	assert.Equal(t, 0, canvases.Len())
+	assert.Equal(t, 0, renderers.Len())
+}
+
 func Test_expiringCache(t *testing.T) {
 	tm := &timeMock{}
 	tm.setTime(10, 10)
@@ -235,9 +336,50 @@ type dummyCanvas struct {
 	fyne.Canvas
 }
 
+type dummyCanvasObject struct {
+	fyne.CanvasObject
+}
+
+type dummyTheme struct{}
+
+func (dummyTheme) Color(fyne.ThemeColorName, fyne.ThemeVariant) color.Color {
+	return color.Black
+}
+
+func (dummyTheme) Font(fyne.TextStyle) fyne.Resource { return nil }
+
+func (dummyTheme) Icon(fyne.ThemeIconName) fyne.Resource { return nil }
+
+func (dummyTheme) Size(fyne.ThemeSizeName) float32 { return 0 }
+
 type dummyWidget struct {
 	fyne.Widget
 	onDestroy func()
+}
+
+type dummyBaseWidget struct {
+	dummyWidget
+	impl fyne.Widget
+}
+
+func (*dummyBaseWidget) ExtendBaseWidget(fyne.Widget) {}
+
+func (w *dummyBaseWidget) super() fyne.Widget {
+	return w.impl
+}
+
+type dummyMobileScope struct {
+	fyne.CanvasObject
+}
+
+func (*dummyMobileScope) SetDeviceIsMobile(bool) {}
+
+type nilRendererWidget struct {
+	dummyWidget
+}
+
+func (*nilRendererWidget) CreateRenderer() fyne.WidgetRenderer {
+	return nil
 }
 
 func (w *dummyWidget) CreateRenderer() fyne.WidgetRenderer {
@@ -300,6 +442,8 @@ func testClearAll() {
 	objectTextures.Clear()
 	renderers.Clear()
 	blurKernels.Clear()
+	fontSizeCache.Clear()
+	overrides.Clear()
 	timeNow = time.Now
 	refreshNow()
 }

--- a/internal/cache/blur_kernel_test.go
+++ b/internal/cache/blur_kernel_test.go
@@ -1,0 +1,31 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlurKernelCache(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	values, ok := GetBlurKernel(1.5)
+	assert.False(t, ok)
+	assert.Nil(t, values)
+
+	tm := &timeMock{}
+	tm.setTime(10, 10)
+	SetBlurKernel(1.5, []float32{0.2, 0.6, 0.2})
+	values, ok = GetBlurKernel(1.5)
+	assert.True(t, ok)
+	assert.Equal(t, []float32{0.2, 0.6, 0.2}, values)
+
+	lastClean = time.Time{}
+	tm.setTime(11, 20)
+	Clean(false)
+
+	_, ok = GetBlurKernel(1.5)
+	assert.False(t, ok)
+}

--- a/internal/cache/canvases_test.go
+++ b/internal/cache/canvases_test.go
@@ -34,6 +34,17 @@ func TestSetCanvasForObject(t *testing.T) {
 	assert.Equal(t, 2, called)
 }
 
+func TestGetCanvasForObject_Missing(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	obj := &dummyWidget{}
+	assert.Nil(t, GetCanvasForObject(obj))
+
+	canvases.Store(obj, nil)
+	assert.Nil(t, GetCanvasForObject(obj))
+}
+
 func TestSetCanvasForObject_keepsAlive(t *testing.T) {
 	testClearAll()
 	defer testClearAll()

--- a/internal/cache/svg_test.go
+++ b/internal/cache/svg_test.go
@@ -4,8 +4,9 @@ import (
 	"image"
 	"testing"
 
-	"fyne.io/fyne/v2"
 	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
 )
 
 func TestSvgCacheGet(t *testing.T) {
@@ -43,6 +44,23 @@ func TestSvgCacheReset(t *testing.T) {
 
 	ResetThemeCaches()
 	assert.Equal(t, 0, svgs.Len())
+}
+
+func TestSvgCacheOverrideName(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	w := &dummyWidget{}
+	tex := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+	SetSvg("icon.svg", w, tex, 4, 4)
+	assert.Equal(t, tex, GetSvg("icon.svg", w, 4, 4))
+	assert.Equal(t, tex, GetSvg("icon.svg", nil, 4, 4))
+
+	testClearAll()
+	OverrideTheme(w, dummyTheme{})
+	SetSvg("icon.svg", w, tex, 4, 4)
+	assert.Equal(t, tex, GetSvg("icon.svg", w, 4, 4))
+	assert.Nil(t, GetSvg("icon.svg", nil, 4, 4))
 }
 
 func addFileToCache(path string, w, h int) image.Image {

--- a/internal/cache/text_test.go
+++ b/internal/cache/text_test.go
@@ -2,9 +2,11 @@ package cache
 
 import (
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"fyne.io/fyne/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTextCacheGet(t *testing.T) {
@@ -21,4 +23,29 @@ func TestTextCacheGet(t *testing.T) {
 	bound, base = GetFontMetrics("hi", 10, fyne.TextStyle{}, nil)
 	assert.Equal(t, fyne.NewSize(10, 10), bound)
 	assert.Equal(t, float32(8), base)
+}
+
+func TestFontMetricsWithSourceAndExpiry(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	res := fyne.NewStaticResource("font.ttf", []byte("x"))
+	SetFontMetrics("hi", 10, fyne.TextStyle{}, res, fyne.NewSize(12, 12), 7)
+	bound, base := GetFontMetrics("hi", 10, fyne.TextStyle{}, res)
+	assert.Equal(t, fyne.NewSize(12, 12), bound)
+	assert.Equal(t, float32(7), base)
+
+	ClearFontMetrics()
+	bound, base = GetFontMetrics("hi", 10, fyne.TextStyle{}, res)
+	assert.True(t, bound.IsZero())
+	assert.Equal(t, float32(0), base)
+
+	tm := &timeMock{}
+	tm.setTime(10, 10)
+	SetFontMetrics("hi", 10, fyne.TextStyle{}, res, fyne.NewSize(12, 12), 7)
+	lastClean = time.Time{}
+	tm.setTime(11, 20)
+	Clean(false)
+	bound, _ = GetFontMetrics("hi", 10, fyne.TextStyle{}, res)
+	assert.True(t, bound.IsZero())
 }

--- a/internal/cache/texture_desktop_test.go
+++ b/internal/cache/texture_desktop_test.go
@@ -1,0 +1,7 @@
+//go:build !android && !ios && !mobile && !wasm && !test_web_driver
+
+package cache
+
+func testTexture(value uint32) TextureType {
+	return TextureType(value)
+}

--- a/internal/cache/texture_gomobile_test.go
+++ b/internal/cache/texture_gomobile_test.go
@@ -1,0 +1,7 @@
+//go:build android || ios || mobile
+
+package cache
+
+func testTexture(value uint32) TextureType {
+	return TextureType{Value: value}
+}

--- a/internal/cache/texture_test.go
+++ b/internal/cache/texture_test.go
@@ -1,0 +1,113 @@
+package cache
+
+import (
+	"image/color"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+)
+
+func TestObjectTextures(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	c := &dummyCanvas{}
+	other := &dummyCanvas{}
+	obj := &dummyCanvasObject{}
+	otherObj := &dummyCanvasObject{}
+
+	tex, ok := GetTexture(obj)
+	assert.False(t, ok)
+	assert.Equal(t, NoTexture, tex)
+	assert.False(t, IsValid(tex))
+
+	tm := &timeMock{}
+	tm.setTime(10, 10)
+	SetTexture(obj, TextureType(7), c)
+	tex, ok = GetTexture(obj)
+	assert.True(t, ok)
+	assert.Equal(t, TextureType(7), tex)
+	assert.True(t, IsValid(tex))
+
+	visited := 0
+	RangeTexturesFor(c, func(_ fyne.CanvasObject) { visited++ })
+	assert.Equal(t, 1, visited)
+
+	visited = 0
+	RangeTexturesFor(other, func(_ fyne.CanvasObject) { visited++ })
+	assert.Equal(t, 0, visited)
+
+	DeleteTexture(obj)
+	_, ok = GetTexture(obj)
+	assert.False(t, ok)
+
+	objectTextures.Store(obj, nil)
+	tex, ok = GetTexture(obj)
+	assert.False(t, ok)
+	assert.Equal(t, NoTexture, tex)
+
+	SetTexture(obj, TextureType(1), c)
+	SetTexture(otherObj, TextureType(2), other)
+	tm.now = tm.now.Add(ValidDuration + time.Second)
+
+	expired := 0
+	RangeExpiredTexturesFor(c, func(_ fyne.CanvasObject) { expired++ })
+	assert.Equal(t, 1, expired)
+
+	expired = 0
+	RangeExpiredTexturesFor(other, func(_ fyne.CanvasObject) { expired++ })
+	assert.Equal(t, 1, expired)
+}
+
+func TestTextTextures(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	c := &dummyCanvas{}
+	other := &dummyCanvas{}
+	ent := FontCacheEntry{
+		fontSizeEntry: fontSizeEntry{Text: "hi", Size: 10},
+		Canvas:        c,
+		Color:         color.Black,
+	}
+	otherEnt := FontCacheEntry{
+		fontSizeEntry: fontSizeEntry{Text: "yo", Size: 10},
+		Canvas:        other,
+	}
+
+	tex, ok := GetTextTexture(ent)
+	assert.False(t, ok)
+	assert.Equal(t, NoTexture, tex)
+
+	textTextures.Store(ent, nil)
+	tex, ok = GetTextTexture(ent)
+	assert.False(t, ok)
+	assert.Equal(t, NoTexture, tex)
+
+	freed := 0
+	SetTextTexture(ent, TextureType(3), c, func() { freed++ })
+	SetTextTexture(otherEnt, TextureType(4), other, func() { freed++ })
+
+	tex, ok = GetTextTexture(ent)
+	assert.True(t, ok)
+	assert.Equal(t, TextureType(3), tex)
+
+	DeleteTextTexturesFor(c)
+	assert.Equal(t, 1, freed)
+	_, ok = GetTextTexture(ent)
+	assert.False(t, ok)
+	_, ok = GetTextTexture(otherEnt)
+	assert.True(t, ok)
+
+	tm := &timeMock{}
+	tm.setTime(10, 10)
+	SetTextTexture(ent, TextureType(5), c, func() { freed++ })
+	tm.now = tm.now.Add(ValidDuration + time.Second)
+	RangeExpiredTexturesFor(c, func(_ fyne.CanvasObject) {})
+	assert.Equal(t, 2, freed)
+	_, ok = GetTextTexture(ent)
+	assert.False(t, ok)
+}

--- a/internal/cache/texture_test.go
+++ b/internal/cache/texture_test.go
@@ -26,10 +26,10 @@ func TestObjectTextures(t *testing.T) {
 
 	tm := &timeMock{}
 	tm.setTime(10, 10)
-	SetTexture(obj, TextureType(7), c)
+	SetTexture(obj, testTexture(7), c)
 	tex, ok = GetTexture(obj)
 	assert.True(t, ok)
-	assert.Equal(t, TextureType(7), tex)
+	assert.Equal(t, testTexture(7), tex)
 	assert.True(t, IsValid(tex))
 
 	visited := 0
@@ -49,8 +49,8 @@ func TestObjectTextures(t *testing.T) {
 	assert.False(t, ok)
 	assert.Equal(t, NoTexture, tex)
 
-	SetTexture(obj, TextureType(1), c)
-	SetTexture(otherObj, TextureType(2), other)
+	SetTexture(obj, testTexture(1), c)
+	SetTexture(otherObj, testTexture(2), other)
 	tm.now = tm.now.Add(ValidDuration + time.Second)
 
 	expired := 0
@@ -88,12 +88,12 @@ func TestTextTextures(t *testing.T) {
 	assert.Equal(t, NoTexture, tex)
 
 	freed := 0
-	SetTextTexture(ent, TextureType(3), c, func() { freed++ })
-	SetTextTexture(otherEnt, TextureType(4), other, func() { freed++ })
+	SetTextTexture(ent, testTexture(3), c, func() { freed++ })
+	SetTextTexture(otherEnt, testTexture(4), other, func() { freed++ })
 
 	tex, ok = GetTextTexture(ent)
 	assert.True(t, ok)
-	assert.Equal(t, TextureType(3), tex)
+	assert.Equal(t, testTexture(3), tex)
 
 	DeleteTextTexturesFor(c)
 	assert.Equal(t, 1, freed)
@@ -104,7 +104,7 @@ func TestTextTextures(t *testing.T) {
 
 	tm := &timeMock{}
 	tm.setTime(10, 10)
-	SetTextTexture(ent, TextureType(5), c, func() { freed++ })
+	SetTextTexture(ent, testTexture(5), c, func() { freed++ })
 	tm.now = tm.now.Add(ValidDuration + time.Second)
 	RangeExpiredTexturesFor(c, func(_ fyne.CanvasObject) {})
 	assert.Equal(t, 2, freed)

--- a/internal/cache/texture_wasm_test.go
+++ b/internal/cache/texture_wasm_test.go
@@ -1,0 +1,9 @@
+//go:build wasm || test_web_driver
+
+package cache
+
+import "syscall/js"
+
+func testTexture(value uint32) TextureType {
+	return TextureType{Value: js.ValueOf(value)}
+}

--- a/internal/cache/theme_test.go
+++ b/internal/cache/theme_test.go
@@ -1,0 +1,82 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/fyne/v2"
+)
+
+func TestOverrideTheme(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	th := dummyTheme{}
+	w := &dummyWidget{}
+	child := &dummyCanvasObject{}
+	Renderer(w).(*dummyWidgetRenderer).objects = []fyne.CanvasObject{child}
+
+	OverrideTheme(w, th)
+	assert.Equal(t, th, WidgetTheme(w))
+	assert.NotEmpty(t, WidgetScopeID(w))
+	assert.Equal(t, th, WidgetTheme(child))
+	assert.Equal(t, WidgetScopeID(w), WidgetScopeID(child))
+}
+
+func TestOverrideTheme_ContainerAndPrimitive(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	th := dummyTheme{}
+	child := &dummyCanvasObject{}
+	nested := &dummyWidget{}
+	c := &fyne.Container{Objects: []fyne.CanvasObject{child, nested}}
+
+	OverrideTheme(c, th)
+	assert.Equal(t, th, WidgetTheme(child))
+	assert.Equal(t, th, WidgetTheme(nested))
+	assert.Nil(t, WidgetTheme(c))
+
+	primitive := &dummyCanvasObject{}
+	OverrideTheme(primitive, th)
+	assert.Equal(t, th, WidgetTheme(primitive))
+}
+
+func TestOverrideTheme_SkipsMobileScopeAndNilRenderer(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	th := dummyTheme{}
+	mobile := &dummyMobileScope{}
+	OverrideTheme(mobile, th)
+	assert.Nil(t, WidgetTheme(mobile))
+	assert.Empty(t, WidgetScopeID(mobile))
+
+	w := &nilRendererWidget{}
+	OverrideTheme(w, th)
+	assert.Equal(t, th, WidgetTheme(w))
+}
+
+func TestOverrideThemeMatchingScope(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	th := dummyTheme{}
+	parent := &dummyCanvasObject{}
+	child := &dummyCanvasObject{}
+
+	assert.False(t, OverrideThemeMatchingScope(child, parent))
+	assert.Nil(t, WidgetTheme(child))
+
+	OverrideTheme(parent, th)
+	assert.True(t, OverrideThemeMatchingScope(child, parent))
+	assert.Equal(t, th, WidgetTheme(child))
+	assert.Equal(t, WidgetScopeID(parent), WidgetScopeID(child))
+}
+
+func TestWidgetThemeAndScopeIDWithoutOverride(t *testing.T) {
+	obj := &dummyCanvasObject{}
+	assert.Nil(t, WidgetTheme(obj))
+	assert.Empty(t, WidgetScopeID(obj))
+}

--- a/internal/cache/widget_test.go
+++ b/internal/cache/widget_test.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCachedRenderer(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	r, ok := CachedRenderer(nil)
+	assert.False(t, ok)
+	assert.Nil(t, r)
+
+	inner := &dummyWidget{}
+	want := Renderer(inner)
+
+	outer := &dummyBaseWidget{impl: inner}
+	r, ok = CachedRenderer(outer)
+	assert.True(t, ok)
+	assert.Equal(t, want, r)
+
+	unwired := &dummyBaseWidget{}
+	r, ok = CachedRenderer(unwired)
+	assert.False(t, ok)
+	assert.Nil(t, r)
+}
+
+func TestDestroyRendererAndIsRendered(t *testing.T) {
+	testClearAll()
+	t.Cleanup(testClearAll)
+
+	destroyed := 0
+	w := &dummyWidget{onDestroy: func() { destroyed++ }}
+	assert.False(t, IsRendered(w))
+
+	DestroyRenderer(w)
+	assert.Zero(t, destroyed)
+
+	Renderer(w)
+	assert.True(t, IsRendered(w))
+
+	DestroyRenderer(w)
+	assert.Equal(t, 1, destroyed)
+	assert.False(t, IsRendered(w))
+
+	renderers.Store(w, nil)
+	DestroyRenderer(w)
+	assert.False(t, IsRendered(w))
+}
+
+func TestRendererNilWidget(t *testing.T) {
+	assert.Nil(t, Renderer(nil))
+}


### PR DESCRIPTION
### Description:

PR #6465 removed per-object `time.Now()` calls by stamping cache entries from a clock sample refreshed in `Clean`. After a driver goes longer than `ValidDuration` without painting, entries used before its next `Clean` receive deadlines based on the stale sample and can be deleted immediately by that same cleanup.

This change detects when the sample is older than the complete cache lifetime. It refreshes the sample as usual but defers deletion for one pass, allowing active entries to be restamped before the next eligible cleanup. Genuinely stale entries are still removed on that following pass, and the per-object path remains a single atomic load plus an add.

The regression test models both an old entry and one touched immediately before the first frame after a long idle. It verifies that the ambiguous first cleanup preserves both, then that the next pass removes the old entry while retaining the active one.

Fixes #6509

### Testing:

- `go test -race -count=1 ./internal/cache`
- `go test -race -tags no_glfw,ci,migrated_fynedo ./...`
- `go vet -tags no_glfw,ci,migrated_fynedo ./...`
- `golangci-lint run --verbose`
- `gofumpt -d -e .`
- `goimports -e -d .`
- PicFetch's accelerated downstream reproducer with `FYNE_CACHE=100ms`

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
