### PR TITLE
Store new desktop app data outside the fyne subdirectory

### DIFF
--- a/app/appdir.go
+++ b/app/appdir.go
@@ -1,0 +1,25 @@
+//go:build !android && !ios && !mobile
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// appDir returns the directory for this app's data given the "fyne" directory
+// that used to hold all apps. Apps that already have data in there keep using
+// it, new apps live directly under the parent (e.g. ~/.config/app_id).
+// Apps without an ID have nothing to migrate, so they stay in the old place.
+// So does everything under a root that is not an absolute "fyne" directory,
+// which covers test builds and web where there is no platform location.
+func (a *fyneApp) appDir(fyneDir string) string {
+	old := filepath.Join(fyneDir, a.UniqueID())
+	if a.missingID || !filepath.IsAbs(fyneDir) || filepath.Base(fyneDir) != "fyne" {
+		return old
+	}
+	if _, err := os.Stat(old); err == nil {
+		return old
+	}
+	return filepath.Join(filepath.Dir(fyneDir), a.UniqueID())
+}

--- a/app/appdir_test.go
+++ b/app/appdir_test.go
@@ -1,0 +1,39 @@
+//go:build !android && !ios && !mobile
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFyneApp_appDir(t *testing.T) {
+	parent := t.TempDir()
+	fyneDir := filepath.Join(parent, "fyne")
+	testDir := filepath.Join(parent, "fyne-test")
+	require.NoError(t, os.MkdirAll(filepath.Join(fyneDir, "io.fyne.old"), 0o700))
+
+	noID, noIDOld := &fyneApp{}, &fyneApp{}
+	require.NoError(t, os.MkdirAll(filepath.Join(fyneDir, noIDOld.UniqueID()), 0o700))
+
+	for name, tt := range map[string]struct {
+		app  *fyneApp
+		root string
+		want string
+	}{
+		"existing app keeps fyne subdirectory":      {&fyneApp{uniqueID: "io.fyne.old"}, fyneDir, filepath.Join(fyneDir, "io.fyne.old")},
+		"new app moves out of fyne subdirectory":    {&fyneApp{uniqueID: "io.fyne.new"}, fyneDir, filepath.Join(parent, "io.fyne.new")},
+		"root not named fyne is left alone":         {&fyneApp{uniqueID: "io.fyne.new"}, testDir, filepath.Join(testDir, "io.fyne.new")},
+		"relative root is left alone":               {&fyneApp{uniqueID: "io.fyne.new"}, "fyne", filepath.Join("fyne", "io.fyne.new")},
+		"app without ID stays in fyne subdirectory": {noID, fyneDir, filepath.Join(fyneDir, noID.UniqueID())},
+		"app without ID keeps existing data":        {noIDOld, fyneDir, filepath.Join(fyneDir, noIDOld.UniqueID())},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.app.appDir(tt.root))
+		})
+	}
+}

--- a/app/cache_other.go
+++ b/app/cache_other.go
@@ -11,5 +11,5 @@ import (
 
 func rootCacheDir(a fyne.App) string {
 	desktopCache, _ := os.UserCacheDir()
-	return filepath.Join(desktopCache, "fyne", a.UniqueID())
+	return a.(*fyneApp).appDir(filepath.Join(desktopCache, "fyne"))
 }

--- a/app/preferences_other.go
+++ b/app/preferences_other.go
@@ -15,7 +15,7 @@ func (p *preferences) storagePath() string {
 
 // storageRoot returns the location of the app storage
 func (a *fyneApp) storageRoot() string {
-	return filepath.Join(app.RootConfigDir(), a.UniqueID())
+	return a.appDir(app.RootConfigDir())
 }
 
 func (p *preferences) watch() {


### PR DESCRIPTION
On desktop every app's preferences, documents and cache were placed under a "fyne" subdirectory of the platform config and cache roots. Users looking for an app's files have no reason to know which toolkit it was built with, so new apps now get ~/.config/app_id and ~/.cache/app_id (or the platform equivalent). As suggested in the issue nothing is migrated automatically. The config root and the cache root are checked separately: whichever already holds a directory for the app keeps it, so an app that only ever used one of them gets the new location for the other.

The Fyne-wide settings.json and theme.json stay under "fyne", and mobile and web storage are untouched. Apps without an ID also stay put. A unit test covers both locations.

Fixes #6464
