### PR TITLE
Clarify *CornerRadius documentation

### DIFF
--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -28,25 +28,25 @@ type Rectangle struct {
 	Aspect float32
 
 	// The radius of the rectangle top-right corner only.
-	// Note: Overridden by [Rectangle.CornerRadius] if 0.
+	// Note: Falls back to [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	TopRightCornerRadius float32
 
 	// The radius of the rectangle top-left corner only.
-	// Note: Overridden by [Rectangle.CornerRadius] if 0.
+	// Note: Falls back to [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	TopLeftCornerRadius float32
 
 	// The radius of the rectangle bottom-right corner only.
-	// Note: Overridden by [Rectangle.CornerRadius] if 0.
+	// Note: Falls back to [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	BottomRightCornerRadius float32
 
 	// The radius of the rectangle bottom-left corner only.
-	// Note: Overridden by [Rectangle.CornerRadius] if 0.
+	// Note: Falls back to [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	BottomLeftCornerRadius float32

--- a/canvas/rectangle.go
+++ b/canvas/rectangle.go
@@ -28,21 +28,25 @@ type Rectangle struct {
 	Aspect float32
 
 	// The radius of the rectangle top-right corner only.
+	// Note: Overridden by [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	TopRightCornerRadius float32
 
 	// The radius of the rectangle top-left corner only.
+	// Note: Overridden by [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	TopLeftCornerRadius float32
 
 	// The radius of the rectangle bottom-right corner only.
+	// Note: Overridden by [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	BottomRightCornerRadius float32
 
 	// The radius of the rectangle bottom-left corner only.
+	// Note: Overridden by [Rectangle.CornerRadius] if 0.
 	//
 	// Since: 2.7
 	BottomLeftCornerRadius float32


### PR DESCRIPTION
### Description:
Clarify rectangle CornerRadius docs to specify that 0 value corner-specific radii is overridden by CornerRadius, as this isn't intuitive.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
