### PR TITLE
perf(software): reuse the painter's intermediate frame in Capture()

### DIFF
--- a/driver/software/canvas.go
+++ b/driver/software/canvas.go
@@ -89,6 +89,13 @@ type canvas struct {
 	propertyLock sync.RWMutex
 }
 
+// scratchPainter is implemented by painters that can render into a pooled
+// frame, so that Capture does not need a second full-frame allocation.
+type scratchPainter interface {
+	PaintScratch(fyne.Canvas) *image.NRGBA
+	ReleaseScratch(*image.NRGBA)
+}
+
 func (c *canvas) Capture() image.Image {
 	cache.Clean(true)
 	size := c.Size()
@@ -99,7 +106,13 @@ func (c *canvas) Capture() image.Image {
 	}
 
 	if c.painter != nil {
-		draw.Draw(img, bounds, c.painter.Paint(c), image.Point{}, draw.Over)
+		if scratch, ok := c.painter.(scratchPainter); ok {
+			frame := scratch.PaintScratch(c)
+			defer scratch.ReleaseScratch(frame)
+			draw.Draw(img, bounds, frame, image.Point{}, draw.Over)
+		} else {
+			draw.Draw(img, bounds, c.painter.Paint(c), image.Point{}, draw.Over)
+		}
 	}
 
 	return img

--- a/driver/software/capture_bench_test.go
+++ b/driver/software/capture_bench_test.go
@@ -1,0 +1,20 @@
+package software
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+)
+
+func BenchmarkCanvas_Capture(b *testing.B) {
+	c := NewCanvas()
+	c.SetContent(container.NewVBox(widget.NewLabel("Hello"), widget.NewButton("OK", nil)))
+	c.Resize(fyne.NewSize(400, 300))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.Capture()
+	}
+}

--- a/internal/painter/software/painter.go
+++ b/internal/painter/software/painter.go
@@ -2,6 +2,7 @@ package software
 
 import (
 	"image"
+	"sync"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -20,9 +21,51 @@ func NewPainter() *Painter {
 // Paint is the main entry point for a simple software painter.
 // The canvas to be drawn is passed in as a parameter and the return is an
 // image containing the result of rendering.
-func (*Painter) Paint(c fyne.Canvas) image.Image {
+func (p *Painter) Paint(c fyne.Canvas) image.Image {
 	bounds := image.Rect(0, 0, scale.ToScreenCoordinate(c, c.Size().Width), scale.ToScreenCoordinate(c, c.Size().Height))
 	base := image.NewNRGBA(bounds)
+	p.paintInto(c, base)
+	return base
+}
+
+// PaintScratch renders the canvas like Paint but into a frame buffer taken
+// from an internal pool. The caller must hand the image back with
+// ReleaseScratch once it has been consumed and must not retain it afterwards.
+// It is intended for callers that consume the frame immediately, such as a
+// software canvas capture that composites it onto its own image.
+func (p *Painter) PaintScratch(c fyne.Canvas) *image.NRGBA {
+	bounds := image.Rect(0, 0, scale.ToScreenCoordinate(c, c.Size().Width), scale.ToScreenCoordinate(c, c.Size().Height))
+	need := bounds.Dx() * bounds.Dy() * 4
+	base, _ := framePool.Get().(*image.NRGBA)
+	if base == nil || cap(base.Pix) < need {
+		base = image.NewNRGBA(bounds)
+	} else {
+		base.Pix = base.Pix[:need]
+		clear(base.Pix)
+		base.Stride = bounds.Dx() * 4
+		base.Rect = bounds
+	}
+	p.paintInto(c, base)
+	return base
+}
+
+// ReleaseScratch returns a frame obtained from PaintScratch to the pool.
+// Frames larger than maxPooledFrameBytes are dropped so that one oversized
+// capture does not pin a large buffer in memory for the life of the process.
+func (*Painter) ReleaseScratch(img *image.NRGBA) {
+	if img == nil || cap(img.Pix) > maxPooledFrameBytes {
+		return
+	}
+	framePool.Put(img)
+}
+
+// maxPooledFrameBytes bounds the size of frames kept in the pool
+// (a 3840x2160 NRGBA frame).
+const maxPooledFrameBytes = 3840 * 2160 * 4
+
+var framePool sync.Pool
+
+func (*Painter) paintInto(c fyne.Canvas, base *image.NRGBA) {
 
 	paint := func(obj fyne.CanvasObject, pos, clipPos fyne.Position, clipSize fyne.Size) bool {
 		w := fyne.Min(clipPos.X+clipSize.Width, c.Size().Width)
@@ -69,6 +112,4 @@ func (*Painter) Paint(c fyne.Canvas) image.Image {
 	for _, o := range c.Overlays().List() {
 		driver.WalkVisibleObjectTree(o, paint, nil)
 	}
-
-	return base
 }

--- a/internal/painter/software/painter.go
+++ b/internal/painter/software/painter.go
@@ -66,7 +66,6 @@ const maxPooledFrameBytes = 3840 * 2160 * 4
 var framePool sync.Pool
 
 func (*Painter) paintInto(c fyne.Canvas, base *image.NRGBA) {
-
 	paint := func(obj fyne.CanvasObject, pos, clipPos fyne.Position, clipSize fyne.Size) bool {
 		w := fyne.Min(clipPos.X+clipSize.Width, c.Size().Width)
 		h := fyne.Min(clipPos.Y+clipSize.Height, c.Size().Height)

--- a/internal/painter/software/scratch_external_test.go
+++ b/internal/painter/software/scratch_external_test.go
@@ -1,0 +1,33 @@
+package software_test
+
+import (
+	"bytes"
+	"image"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/internal/painter/software"
+	"fyne.io/fyne/v2/test"
+)
+
+func TestPaintScratch_MatchesPaintAcrossSizes(t *testing.T) {
+	p := software.NewPainter()
+	for _, size := range []fyne.Size{{Width: 64, Height: 48}, {Width: 32, Height: 96}, {Width: 128, Height: 16}} {
+		c := test.NewCanvas()
+		rect := canvas.NewRectangle(image.White)
+		rect.Resize(fyne.NewSize(size.Width/2, size.Height/2))
+		c.SetContent(rect)
+		c.Resize(size)
+
+		want := p.Paint(c).(*image.NRGBA)
+		got := p.PaintScratch(c)
+		if got.Rect != want.Rect || got.Stride != want.Stride {
+			t.Fatalf("size %v: geometry differs: got rect=%v stride=%d, want rect=%v stride=%d", size, got.Rect, got.Stride, want.Rect, want.Stride)
+		}
+		if !bytes.Equal(got.Pix, want.Pix) {
+			t.Fatalf("size %v: pixels differ between Paint and PaintScratch", size)
+		}
+		p.ReleaseScratch(got)
+	}
+}

--- a/internal/painter/software/scratch_test.go
+++ b/internal/painter/software/scratch_test.go
@@ -1,0 +1,16 @@
+package software
+
+import (
+	"image"
+	"testing"
+)
+
+func TestReleaseScratch_DropsOversizedFrames(t *testing.T) {
+	p := NewPainter()
+	big := image.NewNRGBA(image.Rect(0, 0, 1, maxPooledFrameBytes/4+1))
+	p.ReleaseScratch(big)
+	if got, _ := framePool.Get().(*image.NRGBA); got != nil && cap(got.Pix) > maxPooledFrameBytes {
+		t.Fatalf("oversized frame was kept in the pool (cap=%d)", cap(got.Pix))
+	}
+	p.ReleaseScratch(nil)
+}


### PR DESCRIPTION
### Description:

`software.canvas.Capture()` allocates a full-frame image, then
`painter/software.Painter.Paint()` allocates a second one, which is composited
onto the first with `draw.Over` and discarded. This change adds an internal
`PaintScratch` / `ReleaseScratch` pair on the software painter that renders
into a pooled frame; `Capture()` uses it through an optional interface and
falls back to `Paint()` for any other painter. Output is pixel-identical: the
two-step composition (transparent frame, then `Over` the background) is kept
as is. Frames above 4K are not returned to the pool. `driver.Painter` is
unchanged.

Benchmark, 400x300 canvas with a label and a button, Linux amd64:

    develop:  1 108 769 B/op   155 allocs/op   2.14 ms/op
    this PR:    639 086 B/op   153 allocs/op   2.08 ms/op

Related: #6500, #6501 (superseded), #6502 (closed, discussion).

### Checklist:

- [x] Tests included (pixel parity across sizes, pool size cap).
- [x] Lint and formatter run with no errors.
- [x] Tests all pass (`driver/software`, `internal/painter/software`, `test` under `-race`;
      `widget`/`dialog` golden tests unchanged: the same platform font failures
      before and after).

#### Where applicable:

- [x] Public APIs match existing style and have Since: line. (No public API change.)
- [x] Any breaking changes have a deprecation path or have been discussed. (None.)
- [x] Check for binary size increases when importing new modules. (No new module.)
