### PR TITLE
Use SetMainGoroutine instead of IsMainGoroutine check, like mobile driver

### DIFF
--- a/internal/driver/glfw/driver.go
+++ b/internal/driver/glfw/driver.go
@@ -184,9 +184,7 @@ func (d *gLDriver) initFailed(msg string, err error) {
 }
 
 func (d *gLDriver) Run() {
-	if !async.IsMainGoroutine() {
-		panic("Run() or ShowAndRun() must be called from main goroutine")
-	}
+	async.SetMainGoroutine()
 
 	go d.catchTerm()
 	d.runGL()


### PR DESCRIPTION
### Description:

The mobile driver explicitly calls async.SetMainGoroutine() and sets the main goroutine inside the Run method at fyne.io/fyne/v2/internal/driver/mobile/driver.go:183. In contrast, gLDriver panics at this point if it is running on a goroutine different from the main goroutine. Instead, it would be better to call SetMainGoroutine(), as the mobile driver does.


### Checklist:

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
