### PR TITLE
ParseMarkdown: Clear scroll container for full refresh

### DIFF
--- a/widget/markdown.go
+++ b/widget/markdown.go
@@ -26,6 +26,9 @@ func NewRichTextFromMarkdown(content string) *RichText {
 // It will replace the content of this widget similarly to SetText, but with the appropriate formatting.
 func (t *RichText) ParseMarkdown(content string) {
 	t.Segments = parseMarkdown(content)
+	if t.scr != nil && !isEmptyScroll(t.scr) {
+		clearScrollContainer(t.scr)
+	}
 	t.Refresh()
 }
 

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -948,6 +948,16 @@ func isEmptyScroll(o *widget.Scroll) bool {
 	return false
 }
 
+func clearScrollContainer(o *widget.Scroll) {
+	if c, ok := o.Content.(*fyne.Container); ok {
+		if len(c.Objects) == 2 {
+			if inner, ok := c.Objects[1].(*fyne.Container); ok {
+				inner.Objects = nil
+			}
+		}
+	}
+}
+
 // howManyRunesFit accepts a rune slice, an available width, an average
 // character width, and a function that calculates the (pixel) size of a given
 // rune slice.


### PR DESCRIPTION
### Description:

PR #6343 reduced the frequency of recreating the scroll container content of RichText widgets. However, this introduced an unwanted side effect: scrollable RichText widgets are no longer updated in `ParseMarkdown`.

Fixes #6524.

### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.