### PR TITLE
Fix issue where iOS feels much slower than Android

### DIFF
--- a/internal/driver/mobile/app/darwin_ios.go
+++ b/internal/driver/mobile/app/darwin_ios.go
@@ -218,29 +218,40 @@ func lifecycleMemoryWarning() {
 	cleanCaches()
 }
 
-// painting is true from BeginPaint until drawloop completed.
+// painting is true while the driver is handling a paint, from BeginPaint until
+// EndPaint or the publish that ends it.
 var painting atomic.Bool
 
-// BeginPaint records that a frame's drawing commands are about to be issued,
-// and that a matching Publish will follow.
+// paintDone wakes the UI thread from a paint that ended without publishing a
+// frame, which it cannot see from the atomic alone.
+var paintDone = make(chan struct{}, 1)
+
+// BeginPaint records that the driver has started a paint.
 func BeginPaint() {
+	select {
+	case <-paintDone: // drop a wakeup left over from the last paint
+	default:
+	}
 	painting.Store(true)
+}
+
+// EndPaint records that the driver has finished a paint, published or not.
+func EndPaint() {
+	painting.Store(false)
+	select {
+	case paintDone <- struct{}{}:
+	default:
+	}
 }
 
 // needsDraw reports whether the UI thread has pending changes to draw.
 //
 //export needsDraw
 func needsDraw() C.int {
-	if painting.Load() {
+	if painting.Load() || theApp.worker.HasWork() {
 		return 1
 	}
-
-	select {
-	case <-theApp.worker.WorkAvailable():
-		return 1
-	default:
-		return 0
-	}
+	return 0
 }
 
 //export drawloop
@@ -269,6 +280,8 @@ func drawloop() {
 		case <-theApp.publish:
 			painting.Store(false)
 			theApp.publishResult <- PublishResult{}
+			return
+		case <-paintDone:
 			return
 		}
 	}

--- a/internal/driver/mobile/app/darwin_ios.go
+++ b/internal/driver/mobile/app/darwin_ios.go
@@ -218,30 +218,14 @@ func lifecycleMemoryWarning() {
 	cleanCaches()
 }
 
-// painting is true while the driver is handling a paint, from BeginPaint until
-// EndPaint or the publish that ends it.
+// painting is true from BeginPaint until drawloop takes the publish that ends
+// the frame. The UI thread reads it, so it has to be atomic.
 var painting atomic.Bool
 
-// paintDone wakes the UI thread from a paint that ended without publishing a
-// frame, which it cannot see from the atomic alone.
-var paintDone = make(chan struct{}, 1)
-
-// BeginPaint records that the driver has started a paint.
+// BeginPaint records that the driver is about to queue a frame's GL calls and
+// will follow them with a Publish.
 func BeginPaint() {
-	select {
-	case <-paintDone: // drop a wakeup left over from the last paint
-	default:
-	}
 	painting.Store(true)
-}
-
-// EndPaint records that the driver has finished a paint, published or not.
-func EndPaint() {
-	painting.Store(false)
-	select {
-	case paintDone <- struct{}{}:
-	default:
-	}
 }
 
 // needsDraw reports whether the UI thread has pending changes to draw.
@@ -261,27 +245,17 @@ func drawloop() {
 
 	workAvailable := theApp.worker.WorkAvailable()
 	for {
-		// Run everything that is already queued
-		select {
-		case <-workAvailable:
-			theApp.worker.DoWork()
-			continue
-		default:
-		}
+		theApp.worker.DoWork() // returns straight away when nothing is queued
 
 		if !painting.Load() {
-			// Nothing left in the draw queue, relinquish control
-			return
+			return // no frame is coming, so hand the thread back to UIKit
 		}
 
 		select {
-		case <-workAvailable:
-			theApp.worker.DoWork()
+		case <-workAvailable: // loop round and run it
 		case <-theApp.publish:
 			painting.Store(false)
 			theApp.publishResult <- PublishResult{}
-			return
-		case <-paintDone:
 			return
 		}
 	}

--- a/internal/driver/mobile/app/darwin_ios.go
+++ b/internal/driver/mobile/app/darwin_ios.go
@@ -38,7 +38,7 @@ import (
 	"log"
 	"runtime"
 	"strings"
-	"time"
+	"sync/atomic"
 	"unsafe"
 
 	"fyne.io/fyne/v2/internal/driver/mobile/event/lifecycle"
@@ -218,19 +218,57 @@ func lifecycleMemoryWarning() {
 	cleanCaches()
 }
 
+// painting is true from BeginPaint until drawloop completed.
+var painting atomic.Bool
+
+// BeginPaint records that a frame's drawing commands are about to be issued,
+// and that a matching Publish will follow.
+func BeginPaint() {
+	painting.Store(true)
+}
+
+// needsDraw reports whether the UI thread has pending changes to draw.
+//
+//export needsDraw
+func needsDraw() C.int {
+	if painting.Load() {
+		return 1
+	}
+
+	select {
+	case <-theApp.worker.WorkAvailable():
+		return 1
+	default:
+		return 0
+	}
+}
+
 //export drawloop
 func drawloop() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	for workAvailable := theApp.worker.WorkAvailable(); ; {
+	workAvailable := theApp.worker.WorkAvailable()
+	for {
+		// Run everything that is already queued
+		select {
+		case <-workAvailable:
+			theApp.worker.DoWork()
+			continue
+		default:
+		}
+
+		if !painting.Load() {
+			// Nothing left in the draw queue, relinquish control
+			return
+		}
+
 		select {
 		case <-workAvailable:
 			theApp.worker.DoWork()
 		case <-theApp.publish:
+			painting.Store(false)
 			theApp.publishResult <- PublishResult{}
-			return
-		case <-time.After(100 * time.Millisecond): // in case the method blocked!!
 			return
 		}
 	}

--- a/internal/driver/mobile/app/darwin_ios.m
+++ b/internal/driver/mobile/app/darwin_ios.m
@@ -170,7 +170,9 @@ static CGFloat keyboardHeight;
 }
 
 - (void)render:(CADisplayLink*)displayLink {
-    [self.glview display];
+    if (needsDraw()) {
+        [self.glview display];
+    }
 }
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect {

--- a/internal/driver/mobile/app/paint_notios.go
+++ b/internal/driver/mobile/app/paint_notios.go
@@ -1,0 +1,7 @@
+//go:build !ios
+
+package app
+
+// BeginPaint records that a frame's drawing commands are about to be issued.
+// Only iOS needs this, so no-op here for everyone else.
+func BeginPaint() {}

--- a/internal/driver/mobile/app/paint_notios.go
+++ b/internal/driver/mobile/app/paint_notios.go
@@ -5,6 +5,3 @@ package app
 // BeginPaint records that a frame's drawing commands are about to be issued.
 // Only iOS needs this, so no-op here for everyone else.
 func BeginPaint() {}
-
-// EndPaint records that the driver has finished a paint.
-func EndPaint() {}

--- a/internal/driver/mobile/app/paint_notios.go
+++ b/internal/driver/mobile/app/paint_notios.go
@@ -5,3 +5,6 @@ package app
 // BeginPaint records that a frame's drawing commands are about to be issued.
 // Only iOS needs this, so no-op here for everyone else.
 func BeginPaint() {}
+
+// EndPaint records that the driver has finished a paint.
+func EndPaint() {}

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -320,7 +320,6 @@ func (d *driver) handleLifecycle(e lifecycle.Event, w *window) {
 			app.BeginPaint()
 			d.paintWindow(w, s)
 			d.app.Publish()
-			app.EndPaint()
 		}
 		if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
 			f()
@@ -338,32 +337,33 @@ func (d *driver) handlePaint(e paint.Event, w *window) {
 		return
 	}
 
-	// Painter init and drawing both queue GL calls that only the UI thread can
-	// run, so keep it with us for the whole paint - not just the draw.
-	app.BeginPaint()
-	defer app.EndPaint()
+	d.animation.TickAnimations()
+	needsInit := !c.initialized
+	canvasNeedRefresh := c.FreeDirtyTextures() > 0 || c.CheckDirtyAndClear()
+	if !needsInit && !canvasNeedRefresh {
+		cache.Clean(false)
+		return
+	}
 
-	if !c.initialized {
+	// Everything below queues GL calls that only the UI thread can run, and it blocks on each one.
+	app.BeginPaint()
+
+	if needsInit {
 		c.initialized = true
 		c.Painter().Init() // we cannot init until the context is set above
 	}
 
-	d.animation.TickAnimations()
-	canvasNeedRefresh := c.FreeDirtyTextures() > 0 || c.CheckDirtyAndClear()
-	if canvasNeedRefresh {
-		newSize := fyne.NewSize(float32(d.currentSize.WidthPx)/c.scale, float32(d.currentSize.HeightPx)/c.scale)
-
-		if c.EnsureMinSize() {
-			c.sizeContent(newSize) // force resize of content
-		} else { // if screen changed
-			w.Resize(newSize)
-		}
-
-		d.paintWindow(w, newSize)
-		d.app.Publish()
-		w.updateAccessibility()
+	newSize := fyne.NewSize(float32(d.currentSize.WidthPx)/c.scale, float32(d.currentSize.HeightPx)/c.scale)
+	if c.EnsureMinSize() {
+		c.sizeContent(newSize) // force resize of content
+	} else { // if screen changed
+		w.Resize(newSize)
 	}
-	cache.Clean(canvasNeedRefresh)
+
+	d.paintWindow(w, newSize)
+	d.app.Publish()
+	w.updateAccessibility()
+	cache.Clean(true)
 }
 
 func (*driver) onStart() {

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -317,8 +317,10 @@ func (d *driver) handleLifecycle(e lifecycle.Event, w *window) {
 			}
 
 			s := fyne.NewSize(float32(d.currentSize.WidthPx)/c.scale, float32(d.currentSize.HeightPx)/c.scale)
+			app.BeginPaint()
 			d.paintWindow(w, s)
 			d.app.Publish()
+			app.EndPaint()
 		}
 		if f := fyne.CurrentApp().Lifecycle().(*intapp.Lifecycle).OnExitedForeground(); f != nil {
 			f()
@@ -335,6 +337,12 @@ func (d *driver) handlePaint(e paint.Event, w *window) {
 	if d.glctx == nil || e.External {
 		return
 	}
+
+	// Painter init and drawing both queue GL calls that only the UI thread can
+	// run, so keep it with us for the whole paint - not just the draw.
+	app.BeginPaint()
+	defer app.EndPaint()
+
 	if !c.initialized {
 		c.initialized = true
 		c.Painter().Init() // we cannot init until the context is set above
@@ -372,10 +380,6 @@ func (*driver) onStop() {
 }
 
 func (d *driver) paintWindow(window fyne.Window, s fyne.Size) {
-	// Announce the frame before any of its GL calls are queued.
-	// Currently needed on iOS due to the thread handling there.
-	app.BeginPaint()
-
 	clips := &internal.ClipStack{}
 	c := window.Canvas().(*canvas)
 

--- a/internal/driver/mobile/driver.go
+++ b/internal/driver/mobile/driver.go
@@ -372,6 +372,10 @@ func (*driver) onStop() {
 }
 
 func (d *driver) paintWindow(window fyne.Window, s fyne.Size) {
+	// Announce the frame before any of its GL calls are queued.
+	// Currently needed on iOS due to the thread handling there.
+	app.BeginPaint()
+
 	clips := &internal.ClipStack{}
 	c := window.Canvas().(*canvas)
 

--- a/internal/driver/mobile/gl/interface.go
+++ b/internal/driver/mobile/gl/interface.go
@@ -311,4 +311,7 @@ type Worker interface {
 
 	// DoWork performs any pending OpenGL calls.
 	DoWork()
+
+	// HasWork reports whether any OpenGL calls are queued.
+	HasWork() bool
 }

--- a/internal/driver/mobile/gl/work.go
+++ b/internal/driver/mobile/gl/work.go
@@ -76,6 +76,8 @@ type context struct {
 
 func (ctx *context) WorkAvailable() <-chan struct{} { return ctx.workAvailable.Out() }
 
+func (ctx *context) HasWork() bool { return len(ctx.work) > 0 }
+
 type context3 struct {
 	*context
 }

--- a/internal/driver/mobile/gl/work_other.go
+++ b/internal/driver/mobile/gl/work_other.go
@@ -16,6 +16,10 @@ func (*context) enqueue(c call) uintptr {
 	panic("unimplemented; GOOS/CGO combination not supported")
 }
 
+func (*context) HasWork() bool {
+	panic("unimplemented; GOOS/CGO combination not supported")
+}
+
 func (*context) cString(str string) (uintptr, func()) {
 	panic("unimplemented; GOOS/CGO combination not supported")
 }

--- a/internal/driver/mobile/gl/work_windows.go
+++ b/internal/driver/mobile/gl/work_windows.go
@@ -23,6 +23,8 @@ type context struct {
 
 func (ctx *context) WorkAvailable() <-chan struct{} { return ctx.workAvailable }
 
+func (ctx *context) HasWork() bool { return len(ctx.work) > 0 }
+
 type context3 struct {
 	*context
 }


### PR DESCRIPTION
This resolves an issue where key events are not respected immediately, so repaints lag frames behind...

Thanks for the tip on #6390

This brings iOS up to parity with Android so that #1062 lands well and we all get great performance.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
