### PR TITLE
Fix selection position in center and trailing aligned labels

### DIFF
--- a/widget/label_test.go
+++ b/widget/label_test.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLabel_Binding(t *testing.T) {
@@ -374,4 +375,43 @@ func TestLabelSizeNameWithSelection(t *testing.T) {
 func labelTextRenderTexts(p fyne.Widget) []*canvas.Text {
 	rich := cache.Renderer(p).Objects()[0].(*RichText)
 	return richTextRenderTexts(rich)
+}
+
+func TestLabel_SelectAligned(t *testing.T) {
+	for name, align := range map[string]fyne.TextAlign{
+		"leading":  fyne.TextAlignLeading,
+		"center":   fyne.TextAlignCenter,
+		"trailing": fyne.TextAlignTrailing,
+	} {
+		t.Run(name, func(t *testing.T) {
+			l := NewLabelWithStyle("Hello World", align, fyne.TextStyle{})
+			l.Selectable = true
+			w := test.NewTempWindow(t, l)
+			w.Resize(fyne.NewSize(300, 50))
+			l.Resize(fyne.NewSize(300, 50))
+
+			texts := richTextRenderTexts(l.provider)
+			require.Len(t, texts, 1)
+			text := texts[0]
+			textWidth := fyne.MeasureText(text.Text, text.TextSize, text.TextStyle).Width
+			textX := text.Position().X
+			switch align {
+			case fyne.TextAlignTrailing:
+				textX += text.Size().Width - textWidth
+			case fyne.TextAlignCenter:
+				textX += (text.Size().Width - textWidth) / 2
+			}
+			helloWidth := fyne.MeasureText("Hello", text.TextSize, text.TextStyle).Width
+
+			sel := test.WidgetRenderer(l).Objects()[0].(*focusSelectable)
+			// double tap in the middle of the "Hello" glyphs as they are drawn
+			sel.DoubleTapped(&fyne.PointEvent{Position: fyne.NewPos(textX+helloWidth/2, 10)})
+			assert.Equal(t, "Hello", l.SelectedText())
+
+			rects := test.WidgetRenderer(sel).Objects()
+			require.Len(t, rects, 1)
+			assert.InDelta(t, textX-1, rects[0].Position().X, 0.5)
+			assert.InDelta(t, helloWidth+1, rects[0].Size().Width, 0.5)
+		})
+	}
 }

--- a/widget/richtext.go
+++ b/widget/richtext.go
@@ -344,6 +344,30 @@ func (t *RichText) lineSizeToColumn(col, row int, textSize, innerPad float32) fy
 	return total.Add(fyne.NewSize(innerPad-t.inset.Width, 0))
 }
 
+// rowAlignOffset returns the horizontal offset of the text in the specified row
+// caused by it being center or trailing aligned within the widget width.
+func (t *RichText) rowAlignOffset(row int, textSize, innerPad float32) float32 {
+	bound := t.rowBoundary(row)
+	if bound == nil {
+		return 0
+	}
+	_, align := rowPaddingAndAlign(*bound, 0, fyne.TextAlignLeading)
+	if align == fyne.TextAlignLeading {
+		return 0
+	}
+
+	xInset := innerPad - t.inset.Width
+	lineWidth := t.Size().Width - xInset*2
+	textWidth := t.lineSizeToColumn(t.rowLength(row), row, textSize, innerPad).Width - xInset
+	if text, ok := bound.segments[len(bound.segments)-1].(*TextSegment); ok && bound.ellipsis {
+		textWidth += fyne.MeasureText("…", text.size(), text.Style.TextStyle).Width //revive:disable-line:add-constant
+	}
+	if align == fyne.TextAlignCenter {
+		return (lineWidth - textWidth) / 2
+	}
+	return lineWidth - textWidth
+}
+
 // Row returns the characters in the row specified.
 // The row parameter should be between 0 and t.Rows()-1.
 func (t *RichText) row(row int) []rune {

--- a/widget/selectable.go
+++ b/widget/selectable.go
@@ -207,7 +207,8 @@ func (s *selectable) getRowCol(p fyne.Position) (row, col int) {
 		row = s.provider.rows() - 1
 		col = s.provider.rowLength(row)
 	} else {
-		col = s.cursorColAt(s.provider.row(row), p)
+		offset := s.provider.rowAlignOffset(row, textSize, innerPad)
+		col = s.cursorColAt(s.provider.row(row), p.SubtractXY(offset, 0))
 	}
 
 	return row, col
@@ -346,7 +347,7 @@ func (r *selectableRenderer) buildSelection() {
 	// Convert column, row into x,y
 	getCoordinates := func(column int, row int) (float32, float32) {
 		sz := provider.lineSizeToColumn(column, row, textSize, innerPad)
-		return sz.Width, sz.Height*float32(row) - th.Size(theme.SizeNameInputBorder) + innerPad
+		return sz.Width + provider.rowAlignOffset(row, textSize, innerPad), sz.Height*float32(row) - th.Size(theme.SizeNameInputBorder) + innerPad
 	}
 
 	lineHeight := r.sel.provider.charMinSize(r.sel.password, r.sel.style, textSize).Height


### PR DESCRIPTION
### Description:

Selecting text in a Label with center or trailing alignment drew the highlight from the leading edge, and taps or drags picked columns as if the text were leading aligned. The selectable now applies the row's alignment offset (taken from the RichText row width, including any truncation ellipsis) both when building the selection rectangles and when mapping a pointer position to a column. I added a test that double taps on the first word of a leading, center and trailing Label and checks the selected text and the highlight position against where the text is laid out; center and trailing failed before this change.

Fixes #6519

### Checklist:

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
