### PR TITLE
Fix nil pointer panic in FileDialog before Show

### DIFF
--- a/dialog/file.go
+++ b/dialog/file.go
@@ -717,6 +717,9 @@ func showFile(file *FileDialog) *fileDialog {
 //
 // Since: 2.6
 func (f *FileDialog) Dismiss() {
+	if f.dialog == nil {
+		return
+	}
 	f.dialog.dismiss.OnTapped()
 }
 
@@ -724,6 +727,9 @@ func (f *FileDialog) Dismiss() {
 //
 // Since: 2.1
 func (f *FileDialog) MinSize() fyne.Size {
+	if f.dialog == nil { // the popup is only created on Show
+		return fyne.NewSquareSize(1)
+	}
 	return f.dialog.win.MinSize()
 }
 
@@ -750,6 +756,9 @@ func (f *FileDialog) Show() {
 
 // Refresh causes this dialog to be updated
 func (f *FileDialog) Refresh() {
+	if f.dialog == nil {
+		return
+	}
 	f.dialog.win.Refresh()
 }
 

--- a/dialog/file_test.go
+++ b/dialog/file_test.go
@@ -831,3 +831,19 @@ func TestSetOnClosedBeforeShow(t *testing.T) {
 	d.Hide()
 	assert.True(t, onClosedCalled)
 }
+
+func TestFileDialogSizeBeforeShow(t *testing.T) {
+	win := test.NewTempWindow(t, widget.NewLabel("Content"))
+	win.Resize(fyne.NewSize(1000, 800))
+	d := NewFileOpen(func(fyne.URIReadCloser, error) {}, win)
+
+	// the popup does not exist yet, none of these may panic
+	d.MinSize()
+	d.Refresh()
+	d.Dismiss()
+	d.Resize(fyne.NewSize(700, 500))
+
+	d.Show()
+	assert.Equal(t, fyne.NewSize(700, 500), d.dialog.win.Content.Size())
+	d.Hide()
+}


### PR DESCRIPTION
`FileDialog.MinSize` dereferenced `f.dialog.win` before `Show` had created the popup, so calling it on an unshown dialog panicked, and `Resize` hit the same nil because it clamps against `MinSize`. `Refresh` and `Dismiss` had the same unguarded access.

This adds the nil check the other `FileDialog` methods already have: before the popup exists `MinSize` returns the 1x1 the base dialog uses, and `Refresh` and `Dismiss` do nothing. The new test calls all four before `Show` and checks the requested size lands afterwards; it panics on develop at the line from the issue's trace. The dialog package has some pre-existing locale and golden-image failures on my Windows box that fail the same way on develop.

Fixes #6495
