### PR TITLE
enable Revive rule `exported`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,8 @@ linters:
           arguments:
             - allowNoDefault
         - name: exported
-          disabled: true # TODO
+          exclude:
+            - "**/internal/**" # TODO: enable for internal packages, too?
         - name: flag-parameter
           disabled: true
         - name: function-length

--- a/accessibility.go
+++ b/accessibility.go
@@ -5,6 +5,7 @@ package fyne
 // Since: 2.8
 type AccessibleRole string
 
+// Known values for [AccessibleRole].
 const (
 	AccessibleRoleButton    AccessibleRole = "button"
 	AccessibleRoleContainer AccessibleRole = "container"

--- a/container/clip.go
+++ b/container/clip.go
@@ -24,6 +24,7 @@ func NewClip(content fyne.CanvasObject) *Clip {
 	return &Clip{Content: content}
 }
 
+// CreateRenderer implements the [fyne.Widget] interface.
 func (c *Clip) CreateRenderer() fyne.WidgetRenderer {
 	c.ExtendBaseWidget(c)
 	return newClipRenderer(c)

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -156,7 +156,7 @@ func (w *InnerWindow) SetActive(active bool) {
 	w.Refresh()
 }
 
-// SetContent replaces the first [fyne.CanvasObject] of thw window’s content with the dpecified one.
+// SetContent replaces the first [fyne.CanvasObject] of thw window’s content with the specified one.
 // The window must have a non-empty content.
 func (w *InnerWindow) SetContent(obj fyne.CanvasObject) {
 	w.Content.Objects[0] = obj

--- a/container/innerwindow.go
+++ b/container/innerwindow.go
@@ -68,10 +68,12 @@ func NewInnerWindow(title string, content fyne.CanvasObject) *InnerWindow {
 	return w
 }
 
+// Close closes the window by hiding it.
 func (w *InnerWindow) Close() {
 	w.Hide()
 }
 
+// CreateRenderer implements the [fyne.Widget] interface.
 func (w *InnerWindow) CreateRenderer() fyne.WidgetRenderer {
 	w.ExtendBaseWidget(w)
 	th := w.Theme()
@@ -154,6 +156,8 @@ func (w *InnerWindow) SetActive(active bool) {
 	w.Refresh()
 }
 
+// SetContent replaces the first [fyne.CanvasObject] of thw window’s content with the dpecified one.
+// The window must have a non-empty content.
 func (w *InnerWindow) SetContent(obj fyne.CanvasObject) {
 	w.Content.Objects[0] = obj
 
@@ -168,6 +172,7 @@ func (w *InnerWindow) SetMaximized(maximized bool) {
 	w.Refresh()
 }
 
+// SetPadded allows applications to specify whether the window should have inner padding.
 func (w *InnerWindow) SetPadded(pad bool) {
 	if pad {
 		w.Content.Layout = layout.NewPaddedLayout()
@@ -177,6 +182,7 @@ func (w *InnerWindow) SetPadded(pad bool) {
 	w.Content.Refresh()
 }
 
+// SetTitle updates the current title of the window.
 func (w *InnerWindow) SetTitle(title string) {
 	w.Title = title
 	w.Refresh()

--- a/container/multiplewindows.go
+++ b/container/multiplewindows.go
@@ -31,17 +31,20 @@ func NewMultipleWindows(wins ...*InnerWindow) *MultipleWindows {
 	return m
 }
 
+// Add appends an [InnerWindow] to the managed windows.
 func (m *MultipleWindows) Add(w *InnerWindow) {
 	m.Windows = append(m.Windows, w)
 	m.refreshChildren()
 }
 
+// CreateRenderer implements the [fyne.Widget] interface.
 func (m *MultipleWindows) CreateRenderer() fyne.WidgetRenderer {
 	m.content = New(&multiWinLayout{})
 	m.refreshChildren()
 	return widget.NewSimpleRenderer(intWidget.NewScroll(m.content))
 }
 
+// Refresh implements the [fyne.CanvasObject] interface.
 func (m *MultipleWindows) Refresh() {
 	m.refreshChildren()
 	//	m.BaseWidget.Refresh()

--- a/container/navigation.go
+++ b/container/navigation.go
@@ -152,6 +152,7 @@ type navigatorRenderer struct {
 	objects []fyne.CanvasObject
 }
 
+// CreateRenderer implements the [fyne.Widget] interface.
 func (nav *Navigation) CreateRenderer() fyne.WidgetRenderer {
 	r := &navigatorRenderer{
 		nav: nav,

--- a/container/theme.go
+++ b/container/theme.go
@@ -40,12 +40,14 @@ func NewThemeOverride(obj fyne.CanvasObject, th fyne.Theme) *ThemeOverride {
 	return t
 }
 
+// CreateRenderer implements the [fyne.Widget] interface.
 func (t *ThemeOverride) CreateRenderer() fyne.WidgetRenderer {
 	cache.OverrideTheme(t.Content, addFeatures(t.Theme, t))
 
 	return &overrideRenderer{parent: t, objs: []fyne.CanvasObject{t.holder}}
 }
 
+// Refresh implements the [fyne.CanvasObject] interface.
 func (t *ThemeOverride) Refresh() {
 	if t.holder.Objects[0] != t.Content {
 		t.holder.Objects[0] = t.Content

--- a/dialog/file.go
+++ b/dialog/file.go
@@ -26,6 +26,7 @@ import (
 // Since: 2.5
 type ViewLayout int
 
+// Known values for [ViewLayout].
 const (
 	defaultView ViewLayout = iota
 	ListView

--- a/widget/activity.go
+++ b/widget/activity.go
@@ -31,6 +31,7 @@ func NewActivity() *Activity {
 	return a
 }
 
+// MinSize implements the [fyne.CanvasObject] interface.
 func (a *Activity) MinSize() fyne.Size {
 	a.ExtendBaseWidget(a)
 	return a.BaseWidget.MinSize()
@@ -58,6 +59,7 @@ func (a *Activity) Stop() {
 	a.Refresh()
 }
 
+// CreateRenderer implements the [fyne.Widget] interface.
 func (a *Activity) CreateRenderer() fyne.WidgetRenderer {
 	dots := make([]fyne.CanvasObject, 3)
 	v := fyne.CurrentApp().Settings().ThemeVariant()

--- a/widget/entry.go
+++ b/widget/entry.go
@@ -451,6 +451,7 @@ func (e *Entry) Redo() {
 	e.Refresh()
 }
 
+// Refresh implements the [fyne.CanvasObject] interface.
 func (e *Entry) Refresh() {
 	e.minCache = fyne.Size{}
 

--- a/widget/radio_group.go
+++ b/widget/radio_group.go
@@ -109,6 +109,7 @@ func (r *RadioGroup) itemTapped(item *radioItem, idx int) {
 	r.Refresh()
 }
 
+// Refresh implements the [fyne.CanvasObject] interface.
 func (r *RadioGroup) Refresh() {
 	r.updateSelectedIndex()
 	r.BaseWidget.Refresh()

--- a/widget/table.go
+++ b/widget/table.go
@@ -183,6 +183,7 @@ func (t *Table) CreateRenderer() fyne.WidgetRenderer {
 	return r
 }
 
+// Cursor implements the [desktop.Cursorable] interface.
 func (t *Table) Cursor() desktop.Cursor {
 	if t.hoverHeaderRow != noCellMatch {
 		return desktop.VResizeCursor
@@ -193,6 +194,7 @@ func (t *Table) Cursor() desktop.Cursor {
 	return desktop.DefaultCursor
 }
 
+// Dragged implements the [fyne.Draggable] interface.
 func (t *Table) Dragged(e *fyne.DragEvent) {
 	minSize := t.cellSize
 	col := t.dragCol
@@ -216,6 +218,7 @@ func (t *Table) Dragged(e *fyne.DragEvent) {
 	}
 }
 
+// DragEnd implements the [fyne.Draggable] interface.
 func (t *Table) DragEnd() {
 	t.dragCol = noCellMatch
 	t.dragRow = noCellMatch
@@ -236,6 +239,7 @@ func (t *Table) FocusLost() {
 	t.Refresh() // Item(t.currentHighlight)
 }
 
+// MouseIn implements the [desktop.Hoverable] interface.
 func (t *Table) MouseIn(ev *desktop.MouseEvent) {
 	t.hoverAt(ev.Position)
 }
@@ -245,10 +249,12 @@ func (t *Table) MouseDown(e *desktop.MouseEvent) {
 	t.tapped(e.Position)
 }
 
+// MouseMoved implements the [desktop.Hoverable] interface.
 func (t *Table) MouseMoved(ev *desktop.MouseEvent) {
 	t.hoverAt(ev.Position)
 }
 
+// MouseOut implements the [desktop.Hoverable] interface.
 func (t *Table) MouseOut() {
 	t.hoverOut()
 }
@@ -622,6 +628,7 @@ func (t *Table) ScrollToTrailing() {
 	t.finishScroll()
 }
 
+// Tapped implements the [fyne.Tappable] interface.
 func (t *Table) Tapped(e *fyne.PointEvent) {
 	if e.Position.X < 0 || e.Position.X >= t.Size().Width || e.Position.Y < 0 || e.Position.Y >= t.Size().Height {
 		t.selectedCell = nil


### PR DESCRIPTION
### Description:

This enables the Revive rule `exported` which complains about missing comments on exported stuff.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
